### PR TITLE
fix(core): normalize relativePath to forward slashes on Windows

### DIFF
--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -295,7 +295,7 @@ async function snapshotMtimes(rootDir: string): Promise<Map<string, number>> {
     }
     for (const entry of entries) {
       const full = join(dir, entry);
-      const rel = relative(rootDir, full);
+      const rel = relative(rootDir, full).replace(/\\/g, "/");
       if (shouldIgnore(rel)) continue;
       let info;
       try {

--- a/src/core/discovery.ts
+++ b/src/core/discovery.ts
@@ -85,7 +85,7 @@ export async function discoverFiles(rootDir: string): Promise<{ files: SourceFil
       }
 
       const fullPath = join(dir, entry.name);
-      const relPath = relative(rootDir, fullPath);
+      const relPath = relative(rootDir, fullPath).replace(/\\/g, "/");
 
       if (entry.isDirectory()) {
         if (SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;

--- a/src/core/import-graph.ts
+++ b/src/core/import-graph.ts
@@ -163,10 +163,10 @@ export function sourceLookupKey(source: string): string {
 
 /** Lookup key derived from a file's path, used to match against import sources. */
 export function fileBasename(filePath: string): string {
-  const file = filePath.split("/").pop() ?? filePath;
+  const file = filePath.split(/[/\\]/).pop() ?? filePath;
   const noExt = file.replace(/\.(?:ts|tsx|js|jsx|mjs|cjs)$/, "");
   if (noExt === "index") {
-    const parts = filePath.split("/");
+    const parts = filePath.split(/[/\\]/);
     return parts.length >= 2 ? parts[parts.length - 2] : noExt;
   }
   return noExt;

--- a/src/drift/architectural-contradiction.ts
+++ b/src/drift/architectural-contradiction.ts
@@ -51,7 +51,7 @@ function detectDataAccess(file: DriftFile): { pattern: DataAccessPattern; eviden
 
   // Raw SQL
   const sqlEvidence = extractEvidence(c, /(?:SELECT|INSERT|UPDATE|DELETE)\s+(?:FROM|INTO|SET|\*)\b/gi);
-  if (sqlEvidence.length > 0 && !isRepoFile(file.path)) {
+  if (sqlEvidence.length > 0 && !isRepoFile(file.relativePath)) {
     results.push({ pattern: "raw_sql", evidence: sqlEvidence });
   }
 
@@ -62,7 +62,7 @@ function detectDataAccess(file: DriftFile): { pattern: DataAccessPattern; eviden
 
   // Direct DB
   const dbEvidence = extractEvidence(c, /\b(?:db|pool|client)\.\s*(?:Query|Exec|QueryRow|query|execute|raw)\s*\(/g);
-  if (dbEvidence.length > 0 && !isRepoFile(file.path)) {
+  if (dbEvidence.length > 0 && !isRepoFile(file.relativePath)) {
     results.push({ pattern: "direct_db", evidence: dbEvidence });
   }
 
@@ -157,7 +157,7 @@ function detectDIPattern(file: DriftFile): { pattern: DIPattern; evidence: Evide
 
 function buildProfile(file: DriftFile): FileArchProfile | null {
   if (!file.language) return null;
-  if (!isAnalyzableSource(file.path)) return null;
+  if (!isAnalyzableSource(file.relativePath)) return null;
 
   const dataAccess = detectDataAccess(file);
   const errorHandling = detectErrorHandling(file);
@@ -167,7 +167,7 @@ function buildProfile(file: DriftFile): FileArchProfile | null {
   // Only include files that have meaningful patterns
   if (dataAccess.length === 0 && errorHandling.length === 0 && config.length === 0) return null;
 
-  return { file: file.path, language: file.language, dataAccess, errorHandling, config, di };
+  return { file: file.relativePath, language: file.language, dataAccess, errorHandling, config, di };
 }
 
 /**
@@ -225,7 +225,7 @@ const DATA_ACCESS_PRIORITY: DataAccessPattern[] = ["raw_sql", "direct_db", "http
  * stays in lockstep with this detector's vocabulary.
  */
 export function classifyDataAccessLabel(content: string, path: string): string | null {
-  const hits = detectDataAccess({ content, path, language: "typescript" } as DriftFile);
+  const hits = detectDataAccess({ content, relativePath: path, language: "typescript" } as DriftFile);
   if (hits.length === 0) return null;
   const primary = hits
     .slice()

--- a/src/drift/async-consistency.ts
+++ b/src/drift/async-consistency.ts
@@ -30,7 +30,7 @@ interface FileAsyncProfile {
 
 function analyzeAsync(file: DriftFile): FileAsyncProfile | null {
   if (!file.language || !["javascript", "typescript"].includes(file.language)) return null;
-  if (!isAnalyzableSource(file.path)) return null;
+  if (!isAnalyzableSource(file.relativePath)) return null;
 
   // Counting + classification live in the shared async-style module so the
   // detector and the MCP validate_change tool agree on the vocabulary. Evidence
@@ -50,7 +50,7 @@ function analyzeAsync(file: DriftFile): FileAsyncProfile | null {
     if (isAwait || isThen) evidence.push({ line: i + 1, code: t.slice(0, 100) });
   }
 
-  return { file: file.path, style, awaitCount, thenCount, evidence };
+  return { file: file.relativePath, style, awaitCount, thenCount, evidence };
 }
 
 export const asyncConsistency: DriftDetector = {

--- a/src/drift/comment-style-consistency.ts
+++ b/src/drift/comment-style-consistency.ts
@@ -72,7 +72,7 @@ export const commentStyleConsistency: DriftDetector = {
     let analyzed = 0;
 
     for (const file of ctx.files) {
-      if (!isAnalyzableSource(file.path)) continue;
+      if (!isAnalyzableSource(file.relativePath)) continue;
       if (!file.language) continue;
       // Python/Ruby/etc use #; JS/TS/Go/Rust use //. To avoid false drift
       // from language mix, restrict this check to JS/TS projects where
@@ -82,8 +82,8 @@ export const commentStyleConsistency: DriftDetector = {
       analyzed++;
       const style = dominantStyle(file);
       const list = byStyle.get(style);
-      if (list) list.push(file.path);
-      else byStyle.set(style, [file.path]);
+      if (list) list.push(file.relativePath);
+      else byStyle.set(style, [file.relativePath]);
     }
 
     if (analyzed < 5) return [];

--- a/src/drift/commit-archaeology.ts
+++ b/src/drift/commit-archaeology.ts
@@ -112,7 +112,7 @@ export const commitArchaeology: DriftDetector = {
     let filesWithHistory = 0;
     let filesWithGit = 0;
     for (const f of ctx.files) {
-      if (!isAnalyzableSource(f.path)) continue;
+      if (!isAnalyzableSource(f.relativePath)) continue;
       if (!f.git) continue;
       filesWithGit++;
       if (f.git.commitCountTotal >= 2) filesWithHistory++;
@@ -137,7 +137,7 @@ export const commitArchaeology: DriftDetector = {
     // false findings.
     const profilesByDir = new Map<string, BurstProfile[]>();
     for (const p of profiles) {
-      const dir = directoryOf(p.file.path);
+      const dir = directoryOf(p.file.relativePath);
       const list = profilesByDir.get(dir) ?? [];
       list.push(p);
       profilesByDir.set(dir, list);
@@ -158,7 +158,7 @@ export const commitArchaeology: DriftDetector = {
       const deviating: DeviatingFile[] = burstyInDir.map((p) => {
         const evidence: Evidence[] = [{ line: 1, code: p.reasons.join(" · ") }];
         return {
-          path: p.file.path,
+          path: p.file.relativePath,
           detectedPattern: `burst authorship (score ${p.score}/3)`,
           evidence,
         };
@@ -180,7 +180,7 @@ export const commitArchaeology: DriftDetector = {
         deviatingFiles: deviating,
         dominantFiles: group
           .filter((p) => p.score < BURST_SCORE_THRESHOLD)
-          .map((p) => p.file.path)
+          .map((p) => p.file.relativePath)
           .sort()
           .slice(0, 3),
         recommendation: `Burst-authored files in ${dir}/ deviate from the directory's normal commit shape. Review for AI-generated code that was never touched by a second reviewer.`,

--- a/src/drift/convention-oscillation.ts
+++ b/src/drift/convention-oscillation.ts
@@ -101,7 +101,7 @@ function extractSymbols(file: DriftFile): SymbolInfo[] {
         const conv = classifyName(name);
         if (!conv) continue;
         if (isIdiomatic(name, conv, type, file.language)) continue;
-        symbols.push({ name, convention: conv, symbolType: type, file: file.path, line: i + 1 });
+        symbols.push({ name, convention: conv, symbolType: type, file: file.relativePath, line: i + 1 });
       }
     }
   }
@@ -215,13 +215,13 @@ function analyzeFileNaming(ctx: DriftContext): DriftFinding[] {
     patterns: { pattern: NamingConvention; evidence: Evidence[] }[];
   }[] = [];
   for (const file of ctx.files) {
-    const classified = classifyBaseName(file.path);
+    const classified = classifyBaseName(file.relativePath);
     if (!classified) continue;
     // Empty evidence: filename drift is a file-level property, not a
     // line-level one. A synthetic "line 1" here renders as a misleading
     // code snippet in the report.
     profiles.push({
-      file: file.path,
+      file: file.relativePath,
       patterns: [{ pattern: classified.convention, evidence: [] }],
     });
   }

--- a/src/drift/export-consistency.ts
+++ b/src/drift/export-consistency.ts
@@ -35,7 +35,7 @@ function isSourceFile(path: string): boolean {
 
 function analyzeExports(file: DriftFile): FileExportProfile | null {
   if (!file.language || !["javascript", "typescript"].includes(file.language)) return null;
-  if (!isSourceFile(file.path)) return null;
+  if (!isSourceFile(file.relativePath)) return null;
 
   const lines = file.content.split("\n");
   let hasDefaultExport = false;
@@ -59,7 +59,7 @@ function analyzeExports(file: DriftFile): FileExportProfile | null {
 
   if (!hasDefaultExport && !hasNamedExport) return null;
   const style: ExportStyle = hasDefaultExport ? "default_export" : "named_only";
-  return { file: file.path, style, evidence };
+  return { file: file.relativePath, style, evidence };
 }
 
 const STYLE_NAMES: Record<ExportStyle, string> = {

--- a/src/drift/import-consistency.ts
+++ b/src/drift/import-consistency.ts
@@ -27,7 +27,7 @@ interface FileImportProfile {
 
 function analyzeImports(file: DriftFile): FileImportProfile | null {
   if (!file.language || !["javascript", "typescript"].includes(file.language)) return null;
-  if (!isAnalyzableSource(file.path)) return null;
+  if (!isAnalyzableSource(file.relativePath)) return null;
 
   const lines = file.content.split("\n");
   let relativeCount = 0;
@@ -68,7 +68,7 @@ function analyzeImports(file: DriftFile): FileImportProfile | null {
     relativeCount === 0 ? "alias" :
     relativeCount >= aliasCount ? "relative" : "alias";
 
-  return { file: file.path, pathStyle, evidence };
+  return { file: file.relativePath, pathStyle, evidence };
 }
 
 const PATH_STYLE_NAMES: Record<ImportPathStyle, string> = {

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -40,7 +40,7 @@ export function createDriftDetectors(): DriftDetector[] {
 export function buildDriftContext(ctx: AnalysisContext): DriftContext {
   return {
     files: ctx.files.map((f) => ({
-      path: f.relativePath,
+      relativePath: f.relativePath,
       language: f.language,
       content: f.content,
       lineCount: f.lineCount,

--- a/src/drift/logging-consistency.ts
+++ b/src/drift/logging-consistency.ts
@@ -99,7 +99,7 @@ interface FileLoggerProfile {
 
 function detectFamilies(file: DriftFile): FileLoggerProfile | null {
   if (!file.language) return null;
-  if (!isAnalyzableSource(file.path)) return null;
+  if (!isAnalyzableSource(file.relativePath)) return null;
 
   const matches: { pattern: LoggerFamily; evidence: Evidence[] }[] = [];
   for (const family of Object.keys(FAMILY_PATTERNS) as LoggerFamily[]) {
@@ -107,7 +107,7 @@ function detectFamilies(file: DriftFile): FileLoggerProfile | null {
     if (ev.length > 0) matches.push({ pattern: family, evidence: ev });
   }
   if (matches.length === 0) return null;
-  return { file: file.path, patterns: matches };
+  return { file: file.relativePath, patterns: matches };
 }
 
 export const loggingConsistency: DriftDetector = {

--- a/src/drift/phantom-scaffolding.ts
+++ b/src/drift/phantom-scaffolding.ts
@@ -55,7 +55,7 @@ function extractRouteRegistrations(file: DriftFile): RouteRegistration[] {
     // Go Echo: .GET("/path", handler) or .POST("/path", handler.Method)
     const echoMatch = line.match(/\.\s*(GET|POST|PUT|PATCH|DELETE)\s*\(\s*"([^"]+)"\s*,\s*(\w+(?:\.\w+)?)/);
     if (echoMatch) {
-      routes.push({ method: echoMatch[1], path: echoMatch[2], handlerName: echoMatch[3].split(".").pop()!, file: file.path, line: i + 1 });
+      routes.push({ method: echoMatch[1], path: echoMatch[2], handlerName: echoMatch[3].split(".").pop()!, file: file.relativePath, line: i + 1 });
       continue;
     }
 
@@ -63,14 +63,14 @@ function extractRouteRegistrations(file: DriftFile): RouteRegistration[] {
     const gorillaMatch = line.match(/HandleFunc\s*\(\s*"([^"]+)"\s*,\s*(\w+(?:\.\w+)?)\)/);
     if (gorillaMatch) {
       const methodMatch = lines.slice(i, i + 2).join("").match(/Methods\s*\(\s*"(\w+)"/);
-      routes.push({ method: methodMatch?.[1] ?? "ANY", path: gorillaMatch[1], handlerName: gorillaMatch[2].split(".").pop()!, file: file.path, line: i + 1 });
+      routes.push({ method: methodMatch?.[1] ?? "ANY", path: gorillaMatch[1], handlerName: gorillaMatch[2].split(".").pop()!, file: file.relativePath, line: i + 1 });
       continue;
     }
 
     // JS/TS Express: app.get('/path', handler)
     const expressMatch = line.match(/\.\s*(get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*(\w+))?/);
     if (expressMatch && expressMatch[3]) {
-      routes.push({ method: expressMatch[1].toUpperCase(), path: expressMatch[2], handlerName: expressMatch[3], file: file.path, line: i + 1 });
+      routes.push({ method: expressMatch[1].toUpperCase(), path: expressMatch[2], handlerName: expressMatch[3], file: file.relativePath, line: i + 1 });
       continue;
     }
 
@@ -80,7 +80,7 @@ function extractRouteRegistrations(file: DriftFile): RouteRegistration[] {
       const nextDef = lines.slice(i + 1, i + 5).find((l) => /^(?:async\s+)?def\s+(\w+)/.test(l.trim()));
       const handlerName = nextDef?.match(/def\s+(\w+)/)?.[1] ?? "";
       if (handlerName) {
-        routes.push({ method: pyMatch[1].toUpperCase(), path: pyMatch[2], handlerName, file: file.path, line: i + 1 });
+        routes.push({ method: pyMatch[1].toUpperCase(), path: pyMatch[2], handlerName, file: file.relativePath, line: i + 1 });
       }
     }
   }
@@ -98,8 +98,8 @@ export const phantomScaffolding: DriftDetector = {
     const jsFiles: SourceFile[] = ctx.files
       .filter((f) => f.language === "javascript" || f.language === "typescript")
       .map((f) => ({
-        path: f.path,
-        relativePath: f.path,
+        path: f.relativePath,
+        relativePath: f.relativePath,
         language: f.language as "javascript" | "typescript",
         content: f.content,
         lineCount: f.lineCount,

--- a/src/drift/pivot-detector.ts
+++ b/src/drift/pivot-detector.ts
@@ -50,7 +50,7 @@ function gatherFiles(
   // Dominant files keep their dominant label; deviators bring their own.
   const ageByFile = new Map<string, number | null>();
   for (const f of ctx.files) {
-    ageByFile.set(f.path, f.git?.lastModifiedDaysAgo ?? null);
+    ageByFile.set(f.relativePath, f.git?.lastModifiedDaysAgo ?? null);
   }
 
   const buckets: FileBucket[] = [];

--- a/src/drift/return-shape-consistency.ts
+++ b/src/drift/return-shape-consistency.ts
@@ -114,7 +114,7 @@ function extractFunctionBodies(file: DriftFile): FunctionExtraction[] {
     const start = starts[i];
     const end = i + 1 < starts.length ? starts[i + 1].index : content.length;
     out.push({
-      file: file.path,
+      file: file.relativePath,
       name: start.name,
       line: start.line,
       bodySlice: content.slice(start.index, end),
@@ -254,7 +254,7 @@ export const returnShapeConsistency: DriftDetector = {
 
     for (const file of ctx.files) {
       if (!file.language) continue;
-      if (!isAnalyzableSource(file.path)) continue;
+      if (!isAnalyzableSource(file.relativePath)) continue;
       // Only languages whose error-handling idioms we understand well.
       if (!["javascript", "typescript", "python", "go", "rust"].includes(file.language)) continue;
 
@@ -269,8 +269,8 @@ export const returnShapeConsistency: DriftDetector = {
       // Only keep functions that actually matched a shape, aligned with shapes[]
       const matched = fns.filter((fn) => classifyShape(fn.bodySlice) !== null);
       if (matched.length > 0) {
-        extractionsByFile.set(file.path, matched);
-        shapesByFile.set(file.path, shapes);
+        extractionsByFile.set(file.relativePath, matched);
+        shapesByFile.set(file.relativePath, shapes);
       }
     }
 

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -136,7 +136,7 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
     const pyRateLimit = /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
     const pyValidation = /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
 
-    index.set(file.path, {
+    index.set(file.relativePath, {
       hasAuth: jsAuth || goAuth || pyAuth,
       hasValidation: jsValidation || goValidation || pyValidation,
       hasRateLimit: jsRateLimit || goRateLimit || pyRateLimit,
@@ -172,7 +172,7 @@ function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<strin
   const lines = file.content.split("\n");
   const echoPattern = /\.\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/;
   const gorillaPattern = /HandleFunc\s*\(\s*"([^"]+)".*\.Methods\s*\(\s*"(\w+)"/;
-  const fileMiddleware = fileMw.get(file.path);
+  const fileMiddleware = fileMw.get(file.relativePath);
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -191,7 +191,7 @@ function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<strin
     const perRate = /[Rr]ate[Ll]imit|[Tt]hrottle/.test(context + handlerContent);
 
     routes.push({
-      method, path, file: file.path, line: i + 1,
+      method, path, file: file.relativePath, line: i + 1,
       hasAuth: inheritedAuth(perAuth, fileMiddleware),
       hasValidation: inheritedValidation(perVal, fileMiddleware),
       hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
@@ -203,7 +203,7 @@ function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<strin
 function extractJsRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
   const lines = file.content.split("\n");
   const expressPattern = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
-  const fileMiddleware = fileMw.get(file.path);
+  const fileMiddleware = fileMw.get(file.relativePath);
 
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(expressPattern);
@@ -217,7 +217,7 @@ function extractJsRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<strin
     const perRate = /rateLimit|throttle|limiter/.test(context);
 
     routes.push({
-      method, path, file: file.path, line: i + 1,
+      method, path, file: file.relativePath, line: i + 1,
       hasAuth: inheritedAuth(perAuth, fileMiddleware),
       hasValidation: inheritedValidation(perVal, fileMiddleware),
       hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
@@ -229,7 +229,7 @@ function extractJsRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<strin
 function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
   const lines = file.content.split("\n");
   const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
-  const fileMiddleware = fileMw.get(file.path);
+  const fileMiddleware = fileMw.get(file.relativePath);
 
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(routePattern);
@@ -243,7 +243,7 @@ function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<s
     const perRate = /rate_limit|throttle|limiter/.test(context);
 
     routes.push({
-      method, path, file: file.path, line: i + 1,
+      method, path, file: file.relativePath, line: i + 1,
       hasAuth: inheritedAuth(perAuth, fileMiddleware),
       hasValidation: inheritedValidation(perVal, fileMiddleware),
       hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),

--- a/src/drift/semantic-duplication.ts
+++ b/src/drift/semantic-duplication.ts
@@ -50,11 +50,11 @@ function indexFunctions(files: DriftFile[]): IndexedFunction[] {
   const out: IndexedFunction[] = [];
   for (const file of files) {
     if (!file.language) continue;
-    if (!isAnalyzableSource(file.path)) continue;
+    if (!isAnalyzableSource(file.relativePath)) continue;
 
     const adapted = {
-      path: file.path,
-      relativePath: file.path,
+      path: file.relativePath,
+      relativePath: file.relativePath,
       language: file.language as ExtractedFunction["language"],
       content: file.content,
       lineCount: file.lineCount,

--- a/src/drift/state-management-consistency.ts
+++ b/src/drift/state-management-consistency.ts
@@ -63,7 +63,7 @@ interface StateProfile {
 function analyze(file: DriftFile): StateProfile | null {
   if (!file.language) return null;
   if (file.language !== "javascript" && file.language !== "typescript") return null;
-  if (!isAnalyzableSource(file.path)) return null;
+  if (!isAnalyzableSource(file.relativePath)) return null;
 
   const lines = file.content.split("\n");
   const hits = new Map<StateStrategy, Evidence[]>();
@@ -80,7 +80,7 @@ function analyze(file: DriftFile): StateProfile | null {
 
   if (hits.size === 0) return null;
   const patterns = [...hits.entries()].map(([pattern, evidence]) => ({ pattern, evidence }));
-  return { file: file.path, patterns };
+  return { file: file.relativePath, patterns };
 }
 
 export const stateManagementConsistency: DriftDetector = {

--- a/src/drift/test-structure-consistency.ts
+++ b/src/drift/test-structure-consistency.ts
@@ -62,14 +62,14 @@ function buildTestProfiles(files: DriftFile[], classifier: (c: string) => string
   for (const file of files) {
     if (!file.language) continue;
     if (file.language !== "javascript" && file.language !== "typescript") continue;
-    if (!isTestFile(file.path)) continue;
+    if (!isTestFile(file.relativePath)) continue;
     const family = classifier(file.content);
     if (!family) continue;
     // Empty evidence: framework / mock-style classification is a file-level
     // property. A synthetic line-1 entry would render as a misleading code
     // snippet in the report.
     profiles.push({
-      file: file.path,
+      file: file.relativePath,
       patterns: [{ pattern: family, evidence: [] }],
     });
   }

--- a/src/drift/types.ts
+++ b/src/drift/types.ts
@@ -54,7 +54,7 @@ export interface DriftContext {
 }
 
 export interface DriftFile {
-  path: string;
+  relativePath: string;
   language: string | null;
   content: string;
   lineCount: number;

--- a/src/drift/utils.ts
+++ b/src/drift/utils.ts
@@ -265,7 +265,7 @@ export function buildFileAgeMap(ctx: DriftContext): Map<string, number> | undefi
   if (!ctx.hasGitMetadata) return undefined;
   const m = new Map<string, number>();
   for (const f of ctx.files) {
-    if (f.git) m.set(f.path, f.git.lastModifiedDaysAgo);
+    if (f.git) m.set(f.relativePath, f.git.lastModifiedDaysAgo);
   }
   return m.size > 0 ? m : undefined;
 }

--- a/src/tools-core/tools/check-file-drift.ts
+++ b/src/tools-core/tools/check-file-drift.ts
@@ -73,7 +73,7 @@ export async function run({
   const { baseline, status } = await getBaseline(rootDir);
   // Relativize against the baseline's root so it matches the stored ctx paths,
   // whether the caller passed an absolute path or one relative to rootDir.
-  const rel = relative(rootDir, resolve(rootDir, filePath));
+  const rel = relative(rootDir, resolve(rootDir, filePath)).replace(/\\/g, "/");
   if (!baseline) {
     return noBaselineData({ file: rel, fits: null, deviations: [], more: 0 }) as unknown as CheckFileDriftOut;
   }

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -235,7 +235,7 @@ export async function run({
       confidence: "low",
     }) as unknown as ValidateChangeOut;
   }
-  const relTarget = relative(rootDir, resolve(rootDir, targetPath));
+  const relTarget = relative(rootDir, resolve(rootDir, targetPath)).replace(/\\/g, "/");
   const out: ValidateChangeOut = { status, ...validateChange(baseline, relTarget, body) };
 
   if (!deep) return out;

--- a/test/unit/core/import-graph.test.ts
+++ b/test/unit/core/import-graph.test.ts
@@ -67,3 +67,48 @@ describe("parseExports — single-name re-export trimming", () => {
     expect(names).toContain("internalName");
   });
 });
+
+describe("buildImportGraph — multi-component relative paths", () => {
+  it("resolves incoming imports for files with directory-separated paths", async () => {
+    const { buildImportGraph } = await import("../../../src/core/import-graph.js");
+
+    const indexFile = makeFile(
+      `import { complexityAnalyzer } from "./complexity.js";\nimport { namingAnalyzer } from "./naming.js";\n`,
+      "src/analyzers/index.ts",
+    );
+    const complexityFile = makeFile(
+      `export const complexityAnalyzer = {};\n`,
+      "src/analyzers/complexity.ts",
+    );
+    const namingFile = makeFile(
+      `export const namingAnalyzer = {};\n`,
+      "src/analyzers/naming.ts",
+    );
+
+    const graph = buildImportGraph([indexFile, complexityFile, namingFile]);
+
+    // complexity.ts and naming.ts should each have 1 incoming import from index.ts
+    expect(graph.incomingCount.get("src/analyzers/complexity.ts")).toBe(1);
+    expect(graph.incomingCount.get("src/analyzers/naming.ts")).toBe(1);
+    // index.ts has no one importing it
+    expect(graph.incomingCount.get("src/analyzers/index.ts")).toBe(0);
+  });
+
+  it("resolves barrel index files by parent directory name", async () => {
+    const { buildImportGraph } = await import("../../../src/core/import-graph.js");
+
+    const consumer = makeFile(
+      `import { createRegistry } from "../../analyzers/index.js";\n`,
+      "src/cli/commands/scan.ts",
+    );
+    const barrel = makeFile(
+      `export function createRegistry() {}\n`,
+      "src/analyzers/index.ts",
+    );
+
+    const graph = buildImportGraph([consumer, barrel]);
+
+    // index.ts should be resolved via its parent dir name "analyzers"
+    expect(graph.incomingCount.get("src/analyzers/index.ts")).toBe(1);
+  });
+});

--- a/test/unit/core/import-graph.test.ts
+++ b/test/unit/core/import-graph.test.ts
@@ -112,3 +112,36 @@ describe("buildImportGraph — multi-component relative paths", () => {
     expect(graph.incomingCount.get("src/analyzers/index.ts")).toBe(1);
   });
 });
+
+describe("fileBasename — backslash path handling (Windows regression)", () => {
+  it("resolves basename from a backslash-separated path", async () => {
+    const { fileBasename } = await import("../../../src/core/import-graph.js");
+
+    // On Windows, path.relative() produces backslash paths. fileBasename must
+    // handle both separators so the import graph works regardless of OS.
+    expect(fileBasename("src\\analyzers\\complexity.ts")).toBe("complexity");
+    expect(fileBasename("src\\analyzers\\index.ts")).toBe("analyzers");
+    expect(fileBasename("src/analyzers/complexity.ts")).toBe("complexity");
+    expect(fileBasename("src/analyzers/index.ts")).toBe("analyzers");
+  });
+
+  it("resolves incomingCount even when relativePaths use backslashes", async () => {
+    const { buildImportGraph } = await import("../../../src/core/import-graph.js");
+
+    // Simulate Windows: relativePath has backslashes, but import sources in
+    // code always use forward slashes. The graph must still match them.
+    const indexFile = makeFile(
+      `import { helper } from "./helper.js";\n`,
+      "src\\utils\\index.ts",
+    );
+    const helperFile = makeFile(
+      `export function helper() {}\n`,
+      "src\\utils\\helper.ts",
+    );
+
+    const graph = buildImportGraph([indexFile, helperFile]);
+
+    expect(graph.incomingCount.get("src\\utils\\helper.ts")).toBe(1);
+    expect(graph.incomingCount.get("src\\utils\\index.ts")).toBe(0);
+  });
+});

--- a/test/unit/drift/architectural-contradiction.test.ts
+++ b/test/unit/drift/architectural-contradiction.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("architectural-contradiction detector", () => {

--- a/test/unit/drift/async-consistency.test.ts
+++ b/test/unit/drift/async-consistency.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("async-consistency detector", () => {

--- a/test/unit/drift/comment-style-consistency.test.ts
+++ b/test/unit/drift/comment-style-consistency.test.ts
@@ -4,7 +4,7 @@ import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 
 function makeCtx(files: Partial<DriftFile>[]): DriftContext {
   const fullFiles: DriftFile[] = files.map((f) => ({
-    path: f.path ?? "src/test.ts",
+    relativePath: f.relativePath ?? "src/test.ts",
     language: f.language ?? "typescript",
     content: f.content ?? "",
     lineCount: (f.content ?? "").split("\n").length,
@@ -19,12 +19,12 @@ function makeCtx(files: Partial<DriftFile>[]): DriftContext {
 describe("comment-style-consistency detector", () => {
   it("emits an info finding when JSDoc and plain // coexist across many files", () => {
     const jsdocFiles = Array.from({ length: 4 }, (_, i) => ({
-      path: `src/j${i}.ts`,
+      relativePath: `src/j${i}.ts`,
       language: "typescript" as const,
       content: `/**\n * A documented function.\n * @returns number\n */\nexport function foo${i}() { return ${i}; }\n`,
     }));
     const lineCommentFiles = Array.from({ length: 3 }, (_, i) => ({
-      path: `src/l${i}.ts`,
+      relativePath: `src/l${i}.ts`,
       language: "typescript" as const,
       content: `// does the thing\n// keep going\n// seriously\nexport function bar${i}() { return ${i}; }\n`,
     }));

--- a/test/unit/drift/commit-archaeology.test.ts
+++ b/test/unit/drift/commit-archaeology.test.ts
@@ -8,7 +8,7 @@ function makeFile(
   git: Partial<FileGitMetadata> | null,
 ): DriftFile {
   return {
-    path,
+    relativePath: path,
     language: "typescript",
     content: "// test",
     lineCount: 1,

--- a/test/unit/drift/convention-oscillation.test.ts
+++ b/test/unit/drift/convention-oscillation.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("convention-oscillation detector", () => {

--- a/test/unit/drift/export-consistency.test.ts
+++ b/test/unit/drift/export-consistency.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("export-consistency detector", () => {

--- a/test/unit/drift/import-consistency.test.ts
+++ b/test/unit/drift/import-consistency.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("import-consistency detector", () => {

--- a/test/unit/drift/logging-consistency.test.ts
+++ b/test/unit/drift/logging-consistency.test.ts
@@ -4,7 +4,7 @@ import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 
 function makeCtx(files: Partial<DriftFile>[]): DriftContext {
   const fullFiles: DriftFile[] = files.map((f) => ({
-    path: f.path ?? "src/test.ts",
+    relativePath: f.relativePath ?? "src/test.ts",
     language: f.language ?? "typescript",
     content: f.content ?? "",
     lineCount: (f.content ?? "").split("\n").length,
@@ -19,12 +19,12 @@ function makeCtx(files: Partial<DriftFile>[]): DriftContext {
 describe("logging-consistency detector", () => {
   it("flags the single console.log file in a winston-dominated project", () => {
     const winstonFiles = Array.from({ length: 4 }, (_, i) => ({
-      path: `src/svc${i}.ts`,
+      relativePath: `src/svc${i}.ts`,
       language: "typescript" as const,
       content: `import winston from "winston";\nconst logger = winston.createLogger({});\nlogger.info("started");\n`,
     }));
     const consoleFile = {
-      path: "src/odd.ts",
+      relativePath: "src/odd.ts",
       language: "typescript" as const,
       content: `console.log("hello");\nconsole.error("bad");\n`,
     };
@@ -37,7 +37,7 @@ describe("logging-consistency detector", () => {
 
   it("returns no finding when only console.log is used across the project", () => {
     const files = Array.from({ length: 5 }, (_, i) => ({
-      path: `src/f${i}.ts`,
+      relativePath: `src/f${i}.ts`,
       language: "typescript" as const,
       content: `console.log("hi");\nconsole.error("bye");\n`,
     }));
@@ -50,12 +50,12 @@ describe("logging-consistency detector", () => {
     // anywhere), 1 file uses raw console.* — mirrors the bandcamp repo where
     // createLogger() wraps console.* and NO third-party logger is installed.
     const wrapperFiles = Array.from({ length: 5 }, (_, i) => ({
-      path: `src/svc${i}.ts`,
+      relativePath: `src/svc${i}.ts`,
       language: "typescript" as const,
       content: `import { logger } from "./debug";\nlogger.info("started");\nlogger.warn("careful");\n`,
     }));
     const consoleFile = {
-      path: "src/odd.ts",
+      relativePath: "src/odd.ts",
       language: "typescript" as const,
       content: `console.log("hello");\nconsole.error("bad");\n`,
     };
@@ -69,12 +69,12 @@ describe("logging-consistency detector", () => {
 
   it("still names winston when it is actually present in the code", () => {
     const winstonFiles = Array.from({ length: 5 }, (_, i) => ({
-      path: `src/svc${i}.ts`,
+      relativePath: `src/svc${i}.ts`,
       language: "typescript" as const,
       content: `import winston from "winston";\nconst logger = winston.createLogger({});\nlogger.info("started");\n`,
     }));
     const consoleFile = {
-      path: "src/odd.ts",
+      relativePath: "src/odd.ts",
       language: "typescript" as const,
       content: `console.log("hello");\nconsole.error("bad");\n`,
     };
@@ -89,7 +89,7 @@ describe("logging-consistency detector", () => {
     it("emits divergence when team declares winston but code uses console.log", () => {
       // 5 console.log files. CLAUDE.md declares structured logging.
       const consoleFiles = Array.from({ length: 5 }, (_, i) => ({
-        path: `src/f${i}.ts`,
+        relativePath: `src/f${i}.ts`,
         language: "typescript" as const,
         content: `console.log("hi");\nconsole.error("bye");\n`,
       }));
@@ -114,7 +114,7 @@ describe("logging-consistency detector", () => {
 
     it("no finding when code unanimously matches the declared logger", () => {
       const winstonFiles = Array.from({ length: 5 }, (_, i) => ({
-        path: `src/svc${i}.ts`,
+        relativePath: `src/svc${i}.ts`,
         language: "typescript" as const,
         content: `import winston from "winston";\nlogger.info("hi");\n`,
       }));

--- a/test/unit/drift/phantom-scaffolding.test.ts
+++ b/test/unit/drift/phantom-scaffolding.test.ts
@@ -12,7 +12,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("phantom-scaffolding detector", () => {

--- a/test/unit/drift/pivot-detector.test.ts
+++ b/test/unit/drift/pivot-detector.test.ts
@@ -4,7 +4,7 @@ import type { DriftContext, DriftFile, DriftFinding } from "../../../src/drift/t
 
 function makeFile(path: string, daysAgo: number | null): DriftFile {
   return {
-    path,
+    relativePath: path,
     language: "typescript",
     content: "",
     lineCount: 1,

--- a/test/unit/drift/return-shape-consistency.test.ts
+++ b/test/unit/drift/return-shape-consistency.test.ts
@@ -4,7 +4,7 @@ import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 
 function makeCtx(files: Partial<DriftFile>[]): DriftContext {
   const fullFiles: DriftFile[] = files.map((f) => ({
-    path: f.path ?? "src/test.ts",
+    relativePath: f.relativePath ?? "src/test.ts",
     language: f.language ?? "typescript",
     content: f.content ?? "",
     lineCount: (f.content ?? "").split("\n").length,
@@ -19,7 +19,7 @@ function makeCtx(files: Partial<DriftFile>[]): DriftContext {
 // Sibling helpers in the same dir — reach the MIN_GROUP_SIZE=3 threshold.
 function makeHandlers(entries: { name: string; body: string }[]): DriftFile[] {
   return entries.map((e) => ({
-    path: `src/handlers/${e.name}.ts`,
+    relativePath: `src/handlers/${e.name}.ts`,
     language: "typescript",
     content: `export function ${e.name}() {\n${e.body}\n}\n`,
     lineCount: e.body.split("\n").length + 2,
@@ -95,27 +95,27 @@ describe("return-shape-consistency detector", () => {
     // 4 Go funcs returning (x, err); 1 Go func panicking. Tuple dominates.
     const ctx = makeCtx([
       {
-        path: "handlers/a.go",
+        relativePath: "handlers/a.go",
         language: "go",
         content: `func getA(id string) (User, error) {\n  if id == "" { return nil, err }\n  return user, nil\n}\n`,
       },
       {
-        path: "handlers/b.go",
+        relativePath: "handlers/b.go",
         language: "go",
         content: `func getB(id string) (User, error) {\n  if id == "" { return nil, err }\n  return user, nil\n}\n`,
       },
       {
-        path: "handlers/c.go",
+        relativePath: "handlers/c.go",
         language: "go",
         content: `func getC(id string) (User, error) {\n  if id == "" { return nil, err }\n  return user, nil\n}\n`,
       },
       {
-        path: "handlers/d.go",
+        relativePath: "handlers/d.go",
         language: "go",
         content: `func getD(id string) (User, error) {\n  if id == "" { return nil, err }\n  return user, nil\n}\n`,
       },
       {
-        path: "handlers/e.go",
+        relativePath: "handlers/e.go",
         language: "go",
         content: `func getE(id string) { if id == "" { panic("bad id") } }\n`,
       },
@@ -135,7 +135,7 @@ describe("return-shape-consistency detector", () => {
         { name: "getC", body: "  if (!id) throw new Error('x');\n  return data;" },
       ]),
       {
-        path: "src/handlers/getA.test.ts",
+        relativePath: "src/handlers/getA.test.ts",
         language: "typescript",
         content: `it("does x", () => { if (!x) return null; });\n`,
       },

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("security-consistency detector", () => {

--- a/test/unit/drift/semantic-duplication.test.ts
+++ b/test/unit/drift/semantic-duplication.test.ts
@@ -12,7 +12,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("semantic-duplication detector", () => {

--- a/test/unit/drift/state-management-consistency.test.ts
+++ b/test/unit/drift/state-management-consistency.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("state-management-consistency detector", () => {

--- a/test/unit/drift/test-structure-consistency.test.ts
+++ b/test/unit/drift/test-structure-consistency.test.ts
@@ -11,7 +11,7 @@ function mkCtx(files: DriftFile[]): DriftContext {
 }
 
 function file(path: string, content: string): DriftFile {
-  return { path, language: "typescript", content, lineCount: content.split("\n").length };
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
 }
 
 describe("test-structure-consistency detector", () => {


### PR DESCRIPTION
## Summary

On Windows, `path.relative()` returns backslash-separated paths (e.g., `src\analyzers\complexity.ts`). The import graph's `fileBasename()` splits on `/` only, so on Windows it returns the full path instead of the filename. This causes `incomingCount` to be 0 for every file, producing ~270 false positives from the dead-code and phantom-scaffolding detectors.

**Root cause:** `src/core/discovery.ts` assigns `relativePath` via `path.relative()` without normalizing separators. Downstream code (import-graph, dead-code, phantom-scaffolding, MCP tools) assumes forward slashes.

**Fix:** Normalize `relativePath` to forward slashes at the single point of creation in `discoverFiles()`, apply the same normalization in the three tool commands that compute their own relative paths at runtime, and harden `fileBasename()` to split on both `/` and `\` as defense-in-depth.

**Before (Windows):**
- 146 orphan files (false positives — every file flagged)
- 128 phantom exports in one finding (false positives — every export flagged)
- 79 unused exports (false positives)

**After (Windows):**
- 11 orphan files (legitimate: entry points, scripts, dynamic imports)
- ~66 phantom exports across 9 directory-scoped findings (legitimate: mostly test fixture functions that are intentionally never imported)
- Vibe Drift Score: 91.3 → 91

Also fixes git metadata grafting, which was comparing backslash `relativePath` against git's forward-slash output — meaning temporal weighting and pivot detection were silently broken on Windows.

### Files changed

| File | Change |
|------|--------|
| `src/core/discovery.ts` | `.replace(/\\/g, "/")` on `relativePath` assignment |
| `src/core/import-graph.ts` | `fileBasename()` splits on `/[/\\]/` (defense-in-depth) |
| `src/tools-core/tools/check-file-drift.ts` | Same normalization on runtime `relative()` call |
| `src/tools-core/tools/validate-change.ts` | Same |
| `src/cli/commands/watch.ts` | Same |
| `test/unit/core/import-graph.test.ts` | 4 regression tests: multi-component paths + explicit backslash cases |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Closes #26