### PR TITLE
fix(codedna): deduplicate 5 copy-pasted utility functions

### DIFF
--- a/src/analyzers/naming.ts
+++ b/src/analyzers/naming.ts
@@ -16,6 +16,7 @@
 
 import type { Analyzer } from "./base.js";
 import type { AnalysisContext, Finding, SyntaxNode } from "../core/types.js";
+import { shannonEntropy } from "../utils/math.js";
 
 type Convention = "camelCase" | "snake_case" | "PascalCase" | "SCREAMING_SNAKE";
 
@@ -65,19 +66,6 @@ function extractIdentifiersRegex(content: string): string[] {
     }
   }
   return ids;
-}
-
-/** Shannon entropy of a distribution given raw counts. Range: [0, log₂(k)]. */
-function shannonEntropy(counts: number[]): number {
-  const total = counts.reduce((a, b) => a + b, 0);
-  if (total === 0) return 0;
-  let H = 0;
-  for (const c of counts) {
-    if (c === 0) continue;
-    const p = c / total;
-    H -= p * Math.log2(p);
-  }
-  return H;
 }
 
 export const namingAnalyzer: Analyzer = {

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -64,7 +64,7 @@ interface SerializedBaseline extends Omit<RepoDriftBaseline, "minhashIndex"> {
   minhashIndex: Array<Omit<MinhashEntry, "signature"> & { signature: number[] }>;
 }
 
-function projectHash(rootDir: string): string {
+export function projectHash(rootDir: string): string {
   return createHash("sha256").update(rootDir).digest("hex").slice(0, 16);
 }
 

--- a/src/core/findings-cache.ts
+++ b/src/core/findings-cache.ts
@@ -21,14 +21,11 @@ import { homedir } from "os";
 import { createHash } from "crypto";
 import { join } from "path";
 import type { Finding, SourceFile, SupportedLanguage } from "./types.js";
+import { projectHash } from "./baseline.js";
 
 const ROOT_DIR = join(homedir(), ".vibedrift", "findings-cache");
 const TTL_MS = 30 * 24 * 3600 * 1000;
 const MAX_CACHE_BYTES = 500 * 1024 * 1024;
-
-function projectHash(rootDir: string): string {
-  return createHash("sha256").update(rootDir).digest("hex").slice(0, 16);
-}
 
 function projectDir(rootDir: string): string {
   return join(ROOT_DIR, projectHash(rootDir));

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { createHash } from "crypto";
 import { join } from "path";
 import type { CategoryScores, Finding, DriftFindingReport } from "./types.js";
+import { projectHash } from "./baseline.js";
 
 /**
  * Per-project scan history.
@@ -35,10 +36,6 @@ import type { CategoryScores, Finding, DriftFindingReport } from "./types.js";
 const ROOT_DIR = join(homedir(), ".vibedrift", "scans");
 const HISTORY_SCHEMA_VERSION = 3;
 const HISTORY_RETENTION = 10;
-
-function projectHash(rootDir: string): string {
-  return createHash("sha256").update(rootDir).digest("hex").slice(0, 16);
-}
 
 function projectDir(rootDir: string): string {
   return join(ROOT_DIR, projectHash(rootDir));

--- a/src/drift/async-consistency.ts
+++ b/src/drift/async-consistency.ts
@@ -17,7 +17,7 @@
  */
 
 import type { DriftDetector, DriftContext, DriftFinding, DriftFile, Evidence } from "./types.js";
-import { buildDirectoryScopedVote, buildFileAgeMap, buildPatternDistribution, entropyGate, noConventionFinding, pickIntentHint } from "./utils.js";
+import { buildDirectoryScopedVote, buildFileAgeMap, buildPatternDistribution, entropyGate, isAnalyzableSource, noConventionFinding, pickIntentHint } from "./utils.js";
 import { asyncCounts, classifyAsyncStyle, ASYNC_STYLE_NAMES as STYLE_NAMES, type AsyncStyle } from "./async-style.js";
 
 interface FileAsyncProfile {
@@ -28,15 +28,9 @@ interface FileAsyncProfile {
   evidence: Evidence[];
 }
 
-function isSourceFile(path: string): boolean {
-  if (/(?:test|spec|mock|fixture|__test__|__mocks__|\.test\.|\.spec\.)/i.test(path)) return false;
-  if (/(?:\.config\.|\.d\.ts$|node_modules|dist\/|build\/)/i.test(path)) return false;
-  return true;
-}
-
 function analyzeAsync(file: DriftFile): FileAsyncProfile | null {
   if (!file.language || !["javascript", "typescript"].includes(file.language)) return null;
-  if (!isSourceFile(file.path)) return null;
+  if (!isAnalyzableSource(file.path)) return null;
 
   // Counting + classification live in the shared async-style module so the
   // detector and the MCP validate_change tool agree on the vocabulary. Evidence

--- a/src/drift/import-consistency.ts
+++ b/src/drift/import-consistency.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DriftDetector, DriftContext, DriftFinding, DriftFile, Evidence } from "./types.js";
-import { buildDirectoryScopedVote, buildFileAgeMap, buildPatternDistribution, entropyGate, noConventionFinding, pickIntentHint } from "./utils.js";
+import { buildDirectoryScopedVote, buildFileAgeMap, buildPatternDistribution, entropyGate, isAnalyzableSource, noConventionFinding, pickIntentHint } from "./utils.js";
 
 type ImportPathStyle = "relative" | "alias";
 
@@ -25,15 +25,9 @@ interface FileImportProfile {
   evidence: Evidence[];
 }
 
-function isSourceFile(path: string): boolean {
-  if (/(?:test|spec|mock|fixture|__test__|__mocks__|\.test\.|\.spec\.)/i.test(path)) return false;
-  if (/(?:\.config\.|\.d\.ts$|node_modules|dist\/|build\/)/i.test(path)) return false;
-  return true;
-}
-
 function analyzeImports(file: DriftFile): FileImportProfile | null {
   if (!file.language || !["javascript", "typescript"].includes(file.language)) return null;
-  if (!isSourceFile(file.path)) return null;
+  if (!isAnalyzableSource(file.path)) return null;
 
   const lines = file.content.split("\n");
   let relativeCount = 0;

--- a/src/drift/return-shape-consistency.ts
+++ b/src/drift/return-shape-consistency.ts
@@ -35,6 +35,7 @@ import type {
 import {
   buildPatternDistribution,
   collectDeviatingFiles,
+  directoryOf,
   isAnalyzableSource,
   pickDominantFiles,
   pickIntentHint,
@@ -194,12 +195,6 @@ function classifyShape(body: string): ReturnShape | null {
 export function classifyReturnShapeLabel(body: string): string | null {
   const shape = classifyShape(body);
   return shape ? SHAPE_NAMES[shape] : null;
-}
-
-/** Directory of a relative path — "src/handlers/user.ts" → "src/handlers". */
-function directoryOf(filePath: string): string {
-  const idx = filePath.lastIndexOf("/");
-  return idx === -1 ? "." : filePath.slice(0, idx);
 }
 
 /**

--- a/src/drift/utils.ts
+++ b/src/drift/utils.ts
@@ -26,7 +26,10 @@
  */
 
 import { getLineNumber } from "../utils/text.js";
+import { shannonEntropy } from "../utils/math.js";
 import type { DeviatingFile, DriftCategory, DriftContext, DriftFinding, Evidence } from "./types.js";
+
+export { shannonEntropy };
 
 export function getLineContent(content: string, lineNum: number): string {
   return (content.split("\n")[lineNum - 1] ?? "").trim();
@@ -128,22 +131,6 @@ export function isAnalyzableSource(path: string): boolean {
 }
 
 // ─── Shannon entropy gate ────────────────────────────────────────────
-
-/**
- * Shannon entropy of a discrete distribution given raw counts.
- * Range: [0, log₂(k)] where k is the number of non-zero categories.
- */
-export function shannonEntropy(counts: number[]): number {
-  const total = counts.reduce((a, b) => a + b, 0);
-  if (total === 0) return 0;
-  let H = 0;
-  for (const c of counts) {
-    if (c === 0) continue;
-    const p = c / total;
-    H -= p * Math.log2(p);
-  }
-  return H;
-}
 
 export interface EntropyGateResult {
   /** "no_convention" if the distribution is too uniform to declare a winner;

--- a/src/ml-client/coherence.ts
+++ b/src/ml-client/coherence.ts
@@ -41,7 +41,7 @@ interface CoherencePayload {
   intent_lies: { name: string; explanation: string }[];
 }
 
-function grade(score: number, max: number): string {
+export function grade(score: number, max: number): string {
   const pct = max > 0 ? (score / max) * 100 : 0;
   if (pct >= 90) return "A";
   if (pct >= 75) return "B";

--- a/src/ml-client/summarize.ts
+++ b/src/ml-client/summarize.ts
@@ -1,4 +1,5 @@
 import type { ScanResult } from "../core/types.js";
+import { grade } from "./coherence.js";
 
 const TIMEOUT_MS = 30_000;
 
@@ -20,7 +21,7 @@ export async function fetchAiSummary(
     project: result.context.rootDir.split("/").pop() ?? "project",
     score: result.compositeScore,
     maxScore: result.maxCompositeScore,
-    grade: getGrade(result.compositeScore, result.maxCompositeScore),
+    grade: grade(result.compositeScore, result.maxCompositeScore),
     fileCount: result.context.files.length,
     totalLines: result.context.totalLines,
     languages: [...result.context.languageBreakdown.entries()]
@@ -80,11 +81,4 @@ export async function fetchAiSummary(
   }
 }
 
-function getGrade(score: number, max: number): string {
-  const pct = max > 0 ? (score / max) * 100 : 0;
-  if (pct >= 90) return "A";
-  if (pct >= 75) return "B";
-  if (pct >= 50) return "C";
-  if (pct >= 25) return "D";
-  return "F";
-}
+

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,15 @@
+/**
+ * Shannon entropy of a discrete distribution given raw counts.
+ * Range: [0, log₂(k)] where k is the number of non-zero categories.
+ */
+export function shannonEntropy(counts: number[]): number {
+  const total = counts.reduce((a, b) => a + b, 0);
+  if (total === 0) return 0;
+  let H = 0;
+  for (const c of counts) {
+    if (c === 0) continue;
+    const p = c / total;
+    H -= p * Math.log2(p);
+  }
+  return H;
+}


### PR DESCRIPTION
## Summary

VibeDrift's own self-scan flagged 6 `codedna-fingerprint` findings — exact semantic duplicates of utility functions copy-pasted across multiple files. This PR consolidates each into a single source of truth.

| Function | Was duplicated in | Now lives in |
|----------|-------------------|-------------|
| `shannonEntropy()` | `analyzers/naming.ts`, `drift/utils.ts` | `src/utils/math.ts` (re-exported from drift/utils) |
| `projectHash()` | `core/baseline.ts`, `core/findings-cache.ts`, `core/history.ts` | `core/baseline.ts` (now exported) |
| `isSourceFile()` | `drift/async-consistency.ts`, `drift/import-consistency.ts` | Deleted — both use `isAnalyzableSource` from `drift/utils.ts` |
| `directoryOf()` | `drift/return-shape-consistency.ts`, `drift/utils.ts` | `drift/utils.ts` (already exported) |
| `grade()`/`getGrade()` | `ml-client/coherence.ts`, `ml-client/summarize.ts` | `ml-client/coherence.ts` (now exported) |

**Not touched:**
- `export-consistency.ts` has its own `isSourceFile` with a different regex (extra `index.` exclusion)
- `contentHash()` in `embedding-index.ts` — same algorithm but different semantic purpose
- `projectDir()` in findings-cache/history — each uses a different `ROOT_DIR` constant

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Test
- [x] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Self-scan finding — no tracked issue.
