### PR TITLE
fix(deep): feed repo candidates so in-loop deep finds cross-repo clones

### DIFF
--- a/src/mcp/candidate-feeder.ts
+++ b/src/mcp/candidate-feeder.ts
@@ -1,0 +1,53 @@
+/**
+ * Candidate feeding for in-loop deep checks.
+ *
+ * The /v1/analyze duplicate detector is PAIRWISE: it only flags a clone when the
+ * query function is sent alongside the functions it might duplicate. Sending the
+ * single query function (what the tools did) left the deep path repo-blind — the
+ * server had nothing to compare against and always returned `duplicates: []`.
+ *
+ * This re-extracts the repo's functions from disk, samples them with the same
+ * caps the batch `--deep` path uses, drops the query's own file/id, caps the list
+ * to fit the server's 30-function limit, and returns `[query, ...candidates]` so
+ * the existing pairwise detector can surface query-vs-candidate clones.
+ *
+ * Stateless by design: no server persistence, the cost is one repo walk per deep
+ * call (deep is opt-in and already a network round-trip). Fails soft to `[query]`
+ * so the deep path still runs — yielding no duplicates, exactly as before — if
+ * extraction throws or the repo is empty.
+ *
+ * Follow-up (the data-moat play): a persisted per-repo embedding index would
+ * remove both the per-call repo walk and the 29-candidate recall ceiling.
+ */
+import { buildAnalysisContext } from "../core/discovery.js";
+import { extractAllFunctions } from "../codedna/function-extractor.js";
+import { sampleFunctionsForMl } from "../ml-client/sampler.js";
+import type { MlFunctionPayload } from "../ml-client/types.js";
+
+// /v1/analyze rejects > 30 functions per request (HTTP 400). The query takes one
+// slot, so candidates are capped at 29.
+export const MAX_CANDIDATES = 29;
+
+/**
+ * Build the function list to send for an in-loop deep check: the query function
+ * first, then a capped sample of the repo's OTHER functions to compare it against.
+ * Same-file candidates are dropped (the server skips same-file pairs anyway, and a
+ * function being edited must not match itself).
+ */
+export async function buildCandidatePayloads(
+  rootDir: string,
+  queryPayload: MlFunctionPayload,
+): Promise<MlFunctionPayload[]> {
+  try {
+    const { ctx } = await buildAnalysisContext(rootDir);
+    const fns = extractAllFunctions(ctx.files);
+    const candidates = sampleFunctionsForMl(fns, [])
+      .filter((c) => c.file !== queryPayload.file && c.id !== queryPayload.id)
+      .slice(0, MAX_CANDIDATES);
+    return [queryPayload, ...candidates];
+  } catch {
+    // Degrade to query-only: the deep call still runs and simply finds no
+    // cross-repo clone (the prior behavior), rather than erroring the agent.
+    return [queryPayload];
+  }
+}

