### PR TITLE
feat(deep): in-loop Claude verdict for borderline embedding matches

### DIFF
--- a/src/core/embedding-index.ts
+++ b/src/core/embedding-index.ts
@@ -24,7 +24,10 @@ function indexDir(): string {
 }
 // Bump when the entry shape or vector semantics change, to invalidate all
 // cached indexes at once (mirrors BASELINE_VERSION in core/baseline.ts).
-export const EMBEDDING_INDEX_VERSION = 1;
+// v2: entries now carry the (truncated) function body so a borderline embedding
+// match can be sent to the cloud for a Claude confirm/reject verdict without
+// re-walking the repo. Old v1 indexes (no body) are dropped + rebuilt on load.
+export const EMBEDDING_INDEX_VERSION = 2;
 
 export interface EmbeddingEntry {
   id: string; // `${relativePath}::${name}`
@@ -32,6 +35,7 @@ export interface EmbeddingEntry {
   name: string;
   line: number;
   contentHash: string; // sha256(body)[:16] — staleness/dedupe of a single function
+  body: string; // truncated to the same MAX_LINES the server embeds (for borderline LLM validation)
   vector: number[];
 }
 
@@ -49,6 +53,7 @@ export interface EmbeddingMatch {
   name: string;
   line: number;
   similarity: number;
+  body?: string; // present when the index stores bodies (v2+); used for borderline LLM validation
 }
 
 function indexPath(rootDir: string): string {
@@ -118,6 +123,7 @@ export function findSimilarByEmbedding(
         name: e.name,
         line: e.line,
         similarity: Number(sim.toFixed(3)),
+        body: e.body,
       });
     }
   }

--- a/src/mcp/deep-index.ts
+++ b/src/mcp/deep-index.ts
@@ -6,6 +6,12 @@
  * The index is built lazily on first use and rebuilt when the repo's baseline
  * changes. This replaces re-sending the repo's functions on every deep check.
  *
+ * Two-tier verdict (see the confidence bands below): a strong local cosine match
+ * ships immediately, but a *borderline* match — where embedding similarity alone
+ * is unreliable — is escalated to the cloud for a Claude confirm/reject verdict.
+ * Only the handful of borderline candidates are sent, so the cloud cost stays
+ * bounded while the surfaced results gain LLM-grade precision.
+ *
  * Returns a DeepResult when the index path ran (or the cloud was unreachable —
  * degraded), or `null` when no index could be built (empty repo / no functions),
  * which signals the caller to fall back to stateless candidate-feeding.
@@ -22,12 +28,19 @@ import {
   findSimilarByEmbedding,
   type EmbeddingIndex,
 } from "../core/embedding-index.js";
-import { classifyDegradeReason, type DeepResult, type DeepFinding } from "./deep-client.js";
+import { classifyDegradeReason, deepAnalyze, type DeepResult, type DeepFinding } from "./deep-client.js";
 import type { MlFunctionPayload } from "../ml-client/types.js";
 
-// No LLM validates these locally, so keep the bar high to protect precision.
-const DUPLICATE_FLOOR = 0.85; // below this we don't surface
+// Confidence bands for a local cosine match:
+//   ≥ HIGH_CONFIDENCE       → ship directly as a confirmed semantic duplicate (no cloud call)
+//   [BORDERLINE_FLOOR, HIGH) → ambiguous; send the candidate to the cloud for an LLM verdict
+//   < BORDERLINE_FLOOR       → drop (too weak to be worth a verdict)
+// The borderline band is where embedding cosine is unreliable on its own; routing
+// only those (a handful, not the whole repo) to Claude is what makes the in-loop
+// check both cheap AND precise.
+const BORDERLINE_FLOOR = 0.72; // collect matches from here up
 const HIGH_CONFIDENCE = 0.9; // server's "semantic_duplicate" bar
