### PR TITLE
docs(readme): align with website voice and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@
 
 # VibeDrift
 
-**Ship agentic. Stay coherent.**
+### Your AI agent gets worse as your project grows.
 
-[![Website](https://img.shields.io/badge/vibedrift.ai-f0c000?style=flat&labelColor=1a1a1a)](https://vibedrift.ai) [![npm](https://img.shields.io/npm/v/@vibedrift/cli.svg?color=f0c000)](https://www.npmjs.com/package/@vibedrift/cli) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+It forgets your patterns, repeats code, and breaks what worked. **VibeDrift catches the drift before it spreads** — locally, on your machine.
+
+[![Website](https://img.shields.io/badge/vibedrift.ai-FFD000?style=flat&labelColor=1a1a1a)](https://vibedrift.ai) [![npm](https://img.shields.io/npm/v/@vibedrift/cli.svg?color=FFD000)](https://www.npmjs.com/package/@vibedrift/cli) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE) [![Discord](https://img.shields.io/badge/Discord-join-5865F2?style=flat)](https://discord.gg/YVcQ65Jt3Q)
+
+**Free · Open source · Runs on your machine**
 
 </div>
 
-VibeDrift detects drift in AI-generated code: where new code diverges from the patterns the rest of your codebase already follows. It runs locally, scores your repo against its own conventions, and points you at the exact files. Your code never leaves your machine.
+---
 
-The fastest way to stay coherent is to check drift *while* the agent writes. The [MCP server](#mcp-server) gives Claude Code and Cursor live, in-loop access to your repo's conventions, so new code matches the first time.
+Every fresh agent session starts with no memory of the conventions your codebase already settled on. So it makes reasonable choices that just aren't *your* choices. One handler throws a typed error; the next returns a plain object. Eight services use a repository layer; the ninth reaches for raw SQL. Everything compiles, everything passes review, and the codebase slowly stops agreeing with itself.
+
+That gap is **drift** — and it's invisible to linters, because a linter checks one file at a time. VibeDrift checks your codebase *against itself*: it learns the patterns your code already agrees on, then flags every file that deviates, and points you at the exact line.
 
 > Full documentation, the scoring guide, and what each finding means live at **[vibedrift.ai/guide](https://vibedrift.ai/guide)**.
 
@@ -22,7 +28,7 @@ The fastest way to stay coherent is to check drift *while* the agent writes. The
 npx @vibedrift/cli
 ```
 
-That's it. No install, no signup. Scans the current directory and opens an interactive HTML report.
+That's it. No install, no signup. Scans the current directory and opens an interactive HTML report. Your code never leaves your machine.
 
 Install globally if you prefer:
 
@@ -32,10 +38,6 @@ vibedrift                       # scan ./
 vibedrift ./path/to/project     # scan a specific path
 ```
 
-## Supported languages
-
-JavaScript, TypeScript, Python, Go, Rust.
-
 ## What it finds
 
 - Architectural inconsistencies (half your handlers use a repository, the rest hit raw SQL)
@@ -44,14 +46,26 @@ JavaScript, TypeScript, Python, Go, Rust.
 - Security gaps: hardcoded secrets, injection risks, unsanitized input
 - Dead code, complexity hotspots, and half-finished or placeholder implementations
 
-VibeDrift learns your codebase's dominant patterns and flags the deviators. See the [scoring guide](https://vibedrift.ai/guide) for how findings roll up into a score.
+Under the hood, VibeDrift learns your repo's dominant patterns by majority vote, fingerprints logic with Code DNA to catch near-duplicates, and rolls findings into a **Vibe Drift Score** and a **Hygiene Score**. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the engine and the [scoring guide](https://vibedrift.ai/guide) for how findings are weighted.
+
+**Supported languages:** JavaScript, TypeScript, Python, Go, Rust.
+
+## From detection to prevention
+
+Catching drift after it ships is a postmortem. The real win is checking *while* the agent writes.
+
+1. **Detect** — `vibedrift` scans your repo, scores it against its own conventions, and shows the evidence. Great for audits and CI gates.
+2. **Prevent in the loop** — the [MCP server](#mcp-server) lets your agent ask the codebase about itself *before* it writes a line, so new code matches the first time.
+3. **Prevent at the source** — [VibeLang](https://thevibelang.org), where behavioral intent becomes compiler-enforced, so drift can't compile.
+
+Detection tells you, in-loop prevention nudges you, language-level prevention makes it impossible. MCP is the rung that's live today.
 
 ## Commands
 
 ```
 vibedrift [path]            Scan a project (default command)
-vibedrift watch [path]      Re-scan on file changes (requires login)
-vibedrift mcp               Run the MCP server (Claude Code / Cursor)
+vibedrift watch [path]      Re-scan on file changes (Pro)
+vibedrift mcp               Run the MCP server (Claude Code / Cursor / any MCP client)
 vibedrift login / logout    Account auth
 vibedrift status            Account, plan, and token
 vibedrift hook <action>     Install or remove a git pre-push drift gate
@@ -75,7 +89,7 @@ Run `vibedrift --help` for the complete list.
 
 ## Deep scan
 
-`vibedrift --deep` adds cloud-powered analysis that local static checks cannot do: semantic duplicate detection, name-versus-behavior intent checks, and a synthesized coherence report. Scope it to your change set with `--diff`:
+`vibedrift --deep` adds cloud-powered analysis that local static checks cannot do: semantic duplicate detection, name-versus-behavior intent checks, an in-loop Claude verdict on borderline matches, and a synthesized coherence report graded against your own patterns. Scope it to your change set with `--diff`:
 
 ```bash
 vibedrift login
@@ -84,11 +98,11 @@ vibedrift . --deep --diff       # deep-scan only what you changed (fast pre-PR c
 vibedrift . --deep --diff main  # deep-scan everything that differs from a branch
 ```
 
-Deep scan sends function snippets only (never full files or file paths), processed in memory and not stored. It requires a free account. See [vibedrift.ai](https://vibedrift.ai) for what deep scan includes.
+Deep scan sends function snippets only (never full files or file paths), processed in memory and not stored. The free tier includes a monthly allowance of deep scans; see [vibedrift.ai](https://vibedrift.ai) for current plans.
 
 ## MCP server
 
-VibeDrift ships an MCP server so an AI coding agent can consult your repo's own conventions while it writes, turning drift detection into drift prevention. It exposes five tools:
+VibeDrift ships an MCP server so an AI coding agent can consult your repo's own conventions while it writes — turning drift detection into drift prevention. It exposes five tools:
 
 - `get_intent_hints` reads the conventions your `CLAUDE.md` / `AGENTS.md` / `.cursorrules` declare
 - `get_dominant_pattern` returns the repo's majority pattern for a dimension, with examples to copy
@@ -96,7 +110,7 @@ VibeDrift ships an MCP server so an AI coding agent can consult your repo's own 
 - `find_similar_function` finds an existing near-duplicate so the agent reuses instead of rewriting
 - `validate_change` checks whether a proposed function would introduce drift or duplicate something
 
-These tools run on your machine, send no code, and need no login. They build the repo's baseline automatically on first use.
+These tools run on your machine, send no code, and need no login. They build the repo's baseline automatically on first use. (The `validate_change` and `find_similar_function` tools can opt into a deeper semantic pass, which is the only part that's metered.)
 
 ### Install in any MCP client
 
@@ -108,7 +122,7 @@ VibeDrift is a standard [MCP](https://modelcontextprotocol.io) server launched o
 claude mcp add vibedrift -- npx -y @vibedrift/cli mcp
 ```
 
-**Cursor, Claude Desktop, Windsurf, Cline, VS Code, Zed, and others** use the same command in their MCP config:
+**Cursor, GitHub Copilot, Windsurf, Antigravity, OpenAI Codex, Kiro, Claude Desktop, VS Code, Zed, and any other MCP client** use the same command in their MCP config:
 
 ```json
 {
@@ -177,7 +191,10 @@ MIT. See [LICENSE](./LICENSE). The CLI runs entirely on your machine; the option
 
 ## Links
 
-- **Docs & scoring guide:** [vibedrift.ai/guide](https://vibedrift.ai/guide)
 - **Website:** [vibedrift.ai](https://vibedrift.ai)
+- **Docs & scoring guide:** [vibedrift.ai/guide](https://vibedrift.ai/guide)
+- **Blog:** [vibedrift.ai/blog](https://vibedrift.ai/blog)
+- **Releases:** [vibedrift.ai/releases](https://vibedrift.ai/releases)
+- **FAQ:** [vibedrift.ai/faq](https://vibedrift.ai/faq)
 - **Issues:** [GitHub Issues](https://github.com/VibeDrift/VibeDrift/issues)
 - **Community:** [Discord](https://discord.gg/YVcQ65Jt3Q)


### PR DESCRIPTION
Rework the README to match the brand's tone and positioning while keeping it dev-first:

- Lead with the pain hook ("your AI agent gets worse as your project grows") and the Free / open-source / local trust line
- Frame the product as "drift, not lint" — whole-codebase, not single-file
- Add the detection -> prevention arc (scan, in-loop MCP, VibeLang)
- Add a short engine note (dominant-pattern voting, Code DNA, the two scores) pointing to ARCHITECTURE.md
- Sync the MCP client list with the site (Copilot, Windsurf, Antigravity, Codex, Kiro, any MCP client)
- Correct watch mode to a Pro feature; soften deep-scan tier wording and defer plan details to the site
- Match brand yellow (#FFD000), add a Discord badge, and expand Links (Blog, Releases, FAQ)

## Summary

What does this change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [ ] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [ ] New behavior has tests (bug fixes include a regression test)
- [ ] `README.md` updated if a flag, command, or feature changed
- [ ] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [ ] No secrets, credentials, pricing, or internal strategy added
- [ ] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Closes #
