### PR TITLE
Fix Security Consistency detector correctness; rename from "Security Posture"

### DIFF
--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -6,8 +6,8 @@ import ora from "ora";
 import { buildAnalysisContext, recomputeContextStats } from "../../core/discovery.js";
 import { parseFiles } from "../../utils/ast.js";
 import { createAnalyzerRegistry } from "../../analyzers/index.js";
-import { runDriftDetection, attachEngineComposite } from "../../drift/index.js";
-import { computeScores, SCORING_VERSION } from "../../scoring/engine.js";
+import { runDriftDetection, attachEngineComposite, scoredDriftView } from "../../drift/index.js";
+import { computeScores, applySecurityMinPeerFloor, SCORING_VERSION } from "../../scoring/engine.js";
 import { debug, setDebugEnabled } from "../../core/debug.js";
 import { generateTeaseMessages, countReimplementationCandidates } from "../../output/tease.js";
 import { renderTerminalOutput, renderConciseSummary, renderJsonOutput, renderStarCta, renderDashboardLink, renderLocalReportLink, DASHBOARD_SPINNER_TEXT, DASHBOARD_SPINNER_SUCCESS_SYMBOL } from "../../output/terminal.js";
@@ -395,6 +395,23 @@ async function buildScanResult(
   const previousHygieneScores = await loadPreviousHygieneScores(rootDir);
   const previousScoringVersion = await loadPreviousScoringVersion(rootDir);
 
+  // Demote thin (below-floor) route-consistency security findings to the
+  // advisory hygiene id BEFORE this array becomes result.findings. Applied
+  // here (not only inside computeScores) so the re-tag reaches every render
+  // path that reads result.findings directly (terminal hygiene pane, HTML
+  // hygiene section). computeScores only ever saw a local copy, so a finding
+  // re-tagged there never made it back to the rendered set. Mutates
+  // allFindings in place, mirroring the dedup replace above, so every
+  // downstream reader of this same array reference (result.findings, the
+  // tease generator, the diff digests) sees the demoted id. computeScores
+  // re-applies the same floor on its own copy for standalone callers and
+  // tests; that second pass is a no-op here since the ids are already advisory.
+  const flooredFindings = applySecurityMinPeerFloor(allFindings);
+  if (flooredFindings !== allFindings) {
+    allFindings.length = 0;
+    allFindings.push(...flooredFindings);
+  }
+
   // Score
   if (spinner) spinner.text = "Computing scores...";
   const {
@@ -463,14 +480,26 @@ async function buildScanResult(
     }
   }
 
+  // The DRIFT representation that rendering reads excludes below-floor
+  // route-consistency security findings (demoted to advisory; still present in
+  // `allFindings`/`result.findings` as hygiene-kind so we are never silent).
+  // Applying it here, at the single point where result.driftFindings /
+  // result.driftScores are produced, keeps every raw-driftFindings consumer
+  // (findings library, codebase intent, coherence heatmap, pattern consensus,
+  // CSV/DOCX, context.md) and the per-category breakdown consistent with the
+  // category's N/A WITHOUT a gate in each widget. driftResult.driftFindings
+  // itself is untouched, so the baseline (assembleBaseline) and the diff
+  // digests below keep reading the raw drift representation unchanged.
+  const rendered = scoredDriftView(driftResult.driftFindings ?? [], ctx.totalLines);
+
   const result: ScanResult = {
     context: ctx,
     findings: allFindings,
-    driftFindings: driftResult.driftFindings,
+    driftFindings: rendered.driftFindings,
     // Mirror the single authoritative composite onto driftScores so the
     // uploaded payload + dashboard (result_json.driftScores.composite) match
     // the headline. One composite formula (the engine) — see Phase 0 collapse.
-    driftScores: attachEngineComposite(driftResult.driftScores, compositeScore),
+    driftScores: attachEngineComposite(rendered.driftScores, compositeScore),
     scores,
     compositeScore,
     maxCompositeScore,
@@ -1239,6 +1268,13 @@ export async function runScan(
   // Save history (per-project, in user home dir — not in the project itself).
   // Persisting `scoringVersion` lets future scans detect that this scan was
   // computed under a different formula and skip cross-version deltas.
+  //
+  // Use the RAW driftResult.driftFindings (not the rendered/filtered
+  // result.driftFindings) so the persisted drift digests match the ones the
+  // scan-over-scan diff computes from the same raw array (see buildScanResult).
+  // If these two sources diverged, a below-floor security finding present in
+  // one but not the other would show as a spurious "new/resolved drift finding"
+  // on every scan. Baseline + diff track the raw representation for continuity.
   await saveScanResult(
     rootDir,
     result.scores,
@@ -1246,7 +1282,7 @@ export async function runScan(
     result.hygieneScores,
     result.hygieneScore,
     result.findings,
-    result.driftFindings,
+    pipeline.driftResult.driftFindings,
     result.scoringVersion,
   );
 

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -27,7 +27,7 @@ import type { IntentHint } from "../intent/types.js";
 
 const CACHE_DIR = join(homedir(), ".vibedrift", "baseline-cache");
 /** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
-export const BASELINE_VERSION = 1;
+export const BASELINE_VERSION = 2;
 
 export interface CategoryVote {
   driftCategory: DriftCategory;
@@ -54,6 +54,12 @@ export interface RepoDriftBaseline {
   rootDir: string;
   ctxFiles: Array<{ path: string; hash: string }>;
   perCategoryVote: Partial<Record<DriftCategory, CategoryVote>>;
+  /** Per-security-sub-convention votes (Auth middleware / Input validation /
+   *  Rate limiting), keyed by sub-category label. Kept separate from
+   *  perCategoryVote, which collapses all three into one security_posture slot
+   *  by widest denominator — so get_dominant_pattern('auth') can read the AUTH
+   *  vote, not whichever sub-convention had the most routes. */
+  securitySubVotes?: Partial<Record<string, CategoryVote>>;
   intentHints: IntentHint[];
   minhashIndex: MinhashEntry[];
   builtAt: number;
@@ -95,15 +101,42 @@ export function votesFromFindings(
   for (const f of findings) {
     const existing = out[f.driftCategory];
     if (existing && existing.totalRelevantFiles >= f.totalRelevantFiles) continue;
-    out[f.driftCategory] = {
-      driftCategory: f.driftCategory,
-      dominantPattern: f.dominantPattern,
-      dominantCount: f.dominantCount,
-      totalRelevantFiles: f.totalRelevantFiles,
-      consistencyScore: f.consistencyScore,
-      dominantFiles: f.dominantFiles ?? [],
-      deviators: f.deviatingFiles.map((d) => ({ path: d.path, detectedPattern: d.detectedPattern })),
-    };
+    out[f.driftCategory] = toCategoryVote(f);
+  }
+  return out;
+}
+
+/** Build a CategoryVote from a single finding. Shared by votesFromFindings
+ *  (keyed by driftCategory) and securitySubVotesFromFindings (keyed by
+ *  subCategory) so the vote shape lives in exactly one place. */
+export function toCategoryVote(f: DriftFinding): CategoryVote {
+  return {
+    driftCategory: f.driftCategory,
+    dominantPattern: f.dominantPattern,
+    dominantCount: f.dominantCount,
+    totalRelevantFiles: f.totalRelevantFiles,
+    consistencyScore: f.consistencyScore,
+    dominantFiles: f.dominantFiles ?? [],
+    deviators: f.deviatingFiles.map((d) => ({ path: d.path, detectedPattern: d.detectedPattern })),
+  };
+}
+
+/**
+ * Like votesFromFindings but for the security sub-conventions, keyed by
+ * `subCategory` instead of `driftCategory`. Only security_posture findings that
+ * carry a subCategory participate; each sub-key keeps the widest-denominator
+ * finding (same tie-break as votesFromFindings).
+ */
+export function securitySubVotesFromFindings(
+  findings: DriftFinding[],
+): Partial<Record<string, CategoryVote>> {
+  const out: Partial<Record<string, CategoryVote>> = {};
+  for (const f of findings) {
+    if (f.driftCategory !== "security_posture" || !f.subCategory) continue;
+    const key = f.subCategory;
+    const existing = out[key];
+    if (existing && existing.totalRelevantFiles >= f.totalRelevantFiles) continue;
+    out[key] = toCategoryVote(f);
   }
   return out;
 }
@@ -140,6 +173,7 @@ export function assembleBaseline(
     rootDir,
     ctxFiles,
     perCategoryVote: votesFromFindings(driftFindings),
+    securitySubVotes: securitySubVotesFromFindings(driftFindings),
     intentHints: ctx.intentHints ?? [],
     minhashIndex,
     builtAt: Date.now(),

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -1,7 +1,7 @@
 import type { AnalysisContext, Finding } from "../core/types.js";
 import type { DriftContext, DriftFinding, DriftDetector, DriftCategory } from "./types.js";
 import { DRIFT_WEIGHTS } from "./types.js";
-import { categoryHealth } from "../scoring/engine.js";
+import { categoryHealth, isBelowSecurityPeerFloor } from "../scoring/engine.js";
 import { architecturalContradiction } from "./architectural-contradiction.js";
 import { conventionOscillation } from "./convention-oscillation.js";
 import { securityConsistency } from "./security-consistency.js";
@@ -148,6 +148,39 @@ function computeDriftScores(findings: Finding[], totalLines: number): DriftScore
 
   // The loop populates every DriftCategory key, so the cast is safe.
   return scores as unknown as DriftScores;
+}
+
+/**
+ * The DRIFT representation that RENDERING should read: the raw drift findings
+ * minus the below-floor route-consistency security findings, plus the
+ * per-category `driftScores` breakdown recomputed from that same scored set.
+ *
+ * A route-consistency security finding whose peer sample is below
+ * MIN_SECURITY_PEERS is demoted to an advisory hygiene finding on the `Finding`
+ * track (see `applySecurityMinPeerFloor`), so the category scores N/A. Every
+ * consumer that reads the raw `driftFindings` (the findings library, codebase
+ * intent, the coherence heatmap, pattern consensus, CSV/DOCX drift sections,
+ * context.md, the deep-scan coherence input) must therefore NOT see it, or it
+ * would contradict that N/A. Excluding it here, at ONE source point, keeps them
+ * all consistent without a gate in each widget. Recomputing `driftScores` from
+ * the scored set (rather than filtering the raw breakdown) is what makes
+ * `driftScores.security_posture` match the listed drift findings even in the
+ * multi-sub-check case (e.g. auth voted over 5 mutating routes stays scored
+ * while validation voted over 2 is below floor).
+ *
+ * The finding still surfaces as advisory via `result.findings` (hygiene-kind),
+ * so a small insecure repo is never silent. The RAW `driftFindings` produced by
+ * `runDriftDetection` are intentionally left untouched for the baseline
+ * (`assembleBaseline`) and the scan-over-scan diff, which track the raw drift
+ * representation for continuity.
+ */
+export function scoredDriftView(
+  driftFindings: DriftFinding[],
+  totalLines: number,
+): { driftFindings: DriftFinding[]; driftScores: DriftScores } {
+  const scored = driftFindings.filter((d) => !isBelowSecurityPeerFloor(d));
+  const driftScores = computeDriftScores(scored.map(driftFindingToFinding), totalLines);
+  return { driftFindings: scored, driftScores };
 }
 
 /**

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -32,6 +32,7 @@
  */
 
 import type { DriftDetector, DriftContext, DriftFinding, DriftFile } from "./types.js";
+import { SECURITY_SUBCATEGORIES } from "./types.js";
 import { pickIntentHint } from "./utils.js";
 
 const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
@@ -70,7 +71,7 @@ function analyzeUniformAuthGap(
 
   return {
     detector: "security_posture",
-    subCategory: "Auth middleware",
+    subCategory: SECURITY_SUBCATEGORIES.auth,
     driftCategory: "security_posture",
     severity: unauthed.length > 2 ? "error" : "warning",
     confidence,
@@ -310,7 +311,13 @@ export const securityConsistency: DriftDetector = {
     const healthPaths = /^\/(?:health|healthz|ready|metrics|ping)$/;
     const authHint = pickIntentHint(ctx, "security_posture");
 
-    const authFinding = analyzeSecurityProperty(routes, "Auth middleware", (r) => r.hasAuth, healthPaths);
+    // Auth applies to every state-changing route (POST/PUT/PATCH/DELETE).
+    // Rescoped from `routes`: counting read-only GETs put intentionally-public
+    // reads in the denominator and made the "X of Y mutating routes" line false.
+    // Same set as analyzeUniformAuthGap so the primary vote and its fallback agree.
+    const authRoutes = routes.filter((r) => MUTATION_METHODS.includes(r.method));
+
+    const authFinding = analyzeSecurityProperty(authRoutes, SECURITY_SUBCATEGORIES.auth, (r) => r.hasAuth, healthPaths);
     if (authFinding) {
       findings.push(authFinding);
     } else {
@@ -326,11 +333,11 @@ export const securityConsistency: DriftDetector = {
 
     const mutationRoutes = routes.filter((r) => ["POST", "PUT", "PATCH"].includes(r.method));
     if (mutationRoutes.length >= 2) {
-      const valFinding = analyzeSecurityProperty(mutationRoutes, "Input validation", (r) => r.hasValidation, healthPaths);
+      const valFinding = analyzeSecurityProperty(mutationRoutes, SECURITY_SUBCATEGORIES.validation, (r) => r.hasValidation, healthPaths);
       if (valFinding) findings.push(valFinding);
     }
 
-    const rateLimitFinding = analyzeSecurityProperty(routes, "Rate limiting", (r) => r.hasRateLimit, healthPaths);
+    const rateLimitFinding = analyzeSecurityProperty(routes, SECURITY_SUBCATEGORIES.rateLimit, (r) => r.hasRateLimit, healthPaths);
     if (rateLimitFinding) findings.push(rateLimitFinding);
 
     return findings;

--- a/src/drift/types.ts
+++ b/src/drift/types.ts
@@ -155,3 +155,15 @@ export interface DriftFinding {
   };
   recommendation: string;
 }
+
+/**
+ * Canonical labels for the three security sub-conventions the route-consistency
+ * detector votes on. Single source of truth so the detector's emitted
+ * `subCategory` and the baseline sub-vote lookup (get_dominant_pattern) can
+ * never drift apart.
+ */
+export const SECURITY_SUBCATEGORIES = {
+  auth: "Auth middleware",
+  validation: "Input validation",
+  rateLimit: "Rate limiting",
+} as const;

--- a/src/output/csv.ts
+++ b/src/output/csv.ts
@@ -44,10 +44,17 @@ function csvScoreCategories(result: ScanResult): string[] {
 
   const ds = result.driftScores ?? {};
   if (Object.keys(ds).length > 0) {
+    // securityPosture N/A on the floored composite (result.scores) means every
+    // security drift finding was below the peer floor and demoted to advisory.
+    // The driftScores breakdown credits an empty category full health
+    // (security_posture -> 14/14, 0 findings), which would still read as a
+    // scored bar next to the composite's N/A. Suppress that one row to match.
+    const securityIsNa = result.scores.securityPosture?.applicable === false;
     lines.push("DRIFT SCORES");
     lines.push(row("Category", "Score", "Max Score", "Findings", "Grade"));
     for (const [key, val] of Object.entries(ds)) {
       if (key === "composite" || key === "grade") continue;
+      if (key === "security_posture" && securityIsNa) continue;
       const v = val as any;
       if (v?.score !== undefined) {
         lines.push(row(key, v.score, v.maxScore, v.findings ?? 0));
@@ -59,11 +66,15 @@ function csvScoreCategories(result: ScanResult): string[] {
 }
 
 function csvDriftFindings(result: ScanResult): string[] {
-  if ((result.driftFindings ?? []).length === 0) return [];
+  // result.driftFindings already excludes below-floor route-consistency
+  // security findings (scoredDriftView at the scan source), so a thin finding
+  // is never listed as a scored drift finding here.
+  const driftFindings = result.driftFindings ?? [];
+  if (driftFindings.length === 0) return [];
   const lines: string[] = [];
   lines.push("DRIFT FINDINGS");
   lines.push(row("Severity", "Category", "Finding", "Dominant Pattern", "Dominant Count", "Total Files", "Consistency %", "Deviating Files", "Recommendation"));
-  for (const d of result.driftFindings) {
+  for (const d of driftFindings) {
     const devFiles = d.deviatingFiles.map((f) => f.path).join("; ");
     lines.push(row(
       d.severity, d.driftCategory, d.finding,

--- a/src/output/docx.ts
+++ b/src/output/docx.ts
@@ -203,7 +203,7 @@ function buildDocxScoreTable(result: ScanResult): string {
   const ds = result.driftScores ?? {};
   const catRows = [
     ["Architectural Consistency", ds.architectural_consistency],
-    ["Security Posture", ds.security_posture],
+    ["Security Consistency", ds.security_posture],
     ["Semantic Duplication", ds.semantic_duplication],
     ["Convention Drift", ds.naming_conventions],
     ["Phantom Scaffolding", ds.phantom_scaffolding],

--- a/src/output/docx.ts
+++ b/src/output/docx.ts
@@ -2,6 +2,7 @@ import { deflateRawSync } from "zlib";
 import type { ScanResult } from "../core/types.js";
 import { getVersion } from "../core/version.js";
 import { formatCount } from "./format.js";
+import { getAnalyzerKind } from "../scoring/categories.js";
 
 // ──── Minimal ZIP generator (OOXML requires ZIP container) ────
 
@@ -201,12 +202,18 @@ function buildDocxScoreTable(result: ScanResult): string {
   parts.push(para(""));
 
   const ds = result.driftScores ?? {};
-  const catRows = [
-    ["Architectural Consistency", ds.architectural_consistency],
-    ["Security Consistency", ds.security_posture],
-    ["Semantic Duplication", ds.semantic_duplication],
-    ["Convention Drift", ds.naming_conventions],
-    ["Phantom Scaffolding", ds.phantom_scaffolding],
+  // securityPosture N/A on the floored composite (result.scores) means every
+  // security drift finding was below the peer floor and demoted to advisory.
+  // The driftScores breakdown credits an empty category full health
+  // (security_posture -> 14/14, 0 findings), so render that row as N/A to match
+  // the composite instead of a scored-looking value.
+  const securityIsNa = result.scores.securityPosture?.applicable === false;
+  const catRows: { name: string; cs: any; na: boolean }[] = [
+    { name: "Architectural Consistency", cs: ds.architectural_consistency, na: false },
+    { name: "Security Consistency", cs: ds.security_posture, na: securityIsNa },
+    { name: "Semantic Duplication", cs: ds.semantic_duplication, na: false },
+    { name: "Convention Drift", cs: ds.naming_conventions, na: false },
+    { name: "Phantom Scaffolding", cs: ds.phantom_scaffolding, na: false },
   ];
 
   const headerRow = tableRow([
@@ -215,13 +222,12 @@ function buildDocxScoreTable(result: ScanResult): string {
     tableCellSimple("Max", "D9E2F3", true),
     tableCellSimple("Findings", "D9E2F3", true),
   ]);
-  const dataRows = catRows.map(([catName, catScore]) => {
-    const cs = catScore as any;
+  const dataRows = catRows.map(({ name, cs, na }) => {
     return tableRow([
-      tableCellSimple(catName as string),
-      tableCellSimple(String(cs?.score ?? 0)),
-      tableCellSimple(String(cs?.maxScore ?? 0)),
-      tableCellSimple(String(cs?.findings ?? 0)),
+      tableCellSimple(name),
+      tableCellSimple(na ? "N/A" : String(cs?.score ?? 0)),
+      tableCellSimple(na ? "N/A" : String(cs?.maxScore ?? 0)),
+      tableCellSimple(na ? "N/A" : String(cs?.findings ?? 0)),
     ]);
   }).join("");
 
@@ -236,8 +242,12 @@ function buildDocxIntentSection(result: ScanResult): string {
   parts.push(para("The following patterns represent the dominant approach established by the majority of files in this codebase."));
   parts.push(para(""));
 
+  // result.driftFindings already excludes below-floor security findings
+  // (scoredDriftView at the scan source), so a thin finding's pattern is never
+  // presented as established codebase intent while its category scores N/A.
+  const driftFindings = result.driftFindings ?? [];
   const intentSeen = new Set<string>();
-  for (const d of (result.driftFindings ?? [])) {
+  for (const d of driftFindings) {
     const key = d.driftCategory + "::" + d.dominantPattern;
     if (intentSeen.has(key)) continue;
     intentSeen.add(key);
@@ -252,10 +262,14 @@ function buildDocxIntentSection(result: ScanResult): string {
 function buildDocxDriftSection(result: ScanResult): string {
   const parts: string[] = [];
   parts.push(para("3. DRIFT FINDINGS", "Heading1"));
-  parts.push(para(`${(result.driftFindings ?? []).length} cross-file contradictions detected.`));
+  // result.driftFindings already excludes below-floor security findings
+  // (scoredDriftView at the scan source), so a thin finding is never listed as
+  // a scored drift finding here and the count matches what is listed.
+  const driftFindings = result.driftFindings ?? [];
+  parts.push(para(`${driftFindings.length} cross-file contradictions detected.`));
   parts.push(para(""));
 
-  for (const d of (result.driftFindings ?? [])) {
+  for (const d of driftFindings) {
     const sevStr = d.severity === "error" ? "CRITICAL" : d.severity === "warning" ? "WARNING" : "INFO";
     parts.push(para(`[${sevStr}] ${d.finding}`, "Heading2"));
     parts.push(para(`Category: ${d.driftCategory.replace(/_/g, " ")} | Consistency: ${d.consistencyScore}% | Confidence: ${Math.round(d.confidence * 100)}%`));
@@ -399,7 +413,18 @@ function buildDocxPerFileTable(result: ScanResult): string {
 function buildDocxFindingsTable(result: ScanResult): string {
   const parts: string[] = [];
   parts.push(para("6. STATIC ANALYSIS FINDINGS", "Heading1"));
-  const statics = result.findings.filter((f) => !f.tags?.includes("drift") && !f.tags?.includes("codedna"));
+  // This is DOCX's only general (non-drift) findings section. Include every
+  // hygiene-kind finding here, even one that carries a legacy "drift" tag: a
+  // route-consistency security finding demoted below the peer floor is now
+  // hygiene-kind (analyzerId security_posture-advisory) but still tagged
+  // "drift" from its origin, and it is (correctly) excluded from the drift
+  // sections above. Without this kind-aware clause it would be filtered out
+  // here too and vanish from the DOCX entirely, going silent on exactly the
+  // small insecure repos this floor exists to keep visible.
+  const statics = result.findings.filter((f) =>
+    getAnalyzerKind(f.analyzerId) === "hygiene" ||
+    (!f.tags?.includes("drift") && !f.tags?.includes("codedna")),
+  );
   parts.push(para(`${statics.length} findings from ${13} static analyzers.`));
   parts.push(para(""));
 

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -691,6 +691,9 @@ function buildDriftFindingsLibrary(result: ScanResult): string {
   const groups = order.map((cat) => ({
     cat,
     label: DRIFT_CAT_LABEL[cat] ?? cat,
+    // result.driftFindings already excludes below-floor route-consistency
+    // security findings (scoredDriftView at the scan source), so no per-widget
+    // gate is needed here.
     findings: (result.driftFindings ?? []).filter((f) => f.driftCategory === cat),
   })).filter((g) => g.findings.length > 0);
   if (groups.length === 0) return "";
@@ -956,6 +959,9 @@ function buildEmbeddedData(result: ScanResult): string {
     fileCount: result.context.files.length,
     totalLines: result.context.totalLines,
     scanTimeMs: result.scanTimeMs,
+    // result.driftFindings already excludes below-floor security findings
+    // (scoredDriftView at the scan source), so the client-side "Export CSV"
+    // data cannot list one under "DRIFT FINDINGS" either.
     driftFindings: (result.driftFindings ?? []).map((d) => ({
       severity: d.severity,
       category: d.driftCategory,

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -11,7 +11,7 @@ const SCORING_CATEGORY_LABELS: Record<string, string> = {
   architecturalConsistency: "Architectural",
   redundancy: "Redundancy",
   dependencyHealth: "Dependencies",
-  securityPosture: "Security",
+  securityPosture: "Security Consistency",
   intentClarity: "Intent Clarity",
 };
 
@@ -435,10 +435,14 @@ function buildCategoryBreakdown(result: ScanResult): string {
   const cards = SCORING_CATEGORY_ORDER.filter((cat) => cat !== "dependencyHealth").map((cat) => {
     const s = scores[cat];
     const label = esc(SCORING_CATEGORY_LABELS[cat]);
+    const gloss =
+      cat === "securityPosture"
+        ? `<div class="note">Consistency of this repo's own auth and validation patterns, not the absence of vulnerabilities.</div>`
+        : "";
     if (!s || !s.applicable) {
       // These drift detectors ran but found no applicable code in this repo.
       const naNote = "No findings in this repo";
-      return `<div class="va-cat na"><div class="top"><span class="name">${label}</span></div><div class="val">N/A</div><div class="note">${naNote}</div></div>`;
+      return `<div class="va-cat na"><div class="top"><span class="name">${label}</span></div><div class="val">N/A</div><div class="note">${naNote}</div>${gloss}</div>`;
     }
     const catPct = s.maxScore > 0 ? (s.score / s.maxScore) * 100 : 0;
     const col = pctToken(catPct);
@@ -446,6 +450,7 @@ function buildCategoryBreakdown(result: ScanResult): string {
       <div class="top"><span class="name">${label}</span><span class="gdot" style="background:${col}"></span></div>
       <div class="val num">${s.score.toFixed(1)}<span class="s"> /${s.maxScore}</span></div>
       <div class="t"><i style="width:${catPct.toFixed(0)}%;background:${col}"></i></div>
+      ${gloss}
     </div>`;
   }).join("");
 
@@ -653,7 +658,7 @@ function buildIntentCoherenceHeatmap(result: ScanResult): string {
 
 const DRIFT_CAT_LABEL: Record<string, string> = {
   architectural_consistency: "Architectural consistency",
-  security_posture: "Security posture",
+  security_posture: "Security consistency",
   semantic_duplication: "Semantic duplication",
   naming_conventions: "Convention drift",
   phantom_scaffolding: "Phantom scaffolding",
@@ -1137,7 +1142,7 @@ a:hover{text-decoration-color:var(--brand)}
 .va-cat .t{height:5px;border-radius:3px;background:var(--bg-code);margin-top:10px;overflow:hidden}
 .va-cat .t i{display:block;height:100%;border-radius:3px}
 .va-cat.na .val{color:var(--text-tertiary);font-size:18px}
-.va-cat.na .note{font-size:11px;color:var(--text-tertiary);margin-top:8px}
+.va-cat .note{font-size:11px;color:var(--text-tertiary);margin-top:8px}
 
 /* fix first */
 .va-fix{background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--r);overflow:hidden}

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -596,6 +596,14 @@ function renderCategoryBars(result: ScanResult): string[] {
       }
       lines.push(`  ${label} ${color(`${s.score.toFixed(0).padStart(2)}/${s.maxScore}`)}  ${bar}${deltaStr}`);
     }
+
+    if (cat === "securityPosture") {
+      lines.push(
+        chalk.dim(
+          `  ${padRight("", 28)}   consistent ≠ safe: measures how uniformly this repo applies its own auth and validation patterns, not the absence of vulnerabilities`,
+        ),
+      );
+    }
   }
 
   lines.push(`  ${"─".repeat(34)}`);

--- a/src/scoring/categories.ts
+++ b/src/scoring/categories.ts
@@ -117,6 +117,10 @@ export const CATEGORY_CONFIG: Record<ScoringCategory, CategoryConfig> = {
       // Cross-file auth/validation/rate-limiting consistency — real drift
       // (analyzerId `drift-security_posture`, from driftCategory).
       { id: "drift-security_posture", applicableLanguages: "all", kind: "drift" },
+      // Route-consistency findings with too few peer routes to score
+      // (see applySecurityMinPeerFloor). Advisory: renders on the hygiene
+      // track, never touches the drift composite.
+      { id: "security_posture-advisory", applicableLanguages: "all", kind: "hygiene" },
       // Code DNA taint analysis
       { id: "codedna-taint", applicableLanguages: "all", kind: "drift" },
     ],

--- a/src/scoring/categories.ts
+++ b/src/scoring/categories.ts
@@ -109,7 +109,7 @@ export const CATEGORY_CONFIG: Record<ScoringCategory, CategoryConfig> = {
     ],
   },
   securityPosture: {
-    name: "Security Posture",
+    name: "Security Consistency",
     maxScore: 20,
     analyzers: [
       // Generic OWASP regex checks

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -54,7 +54,7 @@ import {
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v7";
+export const SCORING_VERSION = "v8";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -129,6 +129,30 @@ export function applySecurityMinPeerFloor(findings: Finding[]): Finding[] {
   return changed ? out : findings;
 }
 
+// The route-consistency drift finding's `driftCategory`: SECURITY_DRIFT_ID
+// (the `Finding.analyzerId`) without the "drift-" prefix. The raw
+// `DriftFindingReport` array keeps this category tag but has no `analyzerId`,
+// so renderers that read `driftFindings` directly test the floor on this
+// instead of on the demoted analyzer id.
+const SECURITY_DRIFT_CATEGORY = "security_posture";
+
+/**
+ * DriftFinding-report view of the same min-peer floor `applySecurityMinPeerFloor`
+ * applies to `Finding`s. Output renderers (HTML, CSV, DOCX) read the raw
+ * `result.driftFindings` (`DriftFindingReport[]`), which has no `analyzerId`,
+ * so the Finding-level floor never touches it. They use this predicate to
+ * exclude below-floor route-consistency security findings from every surface
+ * that lists a drift finding, keeping those exports from contradicting the
+ * category's N/A. Single source of truth for the below-floor test so the three
+ * renderers cannot drift apart from each other or from applySecurityMinPeerFloor.
+ */
+export function isBelowSecurityPeerFloor(d: {
+  driftCategory: string;
+  totalRelevantFiles: number;
+}): boolean {
+  return d.driftCategory === SECURITY_DRIFT_CATEGORY && d.totalRelevantFiles < MIN_SECURITY_PEERS;
+}
+
 /**
  * Place a composite Vibe Drift Score on a peer percentile against a bundled
  * corpus of real-world repos in the same language. Pure, local, deterministic,

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -103,6 +103,33 @@ export function applyReimplementationConcentrationGate(
 }
 
 /**
+ * Route-consistency security findings need a minimum peer sample before they
+ * move the composite. Below MIN_SECURITY_PEERS relevant routes a single
+ * deviator is too large a fraction of too small a sample to trust — the
+ * uniform-auth-gap baseline can fire on as few as 2 mutating routes. Such thin
+ * findings are re-tagged to a hygiene id so they still RENDER (informational)
+ * but never dent the Vibe Drift Score. Findings at or above the floor keep the
+ * drift id and score, ramped by groupSampleConfidence up to
+ * SAMPLE_FULL_CONFIDENCE (8). Route-independent taint findings (codedna-taint)
+ * are unaffected. Pure; returns the same array reference when nothing re-tags.
+ */
+export const MIN_SECURITY_PEERS = 4;
+const SECURITY_DRIFT_ID = "drift-security_posture";
+const SECURITY_ADVISORY_ID = "security_posture-advisory";
+
+export function applySecurityMinPeerFloor(findings: Finding[]): Finding[] {
+  let changed = false;
+  const out = findings.map((f) => {
+    if (f.analyzerId !== SECURITY_DRIFT_ID) return f;
+    const n = f.driftSignal?.totalRelevantFiles ?? 0;
+    if (n >= MIN_SECURITY_PEERS) return f;
+    changed = true;
+    return { ...f, analyzerId: SECURITY_ADVISORY_ID };
+  });
+  return changed ? out : findings;
+}
+
+/**
  * Place a composite Vibe Drift Score on a peer percentile against a bundled
  * corpus of real-world repos in the same language. Pure, local, deterministic,
  * and FREE — only surfacing the result is Pro-gated (see `isPeerGroundedEntitled`).
@@ -679,6 +706,12 @@ export function computeScores(
   // its hygiene id and stays informational. Applied here so the gate sees the
   // full finding set together with totalLines.
   findings = applyReimplementationConcentrationGate(findings, totalLines);
+
+  // Route-consistency findings with too few peer routes to trust are demoted to
+  // an advisory hygiene id here (see applySecurityMinPeerFloor) so they render
+  // but do not move the composite. Applied after the reimplementation gate so
+  // both re-tags see the full finding set.
+  findings = applySecurityMinPeerFloor(findings);
 
   const mutateImpact = options.mutateImpact ?? true;
   const previousScoringVersion = options.previousScoringVersion;

--- a/src/tools-core/tools/get-dominant-pattern.ts
+++ b/src/tools-core/tools/get-dominant-pattern.ts
@@ -8,6 +8,7 @@
  */
 import { z } from "zod";
 import type { DriftCategory } from "../../drift/types.js";
+import { SECURITY_SUBCATEGORIES } from "../../drift/types.js";
 import type { RepoDriftBaseline } from "../../core/baseline.js";
 import { getBaseline } from "../../mcp/baseline-provider.js";
 import { noBaselineData, type Status } from "../result.js";
@@ -26,6 +27,12 @@ const DIM = {
 export type DominantDimension = keyof typeof DIM;
 export const DIMENSIONS = Object.keys(DIM) as DominantDimension[];
 
+// Dimensions whose vote lives in securitySubVotes (keyed by sub-category label)
+// rather than the collapsed perCategoryVote slot.
+const SECURITY_SUB_DIM: Partial<Record<DominantDimension, string>> = {
+  auth: SECURITY_SUBCATEGORIES.auth,
+};
+
 export const inputSchema = {
   rootDir: z.string().describe("Absolute path to the repository root"),
   dimension: z.enum(DIMENSIONS as [DominantDimension, ...DominantDimension[]]),
@@ -43,7 +50,8 @@ export function dominantPatternFor(
   baseline: RepoDriftBaseline,
   dimension: DominantDimension,
 ): DominantPatternProjection {
-  const vote = baseline.perCategoryVote[DIM[dimension]];
+  const subKey = SECURITY_SUB_DIM[dimension];
+  const vote = subKey ? baseline.securitySubVotes?.[subKey] : baseline.perCategoryVote[DIM[dimension]];
   if (!vote) {
     return {
       dimension,

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -10,6 +10,7 @@ import {
   loadBaselineUnchecked,
   computeBaselineKey,
   votesFromFindings,
+  securitySubVotesFromFindings,
 } from "../../../src/core/baseline.js";
 import { buildAnalysisContext } from "../../../src/core/discovery.js";
 import { runDriftDetection } from "../../../src/drift/index.js";
@@ -71,6 +72,18 @@ describe("votesFromFindings", () => {
   it("handles a missing optional dominantFiles as an empty array", () => {
     const votes = votesFromFindings([fakeFinding({ dominantFiles: undefined })]);
     expect(votes.async_patterns!.dominantFiles).toEqual([]);
+  });
+
+  it("keeps auth/validation/rate-limit as SEPARATE security sub-votes (no collision)", () => {
+    const subVotes = securitySubVotesFromFindings([
+      fakeFinding({ driftCategory: "security_posture", subCategory: "Auth middleware", dominantPattern: "Auth middleware applied", totalRelevantFiles: 5, consistencyScore: 80 }),
+      fakeFinding({ driftCategory: "security_posture", subCategory: "Rate limiting", dominantPattern: "Rate limiting applied", totalRelevantFiles: 12, consistencyScore: 60 }),
+    ]);
+    // Both survive under their own key — the widest-denominator finding does NOT
+    // evict the other (which is the perCategoryVote collision this fixes).
+    expect(subVotes["Auth middleware"]!.dominantPattern).toBe("Auth middleware applied");
+    expect(subVotes["Rate limiting"]!.dominantPattern).toBe("Rate limiting applied");
+    expect(subVotes["Auth middleware"]!.totalRelevantFiles).toBe(5);
   });
 });
 

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -80,4 +80,22 @@ describe("security-consistency detector", () => {
       expect(authFinding!.confidence).toBeGreaterThan(0.75);
     });
   });
+
+  it("does not flag a public GET for missing auth — only mutating routes are the auth peer group", () => {
+    const files = [
+      file(
+        "src/routes/api.ts",
+        `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+      ),
+      file("src/routes/public.ts", `router.get("/catalog", listCatalog);\n`),
+    ];
+    const findings = securityConsistency.detect(mkCtx(files));
+    const authFinding = findings.find((f) => f.subCategory === "Auth middleware");
+    // 4 mutating routes all authed → no auth deviation; the public GET is NOT
+    // in the denominator (old behavior voted over all 5 routes and flagged it).
+    expect(authFinding).toBeUndefined();
+  });
 });

--- a/test/unit/output/security-advisory-render.test.ts
+++ b/test/unit/output/security-advisory-render.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from "vitest";
+import { inflateRawSync } from "zlib";
+import { renderTerminalOutput } from "../../../src/output/terminal.js";
+import { renderHtmlReport } from "../../../src/output/html.js";
+import { renderCsvReport } from "../../../src/output/csv.js";
+import { renderDocxReport } from "../../../src/output/docx.js";
+import { applySecurityMinPeerFloor, MIN_SECURITY_PEERS, computeScores } from "../../../src/scoring/engine.js";
+import { scoredDriftView, driftFindingToFinding, attachEngineComposite } from "../../../src/drift/index.js";
+import type { DriftFinding } from "../../../src/drift/types.js";
+import type { ScanResult, PerFileScore } from "../../../src/core/types.js";
+
+/**
+ * Render-level regression suite for the min-peer-floor consistency fix.
+ *
+ * A route-consistency security drift finding whose peer sample is below
+ * MIN_SECURITY_PEERS is demoted to an advisory hygiene finding on the `Finding`
+ * track. The ROOT fix (`scoredDriftView` in src/drift/index.ts, wired at the
+ * scan source in buildScanResult) removes such findings from the DRIFT
+ * representation entirely (both `result.driftFindings` and `result.driftScores`),
+ * so every raw-driftFindings consumer (drift findings library, codebase intent,
+ * coherence heatmap, CSV/DOCX drift sections) is consistent with the category's
+ * N/A WITHOUT a per-widget gate. The finding still surfaces as advisory via
+ * `result.findings` (hygiene-kind), so we are never silent.
+ *
+ * These fixtures are built through the SAME functions the scan pipeline uses
+ * (`scoredDriftView`, `applySecurityMinPeerFloor`, `computeScores`) from a RAW
+ * drift set that INCLUDES the below-floor finding, so the tests exercise the
+ * source exclusion, not a pre-massaged fixture.
+ */
+
+const RAW_MESSAGE = "DRIFT: 1 mutating route(s) lack auth while the codebase uses auth elsewhere";
+const TOTAL_LINES = 500;
+
+// Below MIN_SECURITY_PEERS (4): the "small repo, 2-3 mutating routes, auth gap".
+// consistencyScore is 67% (>= 60) on purpose: high enough that the finding WOULD
+// pass extractIntentPatterns' consistency gate and appear as a "Security"
+// codebase-intent card if it were not excluded from the drift representation.
+// That is what makes the codebase-intent test able to catch a leak.
+function rawThinSecurity(): DriftFinding {
+  return {
+    detector: "security_posture",
+    subCategory: "Auth middleware",
+    driftCategory: "security_posture",
+    severity: "warning",
+    confidence: 0.6,
+    finding: "1 mutating route(s) lack auth while the codebase uses auth elsewhere",
+    dominantPattern: "auth on mutating routes",
+    dominantCount: 2,
+    totalRelevantFiles: 3,
+    consistencyScore: 67,
+    deviatingFiles: [
+      { path: "src/routes/admin.ts", detectedPattern: "POST /admin no auth", evidence: [{ line: 12, code: "POST /admin" }] },
+    ],
+    dominantFiles: [],
+    recommendation: "Add auth middleware to this route, or confirm it is intentionally public.",
+  };
+}
+
+// A security sub-check finding with a configurable peer sample, used to build
+// the multi-sub-check scenario (auth voted over many routes, validation over a
+// subset). subCategory distinguishes the sub-checks.
+function rawSecuritySub(subCategory: string, totalRelevantFiles: number, dominantCount: number): DriftFinding {
+  return {
+    detector: "security_posture",
+    subCategory,
+    driftCategory: "security_posture",
+    severity: "warning",
+    confidence: 0.6,
+    finding: `${subCategory}: ${totalRelevantFiles - dominantCount} route(s) deviate`,
+    dominantPattern: subCategory,
+    dominantCount,
+    totalRelevantFiles,
+    consistencyScore: Math.round((dominantCount / totalRelevantFiles) * 100),
+    deviatingFiles: [
+      { path: "src/routes/admin.ts", detectedPattern: `${subCategory} missing`, evidence: [{ line: 3, code: "handler" }] },
+    ],
+    dominantFiles: [],
+    recommendation: `Apply ${subCategory} consistently.`,
+  };
+}
+
+// An unrelated architectural finding at/above any floor, carrying a subCategory
+// so it produces a heatmap column and an intent card (proving those widgets
+// render and that ONLY the security finding is absent, not everything).
+function rawArch(): DriftFinding {
+  return {
+    detector: "architectural_consistency",
+    subCategory: "data_access",
+    driftCategory: "architectural_consistency",
+    severity: "warning",
+    confidence: 0.8,
+    finding: "src/order.ts uses raw SQL while peers use a repository",
+    dominantPattern: "repository",
+    dominantCount: 5,
+    totalRelevantFiles: 6,
+    consistencyScore: 83,
+    deviatingFiles: [
+      { path: "src/order.ts", detectedPattern: "raw SQL", evidence: [{ line: 4, code: "db.query(...)" }] },
+    ],
+    dominantFiles: ["src/repo.ts"],
+    recommendation: "Use the repository pattern.",
+  };
+}
+
+/**
+ * Build a ScanResult exactly the way buildScanResult now does: floor the mapped
+ * findings for result.findings (advisory surfacing), and derive the rendered
+ * DRIFT representation via scoredDriftView (below-floor security excluded).
+ * perFileScores is populated from the findings' files so the coherence heatmap
+ * actually renders (the previous fixture used an empty Map, making the heatmap
+ * blind to this bug).
+ */
+function mkPipelineResult(rawDrift: DriftFinding[]): ScanResult {
+  const mapped = rawDrift.map(driftFindingToFinding);
+  const floored = applySecurityMinPeerFloor(mapped);
+  const { scores, hygieneScores, hygieneScore, maxHygieneScore, compositeScore, maxCompositeScore } =
+    computeScores(floored, TOTAL_LINES);
+  const rendered = scoredDriftView(rawDrift, TOTAL_LINES);
+
+  const perFileScores = new Map<string, PerFileScore>();
+  for (const f of floored) {
+    const file = f.locations[0]?.file;
+    if (!file) continue;
+    if (!perFileScores.has(file)) {
+      perFileScores.set(file, {
+        file,
+        findings: floored.filter((x) => x.locations[0]?.file === file),
+        score: 62,
+        maxScore: 100,
+      });
+    }
+  }
+
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map([["typescript", { files: 3 }]]),
+      totalLines: TOTAL_LINES,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore,
+    maxCompositeScore,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores,
+    hygieneScore,
+    maxHygieneScore,
+    hygieneScores,
+    findings: floored,
+    driftFindings: rendered.driftFindings,
+    driftScores: attachEngineComposite(rendered.driftScores, compositeScore),
+    perFileScores,
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+  } as unknown as ScanResult;
+}
+
+/** Inflate a DOCX (OOXML zip) and return word/document.xml as text. */
+function docxDocumentXml(zip: Buffer): string {
+  let off = 0;
+  while (off + 4 <= zip.length && zip.readUInt32LE(off) === 0x04034b50) {
+    const compSize = zip.readUInt32LE(off + 18);
+    const nameLen = zip.readUInt16LE(off + 26);
+    const extraLen = zip.readUInt16LE(off + 28);
+    const name = zip.slice(off + 30, off + 30 + nameLen).toString("utf-8");
+    const dataStart = off + 30 + nameLen + extraLen;
+    const data = zip.slice(dataStart, dataStart + compSize);
+    if (name === "word/document.xml") return inflateRawSync(data).toString("utf-8");
+    off = dataStart + compSize;
+  }
+  throw new Error("word/document.xml not found in DOCX");
+}
+
+/** Strip XML tags so section text can be searched as plain prose. */
+function docxText(zip: Buffer): string {
+  return docxDocumentXml(zip).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ");
+}
+
+/** Slice a labelled HTML section (from one heading up to the next). */
+function htmlSection(html: string, fromHeading: string, toHeading: string): string {
+  const start = html.indexOf(fromHeading);
+  const end = html.indexOf(toHeading, start + 1);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return html.slice(start, end);
+}
+
+// The below-floor case: only security finding is thin, plus an unrelated arch
+// finding so the drift widgets have something legitimate to render.
+const THIN_PLUS_ARCH = () => mkPipelineResult([rawThinSecurity(), rawArch()]);
+
+describe("min-peer-floor render consistency (root fix)", () => {
+  it("computeScores marks Security Consistency N/A on the drift track (sanity)", () => {
+    expect(THIN_PLUS_ARCH().scores.securityPosture.applicable).toBe(false);
+  });
+
+  describe("scoredDriftView (source exclusion)", () => {
+    it("drops a below-floor security finding while keeping at/above-floor and unrelated findings", () => {
+      const { driftFindings } = scoredDriftView([rawThinSecurity(), rawArch()], TOTAL_LINES);
+      expect(driftFindings.map((d) => d.driftCategory)).not.toContain("security_posture");
+      expect(driftFindings.map((d) => d.driftCategory)).toContain("architectural_consistency");
+    });
+
+    it("multi-sub-check: keeps auth (n>=4), drops validation (n<4), and driftScores counts only the scored sub-finding", () => {
+      const auth = rawSecuritySub("Auth middleware", 5, 3); // n=5 >= floor -> scored
+      const validation = rawSecuritySub("Input validation", 2, 1); // n=2 < floor -> below
+      const { driftFindings, driftScores } = scoredDriftView([auth, validation, rawArch()], TOTAL_LINES);
+
+      const secSubs = driftFindings.filter((d) => d.driftCategory === "security_posture").map((d) => d.subCategory);
+      expect(secSubs).toContain("Auth middleware");
+      expect(secSubs).not.toContain("Input validation");
+
+      // driftScores.security_posture reflects ONLY the scored sub-finding, so the
+      // CSV/DOCX score-row count matches what the drift findings list shows.
+      expect(driftScores.security_posture.findings).toBe(1);
+    });
+
+    it("all-below-floor security yields zero security drift findings and an empty-category breakdown", () => {
+      const { driftFindings, driftScores } = scoredDriftView([rawSecuritySub("Auth middleware", 2, 1)], TOTAL_LINES);
+      expect(driftFindings.length).toBe(0);
+      expect(driftScores.security_posture.findings).toBe(0);
+    });
+  });
+
+  describe("terminal", () => {
+    it("shows Security Consistency N/A in the drift pane and surfaces the finding in the hygiene pane", () => {
+      const out = renderTerminalOutput(THIN_PLUS_ARCH());
+      expect(out).toContain("Security Consistency (N/A)");
+      const hygieneBannerIdx = out.indexOf("Hygiene findings");
+      const messageIdx = out.indexOf(RAW_MESSAGE);
+      expect(hygieneBannerIdx).toBeGreaterThan(-1);
+      expect(messageIdx).toBeGreaterThan(hygieneBannerIdx);
+    });
+  });
+
+  describe("html (detailed report)", () => {
+    it("drift findings library: no security card, arch card present, advisory surfaced in hygiene", () => {
+      const html = renderHtmlReport(THIN_PLUS_ARCH(), "detailed");
+      const library = htmlSection(html, "Drift findings", "File ranking");
+      expect(library).not.toContain(rawThinSecurity().finding);
+      expect(library).toContain(rawArch().finding);
+      // Advisory finding still appears somewhere (the Hygiene section reads
+      // result.findings, which carries the demoted id).
+      expect(html).toContain(RAW_MESSAGE);
+    });
+
+    it("codebase intent: no Security pattern card, unrelated Data Access card present", () => {
+      const html = renderHtmlReport(THIN_PLUS_ARCH(), "detailed");
+      const intent = htmlSection(html, "Codebase intent", "Intent coherence");
+      expect(intent).not.toContain("Security");
+      expect(intent).toContain("Data Access");
+    });
+
+    it("coherence heatmap: renders (non-blind) with a Data Access column and NO Security column", () => {
+      const html = renderHtmlReport(THIN_PLUS_ARCH(), "detailed");
+      const heatmap = htmlSection(html, "Intent coherence", "Drift findings");
+      // The heatmap actually rendered a category column (the old fixture used an
+      // empty perFileScores, so it rendered "" and could never catch this).
+      expect(heatmap).toContain('hm-cat">Data Access');
+      // The below-floor security finding produced NO Security column.
+      expect(heatmap).not.toContain('hm-cat">Security');
+    });
+  });
+
+  describe("csv export", () => {
+    it("DRIFT FINDINGS omits the thin finding; ALL FINDINGS surfaces it as advisory; DRIFT SCORES omits the security row", () => {
+      const csv = renderCsvReport(THIN_PLUS_ARCH());
+
+      const driftFindingsStart = csv.indexOf("DRIFT FINDINGS");
+      const allFindingsStart = csv.indexOf("ALL FINDINGS");
+      const driftScoresStart = csv.indexOf("DRIFT SCORES");
+      expect(driftScoresStart).toBeGreaterThan(-1);
+      expect(driftFindingsStart).toBeGreaterThan(driftScoresStart);
+      expect(allFindingsStart).toBeGreaterThan(driftFindingsStart);
+
+      const driftScoresSection = csv.slice(driftScoresStart, driftFindingsStart);
+      expect(driftScoresSection).not.toContain("security_posture");
+      expect(driftScoresSection).toContain("architectural_consistency");
+
+      const driftFindingsSection = csv.slice(driftFindingsStart, allFindingsStart);
+      expect(driftFindingsSection).not.toContain("security_posture");
+      expect(driftFindingsSection).toContain("raw SQL");
+
+      const allFindingsSection = csv.slice(allFindingsStart);
+      expect(allFindingsSection).toContain("security_posture-advisory");
+      expect(allFindingsSection).toContain(RAW_MESSAGE);
+    });
+  });
+
+  describe("docx export", () => {
+    it("Security score-table row is N/A, thin finding excluded from DRIFT FINDINGS, surfaced in general findings", () => {
+      const text = docxText(renderDocxReport(THIN_PLUS_ARCH()));
+
+      expect(text).toContain("Security Consistency N/A N/A N/A");
+
+      const driftStart = text.indexOf("3. DRIFT FINDINGS");
+      const driftEnd = text.indexOf("FILE RANKING");
+      expect(driftStart).toBeGreaterThan(-1);
+      expect(driftEnd).toBeGreaterThan(driftStart);
+      const driftSection = text.slice(driftStart, driftEnd);
+      expect(driftSection).not.toContain("1 mutating route(s) lack auth");
+      expect(driftSection).toContain("raw SQL");
+      expect(driftSection).toContain("1 cross-file contradictions detected");
+
+      const staticSection = text.slice(text.indexOf("STATIC ANALYSIS FINDINGS"));
+      expect(staticSection).toContain("security_posture-advisory");
+      expect(staticSection).toContain("1 mutating route(s) lack auth");
+    });
+
+    it("does not present the demoted finding's pattern as established codebase intent", () => {
+      const text = docxText(renderDocxReport(THIN_PLUS_ARCH()));
+      const intentSection = text.slice(text.indexOf("CODEBASE INTENT"), text.indexOf("3. DRIFT FINDINGS"));
+      expect(intentSection).not.toContain("SECURITY");
+      expect(intentSection).toContain("ARCHITECTURAL CONSISTENCY");
+    });
+  });
+
+  describe("at/above-floor findings are unaffected", () => {
+    it("a well-sampled (n>=MIN_SECURITY_PEERS) security finding stays a scored drift finding", () => {
+      const atFloor = rawSecuritySub("Auth middleware", MIN_SECURITY_PEERS, 3);
+      atFloor.finding = "1 mutating route(s) lack auth (at floor)";
+      const result = mkPipelineResult([atFloor]);
+
+      expect(result.scores.securityPosture.applicable).toBe(true);
+      const html = renderHtmlReport(result, "detailed");
+      const library = htmlSection(html, "Drift findings", "File ranking");
+      expect(library).toContain("1 mutating route(s) lack auth (at floor)");
+    });
+  });
+});

--- a/test/unit/scoring/categories-labels.test.ts
+++ b/test/unit/scoring/categories-labels.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { CATEGORY_CONFIG } from "../../../src/scoring/categories.js";
+
+describe("security dimension user-facing name", () => {
+  it("renders as 'Security Consistency', not 'Security Posture'", () => {
+    expect(CATEGORY_CONFIG.securityPosture.name).toBe("Security Consistency");
+  });
+  it("keeps the internal ScoringCategory key unchanged", () => {
+    expect(CATEGORY_CONFIG.securityPosture).toBeDefined();
+    expect(CATEGORY_CONFIG.securityPosture.analyzers.some((a) => a.id === "drift-security_posture")).toBe(true);
+  });
+});

--- a/test/unit/scoring/category-applicability.test.ts
+++ b/test/unit/scoring/category-applicability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeScores } from "../../../src/scoring/engine.js";
+import { computeScores, MIN_SECURITY_PEERS } from "../../../src/scoring/engine.js";
 import { isCategoryApplicable, DRIFT_DISPLAY_CATEGORIES } from "../../../src/scoring/categories.js";
 import { applicableCategoryCount } from "../../../src/output/terminal.js";
 import type { Finding } from "../../../src/core/types.js";
@@ -22,7 +22,11 @@ import type { Finding } from "../../../src/core/types.js";
  *      never silently vanishes.
  */
 
-function mk(analyzerId: string, severity: Finding["severity"] = "warning"): Finding {
+function mk(
+  analyzerId: string,
+  severity: Finding["severity"] = "warning",
+  driftSignal?: Finding["driftSignal"],
+): Finding {
   return {
     analyzerId,
     severity,
@@ -30,7 +34,22 @@ function mk(analyzerId: string, severity: Finding["severity"] = "warning"): Find
     message: `test finding for ${analyzerId}`,
     locations: [{ file: "src/example.ts", line: 1 }],
     tags: [],
+    ...(driftSignal ? { driftSignal } : {}),
   };
+}
+
+// A drift-security_posture finding with a peer sample AT the min-peer floor
+// (see applySecurityMinPeerFloor, src/scoring/engine.ts). Real detector output
+// always carries driftSignal for this category (driftFindingToFinding,
+// src/drift/index.ts) — a bare mk("drift-security_posture") with no
+// driftSignal is a 0-peer sample and is (correctly) demoted to advisory by the
+// floor, so these "real finding" guards use a well-sampled fixture instead.
+function wellSampledSecurityFinding(severity: Finding["severity"] = "warning"): Finding {
+  return mk("drift-security_posture", severity, {
+    consistencyScore: 50,
+    dominantCount: MIN_SECURITY_PEERS - 1,
+    totalRelevantFiles: MIN_SECURITY_PEERS,
+  });
 }
 
 describe("why a category is N/A: drift-detector presence (isCategoryApplicable)", () => {
@@ -90,7 +109,7 @@ describe("N/A means nothing to measure — a real surface always scores", () => 
   });
 
   it("ANTI-BUG GUARD: a security surface (real drift finding) is SCORED, never hidden as N/A", () => {
-    const { scores } = computeScores([mk("drift-security_posture", "error")], 30000);
+    const { scores } = computeScores([wellSampledSecurityFinding("error")], 30000);
     expect(scores.securityPosture.applicable).toBe(true);
     expect(scores.securityPosture.findingCount).toBeGreaterThan(0);
   });
@@ -117,6 +136,6 @@ describe("N/A set is exactly the honest set; composite excludes N/A", () => {
 
   it("composite counts only applicable categories, and a new surface adds to the count", () => {
     expect(applicableCategoryCount(computeScores([], 30000).scores)).toBe(2); // arch + redundancy
-    expect(applicableCategoryCount(computeScores([mk("drift-security_posture")], 30000).scores)).toBe(3); // + security
+    expect(applicableCategoryCount(computeScores([wellSampledSecurityFinding()], 30000).scores)).toBe(3); // + security
   });
 });

--- a/test/unit/scoring/security-min-peer-floor.test.ts
+++ b/test/unit/scoring/security-min-peer-floor.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { applySecurityMinPeerFloor, MIN_SECURITY_PEERS, computeScores } from "../../../src/scoring/engine.js";
+import type { Finding } from "../../../src/core/types.js";
+
+function secFinding(totalRelevantFiles: number, analyzerId = "drift-security_posture"): Finding {
+  return {
+    analyzerId,
+    severity: "warning",
+    confidence: 0.75,
+    message: "DRIFT: auth missing on 1 of N routes",
+    locations: [{ file: "src/routes/a.ts", line: 1 }],
+    tags: ["drift"],
+    driftSignal: { consistencyScore: 50, dominantCount: totalRelevantFiles - 1, totalRelevantFiles },
+  };
+}
+
+describe("applySecurityMinPeerFloor", () => {
+  it("re-tags a thin (< MIN_SECURITY_PEERS) security finding to the advisory hygiene id", () => {
+    const out = applySecurityMinPeerFloor([secFinding(2)]);
+    expect(out[0].analyzerId).toBe("security_posture-advisory");
+  });
+
+  it("keeps a security finding at the floor as scored drift", () => {
+    const out = applySecurityMinPeerFloor([secFinding(MIN_SECURITY_PEERS)]);
+    expect(out[0].analyzerId).toBe("drift-security_posture");
+  });
+
+  it("never touches codedna-taint findings", () => {
+    const out = applySecurityMinPeerFloor([secFinding(1, "codedna-taint")]);
+    expect(out[0].analyzerId).toBe("codedna-taint");
+  });
+
+  it("a thin security finding does not move the drift composite (advisory → N/A)", () => {
+    const { scores } = computeScores([secFinding(2)], 1000);
+    // The only security drift finding was demoted → surface-specific category is N/A.
+    expect(scores.securityPosture.applicable).toBe(false);
+  });
+
+  it("a security finding at the floor is scored", () => {
+    const { scores } = computeScores([secFinding(MIN_SECURITY_PEERS)], 1000);
+    expect(scores.securityPosture.applicable).toBe(true);
+    expect(scores.securityPosture.score).toBeLessThan(20);
+  });
+});

--- a/test/unit/tools/get-dominant-pattern.test.ts
+++ b/test/unit/tools/get-dominant-pattern.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { dominantPatternFor } from "../../../src/tools-core/tools/get-dominant-pattern.js";
+import type { RepoDriftBaseline, CategoryVote } from "../../../src/core/baseline.js";
+
+function vote(pattern: string, dom: number, total: number): CategoryVote {
+  return { driftCategory: "security_posture", dominantPattern: pattern, dominantCount: dom, totalRelevantFiles: total, consistencyScore: Math.round((dom / total) * 100), dominantFiles: [], deviators: [] };
+}
+
+function baseline(over: Partial<RepoDriftBaseline>): RepoDriftBaseline {
+  return {
+    key: "k", rootDir: "/r", ctxFiles: [{ path: "a.ts", hash: "h" }],
+    perCategoryVote: {}, securitySubVotes: {}, intentHints: [], minhashIndex: [], builtAt: 0,
+    ...over,
+  };
+}
+
+describe("dominantPatternFor — auth reads the auth sub-vote, not the collided slot", () => {
+  it("returns the Auth middleware vote even when rate-limit has a wider denominator", () => {
+    const b = baseline({
+      // The collided perCategoryVote slot holds the WIDER rate-limit finding.
+      perCategoryVote: { security_posture: vote("Rate limiting applied", 6, 12) },
+      securitySubVotes: {
+        "Auth middleware": vote("Auth middleware applied", 4, 5),
+        "Rate limiting": vote("Rate limiting applied", 6, 12),
+      },
+    });
+    const out = dominantPatternFor(b, "auth");
+    expect(out.dominantPattern).toBe("Auth middleware applied");
+    expect(out.consistency).toContain("4 of 5");
+  });
+
+  it("falls back to the consistent projection when securitySubVotes is absent (stale pre-upgrade baseline)", () => {
+    // Simulates a v1 on-disk baseline served stale by getBaseline via
+    // loadBaselineUnchecked: it predates the securitySubVotes field entirely,
+    // so the field is undefined at runtime, not an empty object.
+    const b = baseline({
+      perCategoryVote: { security_posture: vote("Rate limiting applied", 6, 12) },
+      securitySubVotes: undefined,
+    });
+    expect(() => dominantPatternFor(b, "auth")).not.toThrow();
+    const out = dominantPatternFor(b, "auth");
+    expect(out.dominantPattern).toBe("consistent");
+    expect(out.consistency).toBe("100% — no deviations detected");
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,21 @@
 # CLI backlog
 
+- **scan-over-scan diff still tracks the RAW drift representation**: `result.diff`
+  / the persisted history digests read `driftResult.driftFindings` (raw), so a
+  below-floor route-consistency security finding participates in the drift diff.
+  If such a finding is newly introduced between two same-version scans, the
+  terminal diff banner (`renderDiffBanner` top-new-drift) could momentarily call
+  it a "new drift finding" even though the report body renders it as advisory.
+  The same raw-digest diff source also feeds `## Recent trajectory` in
+  `src/output/context-md.ts`, so `--write-context` could commit that raw finding
+  text into the committed `.vibedrift/context.md` in the same scenario (a more
+  durable surface than the ephemeral terminal line).
+  This is deliberate for now: the baseline (`assembleBaseline`) and diff track
+  the raw representation for continuity, and the first-scan-after-upgrade case is
+  already silenced by the SCORING_VERSION-mismatch guard. If we want the diff to
+  match the rendered (scored) view, feed `scoredDriftView(...).driftFindings` to
+  both the diff digest (buildScanResult) and `saveScanResult` together (keep the
+  two sources identical or a spurious per-scan diff reappears).
 - **`watch` renderer shows signed-out copy while authenticated** (v0.14.8): watch
   output includes the "Sign in with `vibedrift login`…" hint and free-tier deep
   tease even on a logged-in session. Fix the auth-state branch in the renderer.

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,10 @@
+# CLI backlog
+
+- **`watch` renderer shows signed-out copy while authenticated** (v0.14.8): watch
+  output includes the "Sign in with `vibedrift login`…" hint and free-tier deep
+  tease even on a logged-in session. Fix the auth-state branch in the renderer.
+- **Default `--deep` output should surface the AI results inline**: the concise
+  deep render shows "AI fix prompts ready" + the dashboard link, but the
+  coherence audit, AI-validated findings, and intent-mismatch checks only
+  appear with `--format terminal`. Add a short AI summary (coherence grade +
+  top finding) to the default deep render.


### PR DESCRIPTION
## What this changes

Hardens the route-level security **consistency** detector and renames the dimension from "Security Posture" to **Security Consistency**, to reflect what it actually measures: whether new code follows the auth / input-validation / rate-limit conventions the rest of the repo already uses, not an absolute security grade.

### Fixes

- **The auth consistency vote now scopes to state-changing routes.** It previously counted read-only `GET` routes in the denominator, which pulled intentionally-public reads into the vote and made the "N of M routes require auth" summary inaccurate.
- **Thin route samples no longer move the score.** A route-consistency finding drawn from too few peer routes to be reliable is surfaced as advisory (informational) instead of affecting the Vibe Drift Score. It still renders, so a small repo is never silently passed.
- **`get_dominant_pattern("auth")` returns the auth convention.** Auth, input-validation, and rate-limit conventions now have separate cached votes, so querying one no longer returns whichever happened to have the widest sample.
- **Consistent advisory rendering.** A below-threshold advisory finding renders the same way across the terminal, HTML, CSV, and DOCX outputs, and never appears as a scored drift finding while the category reads not-applicable.

### Rename

- "Security Posture" is now "Security Consistency" everywhere it is shown (score bar, HTML report card, DOCX export), with a permanent note that consistency is not the same as the absence of vulnerabilities. Internal identifiers and analyzer IDs are unchanged.

### Migration notes

- The scoring formula version is bumped, so the first scan after upgrading suppresses cross-version score deltas (a one-time, silent migration, no per-scan banner).
- The cached baseline format version is bumped; stale baselines rebuild automatically on the next scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkqH9w2pU7b7Hctbe45h2t
