### PR TITLE
feat(coherence): render the deep-scan hero report in CLI + HTML (paid)

### DIFF
--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -899,6 +899,24 @@ export async function runScan(
     }
   }
 
+  // Coherence report — the deep-scan hero. PAID-ONLY, and only on a deep scan
+  // (it synthesizes the deep findings + drift into a ranked audit). The server
+  // route is require_paid; this client-side gate avoids a guaranteed 402 round
+  // trip for free plans. Best-effort: a null report just renders nothing.
+  if (options.deep && bearerToken && networkEnabled && paid) {
+    try {
+      const targetUrl = apiUrl ?? (await resolveApiUrl(options.apiUrl));
+      const { fetchCoherenceReport } = await import("../../ml-client/coherence.js");
+      const report = await fetchCoherenceReport(result, targetUrl, bearerToken);
+      if (report) result.coherenceReport = report;
+      if (options.verbose && report) {
+        console.error(`[coherence] grade ${report.coherenceGrade}, ${report.rankedIssues.length} ranked issues`);
+      }
+    } catch (err: any) {
+      if (options.verbose) console.error(`[coherence] skipped: ${err.message ?? err}`);
+    }
+  }
+
   // Anonymous scan beacon — fires on every scan unless telemetry is
   // disabled or --local-only is set. Best-effort, never delays the scan.
   if (networkEnabled) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -111,6 +111,29 @@ export interface CargoToml {
   dependencies: Record<string, string>;
 }
 
