### PR TITLE
fix(cli): concise scan summary (not the full report) + DEP0190 + sync status

### DIFF
--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -10,7 +10,7 @@ import { runDriftDetection, attachEngineComposite } from "../../drift/index.js";
 import { computeScores, SCORING_VERSION } from "../../scoring/engine.js";
 import { debug, setDebugEnabled } from "../../core/debug.js";
 import { generateTeaseMessages, countReimplementationCandidates } from "../../output/tease.js";
-import { renderTerminalOutput, renderJsonOutput, renderStarCta } from "../../output/terminal.js";
+import { renderTerminalOutput, renderConciseSummary, renderJsonOutput, renderStarCta } from "../../output/terminal.js";
 import { renderHtmlReport } from "../../output/html.js";
 import {
   saveScanResult,
@@ -604,6 +604,12 @@ export async function logAndRender(
       sanitizedResult.scanType = options.deep ? "deep" : "free";
       sanitizedResult.scannedAt = new Date().toISOString();
 
+      // On large repos the result_json upload can take several seconds. Show a
+      // status line (stderr, so --json stdout stays clean) so it doesn't look
+      // like the scan hung between the timings and the report.
+      if (!options.json) {
+        console.error(chalk.dim("  Syncing scan to your dashboard…"));
+      }
       const logResult = await logScan({
         token: bearerToken,
         apiUrl,
@@ -724,11 +730,13 @@ async function renderToFormat(
   }
 
   if (format === "html") {
-    // Print the rich terminal summary (update banner, score, category bars,
-    // Fix Plan, findings) for authenticated runs too — they were only seeing
-    // "report saved", while logged-out runs got the full in-terminal UI. Then
-    // write + serve the HTML report as before, so authed users get both.
-    console.log(renderTerminalOutput(result, { plan }));
+    // Print a tight, scannable high-level summary on stdout: the update banner,
+    // scan header, Vibe Drift Score with category bars and the Hygiene Score,
+    // and the top 3 fixes. The full report (every finding, the hygiene pane,
+    // per-directory drift, exact duplicates) lives in the HTML report we write
+    // and serve below, so authed users get a clean terminal summary and the
+    // complete detail in the browser.
+    console.log(renderConciseSummary(result, plan));
     const scanId = (result as any).__scanId as string | undefined;
     const beaconApiUrl = (result as any).__apiUrl as string | undefined;
     const beaconOpts = { ...(scanId ? { scanId, beaconApiUrl } : {}), isPaid: paid };
@@ -751,7 +759,8 @@ async function renderToFormat(
     });
     const port = 4173 + Math.floor(Math.random() * 100);
     server.listen(port, () => {
-      console.log(`\n  Report saved to ${outputPath}`);
+      console.log(`\n  ${chalk.dim("Full report (every finding, drift detail, and duplicates) is in the HTML report:")}`);
+      console.log(`  Report saved to ${outputPath}`);
       console.log(`  View in browser: \x1b[36mhttp://localhost:${port}\x1b[0m\n`);
       for (const line of renderStarCta()) console.log(line);
     });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -7,20 +7,23 @@ const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
 /**
  * Spawn config for a global npm install, routed through the shell.
  *
- * The bug this fixes: on Windows `npm` is `npm.cmd`, and Node refuses to spawn
- * a `.cmd` file without a shell (`spawn npm ENOENT`, hardened further after the
- * .cmd-spawn CVE). MINGW64 / Git Bash still reports `process.platform === "win32"`,
- * so there is no POSIX escape hatch — the single cross-platform fix is to let the
- * shell (cmd.exe on Windows, /bin/sh on POSIX) resolve `npm` from PATH/PATHEXT.
+ * Why the shell: on Windows `npm` is `npm.cmd`, and Node refuses to spawn a
+ * `.cmd` file without a shell (`spawn npm ENOENT`, hardened after the .cmd-spawn
+ * CVE). MINGW64 / Git Bash still reports `process.platform === "win32"`, so the
+ * cross-platform fix is to let the shell (cmd.exe / /bin/sh) resolve `npm`.
+ *
+ * Why ONE command string (not command + args array): Node's DEP0190 deprecates
+ * passing an args array together with `shell: true` (the args are concatenated,
+ * not escaped). Passing a single command string with `shell: true` avoids the
+ * warning. Safe here because the only interpolated value, the version inside
+ * `pkgSpec`, is validated by `isSafeVersionToken` before it reaches this point.
  */
 export function npmGlobalInstallSpawn(pkgSpec: string): {
   command: string;
-  args: string[];
   options: SpawnOptions & { shell: true; stdio: "inherit" };
 } {
   return {
-    command: "npm",
-    args: ["i", "-g", pkgSpec],
+    command: `npm i -g ${pkgSpec}`,
     options: { stdio: "inherit", shell: true },
   };
 }
@@ -101,10 +104,10 @@ export async function runUpdate(currentVersion: string): Promise<void> {
   console.log(chalk.dim(`Running: npm i -g ${PACKAGE_NAME}@${latest}\n`));
 
   await new Promise<void>((resolve, reject) => {
-    const { command, args, options } = npmGlobalInstallSpawn(
+    const { command, options } = npmGlobalInstallSpawn(
       `${PACKAGE_NAME}@${latest}`,
     );
-    const child = spawn(command, args, options);
+    const child = spawn(command, options);
     child.on("error", (err) => {
       reject(err);
     });

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -170,7 +170,7 @@ function findingPriority(f: Finding): number {
   return 2 * sev;
 }
 
-function renderFixPlan(result: ScanResult, driftFirst = false): string[] {
+function renderFixPlan(result: ScanResult, driftFirst = false, maxItems = 5): string[] {
   const lines: string[] = [];
   const allSorted = [...result.findings]
     .filter(hasMeaningfulImpact)
@@ -194,17 +194,17 @@ function renderFixPlan(result: ScanResult, driftFirst = false): string[] {
     const diverse: Finding[] = [];
     for (const f of prioritySorted) {
       const key = f.analyzerId;
-      if (seen.has(key) && diverse.length < 5) {
-        // Allow a second from the same analyzer only if we have <5 total
+      if (seen.has(key) && diverse.length < maxItems) {
+        // Allow a second from the same analyzer only if we're short of the cap
         if (diverse.length >= 3) continue;
       }
       seen.add(key);
       diverse.push(f);
-      if (diverse.length >= 5) break;
+      if (diverse.length >= maxItems) break;
     }
     top = diverse;
   } else {
-    top = allSorted.slice(0, 5);
+    top = allSorted.slice(0, maxItems);
   }
 
   if (top.length === 0) return lines;
@@ -748,19 +748,37 @@ export function renderTerminalOutput(result: ScanResult, opts?: { brief?: boolea
 
 /**
  * Brief terminal output for unauthenticated users.
- * Shows: score, category bars, top 5 findings — enough to prove value,
+ * Shows: score, category bars, top findings — enough to prove value,
  * not enough to replace the full report.
+ *
+ * `concise: true` is the authenticated-summary variant: it caps the Fix Plan
+ * at the top 3 items so stdout stays a tight, scannable high-level summary
+ * (score, bars, hygiene, three fixes). The full detail lives in the HTML
+ * report the CLI writes and serves.
  */
-function renderBriefOutput(result: ScanResult, plan?: Plan): string {
+function renderBriefOutput(result: ScanResult, plan?: Plan, opts?: { concise?: boolean }): string {
+  const maxFixes = opts?.concise ? 3 : 5;
   const lines: string[] = [
     ...renderUpdateBanner(result),
     ...renderScoreSection(result),
     ...renderCategoryBars(result),
     ...renderPeerPercentile(result, plan),
-    ...renderFixPlan(result, true),  // drift-first mix for conversion
+    ...renderFixPlan(result, true, maxFixes),  // drift-first mix, capped
   ];
 
   return lines.join("\n");
+}
+
+/**
+ * Concise authenticated summary for the default (html) format. Renders the
+ * update banner, scan header, Vibe Drift Score with category bars and the
+ * Hygiene Score, and the top 3 fixes — a tight high-level summary, not the
+ * wall-of-text full report. The complete findings list, hygiene pane, and
+ * per-directory drift detail all live in the HTML report the CLI saves and
+ * serves alongside this summary.
+ */
+export function renderConciseSummary(result: ScanResult, plan?: Plan): string {
+  return renderBriefOutput(result, plan, { concise: true });
 }
 
 export function renderJsonOutput(result: ScanResult): string {

--- a/test/unit/cli/update.test.ts
+++ b/test/unit/cli/update.test.ts
@@ -6,12 +6,12 @@ import {
 } from "../../../src/cli/commands/update.js";
 
 describe("npmGlobalInstallSpawn", () => {
-  it("routes through the shell so Windows can resolve npm.cmd (fixes spawn npm ENOENT)", () => {
-    const { command, args, options } = npmGlobalInstallSpawn("@vibedrift/cli@0.9.3");
-    expect(command).toBe("npm");
-    expect(args).toEqual(["i", "-g", "@vibedrift/cli@0.9.3"]);
-    // The bug was shell:false — npm is npm.cmd on Windows and Node refuses to
-    // spawn a .cmd without a shell. shell:true is the cross-platform fix.
+  it("routes through the shell as one command string (Windows npm.cmd + avoids DEP0190)", () => {
+    const { command, options } = npmGlobalInstallSpawn("@vibedrift/cli@0.9.3");
+    // One command string (not command + args array): a shell is needed so
+    // Windows resolves npm.cmd, and passing args alongside shell:true triggers
+    // Node's DEP0190 deprecation. A single string avoids it.
+    expect(command).toBe("npm i -g @vibedrift/cli@0.9.3");
     expect(options.shell).toBe(true);
     expect(options.stdio).toBe("inherit");
   });


### PR DESCRIPTION
Three CLI fixes.

### Concise stdout summary (regression fix)
0.14.2 printed the **entire** report to stdout for authenticated runs — every finding, drift line, and duplicate (hundreds of lines). Now stdout shows only a high-level summary: Vibe Drift Score + grade, the category bars, hygiene score, and the **top 3** fixes, plus a pointer to the full HTML report. The complete detail stays in the HTML report. (~42 lines vs hundreds.)

### DEP0190 deprecation warning
`vibedrift update` spawned the global install with `shell:true` **and** an args array, which Node deprecates ([DEP0190]). Now it passes a single command string. The version is still validated by `isSafeVersionToken` before it reaches the shell.

### "Syncing…" status line
On large repos the scan upload can take a few seconds and ran silently, so the CLI looked frozen between the timings and the report. Added a status line (stderr, so `--json` stdout stays clean).

684 tests pass; 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)