### PR TITLE
feat: local per-repo embedding index (fast, cheap in-loop deep dedup)

### DIFF
--- a/src/core/embedding-index.ts
+++ b/src/core/embedding-index.ts
@@ -1,0 +1,126 @@
+/**
+ * Local per-repo embedding index.
+ *
+ * Embeddings are computed server-side (the model only runs there) and returned
+ * to the CLI, which persists the vectors HERE, on the user's machine, under
+ * ~/.vibedrift/embedding-index/ — the same place the MinHash baseline lives.
+ * Your code's vectors never sit on our servers.
+ *
+ * This is what makes in-loop deep checks fast and cheap at scale: a `deep:true`
+ * check embeds only the ONE function being written (one tiny server call) and
+ * cosines it locally against this cached index, instead of re-sending the repo's
+ * functions on every call. The index is keyed by `sha256(rootDir)` and stamped
+ * with the baseline key so it can be invalidated when the repo changes.
+ */
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+// Resolved lazily (not a module const) so it honors the current HOME — tests
+// redirect HOME to a tmp dir, and homedir() reads $HOME first on POSIX.
+function indexDir(): string {
+  return join(homedir(), ".vibedrift", "embedding-index");
+}
+// Bump when the entry shape or vector semantics change, to invalidate all
+// cached indexes at once (mirrors BASELINE_VERSION in core/baseline.ts).
+export const EMBEDDING_INDEX_VERSION = 1;
+
+export interface EmbeddingEntry {
+  id: string; // `${relativePath}::${name}`
+  relativePath: string;
+  name: string;
+  line: number;
+  contentHash: string; // sha256(body)[:16] — staleness/dedupe of a single function
+  vector: number[];
+}
+
+export interface EmbeddingIndex {
+  version: number;
+  rootDir: string;
+  baselineKey: string; // the RepoDriftBaseline key this index was built against (freshness)
+  dim: number;
+  builtAt: number; // epoch ms
+  entries: EmbeddingEntry[];
+}
+
+export interface EmbeddingMatch {
+  relativePath: string;
+  name: string;
+  line: number;
+  similarity: number;
+}
+
+function indexPath(rootDir: string): string {
+  const key = createHash("sha256").update(rootDir).digest("hex").slice(0, 16);
+  return join(indexDir(), `${key}.json`);
+}
+
+/** sha256(body)[:16] — stable per-function content key. */
+export function contentHash(body: string): string {
+  return createHash("sha256").update(body).digest("hex").slice(0, 16);
+}
+
+export async function writeEmbeddingIndex(index: EmbeddingIndex): Promise<void> {
+  await mkdir(indexDir(), { recursive: true, mode: 0o700 });
+  await writeFile(indexPath(index.rootDir), JSON.stringify(index), "utf8");
+}
+
+/** Load the index for a repo, or null if absent/corrupt/stale-version. */
+export async function loadEmbeddingIndex(rootDir: string): Promise<EmbeddingIndex | null> {
+  try {
+    const raw = await readFile(indexPath(rootDir), "utf8");
+    const idx = JSON.parse(raw) as EmbeddingIndex;
+    if (idx.version !== EMBEDDING_INDEX_VERSION || !Array.isArray(idx.entries)) return null;
+    return idx;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the index is missing or was built against a different baseline
+ *  (the repo changed). Callers rebuild when this returns true. */
+export function isIndexStale(index: EmbeddingIndex | null, baselineKey: string): boolean {
+  return !index || index.baselineKey !== baselineKey || index.entries.length === 0;
+}
+
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Cosine the query vector against every entry; return matches at or above the
+ * threshold, sorted descending, capped. `excludeFile` drops the file being
+ * edited so a function never matches itself (mirrors the MinHash path).
+ */
+export function findSimilarByEmbedding(
+  queryVec: number[],
+  index: EmbeddingIndex,
+  opts: { threshold: number; cap: number; excludeFile?: string },
+): EmbeddingMatch[] {
+  const matches: EmbeddingMatch[] = [];
+  for (const e of index.entries) {
+    if (opts.excludeFile && e.relativePath === opts.excludeFile) continue;
+    const sim = cosineSimilarity(queryVec, e.vector);
+    if (sim >= opts.threshold) {
+      matches.push({
+        relativePath: e.relativePath,
+        name: e.name,
+        line: e.line,
+        similarity: Number(sim.toFixed(3)),
+      });
+    }
+  }
+  matches.sort((a, b) => b.similarity - a.similarity);
+  return matches.slice(0, opts.cap);
+}

--- a/src/mcp/candidate-feeder.ts
+++ b/src/mcp/candidate-feeder.ts
@@ -1,0 +1,53 @@
+/**
+ * Candidate feeding for in-loop deep checks.
+ *
+ * The /v1/analyze duplicate detector is PAIRWISE: it only flags a clone when the
+ * query function is sent alongside the functions it might duplicate. Sending the
+ * single query function (what the tools did) left the deep path repo-blind — the
+ * server had nothing to compare against and always returned `duplicates: []`.
+ *
+ * This re-extracts the repo's functions from disk, samples them with the same
+ * caps the batch `--deep` path uses, drops the query's own file/id, caps the list
+ * to fit the server's 30-function limit, and returns `[query, ...candidates]` so
+ * the existing pairwise detector can surface query-vs-candidate clones.
+ *
+ * Stateless by design: no server persistence, the cost is one repo walk per deep
+ * call (deep is opt-in and already a network round-trip). Fails soft to `[query]`
+ * so the deep path still runs — yielding no duplicates, exactly as before — if
+ * extraction throws or the repo is empty.
+ *
+ * Follow-up (the data-moat play): a persisted per-repo embedding index would
+ * remove both the per-call repo walk and the 29-candidate recall ceiling.
+ */
+import { buildAnalysisContext } from "../core/discovery.js";
+import { extractAllFunctions } from "../codedna/function-extractor.js";
+import { sampleFunctionsForMl } from "../ml-client/sampler.js";
+import type { MlFunctionPayload } from "../ml-client/types.js";
+
+// /v1/analyze rejects > 30 functions per request (HTTP 400). The query takes one
+// slot, so candidates are capped at 29.
+export const MAX_CANDIDATES = 29;
+
+/**
+ * Build the function list to send for an in-loop deep check: the query function
+ * first, then a capped sample of the repo's OTHER functions to compare it against.
+ * Same-file candidates are dropped (the server skips same-file pairs anyway, and a
+ * function being edited must not match itself).
+ */
+export async function buildCandidatePayloads(
+  rootDir: string,
+  queryPayload: MlFunctionPayload,
+): Promise<MlFunctionPayload[]> {
+  try {
+    const { ctx } = await buildAnalysisContext(rootDir);
+    const fns = extractAllFunctions(ctx.files);
+    const candidates = sampleFunctionsForMl(fns, [])
+      .filter((c) => c.file !== queryPayload.file && c.id !== queryPayload.id)
+      .slice(0, MAX_CANDIDATES);
+    return [queryPayload, ...candidates];
+  } catch {
+    // Degrade to query-only: the deep call still runs and simply finds no
+    // cross-repo clone (the prior behavior), rather than erroring the agent.
+    return [queryPayload];
+  }
+}

--- a/src/mcp/deep-client.ts
+++ b/src/mcp/deep-client.ts
@@ -83,11 +83,13 @@ export async function deepAnalyze(
       }),
     };
   } catch (e) {
-    return { degraded: true, reason: classify(e), ...empty };
+    return { degraded: true, reason: classifyDegradeReason(e), ...empty };
   }
 }
 
