### PR TITLE
feat: actionable fix prompts + paid gating (fix prompts, hook, watch)

### DIFF
--- a/src/auth/plan.ts
+++ b/src/auth/plan.ts
@@ -1,0 +1,13 @@
+/**
+ * Plan-tier predicate. Single source of truth for paid-only feature gates.
+ *
+ * Fix prompts (the copy-ready, peer-grounded fix for each finding) are a paid
+ * feature; findings, scores, and dominant patterns stay free on every plan. The
+ * client gates the local fix-prompt surfaces on this; the `/v1/fix-prompts` route
+ * is the authoritative server-side backstop (require_paid).
+ */
+export type Plan = "free" | "pro" | "scale";
+
+export function isPaidPlan(plan?: Plan | null): boolean {
+  return plan === "pro" || plan === "scale";
+}

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -11,6 +11,8 @@ import { promisify } from "node:util";
 import { writeFileSync, readFileSync, existsSync, chmodSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import chalk from "chalk";
+import { readConfig } from "../../auth/config.js";
+import { isPaidPlan } from "../../auth/plan.js";
 
 const exec = promisify(execFile);
 
@@ -57,6 +59,18 @@ export async function runHook(action: string, opts: HookOptions = {}, cwd: strin
   }
 
   if (action === "install") {
+    // Installing the score-gating pre-push hook is a Pro/Scale feature (drift
+    // enforcement in your own git workflow). uninstall/status stay open so a
+    // downgraded user can always remove it. Cached-plan check — works offline.
+    if (!isPaidPlan((await readConfig()).plan)) {
+      console.error(chalk.red("\nThe VibeDrift pre-push hook is a Pro/Scale feature.\n"));
+      console.error(chalk.dim("It blocks a push whose Vibe Drift Score is below your threshold —"));
+      console.error(chalk.dim("drift enforcement, in your own git workflow."));
+      console.error("");
+      console.error(`  ${chalk.yellow("Upgrade:")} ${chalk.bold("vibedrift upgrade")}`);
+      console.error("");
+      process.exit(1);
+    }
     const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
     if (existsSync(hookPath)) {
       const existing = readFileSync(hookPath, "utf8");

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -449,13 +449,14 @@ async function writeContextIfRequested(
   result: ScanResult,
   options: ScanOptions,
   rootDir: string,
+  paid: boolean,
 ): Promise<void> {
   if (!options.writeContext) return;
   const { writeContextFiles } = await import("../../output/context-md.js");
   const { basename } = await import("path");
   const projectName = options.projectName ?? basename(rootDir);
   try {
-    const { written, note } = await writeContextFiles(rootDir, result, projectName);
+    const { written, note } = await writeContextFiles(rootDir, result, projectName, paid);
     console.log("");
     console.log(chalk.green(`  ✓ Wrote ${written.length} files to .vibedrift/`));
     for (const f of written) {
@@ -480,6 +481,7 @@ async function logAndRender(
   apiUrl: string | undefined,
   rootDir: string,
   codeDnaResult: any,
+  paid: boolean,
 ): Promise<void> {
   const { findings: allFindings, compositeScore, maxCompositeScore, scanTimeMs } = result;
 
@@ -607,11 +609,11 @@ async function logAndRender(
     console.log(chalk.dim("  ─────────────────────────────────────────────────────────────"));
     console.log("");
     console.log(`  ${chalk.yellow("→")} Track this score over time: ${chalk.underline.cyan("https://vibedrift.ai/login")} ${chalk.dim("(free, 30s)")}`);
-    console.log(`    ${chalk.dim("HTML report · score history · copy-paste AI fix prompts")}`);
+    console.log(`    ${chalk.dim("HTML report · score history · AI fix prompts (Pro)")}`);
     for (const line of renderStarCta()) console.log(line);
     console.log("");
   } else {
-    await renderToFormat(result, format, options);
+    await renderToFormat(result, format, options, paid);
   }
 
   // Fail on score threshold
@@ -624,11 +626,12 @@ async function renderToFormat(
   result: ScanResult,
   format: string,
   options: ScanOptions,
+  paid: boolean,
 ): Promise<void> {
   if (format === "html") {
     const scanId = (result as any).__scanId as string | undefined;
     const beaconApiUrl = (result as any).__apiUrl as string | undefined;
-    const beaconOpts = scanId ? { scanId, beaconApiUrl } : {};
+    const beaconOpts = { ...(scanId ? { scanId, beaconApiUrl } : {}), isPaid: paid };
     const summaryHtml = renderHtmlReport(result, "summary", {}, beaconOpts);
     const detailedHtml = renderHtmlReport(result, "detailed", {}, beaconOpts);
     const outputPath = options.output ?? "vibedrift-report.html";
@@ -844,8 +847,19 @@ export async function runScan(
   // null and skip rendering.
   result.updateCheck = await updateCheckPromise;
 
-  // Rich fix-prompt prose synthesis. Runs when logged in AND network is on.
-  if (bearerToken && networkEnabled) {
+  // Fix prompts are a paid feature (Pro/Scale). Resolve the plan from cached
+  // config and gate every fix-prompt surface on it; the /v1/fix-prompts route is
+  // the authoritative server backstop. Defaults to free-gating on any error, and
+  // works offline / --local-only (cached plan, no network call).
+  let paid = false;
+  try {
+    const { readConfig } = await import("../../auth/config.js");
+    const { isPaidPlan } = await import("../../auth/plan.js");
+    paid = isPaidPlan((await readConfig()).plan);
+  } catch { /* default: free-gated */ }
+
+  // Rich fix-prompt prose synthesis. PAID-ONLY; runs when logged in AND network is on.
+  if (bearerToken && networkEnabled && paid) {
     try {
       const { synthesizeFixPrompts } = await import("../../ml-client/fix-prompts.js");
       await synthesizeFixPrompts(result.findings, result.context, {
@@ -916,7 +930,7 @@ export async function runScan(
     result.scoringVersion,
   );
 
-  await writeContextIfRequested(result, options, rootDir);
+  await writeContextIfRequested(result, options, rootDir, paid);
 
-  await logAndRender(result, options, bearerToken, apiUrl, rootDir, pipeline.codeDnaResult);
+  await logAndRender(result, options, bearerToken, apiUrl, rootDir, pipeline.codeDnaResult, paid);
 }

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -34,6 +34,8 @@ import { join, relative, resolve } from "path";
 import chalk from "chalk";
 import { runScan } from "./scan.js";
 import { resolveToken } from "../../auth/resolver.js";
+import { readConfig } from "../../auth/config.js";
+import { isPaidPlan } from "../../auth/plan.js";
 import type { ScanOptions } from "../../core/types.js";
 
 /** Ignore list — we don't want to fire rescans for editor tempfiles,
@@ -121,6 +123,21 @@ export async function runWatch(
     console.error("");
     console.error(chalk.dim("  Or if you just need a one-time scan without account:"));
     console.error(chalk.dim("    vibedrift ."));
+    console.error("");
+    process.exit(1);
+  }
+
+  // Continuous watch is a Pro/Scale feature (it re-scans on every change and
+  // keeps the .vibedrift/ agent context fresh all session). Free runs one-shot
+  // scans on demand. Cached-plan check — works offline.
+  if (!isPaidPlan((await readConfig()).plan)) {
+    console.error(chalk.red("\nvibedrift watch is a Pro/Scale feature.\n"));
+    console.error(chalk.dim("Continuous drift watch re-scans on every file change and keeps"));
+    console.error(chalk.dim(".vibedrift/ context fresh for your AI agent the whole session."));
+    console.error("");
+    console.error(`  ${chalk.yellow("Upgrade:")} ${chalk.bold("vibedrift upgrade")}`);
+    console.error("");
+    console.error(chalk.dim("  Free: run a one-shot scan any time with  vibedrift ."));
     console.error("");
     process.exit(1);
   }

--- a/src/ml-client/fix-prompts.ts
+++ b/src/ml-client/fix-prompts.ts
@@ -1,11 +1,11 @@
 /**
  * Deep-scan-tier rich fix prompt synthesis.
  *
- * Takes the top-N findings by consistency impact, pulls snippets from each
- * finding's dominant-pattern reference files, and sends them in a batched
- * call to the VibeDrift API's /v1/fix-prompts endpoint. The API returns
- * AI-synthesized prose describing how the peers implement the dominant
- * pattern. That prose is attached to `finding.metadata.fixPromptProse` so
+ * Takes the top-N findings by consistency impact, pulls the drifting code plus
+ * snippets from each finding's dominant-pattern reference files, and sends them
+ * in a batched call to the VibeDrift API's /v1/fix-prompts endpoint. The API
+ * returns an AI-synthesized, ACTIONABLE fix grounded in the drifting code and
+ * the peers. That prose is attached to `finding.metadata.fixPromptProse` so
  * the HTML + terminal + context-md renderers can pick it up via the shared
  * fix-prompt template.
  *
@@ -31,6 +31,9 @@ interface FixPromptRequestItem {
   message: string;
   file: string;
   dominant_pattern: string;
+  // The drifting code itself, so the API can synthesize an ACTIONABLE fix (not
+  // just describe the peers). Extracted from the finding's location.
+  deviating_snippet: string;
   reference_files: RefFileSnippet[];
 }
 
@@ -54,6 +57,17 @@ function extractSnippet(content: string, dominantPattern: string): string {
     }
   }
   return lines.slice(0, MAX_SNIPPET_LINES).join("\n");
+}
+
+/** Extract a window of the file centered on a line (1-based), for the drifting
+ *  snippet. Returns the whole file when it's already short. */
+function extractAroundLine(content: string, line: number): string {
+  const lines = content.split("\n");
+  if (lines.length <= MAX_SNIPPET_LINES) return content;
+  const idx = Math.max(0, line - 1);
+  const start = Math.max(0, idx - Math.floor(MAX_SNIPPET_LINES / 3));
+  const end = Math.min(lines.length, start + MAX_SNIPPET_LINES);
+  return lines.slice(start, end).join("\n");
 }
 
 function buildRequestItems(
@@ -80,12 +94,24 @@ function buildRequestItems(
     if (refs.length === 0) continue;
 
     const firstLoc = finding.locations[0];
+    // The drifting code to fix: prefer the finding's own evidence snippet, else
+    // a window of the deviating file around the location.
+    let deviatingSnippet = firstLoc?.snippet ?? "";
+    if (!deviatingSnippet && firstLoc) {
+      const devFile = fileByPath.get(firstLoc.file);
+      if (devFile) {
+        deviatingSnippet = firstLoc.line
+          ? extractAroundLine(devFile.content, firstLoc.line)
+          : extractSnippet(devFile.content, meta.dominantPattern ?? "");
+      }
+    }
     items.push({
       finding_id: findingKey(finding),
       category: finding.analyzerId,
       message: finding.message.replace(/^DRIFT:\s*/, "").slice(0, 400),
       file: firstLoc?.file ?? "",
       dominant_pattern: meta.dominantPattern ?? "",
+      deviating_snippet: deviatingSnippet,
       reference_files: refs,
     });
   }

--- a/src/output/context-md.ts
+++ b/src/output/context-md.ts
@@ -9,7 +9,7 @@
 import { mkdir, writeFile, readFile } from "fs/promises";
 import { join } from "path";
 import type { ScanResult, Finding, DriftFindingReport } from "../core/types.js";
-import { buildFullFixPlanMarkdown, findingKey, buildFixPromptMarkdown } from "./fix-prompt.js";
+import { buildFullFixPlanMarkdown, findingKey, buildFixPromptMarkdown, buildUpsellBlock } from "./fix-prompt.js";
 import { getVersion } from "../core/version.js";
 import { relativeTime } from "./history-diff.js";
 import { formatCount } from "./format.js";
@@ -37,7 +37,7 @@ function humanize(cat: string): string {
   return cat.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-export function buildContextMarkdown(result: ScanResult, projectName: string): string {
+export function buildContextMarkdown(result: ScanResult, projectName: string, isPaid: boolean = false): string {
   const lines: string[] = [];
   const pct = result.maxCompositeScore > 0
     ? (result.compositeScore / result.maxCompositeScore) * 100
@@ -117,7 +117,12 @@ export function buildContextMarkdown(result: ScanResult, projectName: string): s
 
   lines.push("## If you're an AI agent working on this codebase");
   lines.push("");
-  lines.push("When modifying files here, match the dominant patterns listed above. Re-run `npx @vibedrift/cli` after your changes to verify the drift has closed and the consistency score has improved. The per-finding fix prompts in `.vibedrift/fix-plan.md` give you copy-ready context for each open drift item.");
+  lines.push(
+    "When modifying files here, match the dominant patterns listed above. Re-run `npx @vibedrift/cli` after your changes to verify the drift has closed and the consistency score has improved." +
+      (isPaid
+        ? " The per-finding fix prompts in `.vibedrift/fix-plan.md` give you copy-ready context for each open drift item."
+        : " Per-finding copy-ready fix prompts are a Pro/Scale feature — run `vibedrift upgrade` to generate `.vibedrift/fix-plan.md` for each open drift item."),
+  );
   lines.push("");
 
   lines.push("---");
@@ -181,6 +186,7 @@ export async function writeContextFiles(
   rootDir: string,
   result: ScanResult,
   projectName: string,
+  isPaid: boolean = false,
 ): Promise<{ written: string[]; note: string | null }> {
   const outDir = join(rootDir, OUT_DIR);
   await mkdir(outDir, { recursive: true });
@@ -192,14 +198,22 @@ export async function writeContextFiles(
     fileCount: result.context.files.length,
   };
 
-  const contextMd = buildContextMarkdown(result, projectName);
-  const fixPlanMd = top.length > 0
-    ? buildFullFixPlanMarkdown(top, ctx)
-    : "# VibeDrift Fix Plan\n\nNo drift findings with measurable impact — the codebase is well-aligned.\n";
+  // Fix prompts are a paid feature. Free plans get context.md + patterns.json in
+  // full (score + dominant patterns + open drift), but fix-plan.md / fix-prompts.md
+  // carry an upsell instead of the copy-ready fixes.
+  const contextMd = buildContextMarkdown(result, projectName, isPaid);
   const patternsJson = buildPatternsJson(result);
-  const perFindingBlocks = top
-    .map((f, i) => `<!-- finding ${i + 1}: ${findingKey(f)} -->\n${buildFixPromptMarkdown(f, ctx)}`)
-    .join("\n\n---\n\n");
+  const upsell = buildUpsellBlock(projectName);
+  const fixPlanMd = !isPaid
+    ? upsell
+    : top.length > 0
+      ? buildFullFixPlanMarkdown(top, ctx)
+      : "# VibeDrift Fix Plan\n\nNo drift findings with measurable impact — the codebase is well-aligned.\n";
+  const perFindingBlocks = !isPaid
+    ? upsell
+    : top
+        .map((f, i) => `<!-- finding ${i + 1}: ${findingKey(f)} -->\n${buildFixPromptMarkdown(f, ctx)}`)
+        .join("\n\n---\n\n");
 
   await Promise.all([
     writeFile(join(outDir, "context.md"), contextMd),

--- a/src/output/fix-prompt.ts
+++ b/src/output/fix-prompt.ts
@@ -246,6 +246,23 @@ export function referralFooter(projectName?: string): string {
 }
 
 /**
+ * Shared upsell shown to FREE users in place of fix prompts (a Pro/Scale
+ * feature). Used by every gated surface so the copy is identical. The findings,
+ * scores, and dominant patterns remain free; only the copy-ready fix is paid.
+ */
+export function buildUpsellBlock(projectName?: string): string {
+  return [
+    "# VibeDrift Fix Plan",
+    "",
+    "Per-finding AI fix prompts are a **Pro/Scale** feature. The findings, scores, and dominant patterns are yours on every plan; the copy-ready, peer-grounded fix for each open drift is part of the paid deep scan.",
+    "",
+    "Run `vibedrift upgrade`, then re-run with the same flags to generate a fix for each finding.",
+    "",
+    referralFooter(projectName),
+  ].join("\n");
+}
+
+/**
  * Multi-finding "fix everything" prompt.
  */
 export function buildFullFixPlanMarkdown(

--- a/src/output/fix-prompt.ts
+++ b/src/output/fix-prompt.ts
@@ -10,8 +10,8 @@
  * When finding.metadata carries dominantPattern + dominantFiles, the
  * prompt names the peer baseline and lists reference files. For findings
  * without that metadata, it falls back to message + file/line + evidence.
- * When opts.richProse is provided, a "How the peers do this" section is
- * inserted between "What's drifting" and "What to do".
+ * When opts.richProse is provided (deep-tier actionable fix synthesis), a
+ * "How to fix this" section is inserted between "What's drifting" and "What to do".
  */
 
 import type { Finding } from "../core/types.js";
@@ -193,7 +193,7 @@ export function buildFixPromptMarkdown(
   const richSection: string[] = [];
   const prose = meta.fixPromptProse ?? ctx.richProse;
   if (prose) {
-    richSection.push("", "### How the peers do this", "", prose.trim());
+    richSection.push("", "### How to fix this", "", prose.trim());
   }
 
   const actionHeading = mode === "legacy" ? "### Migration plan (not urgent)" : "### What to do";

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -1307,9 +1307,27 @@ function buildEmbeddedData(result: ScanResult): string {
   return JSON.stringify(data);
 }
 
-function buildEmbeddedPrompts(result: ScanResult): string {
-  const ctx = buildFixPromptContext(result);
+// Copied to the clipboard when a FREE user clicks a "Copy AI Prompt" button.
+// Fix prompts are a paid feature, so the report source never carries the real
+// prompt markdown for a free plan — only this upsell.
+const FIX_PROMPT_UPSELL =
+  "VibeDrift fix prompts are a Pro/Scale feature. Your findings, scores, and dominant patterns are free on every plan; the copy-ready, peer-grounded fix for each one is part of the paid deep scan. Run `vibedrift upgrade` to unlock.";
+
+export function buildEmbeddedPrompts(result: ScanResult, isPaid: boolean): string {
   const map: Record<string, string> = {};
+  if (!isPaid) {
+    // Paid-only: emit the SAME keys so the copy buttons still resolve, but every
+    // value is the upsell — no fix-prompt markdown reaches a free report's source.
+    for (const f of result.findings) {
+      map[findingKey(f)] = FIX_PROMPT_UPSELL;
+      for (const filePath of f.metadata?.legacyFiles ?? []) {
+        map[`${findingKey(f)}-legacy-${filePath}`] = FIX_PROMPT_UPSELL;
+      }
+    }
+    map.__full_fix_plan__ = FIX_PROMPT_UPSELL;
+    return JSON.stringify(map).replace(/<\//g, "<\\/");
+  }
+  const ctx = buildFixPromptContext(result);
   for (const f of result.findings) {
     // Standard drift fix prompt (default mode)
     map[findingKey(f)] = buildFixPromptMarkdown(f, ctx);
@@ -1771,7 +1789,7 @@ export function renderHtmlReport(
   result: ScanResult,
   mode: "summary" | "detailed" = "summary",
   urls: { detailedUrl?: string; summaryUrl?: string } = {},
-  opts: { scanId?: string; beaconApiUrl?: string } = {},
+  opts: { scanId?: string; beaconApiUrl?: string; isPaid?: boolean } = {},
 ): string {
   const projectName = result.context.rootDir.split("/").pop() ?? "project";
   const { compositeScore, maxCompositeScore } = result;
@@ -2134,7 +2152,7 @@ ${buildFooter(result)}
 
 <script>
 window.__VIBEDRIFT_DATA = ${buildEmbeddedData(result)};
-window.__VIBEDRIFT_PROMPTS = ${buildEmbeddedPrompts(result)};
+window.__VIBEDRIFT_PROMPTS = ${buildEmbeddedPrompts(result, opts.isPaid ?? false)};
 ${opts.scanId ? `
 // Report-open beacon — fires once when the report loads in a browser.
 (function() {

--- a/test/unit/auth/plan.test.ts
+++ b/test/unit/auth/plan.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { isPaidPlan } from "../../../src/auth/plan.js";
+
+describe("isPaidPlan", () => {
+  it("is true only for pro and scale", () => {
+    expect(isPaidPlan("pro")).toBe(true);
+    expect(isPaidPlan("scale")).toBe(true);
+  });
+  it("is false for free / null / undefined", () => {
+    expect(isPaidPlan("free")).toBe(false);
+    expect(isPaidPlan(null)).toBe(false);
+    expect(isPaidPlan(undefined)).toBe(false);
+  });
+});

--- a/test/unit/cli/hook.test.ts
+++ b/test/unit/cli/hook.test.ts
@@ -3,7 +3,17 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// Hook install is paid-gated; default the cached plan to a paid plan so the
+// install/uninstall tests exercise the real file logic. The free-gate test
+// overrides it.
+vi.mock("../../../src/auth/config.js", async (orig) => {
+  const actual = await orig<typeof import("../../../src/auth/config.js")>();
+  return { ...actual, readConfig: vi.fn(async () => ({ plan: "pro" })) };
+});
+
 import { buildHookScript, runHook, resolveHooksDir, HOOK_MARKER } from "../../../src/cli/commands/hook.js";
+import { readConfig } from "../../../src/auth/config.js";
 
 describe("buildHookScript", () => {
   it("includes the marker, threshold, and the fail-on-score invocation", () => {
@@ -21,6 +31,7 @@ describe("runHook in a temp git repo", () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "vd-hook-"));
     execFileSync("git", ["init", "-q", dir]);
+    (readConfig as ReturnType<typeof vi.fn>).mockResolvedValue({ plan: "pro" });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -46,6 +57,19 @@ describe("runHook in a temp git repo", () => {
     expect(existsSync(hookPath)).toBe(true);
     await runHook("uninstall", {}, dir);
     expect(existsSync(hookPath)).toBe(false);
+  });
+
+  it("install is paid-only — a free plan is blocked and writes no hook", async () => {
+    (readConfig as ReturnType<typeof vi.fn>).mockResolvedValue({ plan: "free" });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((): never => {
+        throw new Error("process.exit");
+      }) as never);
+    await expect(runHook("install", { threshold: 80 }, dir)).rejects.toThrow("process.exit");
+    const hookPath = join(await resolveHooksDir(dir), "pre-push");
+    expect(existsSync(hookPath)).toBe(false); // gated before any write
+    exitSpy.mockRestore();
   });
 
   it("install refuses to clobber a foreign pre-push hook without --force", async () => {

--- a/test/unit/ml-client/fix-prompts.test.ts
+++ b/test/unit/ml-client/fix-prompts.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { synthesizeFixPrompts } from "../../../src/ml-client/fix-prompts.js";
+import type { AnalysisContext, Finding } from "../../../src/core/types.js";
+
+function ctxWith(files: Array<{ relativePath: string; content: string }>): AnalysisContext {
+  return { files: files.map((f) => ({ ...f, path: f.relativePath, language: "typescript", lineCount: f.content.split("\n").length })) } as unknown as AnalysisContext;
+}
+
+function driftFinding(over: Partial<Finding> = {}): Finding {
+  return {
+    analyzerId: "drift-architectural_consistency",
+    severity: "warning",
+    confidence: 0.8,
+    message: "DRIFT: src/order.ts uses raw SQL while peers use a repository",
+    locations: [{ file: "src/order.ts", line: 1 }],
+    tags: [],
+    consistencyImpact: 1.2,
+    metadata: { dominantPattern: "repository", dominantFiles: ["src/repo.ts"] },
+    ...over,
+  } as Finding;
+}
+
+function stubFetch(impl: (init: any) => any) {
+  const spy = vi.fn(async (_url: string, init: any) => impl(init));
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+describe("synthesizeFixPrompts", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sends the DRIFTING code + peer references, and attaches the returned fix prose", async () => {
+    const ctx = ctxWith([
+      { relativePath: "src/order.ts", content: "export function loadOrder(id){ const r = db.query('select * from orders'); return r; }" },
+      { relativePath: "src/repo.ts", content: "export async function findOrder(id){ return await OrderRepo.findById(id); }" },
+    ]);
+    const finding = driftFinding();
+    const spy = stubFetch(() => ({ ok: true, json: async () => ({ prompts: { "1": "1) Replace db.query with OrderRepo.findById()." } }) }));
+
+    await synthesizeFixPrompts([finding], ctx, { token: "tok" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(spy.mock.calls[0][1].body);
+    const item = body.items[0];
+    expect(item.deviating_snippet).toContain("db.query"); // the code to fix is sent
+    expect(item.dominant_pattern).toBe("repository");
+    expect(item.reference_files[0].path).toBe("src/repo.ts");
+    expect(finding.metadata!.fixPromptProse).toMatch(/OrderRepo\.findById/);
+  });
+
+  it("prefers the finding's own evidence snippet for the drifting code when present", async () => {
+    const ctx = ctxWith([
+      { relativePath: "src/order.ts", content: "// big file\n".repeat(100) },
+      { relativePath: "src/repo.ts", content: "export async function findOrder(id){ return await OrderRepo.findById(id); }" },
+    ]);
+    const finding = driftFinding({ locations: [{ file: "src/order.ts", line: 5, snippet: "db.query('SELECT 1')" }] });
+    const spy = stubFetch(() => ({ ok: true, json: async () => ({ prompts: { "1": "fix it" } }) }));
+
+    await synthesizeFixPrompts([finding], ctx, { token: "tok" });
+    const item = JSON.parse(spy.mock.calls[0][1].body).items[0];
+    expect(item.deviating_snippet).toBe("db.query('SELECT 1')");
+  });
+
+  it("skips findings with no peer reference files (nothing to ground the fix in)", async () => {
+    const ctx = ctxWith([{ relativePath: "src/order.ts", content: "function f(){}" }]);
+    const finding = driftFinding({ metadata: { dominantPattern: "repository", dominantFiles: [] } });
+    const spy = stubFetch(() => ({ ok: true, json: async () => ({ prompts: {} }) }));
+    await synthesizeFixPrompts([finding], ctx, { token: "tok" });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/output/context-md.test.ts
+++ b/test/unit/output/context-md.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { buildContextMarkdown } from "../../../src/output/context-md.js";
+import { buildContextMarkdown, writeContextFiles } from "../../../src/output/context-md.js";
 
 function minimalResult() {
   return {
     compositeScore: 80,
     maxCompositeScore: 100,
-    context: { dominantLanguage: "typescript", files: [{}, {}], totalLines: 1000 },
+    context: { rootDir: "/r/proj", dominantLanguage: "typescript", files: [{}, {}], totalLines: 1000 },
     driftFindings: [],
     findings: [],
   } as any;
@@ -22,5 +25,43 @@ describe("buildContextMarkdown referral link", () => {
     const md = buildContextMarkdown(minimalResult(), "acme-app");
     expect(md).toContain("acme-app");
     expect(md).toContain("Vibe Drift Score");
+  });
+
+  it("points to fix-plan.md when paid, and to upgrade when free", () => {
+    expect(buildContextMarkdown(minimalResult(), "acme-app", true)).toContain(".vibedrift/fix-plan.md`");
+    const free = buildContextMarkdown(minimalResult(), "acme-app", false);
+    expect(free).toMatch(/Pro\/Scale feature/);
+    expect(free).toContain("vibedrift upgrade");
+  });
+});
+
+describe("writeContextFiles — fix prompts are paid", () => {
+  const dirs: string[] = [];
+  afterAll(() => dirs.forEach((d) => rmSync(d, { recursive: true, force: true })));
+  function tmp() {
+    const d = mkdtempSync(join(tmpdir(), "vd-ctx-"));
+    dirs.push(d);
+    return d;
+  }
+
+  it("FREE: fix-plan.md / fix-prompts.md are an upsell; context.md + patterns.json still written", async () => {
+    const dir = tmp();
+    const { written } = await writeContextFiles(dir, minimalResult(), "acme-app", false);
+    expect(written).toContain(".vibedrift/context.md");
+    expect(written).toContain(".vibedrift/patterns.json");
+    const fixPlan = readFileSync(join(dir, ".vibedrift", "fix-plan.md"), "utf8");
+    const fixPrompts = readFileSync(join(dir, ".vibedrift", "fix-prompts.md"), "utf8");
+    expect(fixPlan).toMatch(/Pro\/Scale/);
+    expect(fixPrompts).toMatch(/Pro\/Scale/);
+    // context.md is full content, not an upsell stub
+    expect(readFileSync(join(dir, ".vibedrift", "context.md"), "utf8")).toContain("Vibe Drift Score");
+  });
+
+  it("PAID (no findings): fix-plan.md is the real well-aligned message, not an upsell", async () => {
+    const dir = tmp();
+    await writeContextFiles(dir, minimalResult(), "acme-app", true);
+    const fixPlan = readFileSync(join(dir, ".vibedrift", "fix-plan.md"), "utf8");
+    expect(fixPlan).not.toMatch(/Pro\/Scale/);
+    expect(fixPlan).toContain("well-aligned");
   });
 });

--- a/test/unit/output/html-fix-prompt-gate.test.ts
+++ b/test/unit/output/html-fix-prompt-gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { buildEmbeddedPrompts } from "../../../src/output/html.js";
+
+function resultWithFinding() {
+  return {
+    context: { rootDir: "/r/proj", dominantLanguage: "typescript", files: [{}, {}] },
+    findings: [
+      {
+        analyzerId: "drift-architectural_consistency",
+        severity: "warning",
+        confidence: 0.8,
+        message: "DRIFT: src/order.ts uses raw SQL while peers use a repository",
+        locations: [{ file: "src/order.ts", line: 1 }],
+        tags: [],
+        consistencyImpact: 1.2,
+        metadata: { dominantPattern: "repository", dominantFiles: ["src/repo.ts"], recommendation: "Use the repository." },
+      },
+    ],
+  } as any;
+}
+
+describe("buildEmbeddedPrompts — paid gate", () => {
+  it("FREE: same keys, but every value is an upsell (no fix-prompt markdown in source)", () => {
+    const map = JSON.parse(buildEmbeddedPrompts(resultWithFinding(), false)) as Record<string, string>;
+    const values = Object.values(map);
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) {
+      expect(v).toMatch(/Pro\/Scale feature/);
+      expect(v).toContain("vibedrift upgrade");
+      expect(v).not.toContain("## VibeDrift"); // no real prompt header leaks
+      expect(v).not.toContain("What's drifting"); // no real prompt body leaks
+    }
+    expect(Object.keys(map)).toContain("__full_fix_plan__"); // keys preserved so buttons resolve
+  });
+
+  it("PAID: emits the real fix prompts", () => {
+    const map = JSON.parse(buildEmbeddedPrompts(resultWithFinding(), true)) as Record<string, string>;
+    expect(map.__full_fix_plan__).toContain("VibeDrift Fix Plan");
+    const perFinding = Object.entries(map).find(([k]) => k !== "__full_fix_plan__")?.[1] as string;
+    expect(perFinding).toMatch(/What's drifting|VibeDrift Drift Finding/);
+  });
+});


### PR DESCRIPTION
- Fix-prompt synthesis is actionable (sends the drifting code; relabeled "How to fix this").
- **Paid gating (Pro/Scale):** all fix-prompt surfaces (HTML prompt map + copy buttons, .vibedrift/fix-plan.md + fix-prompts.md, AI prose) are paid-only; free keeps findings/scores/patterns. `vibedrift hook install` and `vibedrift watch` are paid; the local "since last scan" delta stays free. Single source of truth: `isPaidPlan`.

Pairs with the API `feat/actionable-fix-prompts` PR (require_paid on /v1/fix-prompts + timeline gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)