+/**
+ * The deep-scan tier's hero deliverable, synthesized server-side by
+ * /v1/coherence (paid-only). A ranked audit of how internally consistent the
+ * codebase is against ITS OWN dominant patterns — not external best-practice.
+ */
+export interface CoherenceIssue {
+  rank: number;
+  title: string;
+  severity: "critical" | "high" | "medium" | "low";
+  pattern: string; // the repo's own pattern this issue breaks
+  locations: string[];
+  why: string;
+  fix: string;
+}
+
+export interface CoherenceReport {
+  coherenceGrade: string; // A–F
+  coherenceScore: number; // 0–100
+  verdict: string;
+  rankedIssues: CoherenceIssue[];
+  strengths: string[];
+}
+
 export interface ScanResult {
   context: AnalysisContext;
   findings: Finding[];
@@ -156,6 +179,8 @@ export interface ScanResult {
   perFileScores: Map<string, PerFileScore>;
   codeDnaResult?: any; // CodeDnaResult from ../codedna/types
   aiSummary?: { summary: string; highlights: string[] };
+  /** Deep-scan hero report (paid-only; null for free/local scans). */
+  coherenceReport?: CoherenceReport;
   /**
    * Stable identifier of the scoring math used to produce these scores.
    * Cross-version deltas are refused at the engine layer — when this differs

--- a/src/ml-client/coherence.ts
+++ b/src/ml-client/coherence.ts
@@ -1,0 +1,174 @@
+/**
+ * Client for /v1/coherence — the deep-scan tier's hero report.
+ *
+ * Sends the scan's drift findings, the repo's dominant patterns, and the
+ * Claude-confirmed deep findings (semantic duplicates + name-lies) to the API,
+ * which synthesizes a ranked coherence audit graded against the codebase's OWN
+ * patterns. PAID-ONLY: the route is require_paid, so free/anonymous callers get
+ * a non-2xx and this returns null (the caller renders nothing). The CLI also
+ * pre-gates on plan, so this is the network backstop.
+ *
+ * buildCoherencePayload is pure + exported so the extraction (which fields of
+ * ScanResult map to the request) is unit-testable without a network call.
+ */
+import type { ScanResult, CoherenceReport } from "../core/types.js";
+
+const TIMEOUT_MS = 40_000; // synthesis is one Claude call; allow for cold start
+
+interface CoherencePayload {
+  project: string;
+  language: string;
+  file_count: number;
+  total_lines: number;
+  score: number;
+  max_score: number;
+  grade: string;
+  dominant_patterns: {
+    category: string;
+    dominant_pattern: string;
+    dominant_count: number;
+    total_files: number;
+    consistency: number;
+  }[];
+  drift_findings: {
+    category: string;
+    message: string;
+    file: string;
+    severity: string;
+    consistency_impact: number;
+  }[];
+  duplicates: { detail: string; confidence: number }[];
+  intent_lies: { name: string; explanation: string }[];
+}
+
+function grade(score: number, max: number): string {
+  const pct = max > 0 ? (score / max) * 100 : 0;
+  if (pct >= 90) return "A";
+  if (pct >= 75) return "B";
+  if (pct >= 50) return "C";
+  if (pct >= 25) return "D";
+  return "F";
+}
+
+export function buildCoherencePayload(result: ScanResult): CoherencePayload {
+  const drift = result.driftFindings ?? [];
+
+  // One dominant-pattern row per drift category (the category's first finding
+  // carries the repo-wide dominant pattern + consistency).
+  const seenCat = new Set<string>();
+  const dominant_patterns = [] as CoherencePayload["dominant_patterns"];
+  for (const d of drift) {
+    if (seenCat.has(d.driftCategory) || !d.dominantPattern) continue;
+    seenCat.add(d.driftCategory);
+    dominant_patterns.push({
+      category: d.driftCategory,
+      dominant_pattern: d.dominantPattern,
+      dominant_count: d.dominantCount ?? 0,
+      total_files: d.totalRelevantFiles ?? 0,
+      consistency: d.consistencyScore ?? 0,
+    });
+  }
+
+  const drift_findings = drift.map((d) => ({
+    category: d.driftCategory,
+    message: d.finding,
+    file: d.deviatingFiles?.[0]?.path ?? "",
+    severity: d.severity,
+    // DriftFindingReport has no per-finding consistency-impact; recoverable
+    // points are tracked on the static findings, so 0 here is the honest default.
+    consistency_impact: 0,
+  }));
+
+  const mlFindings = result.findings.filter((f) => f.tags?.includes("ml") || f.analyzerId?.startsWith("ml-"));
+  const duplicates = mlFindings
+    .filter((f) => f.analyzerId === "ml-duplicate")
+    .map((f) => ({ detail: f.message, confidence: f.confidence ?? 0 }));
+  const intent_lies = mlFindings
+    .filter((f) => f.analyzerId === "ml-intent")
+    .map((f) => {
+      // ml-intent message: "Function name mismatch: NAME() — ..."
+      const m = f.message.match(/mismatch:\s*([^\s(]+)\s*\(\)/);
+      return { name: m?.[1] ?? (f.locations?.[0]?.file ?? "function"), explanation: f.message };
+    });
+
+  return {
+    project: result.context.rootDir.split("/").pop() || "this codebase",
+    language: result.context.dominantLanguage ?? "unknown",
+    file_count: result.context.files.length,
+    total_lines: result.context.totalLines,
+    score: result.compositeScore,
+    max_score: result.maxCompositeScore,
+    grade: grade(result.compositeScore, result.maxCompositeScore),
+    dominant_patterns,
+    drift_findings,
+    duplicates,
+    intent_lies,
+  };
+}
+
+interface CoherenceApiResponse {
+  coherence_grade?: string;
+  coherence_score?: number;
+  verdict?: string;
+  ranked_issues?: {
+    rank?: number;
+    title?: string;
+    severity?: string;
+    pattern?: string;
+    locations?: string[];
+    why?: string;
+    fix?: string;
+  }[];
+  strengths?: string[];
+}
+
+const SEVERITIES = new Set(["critical", "high", "medium", "low"]);
+
+export async function fetchCoherenceReport(
+  result: ScanResult,
+  apiUrl: string,
+  token?: string,
+): Promise<CoherenceReport | null> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${apiUrl}/v1/coherence`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(buildCoherencePayload(result)),
+      signal: controller.signal,
+    });
+    if (!response.ok) return null; // 402 free / 401 anon / 5xx → render nothing
+
+    const data = (await response.json()) as CoherenceApiResponse;
+    return {
+      coherenceGrade: String(data.coherence_grade ?? ""),
+      coherenceScore: Math.max(0, Math.min(100, Number(data.coherence_score ?? 0))),
+      verdict: String(data.verdict ?? ""),
+      rankedIssues: (data.ranked_issues ?? [])
+        .filter((i) => i.title)
+        .map((i, idx) => {
+          const sev = String(i.severity ?? "medium").toLowerCase();
+          return {
+            rank: Number(i.rank ?? idx + 1),
+            title: String(i.title),
+            severity: (SEVERITIES.has(sev) ? sev : "medium") as CoherenceReport["rankedIssues"][number]["severity"],
+            pattern: String(i.pattern ?? ""),
+            locations: Array.isArray(i.locations) ? i.locations.map(String) : [],
+            why: String(i.why ?? ""),
+            fix: String(i.fix ?? ""),
+          };
+        })
+        .sort((a, b) => a.rank - b.rank),
+      strengths: Array.isArray(data.strengths) ? data.strengths.map(String) : [],
+    };
+  } catch {
+    return null; // offline / timeout → degrade silently
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -488,6 +488,50 @@ function buildAiSummaryWidget(result: ScanResult): string {
 </section>`;
 }
 
+function buildCoherenceReportWidget(result: ScanResult): string {
+  const c = result.coherenceReport;
+  if (!c) return "";
+
+  const sevColor: Record<string, string> = {
+    critical: "#ff4d4d", high: "#ff8a3d", medium: "#ffd000", low: "var(--text-tertiary)",
+  };
+
+  const issues = (c.rankedIssues ?? []).slice(0, 8).map((i) => {
+    const color = sevColor[i.severity] ?? "#ffd000";
+    const locs = i.locations.length
+      ? `<div style="font-size:11px;color:var(--text-tertiary);margin-top:4px">at ${esc(i.locations.slice(0, 4).join(", "))}</div>`
+      : "";
+    const pattern = i.pattern ? `<span style="color:var(--text-tertiary)"> · breaks: ${esc(i.pattern)}</span>` : "";
+    const why = i.why ? `<div style="font-size:13px;color:var(--text-secondary);margin-top:6px">${esc(i.why)}</div>` : "";
+    const fix = i.fix ? `<div style="font-size:13px;color:#3ddc84;margin-top:6px">→ ${esc(i.fix)}</div>` : "";
+    return `<li style="margin:0 0 16px 0;padding-left:14px;border-left:3px solid ${color}">
+      <div style="font-size:14px;font-weight:600;color:var(--text-primary)">
+        <span style="color:${color};text-transform:uppercase;font-size:11px;letter-spacing:.5px">${esc(i.severity)}</span>
+        &nbsp;${esc(i.title)}${pattern}
+      </div>${locs}${why}${fix}
+    </li>`;
+  }).join("");
+
+  const strengths = (c.strengths ?? []).slice(0, 3)
+    .map((s) => `<li style="margin:4px 0;font-size:13px;color:var(--text-secondary)">✓ ${esc(s)}</li>`).join("");
+
+  const gradeStr = c.coherenceGrade ? `${esc(c.coherenceGrade)} · ${c.coherenceScore}/100` : `${c.coherenceScore}/100`;
+
+  return `<section class="section" style="margin-bottom:32px">
+  <div style="background:rgba(0,200,255,0.03);border:1px solid var(--border);border-radius:0;padding:24px 28px">
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
+      <span style="font-size:16px">&#129518;</span>
+      <span class="label" style="margin-bottom:0">COHERENCE AUDIT</span>
+      <span style="margin-left:auto;font-size:13px;font-weight:700;color:var(--accent,#00c8ff)">${gradeStr}</span>
+    </div>
+    ${c.verdict ? `<p style="font-size:15px;color:var(--text-primary);line-height:1.7;margin:0 0 16px">${esc(c.verdict)}</p>` : ""}
+    ${issues ? `<ul style="list-style:none;padding:0;margin:0">${issues}</ul>` : ""}
+    ${strengths ? `<div style="margin-top:14px"><div style="font-size:11px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px">Already coherent</div><ul style="list-style:none;padding:0;margin:0">${strengths}</ul></div>` : ""}
+    <div style="margin-top:12px;font-size:10px;color:var(--text-tertiary)">Graded against this codebase's own patterns · VibeDrift deep scan</div>
+  </div>
+</section>`;
+}
+
 function getDriftCats(result: ScanResult) {
   const ds = result.driftScores ?? {};
   return [
@@ -2118,6 +2162,8 @@ ${buildPatternConsensus(result)}
 </section>
 
 ${buildAiSummaryWidget(result)}
+
+${buildCoherenceReportWidget(result)}
 
 ${buildScoreSection(result)}
 

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -543,6 +543,45 @@ function renderScoreSection(result: ScanResult): string[] {
   return lines;
 }
 
+function renderCoherenceReport(result: ScanResult): string[] {
+  const c = result.coherenceReport;
+  if (!c) return [];
+
+  const sevColor: Record<string, (s: string) => string> = {
+    critical: chalk.red.bold,
+    high: chalk.red,
+    medium: chalk.yellow,
+    low: chalk.dim,
+  };
+
+  const lines: string[] = [];
+  lines.push(chalk.bold("── Coherence Audit (AI-Powered) ───────────────────"));
+  const gradeStr = c.coherenceGrade ? `${c.coherenceGrade} (${c.coherenceScore}/100)` : `${c.coherenceScore}/100`;
+  lines.push(`  ${chalk.bold("Coherence:")} ${chalk.cyan(gradeStr)} — graded against this codebase's own patterns`);
+  if (c.verdict) lines.push(chalk.dim(`  ${c.verdict}`));
+  lines.push("");
+
+  if (c.rankedIssues.length > 0) {
+    for (const issue of c.rankedIssues.slice(0, 6)) {
+      const color = sevColor[issue.severity] ?? chalk.yellow;
+      lines.push(`  ${color(`${issue.rank}. [${issue.severity.toUpperCase()}]`)} ${chalk.bold(issue.title)}`);
+      if (issue.pattern) lines.push(chalk.dim(`     breaks pattern: ${issue.pattern}`));
+      if (issue.locations.length > 0) lines.push(chalk.dim(`     at: ${issue.locations.slice(0, 3).join(", ")}`));
+      if (issue.why) lines.push(chalk.dim(`     why: ${issue.why.slice(0, 160)}`));
+      if (issue.fix) lines.push(chalk.green(`     → ${issue.fix.slice(0, 200)}`));
+      lines.push("");
+    }
+  }
+
+  if (c.strengths.length > 0) {
+    lines.push(chalk.dim("  Already coherent:"));
+    for (const s of c.strengths.slice(0, 3)) lines.push(chalk.dim(`    ✓ ${s}`));
+    lines.push("");
+  }
+
+  return lines;
+}
+
 export function renderTerminalOutput(result: ScanResult, opts?: { brief?: boolean }): string {
   if (opts?.brief) {
     return renderBriefOutput(result);
@@ -556,6 +595,9 @@ export function renderTerminalOutput(result: ScanResult, opts?: { brief?: boolea
     ...renderFindingsList(result),
     ...renderHygienePane(result),
   ];
+
+  // Coherence report \u2014 the deep-scan hero (paid). Leads the deep section.
+  lines.push(...renderCoherenceReport(result));
 
   // Deep insights
   if (result.deepInsights.length > 0) {

--- a/test/unit/ml-client/coherence.test.ts
+++ b/test/unit/ml-client/coherence.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { buildCoherencePayload } from "../../../src/ml-client/coherence.js";
+import type { ScanResult } from "../../../src/core/types.js";
+
+function result(): ScanResult {
+  return {
+    context: {
+      rootDir: "/home/me/acme-app",
+      dominantLanguage: "typescript",
+      files: [{}, {}, {}],
+      totalLines: 4200,
+    },
+    compositeScore: 62,
+    maxCompositeScore: 100,
+    driftFindings: [
+      {
+        driftCategory: "async_patterns",
+        severity: "warning",
+        finding: "uses .then() chains while peers use async/await",
+        dominantPattern: "async/await",
+        dominantCount: 40,
+        totalRelevantFiles: 45,
+        consistencyScore: 89,
+        deviatingFiles: [{ path: "src/legacy/fetch.ts", detectedPattern: ".then()", evidence: [] }],
+      },
+      {
+        // second finding in the SAME category — must not produce a 2nd dominant row
+        driftCategory: "async_patterns",
+        severity: "info",
+        finding: "another .then() chain",
+        dominantPattern: "async/await",
+        dominantCount: 40,
+        totalRelevantFiles: 45,
+        consistencyScore: 89,
+        deviatingFiles: [{ path: "src/legacy/util.ts", detectedPattern: ".then()", evidence: [] }],
+      },
+    ],
+    findings: [
+      { analyzerId: "ml-duplicate", confidence: 0.93, message: "ML-detected semantic duplicate: a.ts::foo and b.ts::bar (93% similar)", tags: ["ml"], locations: [{ file: "a.ts" }] },
+      { analyzerId: "ml-intent", confidence: 0.9, message: "Function name mismatch: validatePayment() — name doesn't match behavior (24% name-body alignment)", tags: ["ml"], locations: [{ file: "pay.ts" }] },
+      { analyzerId: "naming", confidence: 1, message: "not an ml finding", locations: [] },
+    ],
+  } as any;
+}
+
+describe("buildCoherencePayload", () => {
+  it("maps project meta, score, and grade", () => {
+    const p = buildCoherencePayload(result());
+    expect(p.project).toBe("acme-app");
+    expect(p.language).toBe("typescript");
+    expect(p.file_count).toBe(3);
+    expect(p.total_lines).toBe(4200);
+    expect(p.score).toBe(62);
+    expect(p.grade).toBe("C"); // 62% → C
+  });
+
+  it("emits one dominant-pattern row per category (deduped)", () => {
+    const p = buildCoherencePayload(result());
+    expect(p.dominant_patterns).toHaveLength(1);
+    expect(p.dominant_patterns[0]).toMatchObject({
+      category: "async_patterns",
+      dominant_pattern: "async/await",
+      dominant_count: 40,
+      total_files: 45,
+      consistency: 89,
+    });
+  });
+
+  it("includes every drift finding with its deviating file", () => {
+    const p = buildCoherencePayload(result());
+    expect(p.drift_findings).toHaveLength(2);
+    expect(p.drift_findings[0].file).toBe("src/legacy/fetch.ts");
+  });
+
+  it("extracts ml duplicates and intent lies, ignoring non-ml findings", () => {
+    const p = buildCoherencePayload(result());
+    expect(p.duplicates).toHaveLength(1);
+    expect(p.duplicates[0].confidence).toBe(0.93);
+    expect(p.intent_lies).toHaveLength(1);
+    expect(p.intent_lies[0].name).toBe("validatePayment"); // parsed from the message
+  });
+});


### PR DESCRIPTION
Re-targeted to main (original #7 auto-closed when its base branch merged + was deleted). Rebased onto main; reviewed GREEN as #7.

CLI side of /v1/coherence: on a paid deep scan, builds the coherence payload (drift findings + per-category dominant patterns + Claude-confirmed deep findings), POSTs to /v1/coherence, and renders the ranked audit in terminal + HTML. Gated on paid + --deep; null report renders nothing. buildCoherencePayload unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)