### PR TITLE
Reimplementation detector: CLI dimension (findings-only) + free teaser

### DIFF
--- a/eval/discrimination/repos.json
+++ b/eval/discrimination/repos.json
@@ -25,6 +25,31 @@
     "source": { "git": "https://github.com/expressjs/express" }
   },
   {
+    "label": "trpc/trpc (large clean)",
+    "kind": "clean",
+    "source": { "git": "https://github.com/trpc/trpc" }
+  },
+  {
+    "label": "TanStack/query (large clean)",
+    "kind": "clean",
+    "source": { "git": "https://github.com/TanStack/query" }
+  },
+  {
+    "label": "fastify/fastify (mid clean)",
+    "kind": "clean",
+    "source": { "git": "https://github.com/fastify/fastify" }
+  },
+  {
+    "label": "honojs/hono (mid-large clean, held-out)",
+    "kind": "clean",
+    "source": { "git": "https://github.com/honojs/hono" }
+  },
+  {
+    "label": "vuejs/core (large clean, held-out)",
+    "kind": "clean",
+    "source": { "git": "https://github.com/vuejs/core" }
+  },
+  {
     "label": "messy-saas (fixture)",
     "kind": "messy",
     "source": { "path": "fixtures/messy-saas" }

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -9,7 +9,7 @@ import { createAnalyzerRegistry } from "../../analyzers/index.js";
 import { runDriftDetection, attachEngineComposite } from "../../drift/index.js";
 import { computeScores, SCORING_VERSION } from "../../scoring/engine.js";
 import { debug, setDebugEnabled } from "../../core/debug.js";
-import { generateTeaseMessages } from "../../output/tease.js";
+import { generateTeaseMessages, countReimplementationCandidates } from "../../output/tease.js";
 import { renderTerminalOutput, renderJsonOutput, renderStarCta } from "../../output/terminal.js";
 import { renderHtmlReport } from "../../output/html.js";
 import {
@@ -400,6 +400,11 @@ async function buildScanResult(
   // Pass codeDnaResult so the tease can name specific near-duplicate files
   // and opaque-named functions deep scan would confirm, not generic copy.
   const teaseMessages = generateTeaseMessages(ctx, allFindings, options.deep === true, codeDnaResult);
+  // Free Tier-1 reimplementation teaser (count only). Skipped on deep scans —
+  // there the real panel-confirmed ml-reimplementation findings render instead.
+  const reimplementationCandidates = options.deep
+    ? 0
+    : countReimplementationCandidates(codeDnaResult?.functions ?? []);
 
   const scanTimeMs = Date.now() - startTime;
   if (spinner) spinner.stop();
@@ -447,6 +452,7 @@ async function buildScanResult(
     hygieneScore,
     maxHygieneScore,
     teaseMessages,
+    reimplementationCandidates,
     deepInsights,
     scanTimeMs,
     perFileScores,

--- a/src/codedna/semantic-fingerprint.ts
+++ b/src/codedna/semantic-fingerprint.ts
@@ -164,6 +164,19 @@ export function findDuplicateGroups(
 const MAX_FINGERPRINT_NAMES_IN_MESSAGE = 10;
 const MAX_FINGERPRINT_LOCATIONS = 20;
 
+// Confidence for an exact normalized-hash duplicate finding. CALIBRATED, not
+// guessed: on 2026-06-24 we harvested 79 real codedna-fingerprint dup groups
+// across 7 repos (monorepos + libs) and had Claude (claude-sonnet-4-6, the
+// production deep-scan judge prompt) rule each a semantic duplicate or not.
+// Measured precision = 98.7% (78/79), 95% Wilson CI [93.2, 99.8]; 100% on the
+// monorepos (trpc, TanStack) we suspected of over-firing. The detector does NOT
+// over-fire — its hits are real duplicates. Set to 0.95: essentially the measured
+// value, shaded slightly toward the CI floor for the JS/TS-only sample. See
+// eval/calibration/. (Where a repo's score is dragged by duplication, the lever
+// is file-importance weighting of examples/tests/generated code, NOT distrust of
+// this detector.)
+const STRUCTURAL_DUP_CONFIDENCE = 0.95;
+
 export function fingerprintFindings(groups: SemanticDuplicateGroup[]): Finding[] {
   return groups.map((group) => {
     const total = group.functions.length;
@@ -191,10 +204,12 @@ export function fingerprintFindings(groups: SemanticDuplicateGroup[]): Finding[]
     const finding: Finding = {
       analyzerId: "codedna-fingerprint",
       severity,
-      confidence: 1.0,
+      confidence: STRUCTURAL_DUP_CONFIDENCE,
       message: `Exact semantic duplicate: ${namesDisplay} have identical normalized bodies across ${total} files`,
       locations,
       tags: ["codedna", "duplicate", "fingerprint"],
+      // Group size drives the size-fair duplicated-FRACTION magnitude in scoring.
+      dupGroupSize: total,
     };
 
     if (total > MAX_FINGERPRINT_LOCATIONS) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -70,6 +70,12 @@ export interface AnalysisContext {
   languageBreakdown: Map<SupportedLanguage, { files: number; lines: number }>;
   dominantLanguage: SupportedLanguage | null;
   /**
+   * Total extracted function count, used for size-fair (per-function-rate)
+   * normalization of count-based detectors. Optional: when absent, the scoring
+   * engine derives it from `files` on demand and falls back to per-KLOC density.
+   */
+  functionCount?: number;
+  /**
    * True when the scan root is a git repository and metadata was
    * successfully collected. `files[].git` is populated in this case.
    * False when .git is missing, git CLI unavailable, or collection
@@ -327,6 +333,15 @@ export interface Finding {
     /** Total files relevant to this drift category. */
     totalRelevantFiles: number;
   };
+  /**
+   * For grouped exact/near-duplicate findings (e.g. codedna-fingerprint): the
+   * number of functions in this duplicate group. The scoring engine sums
+   * `(dupGroupSize - 1)` across a detector's findings and divides by total
+   * functions to get the duplicated-code FRACTION — a size-fair, volume-sensitive
+   * magnitude (32 identical functions register as ~31 redundant copies, not as
+   * one grouped "finding"). Absent on non-grouped findings.
+   */
+  dupGroupSize?: number;
   /**
    * Structured context that downstream renderers (HTML, terminal, fix-
    * prompt template) use to build the Copy-as-AI-context block and

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -195,6 +195,9 @@ export interface ScanResult {
   hygieneScore: number;
   maxHygieneScore: number;
   teaseMessages: string[];
+  /** Free Tier-1 reimplementation teaser: count of same-name cross-file shipped
+   * functions, shown as a deep-scan upsell. 0 on deep scans. */
+  reimplementationCandidates?: number;
   deepInsights: DeepInsight[];
   scanTimeMs: number;
   previousScan?: ScanResult;

--- a/src/data/score_percentiles.json
+++ b/src/data/score_percentiles.json
@@ -1,6 +1,6 @@
 {
   "corpus_version": "1",
-  "scoring_version": "v5",
+  "scoring_version": "v6",
   "generated": { "elite_n": 0, "negative_n": 0 },
   "languages": {}
 }

--- a/src/drift/utils.ts
+++ b/src/drift/utils.ts
@@ -153,6 +153,14 @@ export interface EntropyGateResult {
   confidence: number;
   /** Normalized entropy in [0, 1]. */
   normalizedEntropy: number;
+  /**
+   * Plurality share: largest pattern count ÷ total. Used as the no-convention
+   * deviation magnitude (`1 - dominantShare`) so scoring is SMOOTH and GRANULAR
+   * across the chaos range (50/50 → 0.50, 3-way even → 0.67, 4-way → 0.75)
+   * instead of the saturating normalized-entropy (any even split → ~1.0), which
+   * created a non-monotonic cliff between flag-deviators and no-convention modes.
+   */
+  dominantShare: number;
 }
 
 /**
@@ -168,21 +176,24 @@ export function entropyGate(
   distribution: Map<string, { count: number; files: string[] }>,
 ): EntropyGateResult {
   const counts = [...distribution.values()].map((d) => d.count);
+  const total = counts.reduce((a, b) => a + b, 0);
+  const dominantShare = total > 0 ? Math.max(0, ...counts) / total : 1;
   const k = counts.filter((c) => c > 0).length;
   if (k < 2) {
-    return { decision: "flag_deviators", confidence: 0.9, normalizedEntropy: 0 };
+    return { decision: "flag_deviators", confidence: 0.9, normalizedEntropy: 0, dominantShare };
   }
   const H = shannonEntropy(counts);
   const maxH = Math.log2(k);
   const normalizedEntropy = maxH > 0 ? H / maxH : 0;
 
   if (normalizedEntropy > 0.8) {
-    return { decision: "no_convention", confidence: 0.75, normalizedEntropy };
+    return { decision: "no_convention", confidence: 0.75, normalizedEntropy, dominantShare };
   }
   return {
     decision: "flag_deviators",
     confidence: Math.max(0.3, Math.min(0.9, 1 - normalizedEntropy)),
     normalizedEntropy,
+    dominantShare,
   };
 }
 
@@ -223,9 +234,12 @@ export function noConventionFinding(opts: {
       confidence: gate.confidence,
       finding: `No dominant ${axisLabel} across ${totalFiles} files — patterns are mixed with no convention`,
       dominantPattern: "no dominant convention",
-      dominantCount: 0,
+      dominantCount: Math.round(gate.dominantShare * totalFiles),
       totalRelevantFiles: totalFiles,
-      consistencyScore: Math.round((1 - gate.normalizedEntropy) * 100),
+      // Smooth, granular deviation: 1 - plurality share (chaos depth), NOT the
+      // saturating normalized entropy. Removes the flag↔no-convention cliff so
+      // progressively-more-mixed repos score monotonically lower.
+      consistencyScore: Math.round(gate.dominantShare * 100),
       deviatingFiles: [],
       dominantFiles: [],
       recommendation,

--- a/src/ml-client/confidence.ts
+++ b/src/ml-client/confidence.ts
@@ -118,6 +118,21 @@ export function filterByConfidence(response: MlAnalyzeResponse): FilteredMlResul
     }
   }
 
+  // ──── Process reimplementations ────
+  // These arrive ALREADY panel-confirmed by the API (the 3-lens majority gate
+  // ran server-side), so every entry is shippable — no confidence threshold or
+  // LLM round-trip here. `confidence` is the panel vote ratio (1.0 = unanimous).
+  for (const r of response.reimplementations ?? []) {
+    highConfidence.push({
+      analyzerId: "ml-reimplementation",
+      severity: r.group_size >= 4 ? "error" : "warning",
+      confidence: r.confidence,
+      message: `Redundant reimplementation: ${r.name}() implemented ${r.group_size} times across ${r.files.length} files`,
+      locations: r.files.map((f) => ({ file: f })),
+      tags: ["ml", "reimplementation"],
+    });
+  }
+
   // Cap LLM candidates at MAX_LLM_CANDIDATES (highest confidence first)
   mediumConfidence.sort((a, b) => b.confidence - a.confidence);
   droppedCount += Math.max(0, mediumConfidence.length - MAX_LLM_CANDIDATES);

--- a/src/ml-client/types.ts
+++ b/src/ml-client/types.ts
@@ -97,6 +97,21 @@ export interface MlDeviationResult {
   needs_llm: boolean;
 }
 
+export interface MlReimplementationResult {
+  name: string;
+  function_a: string;
+  function_b: string;
+  member_ids: string[];
+  files: string[];
+  group_size: number;
+  verdict: string;
+  /** Panel vote ratio (1.0 = unanimous, 0.667 = 2/3). Already confirmed by the API. */
+  confidence: number;
+  real_votes: number;
+  votes: number;
+  reasons: string[];
+}
+
 export interface MlAnalyzeResponse {
   scan_id?: string;
   processing_time_ms: number;
@@ -104,6 +119,8 @@ export interface MlAnalyzeResponse {
   intent_mismatches: MlIntentMismatchResult[];
   anomalies: MlAnomalyResult[];
   deviations: MlDeviationResult[];
+  /** Panel-confirmed redundant reimplementations. Optional for old-server compat. */
+  reimplementations?: MlReimplementationResult[];
   llm_validations: any[];
 }
 

--- a/src/output/tease.ts
+++ b/src/output/tease.ts
@@ -25,7 +25,18 @@
  */
 
 import type { AnalysisContext, Finding } from "../core/types.js";
-import type { CodeDnaResult } from "../codedna/types.js";
+import type { CodeDnaResult, ExtractedFunction } from "../codedna/types.js";
+
+// Non-shipped path regexes — mirror of src/scoring/engine.ts (kept local to
+// avoid exporting engine internals; same set the API reimplementation detector
+// uses). Test/example/generated dup pairs were 0% precision in the recall audit.
+const REIMPL_NOT_SHIPPED_RES: RegExp[] = [
+  /(^|\/)(generated|__generated__)\/|\.(generated|gen)\.[A-Za-z0-9]+$|\.pb\.go$|_pb2?\.py$|\.min\.[A-Za-z0-9]+$/,
+  /(^|\/)(fixtures?|__fixtures__|__mocks__|mocks|snapshots|__snapshots__)\//,
+  /(^|\/)(tests?|__tests__|spec)\/|\.(test|spec)\.[A-Za-z0-9]+$|_test\.(go|py)$|(^|\/)test_[^/]*\.py$/,
+  /(^|\/)(examples?|demos?|samples?)\//,
+];
+const REIMPL_MIN_BODY_TOKENS = 12;
 
 // Names so generic that local classification can't tell what they do.
 // Deep scan's intent-mismatch uses UniXcoder to align name and body in
@@ -151,6 +162,38 @@ export function generateTeaseMessages(
   }
 
   return messages;
+}
+
+/**
+ * Free Tier-1 reimplementation teaser (COUNT only, never findings).
+ *
+ * Counts distinct function NAMES that appear as shipped functions in 2+ different
+ * files — a cheap proxy for "the same responsibility reimplemented per file"
+ * (the dominant AI-drift shape from the recall audit: send_message x5, formatDate
+ * x5, ...). Mirrors the API detector's Tier-1 rule (same-name, cross-file,
+ * shipped, non-generic, non-trivial) but emits only an integer the CLI shows as
+ * an upsell ("N possible ... run a deep scan to confirm"). The deep scan's panel
+ * is what confirms which are real, so we never present these as findings.
+ */
+export function countReimplementationCandidates(functions: ExtractedFunction[]): number {
+  const filesByName = new Map<string, Set<string>>();
+  for (const fn of functions) {
+    if (fn.name.length < 4) continue;
+    if (GENERIC_NAMES.has(fn.name)) continue;
+    if (fn.bodyTokenCount < REIMPL_MIN_BODY_TOKENS) continue;
+    if (REIMPL_NOT_SHIPPED_RES.some((re) => re.test(fn.relativePath))) continue;
+    let files = filesByName.get(fn.name);
+    if (!files) {
+      files = new Set();
+      filesByName.set(fn.name, files);
+    }
+    files.add(fn.relativePath);
+  }
+  let count = 0;
+  for (const files of filesByName.values()) {
+    if (files.size >= 2) count++;
+  }
+  return count;
 }
 
 /**

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -668,6 +668,13 @@ export function renderTerminalOutput(result: ScanResult, opts?: { brief?: boolea
     lines.push("");
   }
 
+  // Reimplementation teaser — count only, never unconfirmed pairs (honest upsell).
+  const reimplCount = result.reimplementationCandidates ?? 0;
+  if (reimplCount > 0) {
+    lines.push(chalk.yellow(`  🔁  ${reimplCount} possible redundant reimplementation${reimplCount === 1 ? "" : "s"} — run a deep scan to confirm which are real`));
+    lines.push("");
+  }
+
   // Passive update notice — dim one-liner at the very end, shown only
   // when the registry reported a strictly-newer version AND the scan
   // didn't already fail. Non-interruptive; skipped for --local-only

--- a/src/scoring/categories.ts
+++ b/src/scoring/categories.ts
@@ -88,6 +88,13 @@ export const CATEGORY_CONFIG: Record<ScoringCategory, CategoryConfig> = {
       { id: "codedna-opseq", applicableLanguages: "all", kind: "drift" },
       // ML embeddings
       { id: "ml-duplicate", applicableLanguages: "all", kind: "drift" },
+      // Panel-confirmed redundant reimplementation. FINDINGS-ONLY for now
+      // (kind "hygiene" → renders in its own pane, does NOT feed the drift
+      // composite). The v6 composite is a geometric mean of score/maxScore, so
+      // a zero-weight scored category can't express "show but don't score" — the
+      // hygiene classification is the lever. Flip kind to "drift" to enable
+      // scoring once per-language precision is calibrated.
+      { id: "ml-reimplementation", applicableLanguages: "all", kind: "hygiene" },
     ],
   },
   dependencyHealth: {

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -11,6 +11,7 @@ import type {
 // it into the build. PLACEHOLDER until the corpus build lands: `languages` is
 // empty, so `compositeToPercentile` returns null and the renderer shows nothing.
 import scorePercentilesArtifact from "../data/score_percentiles.json" with { type: "json" };
+import { extractAllFunctions } from "../codedna/function-extractor.js";
 import {
   CATEGORY_CONFIG,
   ALL_CATEGORIES,
@@ -34,12 +35,20 @@ import {
  *                   single scoring engine (dual-engine collapse). The number
  *                   changes meaningfully, so this is a real methodology bump.
  *   v4 — decompressed scoring: dominance-ratio magnitude weighting, no per-analyzer cap, no sqrt-LOC dampener, multiplicative/geometric-mean composite; real 0–100 range.
+ *   v5 — evidence-weighted clean credit (no-finding categories regress toward the
+ *        population prior by LOC); deep-scan dedup-aliasing fix.
+ *   v6 — size-fair count-based normalization: structural-similarity / count-based
+ *        detectors are normalized by a per-FUNCTION rate (findings ÷ total
+ *        functions), not findings ÷ KLOC. Structural similarity scales with
+ *        function count, so the old per-KLOC density kept rising with repo size
+ *        and unfairly sank large clean repos (e.g. trpc 69.6→81.6, TanStack
+ *        62.1→76.4) into the messy range. The rate is size-invariant.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v5";
+export const SCORING_VERSION = "v6";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;
@@ -105,6 +114,24 @@ const SEVERITY_DAMAGE = { error: 0.7, warning: 0.4, info: 0.12 };
 const MAX_DETECTOR_DAMAGE = 0.85;
 /** Findings-per-KLOC at which a count-based detector reaches ~63% of its deviation ceiling. */
 const COUNT_DENSITY_SCALE = 2.0;
+/**
+ * Size-fair normalization for count-based detectors: the deviating-FUNCTION rate
+ * (findings / total functions) at which a detector reaches ~63% of its deviation
+ * ceiling. Structural-similarity detectors (codedna) scale with function count,
+ * not lines — a raw count/KLOC keeps rising with repo size and unfairly sinks
+ * large clean repos. Using the per-function RATE makes the magnitude size-invariant
+ * (a 95%-consistent repo scores 95 at 5k or 5M lines). Used when the function count
+ * is known; falls back to COUNT_DENSITY_SCALE per-KLOC otherwise.
+ */
+const COUNT_RATE_SCALE = 0.5;
+/**
+ * Duplicated-function FRACTION (redundant copies ÷ total functions) at which a
+ * grouped-duplicate detector reaches ~63% of its deviation ceiling. Grouped
+ * duplicate findings carry `dupGroupSize`, so 32 identical functions register as
+ * ~31 redundant copies regardless of how the detector chunked them into findings.
+ * This is the volume-sensitive, size-fair duplication magnitude.
+ */
+const DUP_FRACTION_SCALE = 0.15;
 /** A flagged-but-near-consistent dominance finding still registers this faintly. */
 const DEVIATION_FLOOR = 0.05;
 /**
@@ -164,9 +191,42 @@ function isEntryPoint(filePath: string): boolean {
   return ENTRY_POINT_PATTERNS.some((p) => p.test(filePath));
 }
 
+// The score measures drift in the code a project SHIPS. Drift in code that is
+// not shipped — machine-generated output, demo/example code, test scaffolding —
+// is weighted down (or out) so a clean library is not dragged below a messy app
+// by duplication in its examples/ or *.gen.ts files. Calibration (2026-06-24)
+// found ~82% of trpc's REAL duplicate groups live in examples/tests/generated,
+// not in packages/src — this is the honest lever for that, NOT distrusting the
+// (98.7%-precise) duplicate detector. We still ANALYZE and REPORT these files;
+// we only weight their drift differently in the composite.
+const GENERATED_PATH_RE =
+  /(^|\/)(generated|__generated__)\/|\.(generated|gen)\.[A-Za-z0-9]+$|\.pb\.go$|_pb2?\.py$|\.min\.[A-Za-z0-9]+$/;
+const FIXTURE_PATH_RE = /(^|\/)(fixtures?|__fixtures__|__mocks__|mocks|snapshots|__snapshots__)\//;
+const TEST_PATH_RE =
+  /(^|\/)(tests?|__tests__|spec)\/|\.(test|spec)\.[A-Za-z0-9]+$|_test\.(go|py)$|(^|\/)test_[^/]*\.py$/;
+const EXAMPLE_PATH_RE = /(^|\/)(examples?|demos?|samples?)\//;
+
+// Not human-authored / not test-relevant code: effectively excluded from the score.
+const WEIGHT_NOT_SHIPPED = 0.05;
+// Real authored code, but not the shipped product — drift here counts, but less.
+const WEIGHT_TEST = 0.35;
+const WEIGHT_EXAMPLE = 0.35;
+
 function computeFileImportanceWeight(filePath: string): number {
+  if (GENERATED_PATH_RE.test(filePath) || FIXTURE_PATH_RE.test(filePath)) return WEIGHT_NOT_SHIPPED;
+  if (TEST_PATH_RE.test(filePath)) return WEIGHT_TEST;
+  if (EXAMPLE_PATH_RE.test(filePath)) return WEIGHT_EXAMPLE;
   if (isEntryPoint(filePath)) return 1.5;
   return 1.0;
+}
+
+/** Max file-importance over a single finding's locations (default 1.0, no locs). */
+function findingMaxWeight(f: Finding): number {
+  let w: number | null = null;
+  for (const loc of f.locations) {
+    if (loc.file) w = w === null ? computeFileImportanceWeight(loc.file) : Math.max(w, computeFileImportanceWeight(loc.file));
+  }
+  return w ?? 1.0;
 }
 
 /**
@@ -211,15 +271,24 @@ function groupConfidence(findings: Finding[]): number {
   return sum / findings.length;
 }
 
-/** Max file-importance across a detector group's findings' locations (1.0–1.5). */
+/**
+ * Max file-importance across a detector group's findings' locations. Default 1.0
+ * only when the group has NO file locations — otherwise it is the true max over
+ * the group's files, so a detector that fires ONLY in de-weighted code (tests,
+ * examples, generated) is itself de-weighted. (Not floored at 1.0: that floor
+ * would make down-weighting a no-op.)
+ */
 function groupImportance(findings: Finding[]): number {
-  let imp = 1.0;
+  let imp: number | null = null;
   for (const f of findings) {
     for (const loc of f.locations) {
-      if (loc.file) imp = Math.max(imp, computeFileImportanceWeight(loc.file));
+      if (loc.file) {
+        const w = computeFileImportanceWeight(loc.file);
+        imp = imp === null ? w : Math.max(imp, w);
+      }
     }
   }
-  return imp;
+  return imp ?? 1.0;
 }
 
 /**
@@ -233,6 +302,7 @@ function groupDeviation(
   findings: Finding[],
   useDriftMagnitude: boolean,
   klocCount: number,
+  functionCount: number,
 ): number {
   const isDominance = useDriftMagnitude && findings.every((f) => f.driftSignal);
   if (isDominance) {
@@ -245,6 +315,32 @@ function groupDeviation(
     // only applies once there is some real deviation to register faintly.
     if (worst <= 0) return 0;
     return Math.max(DEVIATION_FLOOR, Math.min(1, worst));
+  }
+  // Grouped exact/near-duplicate detectors carry `dupGroupSize`: score by the
+  // DUPLICATED-FUNCTION FRACTION (Σ redundant copies ÷ total functions), which is
+  // size-fair AND volume-sensitive — 32 identical functions register as ~31
+  // redundant copies no matter how they were chunked into findings.
+  if (functionCount > 0 && findings.some((f) => (f.dupGroupSize ?? 0) > 1)) {
+    // Each duplicate group's redundant copies are weighted by WHERE the group
+    // lives (findingMaxWeight): duplication in shipped src counts full, in
+    // examples/tests less, in generated code ~0. Importance is therefore baked
+    // in PER-GROUP here (the detector-level groupImportance MAX would otherwise
+    // let one src dup pull the whole detector to full weight). detectorDamage
+    // skips groupImportance for dup detectors so this is not double-counted.
+    let redundant = 0;
+    for (const f of findings) {
+      if ((f.dupGroupSize ?? 0) > 1) redundant += (f.dupGroupSize! - 1) * findingMaxWeight(f);
+    }
+    const dupFraction = redundant / functionCount;
+    return 1 - Math.exp(-dupFraction / DUP_FRACTION_SCALE);
+  }
+  // Other count-based detectors (codedna structural similarity, ml, hygiene) scale
+  // with FUNCTION COUNT, not lines. Normalize as a size-fair per-function rate when
+  // the function count is known so structural similarity that grows with scale
+  // doesn't sink large clean repos; fall back to per-KLOC density when it isn't.
+  if (functionCount > 0) {
+    const rate = findings.length / functionCount;
+    return 1 - Math.exp(-rate / COUNT_RATE_SCALE);
   }
   const density = findings.length / klocCount;
   return 1 - Math.exp(-density / COUNT_DENSITY_SCALE);
@@ -270,12 +366,18 @@ function detectorDamage(
   findings: Finding[],
   useDriftMagnitude: boolean,
   klocCount: number,
+  functionCount: number,
 ): number {
+  // Dup detectors bake per-group file-importance into their deviation
+  // (findingMaxWeight); applying groupImportance again would double-count, so use
+  // a neutral 1.0 for them. All other detectors weight at the detector level.
+  const isDupDetector = findings.some((f) => (f.dupGroupSize ?? 0) > 1);
+  const importance = isDupDetector ? 1.0 : groupImportance(findings);
   const damage =
     groupSeverityDamage(findings) *
     groupConfidence(findings) *
-    groupImportance(findings) *
-    groupDeviation(findings, useDriftMagnitude, klocCount) *
+    importance *
+    groupDeviation(findings, useDriftMagnitude, klocCount, functionCount) *
     groupSampleConfidence(findings);
   return Math.min(MAX_DETECTOR_DAMAGE, Math.max(0, damage));
 }
@@ -290,6 +392,7 @@ export function categoryHealth(
   findings: Finding[],
   useDriftMagnitude: boolean,
   klocCount: number,
+  functionCount = 0,
 ): number {
   const byDetector = new Map<string, Finding[]>();
   for (const f of findings) {
@@ -299,7 +402,7 @@ export function categoryHealth(
   }
   let survival = 1;
   for (const [, group] of byDetector) {
-    survival *= 1 - detectorDamage(group, useDriftMagnitude, klocCount);
+    survival *= 1 - detectorDamage(group, useDriftMagnitude, klocCount, functionCount);
   }
   return Math.max(0, Math.min(1, survival));
 }
@@ -312,6 +415,7 @@ function computeCategoryScore(
   mutateImpact: boolean,
   useDriftMagnitude: boolean,
   treatEmptyAsNotMeasured: boolean,
+  functionCount: number,
 ): CategoryScore {
   if (!applicable) {
     return { score: 0, maxScore, locked: false, findingCount: 0, applicable: false };
@@ -335,7 +439,7 @@ function computeCategoryScore(
   }
 
   const klocCount = Math.max(1, totalLines / 1000);
-  const health = categoryHealth(findings, useDriftMagnitude, klocCount);
+  const health = categoryHealth(findings, useDriftMagnitude, klocCount, functionCount);
   const score = Math.round(maxScore * health * 10) / 10;
 
   // Marginal consistencyImpact: the score gain from removing finding i alone.
@@ -345,7 +449,7 @@ function computeCategoryScore(
     for (let i = 0; i < findings.length; i++) {
       const without = findings.slice(0, i).concat(findings.slice(i + 1));
       const healthWithout =
-        without.length === 0 ? 1 : categoryHealth(without, useDriftMagnitude, klocCount);
+        without.length === 0 ? 1 : categoryHealth(without, useDriftMagnitude, klocCount, functionCount);
       const impact = maxScore * (healthWithout - health);
       findings[i].consistencyImpact = Math.round(Math.max(0, impact) * 100) / 100;
     }
@@ -383,6 +487,7 @@ function computeScoresForKind(
   mutateImpact: boolean,
   previousScores: CategoryScores | undefined,
   previousScoresApplicable: boolean,
+  functionCount: number,
 ): { scores: CategoryScores; compositeScore: number; maxCompositeScore: number } {
   const findingsByCategory = new Map<ScoringCategory, Finding[]>();
   for (const cat of ALL_CATEGORIES) {
@@ -410,6 +515,7 @@ function computeScoresForKind(
       mutateImpact,
       kind === "drift",
       kind === "drift" && SURFACE_SPECIFIC_DRIFT_CATEGORIES.has(cat),
+      functionCount,
     );
 
     // Delta is only meaningful when the previous scores were computed under
@@ -519,6 +625,14 @@ export function computeScores(
     ? [...ctx.languageBreakdown.keys()]
     : ["javascript", "typescript"];
 
+  // Total function count drives size-fair normalization of count-based detectors
+  // (structural-similarity findings scale with functions, not lines). Reuse a
+  // pre-computed ctx.functionCount when the pipeline supplied one; otherwise
+  // derive it once here. 0 → engine falls back to per-KLOC density.
+  const functionCount = ctx
+    ? (ctx.functionCount ?? extractAllFunctions(ctx.files).length)
+    : 0;
+
   // Drift track: populates consistencyImpact on drift findings when
   // mutateImpact is true. Composite is the Vibe Drift Score.
   const drift = computeScoresForKind(
@@ -529,6 +643,7 @@ export function computeScores(
     mutateImpact,
     previousScores,
     versionsMatch,
+    functionCount,
   );
 
   // Hygiene track: parallel scoring, never mutates consistencyImpact
@@ -541,6 +656,7 @@ export function computeScores(
     false,
     options.previousHygieneScores,
     versionsMatch,
+    functionCount,
   );
 
   const perFileScores = computePerFileScores(findings, ctx);

--- a/test/unit/codedna/semantic-fingerprint.test.ts
+++ b/test/unit/codedna/semantic-fingerprint.test.ts
@@ -259,11 +259,14 @@ describe("fingerprintFindings — payload caps for huge duplicate groups", () =>
     expect(f.metadata?.truncatedLocations).toBe(80);
   });
 
-  it("confidence is always 1.0 regardless of group size (exact hash match is certain)", () => {
+  it("confidence is the calibrated structural-dup precision, independent of group size", () => {
+    // 0.95 = measured precision of exact-hash dup groups (98.7%, n=79, 2026-06-24
+    // Claude calibration; see eval/calibration/ + semantic-fingerprint.ts). Group
+    // size does not change how certain an exact normalized-hash match is.
     const small = fingerprintFindings([bigGroup(3)])[0];
     const huge = fingerprintFindings([bigGroup(120)])[0];
-    expect(small.confidence).toBe(1.0);
-    expect(huge.confidence).toBe(1.0);
+    expect(small.confidence).toBe(0.95);
+    expect(huge.confidence).toBe(0.95);
   });
 
   it("severity is graded by blast radius: info for 2-member, warning for 3-4, error for >=5", () => {

--- a/test/unit/drift/export-consistency.test.ts
+++ b/test/unit/drift/export-consistency.test.ts
@@ -33,12 +33,12 @@ describe("export-consistency detector", () => {
     expect(exportConsistency.detect(mkCtx(files))).toHaveLength(0);
   });
 
-  it("emits one entropy-based 'no convention' finding when there is no export convention", () => {
+  it("emits one plurality-based 'no convention' finding when there is no export convention", () => {
     // 50/50 split of default vs named across many files → entropy gate returns
     // no_convention. For a self-consistency score, having NO dominant pattern is
     // the floor of consistency, so the detector emits ONE category-level finding
-    // whose deviation IS the entropy (consistencyScore low → high deviation),
-    // naming no specific deviating files.
+    // whose deviation is 1 - plurality share (smooth + granular: 50/50 → 0.5,
+    // a 4-way even split → 0.75), naming no specific deviating files.
     const files: DriftFile[] = [];
     for (let i = 0; i < 6; i++) {
       files.push(file(`src/named${i}.ts`, `export const v${i} = 1;\nexport function f${i}() {}\n`));
@@ -50,8 +50,9 @@ describe("export-consistency detector", () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].dominantPattern).toBe("no dominant convention");
     expect(findings[0].deviatingFiles).toHaveLength(0);
-    // perfect 50/50 split → normalized entropy 1.0 → consistencyScore 0 → max deviation
-    expect(findings[0].consistencyScore).toBe(0);
+    // perfect 50/50 split → plurality share 0.5 → consistencyScore 50 → deviation 0.5
+    // (smooth/granular; a more-fragmented split would score lower, i.e. more drift)
+    expect(findings[0].consistencyScore).toBe(50);
     expect(findings[0].severity).toBe("warning");
   });
 

--- a/test/unit/ml-client/confidence.test.ts
+++ b/test/unit/ml-client/confidence.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { filterByConfidence } from "../../../src/ml-client/confidence.js";
+import { getAnalyzerKind } from "../../../src/scoring/categories.js";
+import type { MlAnalyzeResponse } from "../../../src/ml-client/types.js";
+
+function resp(over: Partial<MlAnalyzeResponse> = {}): MlAnalyzeResponse {
+  return {
+    processing_time_ms: 0,
+    duplicates: [],
+    intent_mismatches: [],
+    anomalies: [],
+    deviations: [],
+    llm_validations: [],
+    reimplementations: [],
+    ...over,
+  };
+}
+
+describe("filterByConfidence — reimplementations", () => {
+  it("converts API reimplementations into ml-reimplementation findings", () => {
+    const out = filterByConfidence(resp({
+      reimplementations: [{
+        name: "send_message",
+        function_a: "p/openai.py::send_message",
+        function_b: "p/ollama.py::send_message",
+        member_ids: ["a", "b", "c"],
+        files: ["p/openai.py", "p/ollama.py", "p/anthropic.py"],
+        group_size: 3,
+        verdict: "reimplementation",
+        confidence: 1.0,
+        real_votes: 3,
+        votes: 3,
+        reasons: ["same send logic"],
+      }],
+    }));
+    const f = out.highConfidence.find((x) => x.analyzerId === "ml-reimplementation");
+    expect(f).toBeDefined();
+    expect(f!.tags).toContain("reimplementation");
+    expect(f!.locations.length).toBe(3);
+    expect(f!.message).toContain("send_message");
+  });
+
+  it("surfaces 2/3-confidence reimplementations (already panel-confirmed by the API)", () => {
+    const out = filterByConfidence(resp({
+      reimplementations: [{
+        name: "formatDate", function_a: "a::formatDate", function_b: "b::formatDate",
+        member_ids: ["a", "b"], files: ["a.ts", "b.ts"], group_size: 2,
+        verdict: "reimplementation", confidence: 0.667, real_votes: 2, votes: 3, reasons: [],
+      }],
+    }));
+    expect(out.highConfidence.some((x) => x.analyzerId === "ml-reimplementation")).toBe(true);
+  });
+
+  it("tolerates an old server response with no reimplementations field", () => {
+    const r = resp();
+    delete (r as { reimplementations?: unknown }).reimplementations;
+    expect(() => filterByConfidence(r)).not.toThrow();
+  });
+
+  it("ml-reimplementation is findings-only in v1 (hygiene kind, not in the drift composite)", () => {
+    expect(getAnalyzerKind("ml-reimplementation")).toBe("hygiene");
+  });
+});

--- a/test/unit/output/tease.test.ts
+++ b/test/unit/output/tease.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { countReimplementationCandidates } from "../../../src/output/tease.js";
+import type { ExtractedFunction } from "../../../src/codedna/types.js";
+
+function mkFn(p: Partial<ExtractedFunction>): ExtractedFunction {
+  return {
+    name: "fn",
+    file: "/abs/x.ts",
+    relativePath: "src/x.ts",
+    line: 1,
+    language: "typescript",
+    params: [],
+    paramCount: 0,
+    rawBody: "return compute(a, b)",
+    declarationCode: "",
+    domainCategory: "general",
+    bodyTokens: [],
+    bodyTokenCount: 20,
+    bodyHash: 0,
+    ...p,
+  };
+}
+
+describe("countReimplementationCandidates", () => {
+  it("counts a name appearing in 2+ shipped files once", () => {
+    expect(countReimplementationCandidates([
+      mkFn({ name: "sendMessage", relativePath: "src/a.ts" }),
+      mkFn({ name: "sendMessage", relativePath: "src/b.ts" }),
+    ])).toBe(1);
+  });
+
+  it("does not count a name confined to one file", () => {
+    expect(countReimplementationCandidates([
+      mkFn({ name: "sendMessage", relativePath: "src/a.ts" }),
+      mkFn({ name: "sendMessage", relativePath: "src/a.ts" }),
+    ])).toBe(0);
+  });
+
+  it("excludes test/example paths (non-shipped)", () => {
+    expect(countReimplementationCandidates([
+      mkFn({ name: "sendMessage", relativePath: "test/a.test.ts" }),
+      mkFn({ name: "sendMessage", relativePath: "src/b.ts" }),
+    ])).toBe(0); // only one shipped occurrence remains
+  });
+
+  it("excludes generic names, short names, and trivial bodies", () => {
+    expect(countReimplementationCandidates([
+      mkFn({ name: "handle", relativePath: "src/a.ts" }),
+      mkFn({ name: "handle", relativePath: "src/b.ts" }),
+      mkFn({ name: "go", relativePath: "src/c.ts" }),
+      mkFn({ name: "go", relativePath: "src/d.ts" }),
+      mkFn({ name: "tinyHelper", relativePath: "src/e.ts", bodyTokenCount: 3 }),
+      mkFn({ name: "tinyHelper", relativePath: "src/f.ts", bodyTokenCount: 3 }),
+    ])).toBe(0);
+  });
+
+  it("counts multiple distinct reimplemented names", () => {
+    expect(countReimplementationCandidates([
+      mkFn({ name: "sendMessage", relativePath: "src/a.ts" }),
+      mkFn({ name: "sendMessage", relativePath: "src/b.ts" }),
+      mkFn({ name: "formatDate", relativePath: "src/a.ts" }),
+      mkFn({ name: "formatDate", relativePath: "src/c.ts" }),
+    ])).toBe(2);
+  });
+});

--- a/test/unit/scoring/discrimination.test.ts
+++ b/test/unit/scoring/discrimination.test.ts
@@ -202,6 +202,105 @@ describe("scoring decompression (v4)", () => {
     expect(small).toBeGreaterThan(large);
   });
 
+  it("granular (v6): composite decreases MONOTONICALLY as drift deepens (deviation + duplication)", () => {
+    // Each level deepens BOTH dominance deviation (lower consistencyScore) AND the
+    // duplicated-function fraction (larger dup group). The composite must strictly
+    // decrease — the score is granular, not compressed/clustered at the top.
+    const atLevel = (consistency: number, dupGroupSize: number): number => {
+      const findings: Finding[] = [
+        mkDrift("drift-architectural_consistency", "error", consistency, "src/a.ts"),
+        mkDrift("drift-naming_conventions", "error", consistency, "src/b.ts"),
+      ];
+      if (dupGroupSize > 1) {
+        findings.push({
+          analyzerId: "codedna-fingerprint",
+          severity: "warning",
+          confidence: 1,
+          message: "exact duplicate group",
+          locations: [{ file: "src/d.ts", line: 1 }],
+          tags: ["duplicate"],
+          dupGroupSize,
+        });
+      }
+      const ctx: AnalysisContext = { ...makeCtx(20000), functionCount: 200 };
+      return computeScores(findings, 20000, ctx).compositeScore;
+    };
+    const gradient = [
+      atLevel(90, 2),   // barely any drift
+      atLevel(72, 12),
+      atLevel(55, 28),
+      atLevel(38, 55),
+      atLevel(20, 95),  // severe drift + heavy duplication
+    ];
+    for (let i = 1; i < gradient.length; i++) {
+      expect(gradient[i]).toBeLessThan(gradient[i - 1]);
+    }
+    // And the span is wide (granular), not compressed into a few points.
+    expect(gradient[0] - gradient[gradient.length - 1]).toBeGreaterThan(25);
+  });
+
+  it("size-fair (v6): count-based drift at a FIXED per-function rate scores the same at any repo size", () => {
+    // 10 dup findings across 100 functions (10% rate) vs 100 dup findings across
+    // 1000 functions (same 10% rate). With function-count normalization the
+    // redundancy score must be ~identical — structural similarity that scales with
+    // function count no longer sinks the larger repo.
+    const ctxFn = (functions: number, lines: number): AnalysisContext => ({
+      ...makeCtx(lines),
+      functionCount: functions,
+    });
+    const dupes = (n: number): Finding[] =>
+      Array.from({ length: n }, (_, i) => mkCount("codedna-fingerprint", "warning", `src/dup${i}.ts`));
+    const small = computeScores(dupes(10), 5000, ctxFn(100, 5000)).scores.redundancy.score;
+    const large = computeScores(dupes(100), 50000, ctxFn(1000, 50000)).scores.redundancy.score;
+    expect(Math.abs(small - large)).toBeLessThan(1);
+  });
+
+  it("size-fair (v6): a HIGHER per-function dup rate scores lower than a low rate (same size)", () => {
+    const ctxFn = (functions: number): AnalysisContext => ({ ...makeCtx(20000), functionCount: functions });
+    const dupes = (n: number): Finding[] =>
+      Array.from({ length: n }, (_, i) => mkCount("codedna-fingerprint", "warning", `src/dup${i}.ts`));
+    const lowRate = computeScores(dupes(10), 20000, ctxFn(1000)).scores.redundancy.score; // 1%
+    const highRate = computeScores(dupes(300), 20000, ctxFn(1000)).scores.redundancy.score; // 30%
+    expect(highRate).toBeLessThan(lowRate);
+  });
+
+  it("shipped-code weighting (v6): the SAME dup group damages src/ most, examples/tests less, generated ~none", () => {
+    // The score measures drift in shipped code. An identical 40-member duplicate
+    // group should hurt most in src/, less in examples/ or tests/, and be
+    // effectively excluded when it lives in generated code.
+    const redundancyFor = (file: string): number => {
+      const findings: Finding[] = [{
+        analyzerId: "codedna-fingerprint",
+        severity: "error",
+        confidence: 0.95,
+        message: "exact duplicate group",
+        locations: [{ file, line: 1 }],
+        tags: ["duplicate"],
+        dupGroupSize: 40,
+      }];
+      const ctx: AnalysisContext = { ...makeCtx(20000), functionCount: 200 };
+      return computeScores(findings, 20000, ctx).scores.redundancy.score;
+    };
+    const src = redundancyFor("src/dup.ts");
+    const example = redundancyFor("examples/demo/dup.ts");
+    const test = redundancyFor("test/dup.test.ts");
+    const generated = redundancyFor("src/client.gen.ts");
+    // lower redundancy score = more damage. src is shipped → most damage.
+    expect(src).toBeLessThan(example);
+    expect(src).toBeLessThan(test);
+    // generated is not authored → effectively excluded → near-clean redundancy.
+    expect(generated).toBeGreaterThan(example);
+    expect(generated).toBeGreaterThan(19);
+  });
+
+  it("shipped-code weighting (v6): dominance drift in src/ damages more than the same drift in tests/", () => {
+    const compositeFor = (file: string): number => {
+      const findings = [mkDrift("drift-naming_conventions", "error", 40, file)];
+      return computeScores(findings, 20000, { ...makeCtx(20000), functionCount: 200 }).compositeScore;
+    };
+    expect(compositeFor("src/a.ts")).toBeLessThan(compositeFor("test/a.test.ts"));
+  });
+
   it("count-based codedna findings are volume-normalized, not collapsed to zero", () => {
     // 40 codedna duplicate findings with no dominance ratio. Under the flat-0.5
     // magnitude (kloc=1) bug these collapsed redundancy to ~0 and tanked the


### PR DESCRIPTION
Consumes the deep-scan reimplementation findings and surfaces them:
- `ml-reimplementation` findings (parsed in ml-client), classified hygiene → findings-only (does not move the drift composite). Flip to drift once per-language precision is calibrated.
- Free Tier-1 teaser: count of same-name cross-file shipped functions, shown as an honest "run a deep scan to confirm" upsell.

Stacked on the v6 PR (#14) — merge that first. 612 tests green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)