+const MAX_BORDERLINE = 8; // cap the cloud cost of a single in-loop check
 const MAX_MATCHES = 20;
 
 export async function deepDuplicatesViaIndex(
@@ -60,17 +73,56 @@ export async function deepDuplicatesViaIndex(
   if (!queryVec) return { degraded: false, intentMismatches: [], duplicates: [] };
 
   const matches = findSimilarByEmbedding(queryVec, index, {
-    threshold: DUPLICATE_FLOOR,
+    threshold: BORDERLINE_FLOOR,
     cap: MAX_MATCHES,
     excludeFile: opts.excludeFile,
   });
 
-  const duplicates: DeepFinding[] = matches.map((m) => ({
-    kind: "duplicate",
-    detail: `${queryPayload.id} ≈ ${m.relativePath}::${m.name}`,
-    confidence: m.similarity,
-    verdict: m.similarity >= HIGH_CONFIDENCE ? "semantic_duplicate" : "possible_duplicate",
-  }));
+  // High-confidence local matches ship directly — cosine alone is reliable here.
+  const duplicates: DeepFinding[] = matches
+    .filter((m) => m.similarity >= HIGH_CONFIDENCE)
+    .map((m) => ({
+      kind: "duplicate",
+      detail: `${queryPayload.id} ≈ ${m.relativePath}::${m.name}`,
+      confidence: m.similarity,
+      verdict: "semantic_duplicate",
+    }));
 
-  return { degraded: false, intentMismatches: [], duplicates };
+  // Borderline matches are ambiguous: ask the cloud for an LLM confirm/reject
+  // verdict instead of surfacing a maybe. We send ONLY the query + the borderline
+  // candidates (each carries its stored body), and filter the server's pairwise
+  // result back to the query. Rejected pairs simply don't come back → dropped.
+  const borderline = matches
+    .filter((m) => m.similarity < HIGH_CONFIDENCE && m.body)
+    .slice(0, MAX_BORDERLINE);
+
+  if (borderline.length > 0) {
+    const candidatePayloads: MlFunctionPayload[] = borderline.map((m) => ({
+      id: `${m.relativePath}::${m.name}`,
+      name: m.name,
+      file: m.relativePath,
+      body: m.body as string,
+      line_start: m.line,
+      line_end: m.line,
+      language: queryPayload.language,
+    }));
+    const verdict = await deepAnalyze(
+      [queryPayload, ...candidatePayloads],
+      queryPayload.language ?? "unknown",
+      queryPayload.id,
+    );
+    if (verdict.degraded) {
+      // The cloud verdict failed (quota/offline/rate-limit). Surface the
+      // high-confidence locals we already have; only report degraded if those
+      // were our only signal, so the caller can tell the user verification ran short.
+      if (duplicates.length === 0) {
+        return { degraded: true, reason: verdict.reason, intentMismatches: [], duplicates: [] };
+      }
+    } else {
+      duplicates.push(...verdict.duplicates);
+    }
+  }
+
+  duplicates.sort((a, b) => b.confidence - a.confidence);
+  return { degraded: false, intentMismatches: [], duplicates: duplicates.slice(0, MAX_MATCHES) };
 }

--- a/src/mcp/deep-index.ts
+++ b/src/mcp/deep-index.ts
@@ -119,7 +119,13 @@ export async function deepDuplicatesViaIndex(
         return { degraded: true, reason: verdict.reason, intentMismatches: [], duplicates: [] };
       }
     } else {
-      duplicates.push(...verdict.duplicates);
+      // Defense-in-depth: surface a borderline pair ONLY if the server's verdict
+      // cleared the high-confidence bar. The server boosts Claude-CONFIRMED pairs
+      // to >= HIGH_CONFIDENCE and leaves uncertain ones at their raw cosine, so
+      // this drops anything Claude didn't confirm — mirroring the full --deep
+      // path's client-side confidence filter rather than trusting the response
+      // verbatim. (Rejected pairs aren't returned at all.)
+      duplicates.push(...verdict.duplicates.filter((d) => d.confidence >= HIGH_CONFIDENCE));
     }
   }
 