-function classify(e: unknown): DegradeReason {
+/** Map a thrown API error to a DegradeReason (402→quota, 429→rate_limited,
+ *  abort/timeout→timeout, else network). Shared with the local-index path. */
+export function classifyDegradeReason(e: unknown): DegradeReason {
   const msg = String((e as Error)?.message ?? e).toLowerCase();
   if (msg.includes("402")) return "quota";
   if (msg.includes("429")) return "rate_limited";

--- a/src/mcp/deep-client.ts
+++ b/src/mcp/deep-client.ts
@@ -34,6 +34,7 @@ export interface DeepResult {
 export async function deepAnalyze(
   functions: MlFunctionPayload[],
   language: string,
+  queryId?: string,
 ): Promise<DeepResult> {
   const empty = { intentMismatches: [], duplicates: [] };
 
@@ -53,20 +54,33 @@ export async function deepAnalyze(
 
   try {
     const resp = await callMlApi(request, tok.token, apiUrl);
+    // When candidates are fed alongside the query (queryId set), the server
+    // returns query-vs-candidate AND candidate-vs-candidate pairs intermixed.
+    // Keep only the ones that involve the query — the function the agent is
+    // actually judging — and drop the candidate-vs-candidate noise.
+    const dupes = (resp.duplicates ?? []).filter(
+      (d) => !queryId || d.function_a === queryId || d.function_b === queryId,
+    );
+    const intents = (resp.intent_mismatches ?? []).filter(
+      (m) => !queryId || m.function_id === queryId,
+    );
     return {
       degraded: false,
-      intentMismatches: (resp.intent_mismatches ?? []).map((m) => ({
+      intentMismatches: intents.map((m) => ({
         kind: "intent" as const,
         detail: m.name,
         confidence: m.confidence,
         verdict: m.llm_verdict,
       })),
-      duplicates: (resp.duplicates ?? []).map((d) => ({
-        kind: "duplicate" as const,
-        detail: `${d.function_a} ≈ ${d.function_b}`,
-        confidence: d.confidence,
-        verdict: d.llm_verdict ?? d.verdict,
-      })),
+      duplicates: dupes.map((d) => {
+        const other = d.function_a === queryId ? d.function_b : d.function_a;
+        return {
+          kind: "duplicate" as const,
+          detail: queryId ? `${queryId} ≈ ${other}` : `${d.function_a} ≈ ${d.function_b}`,
+          confidence: d.confidence,
+          verdict: d.llm_verdict ?? d.verdict,
+        };
+      }),
     };
   } catch (e) {
     return { degraded: true, reason: classify(e), ...empty };

--- a/src/mcp/deep-index.ts
+++ b/src/mcp/deep-index.ts
@@ -1,0 +1,76 @@
+/**
+ * In-loop semantic-duplicate check via the LOCAL embedding index.
+ *
+ * The fast/cheap path: embed ONLY the function being written (one tiny metered
+ * call to /v1/embed), then cosine it locally against the cached per-repo index.
+ * The index is built lazily on first use and rebuilt when the repo's baseline
+ * changes. This replaces re-sending the repo's functions on every deep check.
+ *
+ * Returns a DeepResult when the index path ran (or the cloud was unreachable —
+ * degraded), or `null` when no index could be built (empty repo / no functions),
+ * which signals the caller to fall back to stateless candidate-feeding.
+ *
+ * Scope: duplicates only. In-loop intent-mismatch still lives on the full
+ * `--deep` scan (it needs the server's name-vs-body pass).
+ */
+import { resolveToken, resolveApiUrl } from "../auth/resolver.js";
+import { embedFunctions } from "../ml-client/embed-client.js";
+import { buildEmbeddingIndex } from "../ml-client/build-embedding-index.js";
+import {
+  loadEmbeddingIndex,
+  isIndexStale,
+  findSimilarByEmbedding,
+  type EmbeddingIndex,
+} from "../core/embedding-index.js";
+import { classifyDegradeReason, type DeepResult, type DeepFinding } from "./deep-client.js";
+import type { MlFunctionPayload } from "../ml-client/types.js";
+
+// No LLM validates these locally, so keep the bar high to protect precision.
+const DUPLICATE_FLOOR = 0.85; // below this we don't surface
+const HIGH_CONFIDENCE = 0.9; // server's "semantic_duplicate" bar
+const MAX_MATCHES = 20;
+
+export async function deepDuplicatesViaIndex(
+  rootDir: string,
+  queryPayload: MlFunctionPayload,
+  baselineKey: string,
+  opts: { excludeFile?: string } = {},
+): Promise<DeepResult | null> {
+  const tok = await resolveToken();
+  if (!tok?.token) {
+    return { degraded: true, reason: "no_token", intentMismatches: [], duplicates: [] };
+  }
+  const apiUrl = await resolveApiUrl();
+
+  // Load, or lazily (re)build, the per-repo index.
+  let index: EmbeddingIndex | null = await loadEmbeddingIndex(rootDir);
+  if (isIndexStale(index, baselineKey)) {
+    index = await buildEmbeddingIndex(rootDir, baselineKey, { token: tok.token, apiUrl });
+  }
+  if (!index) return null; // nothing to compare against → caller falls back
+
+  // Embed just the query function (one small metered call).
+  let queryVec: number[] | undefined;
+  try {
+    const [item] = await embedFunctions([queryPayload], tok.token, apiUrl, "mcp");
+    queryVec = item?.vector;
+  } catch (e) {
+    return { degraded: true, reason: classifyDegradeReason(e), intentMismatches: [], duplicates: [] };
+  }
+  if (!queryVec) return { degraded: false, intentMismatches: [], duplicates: [] };
+
+  const matches = findSimilarByEmbedding(queryVec, index, {
+    threshold: DUPLICATE_FLOOR,
+    cap: MAX_MATCHES,
+    excludeFile: opts.excludeFile,
+  });
+
+  const duplicates: DeepFinding[] = matches.map((m) => ({
+    kind: "duplicate",
+    detail: `${queryPayload.id} ≈ ${m.relativePath}::${m.name}`,
+    confidence: m.similarity,
+    verdict: m.similarity >= HIGH_CONFIDENCE ? "semantic_duplicate" : "possible_duplicate",
+  }));
+
+  return { degraded: false, intentMismatches: [], duplicates };
+}

--- a/src/ml-client/build-embedding-index.ts
+++ b/src/ml-client/build-embedding-index.ts
@@ -1,0 +1,86 @@
+/**
+ * Build + persist the per-repo embedding index.
+ *
+ * Extracts the repo's functions, sends their bodies to /v1/embed (the server
+ * computes the vectors and keeps nothing), and stores the vectors locally via
+ * core/embedding-index. This is the one-time cost that makes every later
+ * in-loop deep check fast: those checks embed a single function and cosine it
+ * against this cached index instead of re-sending candidates each call.
+ *
+ * Best-effort: returns null on any failure (no token, offline, empty repo), and
+ * the in-loop deep path then falls back to candidate-feeding.
+ */
+import { buildAnalysisContext } from "../core/discovery.js";
+import { extractAllFunctions } from "../codedna/function-extractor.js";
+import { embedFunctions } from "./embed-client.js";
+import {
+  writeEmbeddingIndex,
+  contentHash,
+  EMBEDDING_INDEX_VERSION,
+  type EmbeddingIndex,
+  type EmbeddingEntry,
+} from "../core/embedding-index.js";
+import type { MlFunctionPayload } from "./types.js";
+
+// Match the server's per-function truncation so a function embeds identically
+// whether it arrives via this index build or a full --deep scan.
+const MAX_LINES = 60;
+
+export async function buildEmbeddingIndex(
+  rootDir: string,
+  baselineKey: string,
+  opts: { token: string; apiUrl?: string; nowMs?: number },
+): Promise<EmbeddingIndex | null> {
+  try {
+    const { ctx } = await buildAnalysisContext(rootDir);
+    const fns = extractAllFunctions(ctx.files);
+    if (fns.length === 0) return null;
+
+    const payloads: MlFunctionPayload[] = fns.map((fn) => {
+      const lines = fn.rawBody.split("\n");
+      const body = lines.length > MAX_LINES ? lines.slice(0, MAX_LINES).join("\n") : fn.rawBody;
+      return {
+        id: `${fn.relativePath}::${fn.name}`,
+        name: fn.name,
+        file: fn.relativePath,
+        body,
+        line_start: fn.line,
+        line_end: fn.line,
+        language: fn.language,
+      };
+    });
+
+    const vectors = await embedFunctions(payloads, opts.token, opts.apiUrl, "cli");
+    if (vectors.length === 0) return null;
+    const byId = new Map(vectors.map((v) => [v.id, v.vector]));
+
+    const entries: EmbeddingEntry[] = [];
+    for (const fn of fns) {
+      const id = `${fn.relativePath}::${fn.name}`;
+      const vector = byId.get(id);
+      if (!vector) continue;
+      entries.push({
+        id,
+        relativePath: fn.relativePath,
+        name: fn.name,
+        line: fn.line,
+        contentHash: contentHash(fn.rawBody),
+        vector,
+      });
+    }
+    if (entries.length === 0) return null;
+
+    const index: EmbeddingIndex = {
+      version: EMBEDDING_INDEX_VERSION,
+      rootDir,
+      baselineKey,
+      dim: vectors[0].vector.length,
+      builtAt: opts.nowMs ?? Date.now(),
+      entries,
+    };
+    await writeEmbeddingIndex(index);
+    return index;
+  } catch {
+    return null;
+  }
+}

--- a/src/ml-client/embed-client.ts
+++ b/src/ml-client/embed-client.ts
@@ -1,0 +1,62 @@
+import type { MlFunctionPayload } from "./types.js";
+
+const DEFAULT_API_URL = "https://vibedrift-api.fly.dev";
+const TIMEOUT_MS = 90_000; // cold starts + model load
+// Stay under the server's per-request cap (96) and the 200KB body limit.
+const EMBED_CHUNK = 48;
+
+export interface EmbeddingItem {
+  id: string;
+  vector: number[];
+}
+
+interface EmbedResponse {
+  model: string;
+  dim: number;
+  embeddings: EmbeddingItem[];
+}
+
+/**
+ * Fetch embedding vectors for a batch of functions from POST /v1/embed.
+ *
+ * Chunks client-side to respect the server's per-request cap. Returns the
+ * concatenated vectors. Throws on a non-2xx so callers can degrade (the index
+ * builder and the in-loop deep path both treat a throw as "no vectors" and fall
+ * back). The server computes embeddings transiently and stores nothing.
+ */
+export async function embedFunctions(
+  functions: MlFunctionPayload[],
+  token: string,
+  apiUrl?: string,
+  source: "cli" | "mcp" = "cli",
+): Promise<EmbeddingItem[]> {
+  const url = `${apiUrl ?? DEFAULT_API_URL}/v1/embed`;
+  const out: EmbeddingItem[] = [];
+
+  for (let i = 0; i < functions.length; i += EMBED_CHUNK) {
+    const chunk = functions.slice(i, i + EMBED_CHUNK);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          functions: chunk.map((f) => ({ id: f.id, body: f.body, language: f.language })),
+          source,
+        }),
+        signal: controller.signal,
+      });
+      if (!resp.ok) {
+        const t = await resp.text().catch(() => "");
+        throw new Error(`Embed API error ${resp.status}: ${t.slice(0, 200)}`);
+      }
+      const data = (await resp.json()) as EmbedResponse;
+      out.push(...(data.embeddings ?? []));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return out;
+}

--- a/src/tools-core/tools/find-similar-function.ts
+++ b/src/tools-core/tools/find-similar-function.ts
@@ -9,6 +9,7 @@ import { getBaseline } from "../../mcp/baseline-provider.js";
 import { findSimilarToBody, type SimMatch } from "../../codedna/find-similar-to-body.js";
 import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
+import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
 
 const SIMILARITY_THRESHOLD = 0.6;
 const MAX_MATCHES = 20;
@@ -62,7 +63,12 @@ export async function run({
   if (!deep) return out;
 
   // Opt-in deep pass — semantic duplicates the local token-LCS index can't see.
-  const deepRes = await deepAnalyze(bodyToPayloads(body, DEEP_QUERY_FILE), inferLanguage(DEEP_QUERY_FILE));
+  // Feed the query alongside a sample of the repo's functions so the server's
+  // pairwise detector has something to compare against (without candidates it is
+  // repo-blind and returns nothing).
+  const queryPayload = bodyToPayloads(body, DEEP_QUERY_FILE)[0];
+  const payloads = await buildCandidatePayloads(rootDir, queryPayload);
+  const deepRes = await deepAnalyze(payloads, inferLanguage(DEEP_QUERY_FILE), queryPayload.id);
   out.deep = deepRes;
   if (deepRes.degraded) {
     out.status = "degraded";

--- a/src/tools-core/tools/find-similar-function.ts
+++ b/src/tools-core/tools/find-similar-function.ts
@@ -10,6 +10,7 @@ import { findSimilarToBody, type SimMatch } from "../../codedna/find-similar-to-
 import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
 import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
+import { deepDuplicatesViaIndex } from "../../mcp/deep-index.js";
 
 const SIMILARITY_THRESHOLD = 0.6;
 const MAX_MATCHES = 20;
@@ -63,12 +64,15 @@ export async function run({
   if (!deep) return out;
 
   // Opt-in deep pass — semantic duplicates the local token-LCS index can't see.
-  // Feed the query alongside a sample of the repo's functions so the server's
-  // pairwise detector has something to compare against (without candidates it is
-  // repo-blind and returns nothing).
+  // Fast path: embed just this function and cosine it against the cached per-repo
+  // embedding index. Cold-start fallback: feed the query + a sample of the repo's
+  // functions to /v1/analyze (the index is built lazily, so this is rare).
   const queryPayload = bodyToPayloads(body, DEEP_QUERY_FILE)[0];
-  const payloads = await buildCandidatePayloads(rootDir, queryPayload);
-  const deepRes = await deepAnalyze(payloads, inferLanguage(DEEP_QUERY_FILE), queryPayload.id);
+  let deepRes = await deepDuplicatesViaIndex(rootDir, queryPayload, baseline.key);
+  if (deepRes === null) {
+    const payloads = await buildCandidatePayloads(rootDir, queryPayload);
+    deepRes = await deepAnalyze(payloads, inferLanguage(DEEP_QUERY_FILE), queryPayload.id);
+  }
   out.deep = deepRes;
   if (deepRes.degraded) {
     out.status = "degraded";

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -21,6 +21,7 @@ import { classifyDataAccessLabel, DATA_ACCESS_NAMES } from "../../drift/architec
 import { findSimilarToBody, type SimMatch } from "../../codedna/find-similar-to-body.js";
 import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
+import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
 
 const DUPLICATE_THRESHOLD = 0.8; // a CHANGE introducing a near-clone — stricter than discovery
 const MAX_MATCHES = 20;
@@ -241,7 +242,13 @@ export async function run({
   // Opt-in deep pass. The local tool is free for everyone; the deep check is
   // metered — the API re-checks entitlement + billing server-side and the
   // client degrades gracefully (never throws) when the budget is empty.
-  const deepRes = await deepAnalyze(bodyToPayloads(body, relTarget), inferLanguage(relTarget));
+  // Feed the proposed function alongside a sample of the repo's functions so the
+  // server's pairwise duplicate detector can surface a cross-repo semantic clone.
+  // buildCandidatePayloads drops candidates in relTarget, mirroring the local
+  // self-exclusion (a function isn't a duplicate of itself).
+  const queryPayload = bodyToPayloads(body, relTarget)[0];
+  const payloads = await buildCandidatePayloads(rootDir, queryPayload);
+  const deepRes = await deepAnalyze(payloads, inferLanguage(relTarget), queryPayload.id);
   out.deep = deepRes;
   if (deepRes.degraded) {
     out.status = "degraded";

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -22,6 +22,7 @@ import { findSimilarToBody, type SimMatch } from "../../codedna/find-similar-to-
 import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
 import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
+import { deepDuplicatesViaIndex } from "../../mcp/deep-index.js";
 
 const DUPLICATE_THRESHOLD = 0.8; // a CHANGE introducing a near-clone — stricter than discovery
 const MAX_MATCHES = 20;
@@ -242,13 +243,18 @@ export async function run({
   // Opt-in deep pass. The local tool is free for everyone; the deep check is
   // metered — the API re-checks entitlement + billing server-side and the
   // client degrades gracefully (never throws) when the budget is empty.
-  // Feed the proposed function alongside a sample of the repo's functions so the
-  // server's pairwise duplicate detector can surface a cross-repo semantic clone.
-  // buildCandidatePayloads drops candidates in relTarget, mirroring the local
-  // self-exclusion (a function isn't a duplicate of itself).
+  // Fast path: embed just the proposed function and cosine it against the cached
+  // per-repo embedding index (relTarget excluded so it can't match itself).
+  // Cold-start fallback: feed the query + a sample of the repo's functions to the
+  // server's pairwise detector (the index builds lazily, so this is rare).
   const queryPayload = bodyToPayloads(body, relTarget)[0];
-  const payloads = await buildCandidatePayloads(rootDir, queryPayload);
-  const deepRes = await deepAnalyze(payloads, inferLanguage(relTarget), queryPayload.id);
+  let deepRes = await deepDuplicatesViaIndex(rootDir, queryPayload, baseline.key, {
+    excludeFile: relTarget,
+  });
+  if (deepRes === null) {
+    const payloads = await buildCandidatePayloads(rootDir, queryPayload);
+    deepRes = await deepAnalyze(payloads, inferLanguage(relTarget), queryPayload.id);
+  }
   out.deep = deepRes;
   if (deepRes.degraded) {
     out.status = "degraded";

--- a/test/unit/core/embedding-index.test.ts
+++ b/test/unit/core/embedding-index.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  cosineSimilarity,
+  findSimilarByEmbedding,
+  isIndexStale,
+  contentHash,
+  writeEmbeddingIndex,
+  loadEmbeddingIndex,
+  type EmbeddingIndex,
+} from "../../../src/core/embedding-index.js";
+
+function idx(rootDir: string): EmbeddingIndex {
+  return {
+    version: 1,
+    rootDir,
+    baselineKey: "bk-1",
+    dim: 3,
+    builtAt: 0,
+    entries: [
+      { id: "a.ts::formatMoney", relativePath: "a.ts", name: "formatMoney", line: 1, contentHash: "h1", vector: [1, 0, 0] },
+      { id: "b.ts::addNumbers", relativePath: "b.ts", name: "addNumbers", line: 1, contentHash: "h2", vector: [0, 1, 0] },
+      { id: "c.ts::nearTwin", relativePath: "c.ts", name: "nearTwin", line: 1, contentHash: "h3", vector: [0.9, 0.1, 0] },
+    ],
+  };
+}
+
+describe("cosineSimilarity", () => {
+  it("is 1 for identical, 0 for orthogonal, and length-guarded", () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 6);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBe(0);
+    expect(cosineSimilarity([1, 0, 0], [1, 0])).toBe(0); // mismatched length
+    expect(cosineSimilarity([0, 0], [0, 0])).toBe(0); // zero vector
+  });
+});
+
+describe("findSimilarByEmbedding", () => {
+  it("returns matches above threshold, sorted desc, capped, self-excluded", () => {
+    const m = findSimilarByEmbedding([1, 0, 0], idx("/r"), { threshold: 0.8, cap: 10 });
+    // formatMoney (cos 1.0) and nearTwin (cos ~0.994) clear 0.8; addNumbers (0) doesn't
+    expect(m.map((x) => x.name)).toEqual(["formatMoney", "nearTwin"]);
+    expect(m[0].similarity).toBeGreaterThanOrEqual(m[1].similarity);
+  });
+
+  it("excludeFile drops the file being edited", () => {
+    const m = findSimilarByEmbedding([1, 0, 0], idx("/r"), { threshold: 0.8, cap: 10, excludeFile: "a.ts" });
+    expect(m.find((x) => x.relativePath === "a.ts")).toBeUndefined();
+    expect(m.some((x) => x.name === "nearTwin")).toBe(true);
+  });
+
+  it("respects the cap", () => {
+    const m = findSimilarByEmbedding([1, 0, 0], idx("/r"), { threshold: 0, cap: 1 });
+    expect(m).toHaveLength(1);
+  });
+});
+
+describe("isIndexStale", () => {
+  it("is stale when absent, key-mismatched, or empty", () => {
+    expect(isIndexStale(null, "bk-1")).toBe(true);
+    expect(isIndexStale(idx("/r"), "bk-2")).toBe(true);
+    expect(isIndexStale({ ...idx("/r"), entries: [] }, "bk-1")).toBe(true);
+    expect(isIndexStale(idx("/r"), "bk-1")).toBe(false);
+  });
+});
+
+describe("write/load round-trip", () => {
+  let home: string;
+  let prevHome: string | undefined;
+  beforeAll(() => {
+    // Redirect homedir() to a temp dir so the test never touches the real ~/.vibedrift
+    home = mkdtempSync(join(tmpdir(), "vd-eidx-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+  afterAll(() => {
+    if (prevHome !== undefined) process.env.HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("persists and reloads an index by rootDir", async () => {
+    const index = idx("/some/repo");
+    await writeEmbeddingIndex(index);
+    const loaded = await loadEmbeddingIndex("/some/repo");
+    expect(loaded?.entries).toHaveLength(3);
+    expect(loaded?.baselineKey).toBe("bk-1");
+    expect(await loadEmbeddingIndex("/other/repo")).toBeNull();
+  });
+
+  it("contentHash is stable and 16 hex chars", () => {
+    const h = contentHash("function f(){ return 1; }");
+    expect(h).toMatch(/^[0-9a-f]{16}$/);
+    expect(contentHash("function f(){ return 1; }")).toBe(h);
+  });
+});

--- a/test/unit/mcp/candidate-feeder.test.ts
+++ b/test/unit/mcp/candidate-feeder.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildCandidatePayloads, MAX_CANDIDATES } from "../../../src/mcp/candidate-feeder.js";
+import type { MlFunctionPayload } from "../../../src/ml-client/types.js";
+
+function query(file: string, id: string): MlFunctionPayload {
+  return {
+    id,
+    name: id.split("::").pop() ?? "q",
+    file,
+    body: "function x(){ return 1; }",
+    line_start: 0,
+    line_end: 0,
+    language: "typescript",
+  };
+}
+
+describe("buildCandidatePayloads", () => {
+  let repo: string;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "vd-cand-"));
+    writeFileSync(
+      join(repo, "a.ts"),
+      "export async function getUserById(repo, id){ const u = await repo.users.findById(id); if(!u) throw new NotFound(); return u; }\n",
+    );
+    writeFileSync(
+      join(repo, "b.ts"),
+      "export function addNumbers(a, b){ const total = a + b; return total; }\n",
+    );
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+  it("returns the query first, then the repo's other functions as candidates", async () => {
+    const q = query("query", "query::newFn");
+    const out = await buildCandidatePayloads(repo, q);
+    expect(out[0]).toBe(q);
+    expect(out.length).toBeGreaterThan(1);
+    expect(out.length).toBeLessThanOrEqual(MAX_CANDIDATES + 1);
+    expect(out.slice(1).some((c) => c.name === "getUserById")).toBe(true);
+  });
+
+  it("drops candidates that share the query's file (no self-match when editing a file)", async () => {
+    const q = query("a.ts", "a.ts::getUserById");
+    const out = await buildCandidatePayloads(repo, q);
+    expect(out[0]).toBe(q);
+    expect(out.slice(1).every((c) => c.file !== "a.ts")).toBe(true);
+  });
+
+  it("degrades to query-only when the repo can't be read", async () => {
+    const q = query("query", "query::x");
+    const out = await buildCandidatePayloads(join(tmpdir(), "vd-does-not-exist-zzz-9182"), q);
+    expect(out).toEqual([q]);
+  });
+});

--- a/test/unit/mcp/deep-client.test.ts
+++ b/test/unit/mcp/deep-client.test.ts
@@ -81,4 +81,27 @@ describe("deepAnalyze", () => {
     expect(r.degraded).toBe(true);
     expect(r.reason).toBe("rate_limited");
   });
+
+  it("filters duplicates + intent to the query when queryId is set", async () => {
+    (resolveToken as ReturnType<typeof vi.fn>).mockResolvedValue({ token: "t", source: "config" });
+    (callMlApi as ReturnType<typeof vi.fn>).mockResolvedValue({
+      processing_time_ms: 5,
+      intent_mismatches: [
+        { function_id: "query::q", name: "q", similarity: 0.2, confidence: 0.9, needs_llm: false },
+        { function_id: "other.ts::z", name: "z", similarity: 0.2, confidence: 0.9, needs_llm: false },
+      ],
+      duplicates: [
+        { function_a: "query::q", function_b: "a.ts::twin", similarity: 0.88, confidence: 0.88, verdict: "semantic_duplicate", needs_llm: false },
+        { function_a: "a.ts::twin", function_b: "b.ts::other", similarity: 0.9, confidence: 0.9, verdict: "semantic_duplicate", needs_llm: false },
+      ],
+      anomalies: [], deviations: [], llm_validations: [],
+    });
+    const r = await deepAnalyze([FN], "typescript", "query::q");
+    // candidate-vs-candidate pair dropped; only the query-involving pair survives
+    expect(r.duplicates).toHaveLength(1);
+    expect(r.duplicates[0].detail).toBe("query::q ≈ a.ts::twin");
+    // intent filtered to the query function only
+    expect(r.intentMismatches).toHaveLength(1);
+    expect(r.intentMismatches[0].detail).toBe("q");
+  });
 });

--- a/test/unit/mcp/deep-index.test.ts
+++ b/test/unit/mcp/deep-index.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../../src/auth/resolver.js", () => ({
+  resolveToken: vi.fn(),
+  resolveApiUrl: vi.fn(async () => "https://api.test"),
+}));
+vi.mock("../../../src/ml-client/embed-client.js", () => ({ embedFunctions: vi.fn() }));
+vi.mock("../../../src/ml-client/build-embedding-index.js", () => ({ buildEmbeddingIndex: vi.fn() }));
+// Keep the real cosine/isIndexStale; only loadEmbeddingIndex is stubbed.
+vi.mock("../../../src/core/embedding-index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/core/embedding-index.js")>();
+  return { ...actual, loadEmbeddingIndex: vi.fn() };
+});
+
+import { deepDuplicatesViaIndex } from "../../../src/mcp/deep-index.js";
+import { resolveToken } from "../../../src/auth/resolver.js";
+import { embedFunctions } from "../../../src/ml-client/embed-client.js";
+import { buildEmbeddingIndex } from "../../../src/ml-client/build-embedding-index.js";
+import { loadEmbeddingIndex, type EmbeddingIndex } from "../../../src/core/embedding-index.js";
+
+function index(baselineKey: string): EmbeddingIndex {
+  return {
+    version: 1,
+    rootDir: "/r",
+    baselineKey,
+    dim: 3,
+    builtAt: 0,
+    entries: [
+      { id: "a.ts::formatMoney", relativePath: "a.ts", name: "formatMoney", line: 1, contentHash: "h", vector: [1, 0, 0] },
+      { id: "b.ts::add", relativePath: "b.ts", name: "add", line: 1, contentHash: "h", vector: [0, 1, 0] },
+    ],
+  };
+}
+const QUERY = { id: "query::formatAmount", name: "formatAmount", file: "query", body: "x", line_start: 0, line_end: 0, language: "typescript" };
+const tok = (t: string | null) => (resolveToken as ReturnType<typeof vi.fn>).mockResolvedValue(t ? { token: t, source: "config" } : null);
+
+describe("deepDuplicatesViaIndex", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("degrades (no_token) and never touches the index when signed out", async () => {
+    tok(null);
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(r).toMatchObject({ degraded: true, reason: "no_token" });
+    expect(loadEmbeddingIndex).not.toHaveBeenCalled();
+    expect(embedFunctions).not.toHaveBeenCalled();
+  });
+
+  it("finds a cross-API clone via the cached index (no rebuild)", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(index("bk"));
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [0.99, 0.01, 0] }]);
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(buildEmbeddingIndex).not.toHaveBeenCalled(); // fresh → no rebuild
+    expect(r?.duplicates).toHaveLength(1);
+    expect(r?.duplicates[0].detail).toBe("query::formatAmount ≈ a.ts::formatMoney");
+    expect(r?.duplicates[0].verdict).toBe("semantic_duplicate");
+    expect(r?.intentMismatches).toEqual([]); // local index = duplicates only
+  });
+
+  it("rebuilds the index when the baseline key changed", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(index("old-key"));
+    (buildEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(index("bk"));
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
+    await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(buildEmbeddingIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null (→ caller falls back) when no index can be built", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (buildEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(r).toBeNull();
+    expect(embedFunctions).not.toHaveBeenCalled();
+  });
+
+  it("degrades (never throws) when the query embed call fails", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(index("bk"));
+    (embedFunctions as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Embed API error 402: quota"));
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(r).toMatchObject({ degraded: true, reason: "quota" });
+  });
+
+  it("excludeFile drops a self-match", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(index("bk"));
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk", { excludeFile: "a.ts" });
+    expect(r?.duplicates).toHaveLength(0); // the only match was in the excluded file
+  });
+});

--- a/test/unit/mcp/tools/find-similar-function.test.ts
+++ b/test/unit/mcp/tools/find-similar-function.test.ts
@@ -7,11 +7,13 @@ vi.mock("../../../../src/mcp/deep-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../../src/mcp/deep-client.js")>();
   return { ...actual, deepAnalyze: vi.fn() };
 });
+vi.mock("../../../../src/mcp/deep-index.js", () => ({ deepDuplicatesViaIndex: vi.fn() }));
 
 import { findSimilarToBody } from "../../../../src/codedna/find-similar-to-body.js";
 import { buildSignature } from "../../../../src/codedna/minhash.js";
 import { run } from "../../../../src/mcp/tools/find-similar-function.js";
 import { deepAnalyze } from "../../../../src/mcp/deep-client.js";
+import { deepDuplicatesViaIndex } from "../../../../src/mcp/deep-index.js";
 import { buildBaseline, writeBaseline } from "../../../../src/core/baseline.js";
 import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
 
@@ -63,7 +65,13 @@ describe("find_similar_function (integration)", () => {
     await writeBaseline(await buildBaseline(repo));
   });
   afterAll(() => rmSync(repo, { recursive: true, force: true }));
-  beforeEach(() => __clearBaselineCache());
+  beforeEach(() => {
+    __clearBaselineCache();
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockClear();
+    // Default: index path unavailable → tools fall back to candidate-feeding,
+    // so the existing deepAnalyze-based assertions still exercise that path.
+    (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  });
 
   it("finds the existing near-duplicate for a new function body", async () => {
     const out = await run({
@@ -102,6 +110,19 @@ describe("find_similar_function (integration)", () => {
     expect(sentFns.length).toBeGreaterThan(1);
     expect(sentFns[0].id).toBe("query::totallyUnrelated");
     expect(sentQueryId).toBe("query::totallyUnrelated");
+  });
+
+  it("deep:true uses the local embedding index when present (skips candidate-feeding)", async () => {
+    (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockResolvedValue({
+      degraded: false,
+      intentMismatches: [],
+      duplicates: [{ kind: "duplicate", detail: "query::q ≈ a.ts::twin", confidence: 0.93, verdict: "semantic_duplicate" }],
+    });
+    const out = await run({ rootDir: repo, body: "function q(){ return 1; }", deep: true });
+    expect(out.deep?.duplicates).toHaveLength(1);
+    expect(out.found).toBe(true);
+    expect(out.status).toBe("partial");
+    expect(deepAnalyze).not.toHaveBeenCalled(); // index path served it; no fallback
   });
 
   it("deep:true degrades on rate_limit without throwing", async () => {

--- a/test/unit/mcp/tools/find-similar-function.test.ts
+++ b/test/unit/mcp/tools/find-similar-function.test.ts
@@ -96,6 +96,12 @@ describe("find_similar_function (integration)", () => {
     expect(out.deep?.duplicates).toHaveLength(1);
     expect(out.found).toBe(true);
     expect(out.status).toBe("partial");
+    // candidate-feeding: the query is sent WITH the repo's functions (not alone),
+    // and its id is passed so the server's pairwise pairs can be filtered to it.
+    const [sentFns, , sentQueryId] = (deepAnalyze as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sentFns.length).toBeGreaterThan(1);
+    expect(sentFns[0].id).toBe("query::totallyUnrelated");
+    expect(sentQueryId).toBe("query::totallyUnrelated");
   });
 
   it("deep:true degrades on rate_limit without throwing", async () => {

--- a/test/unit/mcp/tools/validate-change.test.ts
+++ b/test/unit/mcp/tools/validate-change.test.ts
@@ -9,9 +9,11 @@ vi.mock("../../../../src/mcp/deep-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../../src/mcp/deep-client.js")>();
   return { ...actual, deepAnalyze: vi.fn() };
 });
+vi.mock("../../../../src/mcp/deep-index.js", () => ({ deepDuplicatesViaIndex: vi.fn() }));
 
 import { validateChange, run } from "../../../../src/mcp/tools/validate-change.js";
 import { deepAnalyze } from "../../../../src/mcp/deep-client.js";
+import { deepDuplicatesViaIndex } from "../../../../src/mcp/deep-index.js";
 import { buildSignature } from "../../../../src/codedna/minhash.js";
 import { buildBaseline, writeBaseline, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
 import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
@@ -211,7 +213,13 @@ describe("validate_change (integration)", () => {
     dom = built.perCategoryVote.async_patterns?.dominantPattern;
   });
   afterAll(() => rmSync(repo, { recursive: true, force: true }));
-  beforeEach(() => __clearBaselineCache());
+  beforeEach(() => {
+    __clearBaselineCache();
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockClear();
+    // Default: index unavailable → fall back to candidate-feeding so the existing
+    // deepAnalyze-based assertions still exercise that path.
+    (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  });
 
   it("detects an async conflict for a .then() change against an async/await repo", async () => {
     expect(dom, "fixture should establish an async/await dominant").toBe("async/await");
@@ -248,6 +256,19 @@ describe("validate_change (integration)", () => {
     expect(sentFns[0].file).toBe("feature.ts");
     expect(sentFns.slice(1).every((f: { file: string }) => f.file !== "feature.ts")).toBe(true);
     expect(sentQueryId).toBe(sentFns[0].id);
+  });
+
+  it("deep:true uses the local embedding index when present (skips candidate-feeding)", async () => {
+    (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockResolvedValue({
+      degraded: false,
+      intentMismatches: [],
+      duplicates: [{ kind: "duplicate", detail: "feature.ts::g ≈ a.ts::twin", confidence: 0.93, verdict: "semantic_duplicate" }],
+    });
+    const out = await run({ rootDir: repo, targetPath: join(repo, "feature.ts"), body: AWAIT_BODY, deep: true });
+    expect(out.deep?.duplicates).toHaveLength(1);
+    expect(out.ok).toBe(false);
+    expect(out.status).toBe("partial");
+    expect(deepAnalyze).not.toHaveBeenCalled(); // index path served it; no fallback
   });
 
   it("deep:true degrades gracefully (status=degraded) without throwing on quota", async () => {

--- a/test/unit/mcp/tools/validate-change.test.ts
+++ b/test/unit/mcp/tools/validate-change.test.ts
@@ -241,6 +241,13 @@ describe("validate_change (integration)", () => {
     expect(out.deep?.intentMismatches).toHaveLength(1);
     expect(out.ok).toBe(false);
     expect(out.status).toBe("partial");
+    // candidate-feeding: query (file = relTarget) goes first, repo candidates
+    // follow, and the function under edit's own file is excluded from candidates.
+    const [sentFns, , sentQueryId] = (deepAnalyze as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sentFns.length).toBeGreaterThan(1);
+    expect(sentFns[0].file).toBe("feature.ts");
+    expect(sentFns.slice(1).every((f: { file: string }) => f.file !== "feature.ts")).toBe(true);
+    expect(sentQueryId).toBe(sentFns[0].id);
   });
 
   it("deep:true degrades gracefully (status=degraded) without throwing on quota", async () => {

--- a/test/unit/ml-client/build-embedding-index.test.ts
+++ b/test/unit/ml-client/build-embedding-index.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Stub the network embed call; everything else (extraction, persistence) is real.
+vi.mock("../../../src/ml-client/embed-client.js", () => ({ embedFunctions: vi.fn() }));
+
+import { buildEmbeddingIndex } from "../../../src/ml-client/build-embedding-index.js";
+import { embedFunctions } from "../../../src/ml-client/embed-client.js";
+import { loadEmbeddingIndex } from "../../../src/core/embedding-index.js";
+
+describe("buildEmbeddingIndex", () => {
+  let repo: string;
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "vd-bei-repo-"));
+    writeFileSync(join(repo, "a.ts"), "export function formatMoney(cents){ const d = cents/100; return `$${d}`; }\n");
+    writeFileSync(join(repo, "b.ts"), "export function addNumbers(a, b){ const total = a + b; return total; }\n");
+    home = mkdtempSync(join(tmpdir(), "vd-bei-home-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = home; // redirect ~/.vibedrift to a temp dir
+  });
+  afterAll(() => {
+    if (prevHome !== undefined) process.env.HOME = prevHome;
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  });
+  beforeEach(() => vi.clearAllMocks());
+
+  it("embeds the repo's functions and persists a loadable index", async () => {
+    // Return a vector for whatever ids the builder sends.
+    (embedFunctions as ReturnType<typeof vi.fn>).mockImplementation(async (payloads: any[]) =>
+      payloads.map((p) => ({ id: p.id, vector: [p.id.length, 1, 2] })),
+    );
+    const index = await buildEmbeddingIndex(repo, "bk-1", { token: "tok", nowMs: 123 });
+    expect(index).not.toBeNull();
+    expect(index!.baselineKey).toBe("bk-1");
+    expect(index!.builtAt).toBe(123);
+    expect(index!.dim).toBe(3);
+    expect(index!.entries.some((e) => e.name === "formatMoney")).toBe(true);
+    // round-trips through the local store
+    const loaded = await loadEmbeddingIndex(repo);
+    expect(loaded?.entries.length).toBe(index!.entries.length);
+  });
+
+  it("returns null (no index) when the embed call yields nothing", async () => {
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const index = await buildEmbeddingIndex(repo, "bk-1", { token: "tok" });
+    expect(index).toBeNull();
+  });
+
+  it("returns null when embedding throws (offline) — caller falls back", async () => {
+    (embedFunctions as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
+    const index = await buildEmbeddingIndex(repo, "bk-1", { token: "tok" });
+    expect(index).toBeNull();
+  });
+});

--- a/test/unit/ml-client/embed-client.test.ts
+++ b/test/unit/ml-client/embed-client.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { embedFunctions } from "../../../src/ml-client/embed-client.js";
+import type { MlFunctionPayload } from "../../../src/ml-client/types.js";
+
+function fn(i: number): MlFunctionPayload {
+  return { id: `f${i}.ts::fn${i}`, name: `fn${i}`, file: `f${i}.ts`, body: `function fn${i}(){}`, line_start: 0, line_end: 0, language: "typescript" };
+}
+
+function okResponse(ids: string[]) {
+  return {
+    ok: true,
+    json: async () => ({ model: "m", dim: 3, embeddings: ids.map((id) => ({ id, vector: [1, 2, 3] })) }),
+  };
+}
+
+describe("embedFunctions", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("chunks at 48 functions/request and concatenates the vectors", async () => {
+    const calls: any[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init: any) => {
+      const sent = JSON.parse(init.body).functions.map((f: any) => f.id);
+      calls.push(sent);
+      return okResponse(sent) as any;
+    }));
+    const out = await embedFunctions(Array.from({ length: 100 }, (_, i) => fn(i)), "tok");
+    // 100 -> chunks of 48,48,4 = 3 requests
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toHaveLength(48);
+    expect(calls[2]).toHaveLength(4);
+    expect(out).toHaveLength(100);
+  });
+
+  it("sends a Bearer token and only id/body/language per function", async () => {
+    let init: any;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, i: any) => { init = i; return okResponse([fn(0).id]) as any; }));
+    await embedFunctions([fn(0)], "secret-token");
+    expect(init.headers.Authorization).toBe("Bearer secret-token");
+    const sentFn = JSON.parse(init.body).functions[0];
+    expect(Object.keys(sentFn).sort()).toEqual(["body", "id", "language"]);
+    expect(JSON.parse(init.body).source).toBe("cli");
+  });
+
+  it("throws on a non-2xx so callers can degrade", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 402, text: async () => "quota" }) as any));
+    await expect(embedFunctions([fn(0)], "tok")).rejects.toThrow(/Embed API error 402/);
+  });
+
+  it("returns [] for no functions without calling the network", async () => {
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+    const out = await embedFunctions([], "tok");
+    expect(out).toEqual([]);
+    expect(f).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Persists server-computed embeddings locally under ~/.vibedrift; in-loop deep embeds ONE function (`/v1/embed`) and cosines locally against the cached index, with candidate-feeding as the cold-start fallback. Needs the API `feat/embed-endpoint` PR.

**Stacked on `feat/deep-candidate-feeding` — merge that PR first** (its commits appear here until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)