--- a/src/mcp/deep-client.ts
+++ b/src/mcp/deep-client.ts
@@ -34,6 +34,7 @@ export interface DeepResult {
 export async function deepAnalyze(
   functions: MlFunctionPayload[],
   language: string,
+  queryId?: string,
 ): Promise<DeepResult> {
   const empty = { intentMismatches: [], duplicates: [] };
 
@@ -53,20 +54,33 @@ export async function deepAnalyze(
 
   try {
     const resp = await callMlApi(request, tok.token, apiUrl);
+    // When candidates are fed alongside the query (queryId set), the server
+    // returns query-vs-candidate AND candidate-vs-candidate pairs intermixed.
+    // Keep only the ones that involve the query — the function the agent is
+    // actually judging — and drop the candidate-vs-candidate noise.
+    const dupes = (resp.duplicates ?? []).filter(
+      (d) => !queryId || d.function_a === queryId || d.function_b === queryId,
+    );
+    const intents = (resp.intent_mismatches ?? []).filter(
+      (m) => !queryId || m.function_id === queryId,
+    );
     return {
       degraded: false,
-      intentMismatches: (resp.intent_mismatches ?? []).map((m) => ({
+      intentMismatches: intents.map((m) => ({
         kind: "intent" as const,
         detail: m.name,
         confidence: m.confidence,
         verdict: m.llm_verdict,
       })),
-      duplicates: (resp.duplicates ?? []).map((d) => ({
-        kind: "duplicate" as const,
-        detail: `${d.function_a} ≈ ${d.function_b}`,
-        confidence: d.confidence,
-        verdict: d.llm_verdict ?? d.verdict,
-      })),
+      duplicates: dupes.map((d) => {
+        const other = d.function_a === queryId ? d.function_b : d.function_a;
+        return {
+          kind: "duplicate" as const,
+          detail: queryId ? `${queryId} ≈ ${other}` : `${d.function_a} ≈ ${d.function_b}`,
+          confidence: d.confidence,
+          verdict: d.llm_verdict ?? d.verdict,
+        };
+      }),
     };
   } catch (e) {
     return { degraded: true, reason: classify(e), ...empty };

--- a/src/tools-core/tools/find-similar-function.ts
+++ b/src/tools-core/tools/find-similar-function.ts
@@ -9,6 +9,7 @@ import { getBaseline } from "../../mcp/baseline-provider.js";
 import { findSimilarToBody, type SimMatch } from "../../codedna/find-similar-to-body.js";
 import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
+import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
 
 const SIMILARITY_THRESHOLD = 0.6;
 const MAX_MATCHES = 20;
@@ -62,7 +63,12 @@ export async function run({
   if (!deep) return out;
 
   // Opt-in deep pass — semantic duplicates the local token-LCS index can't see.
-  const deepRes = await deepAnalyze(bodyToPayloads(body, DEEP_QUERY_FILE), inferLanguage(DEEP_QUERY_FILE));
+  // Feed the query alongside a sample of the repo's functions so the server's
+  // pairwise detector has something to compare against (without candidates it is
+  // repo-blind and returns nothing).
+  const queryPayload = bodyToPayloads(body, DEEP_QUERY_FILE)[0];
+  const payloads = await buildCandidatePayloads(rootDir, queryPayload);
+  const deepRes = await deepAnalyze(payloads, inferLanguage(DEEP_QUERY_FILE), queryPayload.id);
   out.deep = deepRes;
   if (deepRes.degraded) {
     out.status = "degraded";

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -21,6 +21,7 @@ import { classifyDataAccessLabel, DATA_ACCESS_NAMES } from "../../drift/architec
 import { findSimilarToBody, type SimMatch } from "../../codedna/find-similar-to-body.js";
 import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
+import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
 
 const DUPLICATE_THRESHOLD = 0.8; // a CHANGE introducing a near-clone — stricter than discovery
 const MAX_MATCHES = 20;
@@ -241,7 +242,13 @@ export async function run({
   // Opt-in deep pass. The local tool is free for everyone; the deep check is
   // metered — the API re-checks entitlement + billing server-side and the
   // client degrades gracefully (never throws) when the budget is empty.
-  const deepRes = await deepAnalyze(bodyToPayloads(body, relTarget), inferLanguage(relTarget));
+  // Feed the proposed function alongside a sample of the repo's functions so the
+  // server's pairwise duplicate detector can surface a cross-repo semantic clone.
+  // buildCandidatePayloads drops candidates in relTarget, mirroring the local
+  // self-exclusion (a function isn't a duplicate of itself).
+  const queryPayload = bodyToPayloads(body, relTarget)[0];
+  const payloads = await buildCandidatePayloads(rootDir, queryPayload);
+  const deepRes = await deepAnalyze(payloads, inferLanguage(relTarget), queryPayload.id);
   out.deep = deepRes;
   if (deepRes.degraded) {
     out.status = "degraded";

--- a/test/unit/mcp/candidate-feeder.test.ts
+++ b/test/unit/mcp/candidate-feeder.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildCandidatePayloads, MAX_CANDIDATES } from "../../../src/mcp/candidate-feeder.js";
+import type { MlFunctionPayload } from "../../../src/ml-client/types.js";
+
+function query(file: string, id: string): MlFunctionPayload {
+  return {
+    id,
+    name: id.split("::").pop() ?? "q",
+    file,
+    body: "function x(){ return 1; }",
+    line_start: 0,
+    line_end: 0,
+    language: "typescript",
+  };
+}
+
+describe("buildCandidatePayloads", () => {
+  let repo: string;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "vd-cand-"));
+    writeFileSync(
+      join(repo, "a.ts"),
+      "export async function getUserById(repo, id){ const u = await repo.users.findById(id); if(!u) throw new NotFound(); return u; }\n",
+    );
+    writeFileSync(
+      join(repo, "b.ts"),
+      "export function addNumbers(a, b){ const total = a + b; return total; }\n",
+    );
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+  it("returns the query first, then the repo's other functions as candidates", async () => {
+    const q = query("query", "query::newFn");
+    const out = await buildCandidatePayloads(repo, q);
+    expect(out[0]).toBe(q);
+    expect(out.length).toBeGreaterThan(1);
+    expect(out.length).toBeLessThanOrEqual(MAX_CANDIDATES + 1);
+    expect(out.slice(1).some((c) => c.name === "getUserById")).toBe(true);
+  });
+
+  it("drops candidates that share the query's file (no self-match when editing a file)", async () => {
+    const q = query("a.ts", "a.ts::getUserById");
+    const out = await buildCandidatePayloads(repo, q);
+    expect(out[0]).toBe(q);
+    expect(out.slice(1).every((c) => c.file !== "a.ts")).toBe(true);
+  });
+
+  it("degrades to query-only when the repo can't be read", async () => {
+    const q = query("query", "query::x");
+    const out = await buildCandidatePayloads(join(tmpdir(), "vd-does-not-exist-zzz-9182"), q);
+    expect(out).toEqual([q]);
+  });
+});

--- a/test/unit/mcp/deep-client.test.ts
+++ b/test/unit/mcp/deep-client.test.ts
@@ -81,4 +81,27 @@ describe("deepAnalyze", () => {
     expect(r.degraded).toBe(true);
     expect(r.reason).toBe("rate_limited");
   });
+
+  it("filters duplicates + intent to the query when queryId is set", async () => {
+    (resolveToken as ReturnType<typeof vi.fn>).mockResolvedValue({ token: "t", source: "config" });
+    (callMlApi as ReturnType<typeof vi.fn>).mockResolvedValue({
+      processing_time_ms: 5,
+      intent_mismatches: [
+        { function_id: "query::q", name: "q", similarity: 0.2, confidence: 0.9, needs_llm: false },
+        { function_id: "other.ts::z", name: "z", similarity: 0.2, confidence: 0.9, needs_llm: false },
+      ],
+      duplicates: [
+        { function_a: "query::q", function_b: "a.ts::twin", similarity: 0.88, confidence: 0.88, verdict: "semantic_duplicate", needs_llm: false },
+        { function_a: "a.ts::twin", function_b: "b.ts::other", similarity: 0.9, confidence: 0.9, verdict: "semantic_duplicate", needs_llm: false },
+      ],
+      anomalies: [], deviations: [], llm_validations: [],
+    });
+    const r = await deepAnalyze([FN], "typescript", "query::q");
+    // candidate-vs-candidate pair dropped; only the query-involving pair survives
+    expect(r.duplicates).toHaveLength(1);
+    expect(r.duplicates[0].detail).toBe("query::q ≈ a.ts::twin");
+    // intent filtered to the query function only
+    expect(r.intentMismatches).toHaveLength(1);
+    expect(r.intentMismatches[0].detail).toBe("q");
+  });
 });

--- a/test/unit/mcp/tools/find-similar-function.test.ts
+++ b/test/unit/mcp/tools/find-similar-function.test.ts
@@ -96,6 +96,12 @@ describe("find_similar_function (integration)", () => {
     expect(out.deep?.duplicates).toHaveLength(1);
     expect(out.found).toBe(true);
     expect(out.status).toBe("partial");
+    // candidate-feeding: the query is sent WITH the repo's functions (not alone),
+    // and its id is passed so the server's pairwise pairs can be filtered to it.
+    const [sentFns, , sentQueryId] = (deepAnalyze as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sentFns.length).toBeGreaterThan(1);
+    expect(sentFns[0].id).toBe("query::totallyUnrelated");
+    expect(sentQueryId).toBe("query::totallyUnrelated");
   });
 
   it("deep:true degrades on rate_limit without throwing", async () => {

--- a/test/unit/mcp/tools/validate-change.test.ts
+++ b/test/unit/mcp/tools/validate-change.test.ts
@@ -241,6 +241,13 @@ describe("validate_change (integration)", () => {
     expect(out.deep?.intentMismatches).toHaveLength(1);
     expect(out.ok).toBe(false);
     expect(out.status).toBe("partial");
+    // candidate-feeding: query (file = relTarget) goes first, repo candidates
+    // follow, and the function under edit's own file is excluded from candidates.
+    const [sentFns, , sentQueryId] = (deepAnalyze as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sentFns.length).toBeGreaterThan(1);
+    expect(sentFns[0].file).toBe("feature.ts");
+    expect(sentFns.slice(1).every((f: { file: string }) => f.file !== "feature.ts")).toBe(true);
+    expect(sentQueryId).toBe(sentFns[0].id);
   });
 
   it("deep:true degrades gracefully (status=degraded) without throwing on quota", async () => {


### PR DESCRIPTION
The /v1/analyze duplicate detector is pairwise, so sending only the query function left validate_change / find_similar_function deep:true repo-blind (always returned `duplicates: []`). Now the tools send `[query, ...<=29 candidates]` and filter the response to query-involving pairs. Stateless; no server change; billing unchanged (per-call). Addresses the repo-blind deep path (CLI todo #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)