--- a/src/ml-client/build-embedding-index.ts
+++ b/src/ml-client/build-embedding-index.ts
@@ -55,19 +55,22 @@ export async function buildEmbeddingIndex(
     const byId = new Map(vectors.map((v) => [v.id, v.vector]));
 
     const entries: EmbeddingEntry[] = [];
-    for (const fn of fns) {
+    fns.forEach((fn, i) => {
       const id = `${fn.relativePath}::${fn.name}`;
       const vector = byId.get(id);
-      if (!vector) continue;
+      if (!vector) return;
       entries.push({
         id,
         relativePath: fn.relativePath,
         name: fn.name,
         line: fn.line,
         contentHash: contentHash(fn.rawBody),
+        // Store the same truncated body that was embedded, so a borderline match
+        // can be re-sent to the cloud for an LLM verdict without re-extraction.
+        body: payloads[i].body ?? "",
         vector,
       });
-    }
+    });
     if (entries.length === 0) return null;
 
     const index: EmbeddingIndex = {

--- a/test/unit/core/embedding-index.test.ts
+++ b/test/unit/core/embedding-index.test.ts
@@ -14,15 +14,15 @@ import {
 
 function idx(rootDir: string): EmbeddingIndex {
   return {
-    version: 1,
+    version: 2,
     rootDir,
     baselineKey: "bk-1",
     dim: 3,
     builtAt: 0,
     entries: [
-      { id: "a.ts::formatMoney", relativePath: "a.ts", name: "formatMoney", line: 1, contentHash: "h1", vector: [1, 0, 0] },
-      { id: "b.ts::addNumbers", relativePath: "b.ts", name: "addNumbers", line: 1, contentHash: "h2", vector: [0, 1, 0] },
-      { id: "c.ts::nearTwin", relativePath: "c.ts", name: "nearTwin", line: 1, contentHash: "h3", vector: [0.9, 0.1, 0] },
+      { id: "a.ts::formatMoney", relativePath: "a.ts", name: "formatMoney", line: 1, contentHash: "h1", body: "function formatMoney(n){ return '$'+n; }", vector: [1, 0, 0] },
+      { id: "b.ts::addNumbers", relativePath: "b.ts", name: "addNumbers", line: 1, contentHash: "h2", body: "function addNumbers(a,b){ return a+b; }", vector: [0, 1, 0] },
+      { id: "c.ts::nearTwin", relativePath: "c.ts", name: "nearTwin", line: 1, contentHash: "h3", body: "function nearTwin(n){ return `$${n}`; }", vector: [0.9, 0.1, 0] },
     ],
   };
 }
@@ -53,6 +53,11 @@ describe("findSimilarByEmbedding", () => {
   it("respects the cap", () => {
     const m = findSimilarByEmbedding([1, 0, 0], idx("/r"), { threshold: 0, cap: 1 });
     expect(m).toHaveLength(1);
+  });
+
+  it("carries the stored body on each match (so borderline matches can be LLM-validated)", () => {
+    const m = findSimilarByEmbedding([1, 0, 0], idx("/r"), { threshold: 0.8, cap: 10 });
+    expect(m[0].body).toContain("formatMoney");
   });
 });
 

--- a/test/unit/mcp/deep-index.test.ts
+++ b/test/unit/mcp/deep-index.test.ts
@@ -150,6 +150,20 @@ describe("deepDuplicatesViaIndex", () => {
     expect(r?.duplicates).toHaveLength(0);
   });
 
+  it("drops a server-returned duplicate that didn't clear the confidence bar (unconfirmed)", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(borderlineIndex());
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
+    // Server returns the pair but unboosted (Claude didn't confirm) → below HIGH_CONFIDENCE.
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockResolvedValue({
+      degraded: false,
+      intentMismatches: [],
+      duplicates: [{ kind: "duplicate", detail: "query::formatAmount ≈ a.ts::maybeTwin", confidence: 0.8, verdict: "possible_duplicate" }],
+    });
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(r?.duplicates).toHaveLength(0); // not confirmed → not surfaced
+  });
+
   it("reports degraded when the only matches are borderline and the cloud verdict fails", async () => {
     tok("t");
     (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(borderlineIndex());

--- a/test/unit/mcp/deep-index.test.ts
+++ b/test/unit/mcp/deep-index.test.ts
@@ -11,23 +11,43 @@ vi.mock("../../../src/core/embedding-index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../src/core/embedding-index.js")>();
   return { ...actual, loadEmbeddingIndex: vi.fn() };
 });
+// Keep the real classifyDegradeReason; only the cloud verdict (deepAnalyze) is stubbed.
+vi.mock("../../../src/mcp/deep-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/mcp/deep-client.js")>();
+  return { ...actual, deepAnalyze: vi.fn() };
+});
 
 import { deepDuplicatesViaIndex } from "../../../src/mcp/deep-index.js";
 import { resolveToken } from "../../../src/auth/resolver.js";
 import { embedFunctions } from "../../../src/ml-client/embed-client.js";
 import { buildEmbeddingIndex } from "../../../src/ml-client/build-embedding-index.js";
 import { loadEmbeddingIndex, type EmbeddingIndex } from "../../../src/core/embedding-index.js";
+import { deepAnalyze } from "../../../src/mcp/deep-client.js";
 
 function index(baselineKey: string): EmbeddingIndex {
   return {
-    version: 1,
+    version: 2,
     rootDir: "/r",
     baselineKey,
     dim: 3,
     builtAt: 0,
     entries: [
-      { id: "a.ts::formatMoney", relativePath: "a.ts", name: "formatMoney", line: 1, contentHash: "h", vector: [1, 0, 0] },
-      { id: "b.ts::add", relativePath: "b.ts", name: "add", line: 1, contentHash: "h", vector: [0, 1, 0] },
+      { id: "a.ts::formatMoney", relativePath: "a.ts", name: "formatMoney", line: 1, contentHash: "h", body: "function formatMoney(n){ return '$'+n; }", vector: [1, 0, 0] },
+      { id: "b.ts::add", relativePath: "b.ts", name: "add", line: 1, contentHash: "h", body: "function add(a,b){ return a+b; }", vector: [0, 1, 0] },
+    ],
+  };
+}
+
+// An index whose only entry sits in the borderline band (cosine ~0.8 with [1,0,0]).
+function borderlineIndex(): EmbeddingIndex {
+  return {
+    version: 2,
+    rootDir: "/r",
+    baselineKey: "bk",
+    dim: 3,
+    builtAt: 0,
+    entries: [
+      { id: "a.ts::maybeTwin", relativePath: "a.ts", name: "maybeTwin", line: 7, contentHash: "h", body: "function maybeTwin(n){ return n * 2; }", vector: [0.8, 0.6, 0] },
     ],
   };
 }
@@ -35,7 +55,12 @@ const QUERY = { id: "query::formatAmount", name: "formatAmount", file: "query", 
 const tok = (t: string | null) => (resolveToken as ReturnType<typeof vi.fn>).mockResolvedValue(t ? { token: t, source: "config" } : null);
 
 describe("deepDuplicatesViaIndex", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: cloud verdict returns nothing (most tests only exercise the
+    // high-confidence local path and never reach it).
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockResolvedValue({ degraded: false, intentMismatches: [], duplicates: [] });
+  });
 
   it("degrades (no_token) and never touches the index when signed out", async () => {
     tok(null);
@@ -55,6 +80,7 @@ describe("deepDuplicatesViaIndex", () => {
     expect(r?.duplicates[0].detail).toBe("query::formatAmount ≈ a.ts::formatMoney");
     expect(r?.duplicates[0].verdict).toBe("semantic_duplicate");
     expect(r?.intentMismatches).toEqual([]); // local index = duplicates only
+    expect(deepAnalyze).not.toHaveBeenCalled(); // ≥0.90 ships locally — no cloud verdict
   });
 
   it("rebuilds the index when the baseline key changed", async () => {
@@ -89,5 +115,47 @@ describe("deepDuplicatesViaIndex", () => {
     (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
     const r = await deepDuplicatesViaIndex("/r", QUERY, "bk", { excludeFile: "a.ts" });
     expect(r?.duplicates).toHaveLength(0); // the only match was in the excluded file
+  });
+
+  it("escalates a borderline match to the cloud and surfaces the LLM verdict", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(borderlineIndex());
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockResolvedValue({
+      degraded: false,
+      intentMismatches: [],
+      duplicates: [{ kind: "duplicate", detail: "query::formatAmount ≈ a.ts::maybeTwin", confidence: 0.94, verdict: "semantic_duplicate" }],
+    });
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    // Sent ONLY the query + the one borderline candidate (with its stored body),
+    // and passed the query id so the server can filter its pairwise result.
+    expect(deepAnalyze).toHaveBeenCalledTimes(1);
+    const [sentFns, , sentQueryId] = (deepAnalyze as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sentFns).toHaveLength(2);
+    expect(sentFns[0].id).toBe("query::formatAmount");
+    expect(sentFns[1].id).toBe("a.ts::maybeTwin");
+    expect(sentFns[1].body).toBe("function maybeTwin(n){ return n * 2; }");
+    expect(sentQueryId).toBe("query::formatAmount");
+    expect(r?.duplicates).toHaveLength(1);
+    expect(r?.duplicates[0].verdict).toBe("semantic_duplicate");
+  });
+
+  it("drops a borderline match the cloud rejects (no false positive surfaced)", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(borderlineIndex());
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockResolvedValue({ degraded: false, intentMismatches: [], duplicates: [] });
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(deepAnalyze).toHaveBeenCalledTimes(1);
+    expect(r?.duplicates).toHaveLength(0);
+  });
+
+  it("reports degraded when the only matches are borderline and the cloud verdict fails", async () => {
+    tok("t");
+    (loadEmbeddingIndex as ReturnType<typeof vi.fn>).mockResolvedValue(borderlineIndex());
+    (embedFunctions as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: QUERY.id, vector: [1, 0, 0] }]);
+    (deepAnalyze as ReturnType<typeof vi.fn>).mockResolvedValue({ degraded: true, reason: "rate_limited", intentMismatches: [], duplicates: [] });
+    const r = await deepDuplicatesViaIndex("/r", QUERY, "bk");
+    expect(r).toMatchObject({ degraded: true, reason: "rate_limited" });
   });
 });

--- a/test/unit/ml-client/build-embedding-index.test.ts
+++ b/test/unit/ml-client/build-embedding-index.test.ts
@@ -41,9 +41,13 @@ describe("buildEmbeddingIndex", () => {
     expect(index!.builtAt).toBe(123);
     expect(index!.dim).toBe(3);
     expect(index!.entries.some((e) => e.name === "formatMoney")).toBe(true);
+    // v2: each entry stores its (truncated) body for borderline LLM validation
+    const fm = index!.entries.find((e) => e.name === "formatMoney");
+    expect(fm!.body).toContain("cents/100"); // the extracted body (sans signature)
     // round-trips through the local store
     const loaded = await loadEmbeddingIndex(repo);
     expect(loaded?.entries.length).toBe(index!.entries.length);
+    expect(loaded!.version).toBe(2);
   });
 
   it("returns null (no index) when the embed call yields nothing", async () => {


### PR DESCRIPTION
The local embedding index surfaced any cosine match ≥0.85 as a duplicate with no LLM in the loop — and embedding cosine is unreliable in exactly the borderline band.

**Two-tier verdict in deepDuplicatesViaIndex:**
- ≥0.90 → ship directly as a confirmed semantic_duplicate (no cloud call)
- [0.72, 0.90) → escalate ONLY the matched candidate(s) to /v1/analyze for a Claude confirm/reject verdict; rejected pairs are dropped (precision win)
- <0.72 → drop

To validate a borderline candidate without re-walking the repo, the index now stores each function's truncated body (`EmbeddingEntry.body`); index version bumped 1→2 so old bodyless indexes auto-rebuild. Cloud cost bounded (MAX_BORDERLINE=8, only when a borderline match exists). Paid path.

Tests: deep-index borderline routing (confirm/reject/degrade), index body round-trip. Full suite 509 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)