### PR TITLE
feat(scoring): score reimplementation only when concentrated

### DIFF
--- a/src/scoring/categories.ts
+++ b/src/scoring/categories.ts
@@ -88,13 +88,16 @@ export const CATEGORY_CONFIG: Record<ScoringCategory, CategoryConfig> = {
       { id: "codedna-opseq", applicableLanguages: "all", kind: "drift" },
       // ML embeddings
       { id: "ml-duplicate", applicableLanguages: "all", kind: "drift" },
-      // Panel-confirmed redundant reimplementation. FINDINGS-ONLY for now
-      // (kind "hygiene" → renders in its own pane, does NOT feed the drift
-      // composite). The v6 composite is a geometric mean of score/maxScore, so
-      // a zero-weight scored category can't express "show but don't score" — the
-      // hygiene classification is the lever. Flip kind to "drift" to enable
-      // scoring once per-language precision is calibrated.
+      // Panel-confirmed redundant reimplementation. Hygiene by default (renders
+      // in its own pane, does NOT feed the composite) because raw reimplementation
+      // COUNT does not separate clean from messy code — large clean repos carry a
+      // sparse baseline. When reimplementation is CONCENTRATED, computeScores
+      // re-tags the findings to the drift-kind id below so they feed the composite
+      // (see applyReimplementationConcentrationGate, calibrated 2026-06-27: 0/249
+      // elite repos cross the bar). The split is the lever the geometric-mean
+      // composite needs to express "show but don't score" vs "score".
       { id: "ml-reimplementation", applicableLanguages: "all", kind: "hygiene" },
+      { id: "ml-reimplementation-concentrated", applicableLanguages: "all", kind: "drift" },
     ],
   },
   dependencyHealth: {

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -54,6 +54,49 @@ export const SCORING_VERSION = "v6";
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;
 
 /**
+ * Reimplementation concentration gate (calibrated 2026-06-27 on the 425-repo
+ * corpus deep-scan run). Panel-confirmed reimplementation findings feed the
+ * Vibe Drift Score ONLY when CONCENTRATED: at least REIMPL_CONCENTRATION_MIN_COUNT
+ * findings AND at least REIMPL_CONCENTRATION_DENSITY_MIN per KLOC.
+ *
+ * Why concentration, not count: across 425 repos, raw reimplementation COUNT did
+ * NOT separate elite from messy/AI-generated repos — large elite repos carry a
+ * sparse-but-common reimplementation baseline (legacy files, parallel platform
+ * impls). DENSITY did: 0 of 249 elite repos reach 1 finding/KLOC, while the
+ * concentrated AI-sprawl repos clear it. The gate is deliberately conservative
+ * (high precision on "clean"): no elite repo in the calibration set crosses it,
+ * so it never penalizes well-structured code. Global threshold for now;
+ * per-language refinement waits for a larger dense-tail sample.
+ */
+export const REIMPL_CONCENTRATION_DENSITY_MIN = 1.0; // panel-confirmed findings per KLOC
+export const REIMPL_CONCENTRATION_MIN_COUNT = 3;
+const REIMPL_HYGIENE_ID = "ml-reimplementation";
+const REIMPL_DRIFT_ID = "ml-reimplementation-concentrated";
+
+/**
+ * Re-tag panel-confirmed reimplementation findings to the drift-kind analyzer id
+ * when, and only when, they are concentrated (see the gate constants above). When
+ * the gate does not fire the findings keep their hygiene id and stay informational.
+ * Pure; returns the same array reference when nothing is re-tagged.
+ */
+export function applyReimplementationConcentrationGate(
+  findings: Finding[],
+  totalLines: number,
+): Finding[] {
+  const reimplCount = findings.reduce(
+    (n, f) => (f.analyzerId === REIMPL_HYGIENE_ID ? n + 1 : n),
+    0,
+  );
+  if (reimplCount < REIMPL_CONCENTRATION_MIN_COUNT) return findings;
+  const kloc = totalLines / 1000;
+  if (kloc <= 0) return findings;
+  if (reimplCount / kloc < REIMPL_CONCENTRATION_DENSITY_MIN) return findings;
+  return findings.map((f) =>
+    f.analyzerId === REIMPL_HYGIENE_ID ? { ...f, analyzerId: REIMPL_DRIFT_ID } : f,
+  );
+}
+
+/**
  * Place a composite Vibe Drift Score on a peer percentile against a bundled
  * corpus of real-world repos in the same language. Pure, local, deterministic,
  * and FREE — only surfacing the result is Pro-gated (see `isPeerGroundedEntitled`).
@@ -625,6 +668,12 @@ export function computeScores(
    */
   previousScoresMismatch?: string;
 } {
+  // Panel-confirmed reimplementation feeds the composite only when concentrated
+  // (see applyReimplementationConcentrationGate). Sparse reimplementation keeps
+  // its hygiene id and stays informational. Applied here so the gate sees the
+  // full finding set together with totalLines.
+  findings = applyReimplementationConcentrationGate(findings, totalLines);
+
   const mutateImpact = options.mutateImpact ?? true;
   const previousScoringVersion = options.previousScoringVersion;
   const versionsMatch = previousScoringVersion === SCORING_VERSION;

--- a/test/unit/scoring/reimpl-concentration-gate.test.ts
+++ b/test/unit/scoring/reimpl-concentration-gate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyReimplementationConcentrationGate,
+  computeScores,
+  REIMPL_CONCENTRATION_DENSITY_MIN,
+  REIMPL_CONCENTRATION_MIN_COUNT,
+} from "../../../src/scoring/engine.js";
+import type { Finding } from "../../../src/core/types.js";
+
+function reimpl(n: number): Finding[] {
+  return Array.from({ length: n }, (_, i) => ({
+    analyzerId: "ml-reimplementation",
+    severity: "warning" as const,
+    message: `reimpl ${i}`,
+    locations: [{ file: `a${i}.py` }],
+    tags: ["ml", "reimplementation"],
+  }));
+}
+
+const other: Finding = {
+  analyzerId: "naming",
+  severity: "warning",
+  message: "naming",
+  locations: [{ file: "x.py" }],
+};
+
+function tags(findings: Finding[], id: string): number {
+  return findings.filter((f) => f.analyzerId === id).length;
+}
+
+describe("applyReimplementationConcentrationGate", () => {
+  it("re-tags reimplementation findings to the drift id when dense (>=1/KLOC and >=3 findings)", () => {
+    // 5 findings in 1000 LOC = 5.0/KLOC, count 5 — clears both bars.
+    const out = applyReimplementationConcentrationGate([...reimpl(5), other], 1000);
+    expect(tags(out, "ml-reimplementation-concentrated")).toBe(5);
+    expect(tags(out, "ml-reimplementation")).toBe(0);
+    // unrelated findings are untouched
+    expect(tags(out, "naming")).toBe(1);
+  });
+
+  it("leaves findings as hygiene when the count is below the minimum", () => {
+    // 2 findings in 100 LOC = 20/KLOC (very dense) but only 2 findings.
+    const out = applyReimplementationConcentrationGate(reimpl(2), 100);
+    expect(tags(out, "ml-reimplementation")).toBe(2);
+    expect(tags(out, "ml-reimplementation-concentrated")).toBe(0);
+  });
+
+  it("leaves findings as hygiene when density is below the threshold", () => {
+    // 3 findings in 10000 LOC = 0.3/KLOC — sparse (the elite baseline shape).
+    const out = applyReimplementationConcentrationGate(reimpl(3), 10000);
+    expect(tags(out, "ml-reimplementation")).toBe(3);
+    expect(tags(out, "ml-reimplementation-concentrated")).toBe(0);
+  });
+
+  it("does not divide by zero on empty/zero LOC", () => {
+    const out = applyReimplementationConcentrationGate(reimpl(5), 0);
+    expect(tags(out, "ml-reimplementation")).toBe(5);
+    expect(tags(out, "ml-reimplementation-concentrated")).toBe(0);
+  });
+
+  it("fires exactly at the calibrated boundary", () => {
+    // count == MIN_COUNT and density == DENSITY_MIN exactly.
+    const n = REIMPL_CONCENTRATION_MIN_COUNT;
+    const loc = (n / REIMPL_CONCENTRATION_DENSITY_MIN) * 1000; // density == DENSITY_MIN
+    const out = applyReimplementationConcentrationGate(reimpl(n), loc);
+    expect(tags(out, "ml-reimplementation-concentrated")).toBe(n);
+  });
+});
+
+describe("reimplementation concentration gate — scoring impact", () => {
+  it("below-gate reimplementation is informational (does not move the composite)", () => {
+    const clean = computeScores([], 1000).compositeScore;
+    const belowGate = computeScores(reimpl(2), 1000).compositeScore; // count < 3
+    expect(belowGate).toBe(clean);
+  });
+
+  it("concentrated reimplementation lowers the composite", () => {
+    const belowGate = computeScores(reimpl(2), 1000).compositeScore; // hygiene
+    const dense = computeScores(reimpl(4), 1000).compositeScore; // 4/KLOC → drift
+    expect(dense).toBeLessThan(belowGate);
+  });
+});


### PR DESCRIPTION
## Summary
Panel-confirmed redundant reimplementation now affects the Vibe Drift Score, but only when it is *concentrated* — at least a minimum number of findings AND a minimum density per KLOC.

Raw reimplementation **count** does not separate clean code from messy code: well-structured repos carry a sparse baseline of parallel and legacy implementations. **Concentration** does separate. So `computeScores` re-tags concentrated reimplementation to a drift-kind analyzer that feeds the composite, while sparse reimplementation keeps its hygiene classification and stays informational in its own pane.

## Behavior
- A repo where the same functions are re-implemented densely across many files takes a score hit.
- A large, well-structured repo with a few parallel or legacy implementations does not.
- The threshold is global and deliberately conservative, so well-structured code is never penalized.

## Tests
Unit + integration coverage for the gate: the re-tag logic, the count and density boundaries, and the end-to-end effect on the composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)