### PR TITLE
Security Consistency: floor, route suppression, and in-loop auth check

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,5 +14,7 @@ useDefault = true
 description = "Synthetic security-test fixtures and placeholder templates (verified: no real secrets)"
 paths = [
   '''test/unit/analyzers/security\.test\.ts''',
+  '''test/unit/analyzers/security-floor\.test\.ts''',
+  '''test/calibration/injectors\.ts''',
   '''\.env\.example$''',
 ]

--- a/src/analyzers/security.ts
+++ b/src/analyzers/security.ts
@@ -16,6 +16,14 @@ interface SecurityPattern {
   // If provided, the pattern is only flagged when the surrounding ±5 lines
   // contain at least one match for this regex (security context proximity check)
   contextRequired?: RegExp;
+  // Absolute-floor rule: high-precision, low-noise. Emitted under the
+  // `security-floor` analyzer id so a later task can render it with a
+  // distinct badge. Does not change scoring (still hygiene-kind).
+  floor?: boolean;
+  // Noisy, low-confidence rule (0.4-0.7). Kept for signal but de-emphasized:
+  // the emitted finding is forced to severity "info" and tagged "demoted"
+  // so the renderer can keep it out of the primary hygiene list.
+  demoted?: boolean;
 }
 
 const SECURITY_PATTERNS: SecurityPattern[] = [
@@ -30,6 +38,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     languages: "all",
     tags: ["security", "secrets"],
     negativeFilter: /(?:example|placeholder|your[_-]|xxx|test|dummy|fake|sample)/i,
+    floor: true,
   },
   // NOTE: `hardcoded-password` removed in Phase 4 — `password = "<4+ chars>"`
   // matched any short string assigned to a password-named var (test fixtures,
@@ -45,6 +54,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     languages: "all",
     tags: ["security", "secrets"],
     negativeFilter: /(?:example|placeholder|your[_-]|xxx|test|dummy|fake|sample)/i,
+    floor: true,
   },
   {
     id: "private-key",
@@ -55,6 +65,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     message: "Private key embedded in source code",
     languages: "all",
     tags: ["security", "secrets", "critical"],
+    floor: true,
   },
   {
     id: "aws-key",
@@ -65,6 +76,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     message: "AWS access key ID detected",
     languages: "all",
     tags: ["security", "secrets", "aws"],
+    floor: true,
   },
 
   // === Injection Vulnerabilities ===
@@ -136,6 +148,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     message: "Direct innerHTML assignment — potential XSS vector",
     languages: ["javascript", "typescript"],
     tags: ["security", "xss"],
+    demoted: true,
   },
   {
     id: "dangerously-set-html",
@@ -181,6 +194,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     negativeFilter: /(?:test|mock|seed|shuffle|animation|color|position|offset|delay|jitter)/i,
     // Only flag near security-relevant code — UI shuffles/animations are not a risk
     contextRequired: /(?:token|secret|password|key|nonce|salt|hash|crypto|auth|session|jwt|api.?key|credential)/i,
+    demoted: true,
   },
 
   // === Path Traversal ===
@@ -193,6 +207,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     message: "Potential path traversal: dynamic value in file operation",
     languages: ["javascript", "typescript"],
     tags: ["security", "path-traversal"],
+    demoted: true,
   },
 
   // === SSRF ===
@@ -206,6 +221,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     languages: "all",
     tags: ["security", "ssrf"],
     negativeFilter: /(?:API_URL|BASE_URL|apiUrl|baseUrl|base\s*\+|endpoint|config\.|process\.env)/i,
+    demoted: true,
   },
 
   // === Python-specific ===
@@ -241,6 +257,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     message: "TLS certificate verification disabled",
     languages: ["go"],
     tags: ["security", "tls"],
+    floor: true,
   },
 
   // === Rust-specific ===
@@ -253,6 +270,7 @@ const SECURITY_PATTERNS: SecurityPattern[] = [
     message: "Unsafe block — ensure memory safety invariants are upheld",
     languages: ["rust"],
     tags: ["security", "memory-safety"],
+    demoted: true,
   },
 ];
 
@@ -267,7 +285,11 @@ export const securityAnalyzer: Analyzer = {
   category: "securityPosture",
   requiresAST: false,
   applicableLanguages: "all",
-  version: 2,
+  // Bumped 3: floor/demoted split (analyzerId now "security-floor" for the
+  // absolute-floor subset; five noisy rules force severity "info" + a
+  // "demoted" tag). Invalidates the on-disk findings cache so already-scanned
+  // repos pick up the new classification on their next run.
+  version: 3,
 
   async analyze(ctx: AnalysisContext): Promise<Finding[]> {
     const findings: Finding[] = [];
@@ -316,8 +338,12 @@ export const securityAnalyzer: Analyzer = {
           const snippet = line.trim();
 
           findings.push({
-            analyzerId: "security",
-            severity: pattern.severity,
+            // Floor rules (private-key, aws-key, hardcoded-api-key,
+            // hardcoded-token, go-tls-skip-verify) get a distinct analyzer
+            // id so their high-precision findings can be surfaced with a
+            // separate badge downstream. All other rules keep "security".
+            analyzerId: pattern.floor ? "security-floor" : "security",
+            severity: pattern.demoted ? "info" : pattern.severity,
             confidence: pattern.confidence,
             message: `${pattern.message} in ${file.relativePath}:${lineNum}`,
             locations: [{
@@ -325,7 +351,7 @@ export const securityAnalyzer: Analyzer = {
               line: lineNum,
               snippet: snippet.length > 120 ? snippet.slice(0, 120) + "..." : snippet,
             }],
-            tags: pattern.tags,
+            tags: pattern.demoted ? [...pattern.tags, "demoted"] : pattern.tags,
           });
         }
       }

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -143,6 +143,13 @@ async function discoverAndFilterFiles(
   const t0 = Date.now();
   const { ctx, warnings } = await buildAnalysisContext(rootDir);
 
+  // Carry the already-loaded project config (cli/index.ts loads it once to
+  // resolve --format/--fail-on-score defaults) onto the context so the
+  // Security Consistency detector's config glob allowlist can read it via
+  // DriftContext.projectConfig. Undefined when the caller didn't load one
+  // (e.g. watch mode) — the allowlist arm simply no-ops in that case.
+  ctx.projectConfig = options.projectConfig;
+
   // Apply --include / --exclude glob filters in-place on the context's files.
   const includes = options.include ?? [];
   const excludes = options.exclude ?? [];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -179,6 +179,7 @@ program
       format: resolvedFormat,
       output: options.output,
       failOnScore: resolvedFailOnScore,
+      projectConfig: projectConfig ?? undefined,
       codedna: options.codedna,
       cache: options.cache,
       deep: options.localOnly ? false : options.deep,

--- a/src/codedna/taint-analysis.ts
+++ b/src/codedna/taint-analysis.ts
@@ -125,6 +125,20 @@ const TAINT_SINKS: SinkPattern[] = [
   { regex: /axios\.\w+\s*\(/, label: "outbound HTTP request", severity: "warning", category: "ssrf" },
 ];
 
+/**
+ * Sink labels whose category is `code_injection` or `command_injection`
+ * (unsanitized input reaching eval/exec). `Finding.message` (built in
+ * `taintFindings` below) embeds the sink's human label, not its category, so
+ * this is the real field a downstream consumer can match on to recognize an
+ * eval/exec-class taint flow without duplicating TAINT_SINKS. Exported for
+ * src/output/floor-badge.ts (the render-only "Security floor" badge, D1).
+ */
+export const INJECTION_SINK_LABELS: ReadonlySet<string> = new Set(
+  TAINT_SINKS.filter((s) => s.category === "code_injection" || s.category === "command_injection").map(
+    (s) => s.label,
+  ),
+);
+
 // ──── Sanitizers that remove taint ────
 
 interface SanitizerPattern {

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -22,6 +22,7 @@ import { runDriftDetection } from "../drift/index.js";
 import { parseFiles } from "../utils/ast.js";
 import { extractAllFunctions } from "../codedna/function-extractor.js";
 import { buildSignature } from "../codedna/minhash.js";
+import { SECURITY_SUPPRESSION_SUBCATEGORY } from "../drift/security-suppression.js";
 import type { AnalysisContext } from "./types.js";
 import type { DriftFinding, DriftCategory } from "../drift/types.js";
 import type { IntentHint } from "../intent/types.js";
@@ -94,12 +95,23 @@ export function computeBaselineKey(files: Array<{ path: string; hash: string }>)
  * covering the most files — the most representative dominant for the category.
  * Fully-consistent categories emit no finding, so they have no entry here and
  * tools report them as 100%-consistent by inference.
+ *
+ * The suppression-audit finding (security-suppression.ts, subCategory
+ * SECURITY_SUPPRESSION_SUBCATEGORY) is excluded: it is a hygiene audit trail
+ * ("N routes excluded"), not a dominance vote, so it must never win the
+ * security_posture slot in place of a real auth/validation/rate-limit vote
+ * (or occupy that slot when no real vote fires at all, which would make
+ * check_file_drift report a nonsensical "route excluded from the security
+ * consistency check" deviation for the suppressed file). It still reaches
+ * `result.findings` for the CLI render; only the persisted baseline vote
+ * excludes it.
  */
 export function votesFromFindings(
   findings: DriftFinding[],
 ): Partial<Record<DriftCategory, CategoryVote>> {
   const out: Partial<Record<DriftCategory, CategoryVote>> = {};
   for (const f of findings) {
+    if (f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY) continue;
     const existing = out[f.driftCategory];
     if (existing && existing.totalRelevantFiles >= f.totalRelevantFiles) continue;
     out[f.driftCategory] = toCategoryVote(f);
@@ -126,7 +138,10 @@ export function toCategoryVote(f: DriftFinding): CategoryVote {
  * Like votesFromFindings but for the security sub-conventions, keyed by
  * `subCategory` instead of `driftCategory`. Only security_posture findings that
  * carry a subCategory participate; each sub-key keeps the widest-denominator
- * finding (same tie-break as votesFromFindings).
+ * finding (same tie-break as votesFromFindings). The suppression-audit
+ * subCategory is excluded for the same reason as in votesFromFindings above:
+ * it is an audit trail, not a sub-convention vote, so it must not leave a
+ * bogus "Suppression audit" entry in the persisted securitySubVotes.
  */
 export function securitySubVotesFromFindings(
   findings: DriftFinding[],
@@ -134,6 +149,7 @@ export function securitySubVotesFromFindings(
   const out: Partial<Record<string, CategoryVote>> = {};
   for (const f of findings) {
     if (f.driftCategory !== "security_posture" || !f.subCategory) continue;
+    if (f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY) continue;
     const key = f.subCategory;
     const existing = out[key];
     if (existing && existing.totalRelevantFiles >= f.totalRelevantFiles) continue;

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -30,6 +30,19 @@ export interface ProjectConfig {
   format?: ReportFormat;
   /** CI score floor: `vibedrift` exits non-zero below this when `--fail-on-score` is not passed. */
   failOnScore?: number;
+  /** Security Consistency check settings. */
+  security?: {
+    /**
+     * Gitignore-style globs matched against a route's file path. A matching
+     * route is excluded from the auth/validation/rate-limit dominance vote
+     * entirely, the same denominator-removing suppression the inline
+     * `@vibedrift-public` annotation gives a single route, declared once
+     * for a whole directory instead of per-route. Matched with the same
+     * `ignore` package `.vibedriftignore` uses, so semantics stay consistent
+     * across the tool.
+     */
+    allowlist?: string[];
+  };
 }
 
 export function projectConfigPath(rootDir: string): string {
@@ -53,6 +66,15 @@ export function normalizeProjectConfig(input: unknown): ProjectConfig | null {
   }
   if (typeof o.failOnScore === "number" && o.failOnScore >= 0 && o.failOnScore <= 100) {
     config.failOnScore = o.failOnScore;
+  }
+  if (o.security && typeof o.security === "object" && !Array.isArray(o.security)) {
+    const sec = o.security as Record<string, unknown>;
+    if (Array.isArray(sec.allowlist)) {
+      const allowlist = sec.allowlist.filter(
+        (g): g is string => typeof g === "string" && g.trim().length > 0,
+      );
+      if (allowlist.length > 0) config.security = { allowlist };
+    }
   }
   return config;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
 import type { Tree, Node as SyntaxNode } from "web-tree-sitter";
+import type { ProjectConfig } from "./project-config.js";
 
 export type { Tree, SyntaxNode };
 
@@ -94,6 +95,15 @@ export interface AnalysisContext {
    * found — hint-seeded voting silently no-ops.
    */
   intentHints?: import("../intent/types.js").IntentHint[];
+  /**
+   * Loaded `.vibedrift/config.json`, when the scan pipeline found and
+   * parsed one. Currently consumed by the Security Consistency detector's
+   * config glob allowlist (`security.allowlist`); optional because several
+   * entry points build an AnalysisContext without loading a project config
+   * (notably the MCP/baseline path in `core/baseline.ts`), and the
+   * allowlist arm simply no-ops when it's absent.
+   */
+  projectConfig?: ProjectConfig;
 }
 
 export interface PackageJson {
@@ -459,4 +469,13 @@ export interface ScanOptions {
    * with --deep: deep-scan only what you changed (a paid, fast PR-gate flow).
    */
   diff?: string | boolean;
+  /**
+   * Already-loaded `.vibedrift/config.json` (the CLI entry point loads it
+   * once to resolve `format`/`failOnScore` defaults before calling
+   * `runScan`; this carries the same object through rather than reloading
+   * it). Set onto `AnalysisContext.projectConfig` so detectors like the
+   * Security Consistency config allowlist can read it. Omitted callers
+   * (e.g. watch mode) simply run without a project config.
+   */
+  projectConfig?: ProjectConfig;
 }

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -176,12 +176,24 @@ function computeDriftScores(findings: Finding[], totalLines: number): DriftScore
  * `runDriftDetection` are intentionally left untouched for the baseline
  * (`assembleBaseline`) and the scan-over-scan diff, which track the raw drift
  * representation for continuity.
+ *
+ * The suppression-audit finding (security-suppression.ts, subCategory
+ * SECURITY_SUPPRESSION_SUBCATEGORY) is excluded here too, independent of the
+ * below-floor check: it is a hygiene audit trail ("N routes excluded"), not a
+ * dominance vote, and `driftFindingToFinding` already routes it to the
+ * hygiene-kind analyzerId. Its `totalRelevantFiles` is just the count of
+ * suppressed routes, so at >= MIN_SECURITY_PEERS suppressions the below-floor
+ * check alone does not catch it and it would otherwise leak into the scored
+ * DRIFT representation (and every renderer that reads it) mislabeled as
+ * "DRIFT: N route(s) excluded from the security consistency check".
  */
 export function scoredDriftView(
   driftFindings: DriftFinding[],
   totalLines: number,
 ): { driftFindings: DriftFinding[]; driftScores: DriftScores } {
-  const scored = driftFindings.filter((d) => !isBelowSecurityPeerFloor(d));
+  const scored = driftFindings.filter(
+    (d) => !isBelowSecurityPeerFloor(d) && d.subCategory !== SECURITY_SUPPRESSION_SUBCATEGORY,
+  );
   const driftScores = computeDriftScores(scored.map(driftFindingToFinding), totalLines);
   return { driftFindings: scored, driftScores };
 }

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -17,6 +17,7 @@ import { stateManagementConsistency } from "./state-management-consistency.js";
 import { testStructureConsistency } from "./test-structure-consistency.js";
 import { commitArchaeology } from "./commit-archaeology.js";
 import { detectPivotsAcrossFindings } from "./pivot-detector.js";
+import { SECURITY_SUPPRESSION_SUBCATEGORY, SECURITY_SUPPRESSION_ANALYZER_ID } from "./security-suppression.js";
 
 export function createDriftDetectors(): DriftDetector[] {
   return [
@@ -209,6 +210,15 @@ function enrichWithIntentDivergence(
   }
 
   return findings.map((f) => {
+    // The suppression-audit finding (security-suppression.ts) is a count of
+    // excluded routes, not a dominance vote — its `dominantPattern` ("no
+    // suppression") is never meant to be compared against a declared
+    // convention label. Without this guard, any repo with a security_posture
+    // intent hint (e.g. CLAUDE.md declaring "auth required on all routes")
+    // would stamp every suppression-audit finding with a spurious
+    // "code contradicts declared intent" divergence, which is false — the
+    // finding is a hygiene audit log entry, not a vote outcome.
+    if (f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY) return f;
     const hint = byCategory.get(f.driftCategory);
     if (!hint) return f;
     // If the finding's voted dominant matches the declared label, no
@@ -249,13 +259,25 @@ export function attachEngineComposite(
 }
 
 export function driftFindingToFinding(d: DriftFinding): Finding {
+  // Suppression-audit findings (src/drift/security-suppression.ts) are the
+  // one deliberate exception to "analyzerId is keyed off driftCategory
+  // alone": they must land on the HYGIENE track under a distinct analyzerId
+  // (registered in scoring/categories.ts as kind "hygiene") so citing an
+  // @vibedrift-public exclusion can never move the Vibe Drift composite, no
+  // matter how many routes are suppressed. Matched on subCategory, which is
+  // not one of SECURITY_SUBCATEGORIES (types.ts) and only ever set by
+  // buildSuppressionAuditFinding.
+  const analyzerId =
+    d.driftCategory === "security_posture" && d.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY
+      ? SECURITY_SUPPRESSION_ANALYZER_ID
+      : `drift-${d.driftCategory}`;
   return {
     // analyzerId is keyed off the typed `driftCategory` enum — NOT the
     // freeform `detector` string — so it always matches a registered id in
     // scoring/categories.ts. Using `detector` (which detectors set
     // inconsistently: some to the category, some to the detector id) was the
     // root of the wiring bug that excluded 11 of 14 detectors from the score.
-    analyzerId: `drift-${d.driftCategory}`,
+    analyzerId,
     severity: d.severity,
     confidence: d.confidence,
     message: `DRIFT: ${d.finding}`,

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -52,6 +52,7 @@ export function buildDriftContext(ctx: AnalysisContext): DriftContext {
     dominantLanguage: ctx.dominantLanguage,
     hasGitMetadata: ctx.hasGitMetadata ?? false,
     intentHints: ctx.intentHints ?? [],
+    projectConfig: ctx.projectConfig,
   };
 }
 

--- a/src/drift/route-auth-classify.ts
+++ b/src/drift/route-auth-classify.ts
@@ -50,7 +50,7 @@ export async function classifyRouteAuth(
 ): Promise<RouteAuthClassification | null> {
   const ext = relTarget.split(".").pop()?.toLowerCase() ?? "";
   const language = JS_TS_EXT[ext];
-  if (!language) return null; // JS/TS only — the AST route extractor is JS/TS.
+  if (!language) return null; // JS/TS only: the AST route extractor is JS/TS.
 
   const file: SourceFile = {
     path: relTarget,

--- a/src/drift/route-auth-classify.ts
+++ b/src/drift/route-auth-classify.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared route-auth classifier for the in-loop `validate_change` security check.
+ *
+ * It deliberately reuses the SAME AST route extractor the batch security
+ * detector uses (`extractJsRoutesAst`), so its verdict can never contradict the
+ * batch detector for the same body. Given a single proposed function body, it
+ * reports whether that body registers a mutating route (POST/PUT/PATCH/DELETE)
+ * and whether EVERY such route carries a visible per-route auth guard.
+ *
+ * Router-scope middleware (`router.use(requireAuth)`) is intentionally NOT
+ * consulted here: a single proposed body cannot see its router's setup, so we
+ * pass `undefined` for the file-middleware arg. That invisibility is exactly why
+ * the consumer hedges to low confidence and never states "this route is
+ * unauthed" as fact.
+ *
+ * JS/TS only: the AST route extractor is JS/TS. Any other language returns null.
+ */
+import { parseFile } from "../utils/ast.js";
+import { extractJsRoutesAst, SECURITY_AST } from "./security-ast.js";
+import type { SourceFile, SupportedLanguage } from "../core/types.js";
+
+// Only JS/TS extensions map to a language here; everything else yields null and
+// the classifier bails (the AST route extractor is JS/TS-specific).
+const JS_TS_EXT: Record<string, SupportedLanguage> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+};
+
+export interface RouteAuthClassification {
+  /** At least one route in the body uses a mutating method (POST/PUT/PATCH/DELETE). */
+  isMutatingRoute: boolean;
+  /** EVERY mutating route in the body carries a visible per-route auth guard.
+   *  Conservative: a single unguarded mutating route makes this false. */
+  hasVisibleAuth: boolean;
+}
+
+/**
+ * Classify a proposed body's route-auth posture, or null when there is nothing
+ * to judge (unsupported language, unparseable body, or no route at all).
+ */
+export async function classifyRouteAuth(
+  body: string,
+  relTarget: string,
+): Promise<RouteAuthClassification | null> {
+  const ext = relTarget.split(".").pop()?.toLowerCase() ?? "";
+  const language = JS_TS_EXT[ext];
+  if (!language) return null; // JS/TS only — the AST route extractor is JS/TS.
+
+  const file: SourceFile = {
+    path: relTarget,
+    relativePath: relTarget,
+    language,
+    content: body,
+    lineCount: body.split("\n").length,
+  };
+  const tree = await parseFile(file);
+  if (!tree) return null;
+
+  // No file-middleware arg: router-scope `router.use()` auth is deliberately not
+  // visible from a single proposed body, so it must not silence the check.
+  const routes = extractJsRoutesAst(tree, relTarget, undefined);
+  if (routes.length === 0) return null; // not a route body → nothing to compare.
+
+  // RouteInfo.method is upper-cased by the extractor; SECURITY_AST.MUTATING is
+  // lower-case. Normalize before the membership test.
+  const mutating = routes.filter((r) => SECURITY_AST.MUTATING.has(r.method.toLowerCase()));
+  return {
+    isMutatingRoute: mutating.length > 0,
+    // `.every` over an empty set is vacuously true; that only matters when there
+    // is no mutating route, in which case the consumer ignores this field.
+    hasVisibleAuth: mutating.every((r) => r.hasAuth === true),
+  };
+}

--- a/src/drift/security-ast.ts
+++ b/src/drift/security-ast.ts
@@ -69,6 +69,9 @@ function middlewareNames(arg: SyntaxNode): string[] {
     if (fn) return [fn.text];
   }
   if (arg.type === "member_expression") return [arg.text];
+  if (arg.type === "array") {
+    return arg.namedChildren.filter((n): n is SyntaxNode => n !== null).flatMap(middlewareNames);
+  }
   return [];
 }
 

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -345,12 +345,20 @@ export const securityConsistency: DriftDetector = {
     const findings: DriftFinding[] = [];
     const fileMw = buildFileMiddlewareIndex(ctx.files);
     // Denominator-removing suppression: a route carrying an inline
-    // `// @vibedrift-public` annotation is dropped BEFORE it reaches any
-    // vote below, so it never inflates the "unauthed" numerator or the
-    // total-routes denominator. Every suppression is cited via the audit
-    // finding pushed immediately below, independent of whatever the votes
-    // decide — a suppressed route always leaves a trail.
-    const { kept: routes, suppressed } = applyRouteSuppressions(extractRoutes(ctx.files, fileMw), ctx.files);
+    // `// @vibedrift-public` annotation, OR whose file matches a config
+    // `security.allowlist` glob (ctx.projectConfig), is dropped BEFORE it
+    // reaches any vote below, so it never inflates the "unauthed" numerator
+    // or the total-routes denominator. Every suppression is cited via the
+    // audit finding pushed immediately below, independent of whatever the
+    // votes decide — a suppressed route always leaves a trail. ctx.projectConfig
+    // is undefined on paths that build their own AnalysisContext without
+    // loading one (e.g. the MCP/baseline path), in which case the allowlist
+    // arm simply no-ops and only annotations suppress.
+    const { kept: routes, suppressed } = applyRouteSuppressions(
+      extractRoutes(ctx.files, fileMw),
+      ctx.files,
+      ctx.projectConfig ?? null,
+    );
     if (suppressed.length > 0) {
       findings.push(buildSuppressionAuditFinding(suppressed));
     }

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -35,6 +35,7 @@ import type { DriftDetector, DriftContext, DriftFinding, DriftFile } from "./typ
 import { SECURITY_SUBCATEGORIES } from "./types.js";
 import { pickIntentHint } from "./utils.js";
 import { extractJsRoutesAst, extractFileMiddlewareAst } from "./security-ast.js";
+import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
 
 const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
@@ -343,7 +344,16 @@ export const securityConsistency: DriftDetector = {
   detect(ctx: DriftContext): DriftFinding[] {
     const findings: DriftFinding[] = [];
     const fileMw = buildFileMiddlewareIndex(ctx.files);
-    const routes = extractRoutes(ctx.files, fileMw);
+    // Denominator-removing suppression: a route carrying an inline
+    // `// @vibedrift-public` annotation is dropped BEFORE it reaches any
+    // vote below, so it never inflates the "unauthed" numerator or the
+    // total-routes denominator. Every suppression is cited via the audit
+    // finding pushed immediately below, independent of whatever the votes
+    // decide — a suppressed route always leaves a trail.
+    const { kept: routes, suppressed } = applyRouteSuppressions(extractRoutes(ctx.files, fileMw), ctx.files);
+    if (suppressed.length > 0) {
+      findings.push(buildSuppressionAuditFinding(suppressed));
+    }
     if (routes.length < 2) return findings;
 
     const healthPaths = /^\/(?:health|healthz|ready|metrics|ping)$/;

--- a/src/drift/security-suppression.ts
+++ b/src/drift/security-suppression.ts
@@ -20,9 +20,11 @@
  * audit trail instead of just shrinking the sample silently.
  */
 
+import ignore from "ignore";
 import type { DeviatingFile, DriftCategory, DriftFile, DriftFinding } from "./types.js";
 import type { RouteInfo } from "./security-consistency.js";
 import type { Tree } from "../core/types.js";
+import type { ProjectConfig } from "../core/project-config.js";
 
 export interface SuppressionRecord {
   path: string;
@@ -116,14 +118,21 @@ function annotationCommentRows(tree: Tree): Set<number> {
  * reject the preceding-line match whenever the preceding line is some route's
  * own registration line — that annotation belongs to that route, not this one.
  *
- * Only the annotation arm is implemented here (Task 4). Task 5 extends this
- * signature with a trailing config param carrying the glob allowlist arm
- * (`reason: "allowlist"`); this function's `reason` is always `"annotation"`
- * today.
+ * A SECOND, independent suppression arm runs after the annotation arm: any
+ * route still `kept` whose file path matches a glob in `config.security.
+ * allowlist` (`.vibedrift/config.json`) is also dropped, with `reason:
+ * "allowlist"`. This lets a team declare a whole public router (e.g.
+ * `src/routes/public/**`) once in a committed file instead of annotating
+ * every route in it. Matched with the same `ignore` package
+ * `.vibedriftignore` uses, so glob semantics stay consistent across the
+ * tool. `config` is optional and commonly absent (e.g. the MCP/baseline
+ * path, which builds its own context without loading a project config) — in
+ * that case the allowlist arm is a no-op and only annotations suppress.
  */
 export function applyRouteSuppressions(
   routes: RouteInfo[],
   files: DriftFile[],
+  config?: ProjectConfig | null,
 ): { kept: RouteInfo[]; suppressed: SuppressionRecord[] } {
   const filesByPath = new Map<string, DriftFile>();
   for (const f of files) filesByPath.set(f.relativePath, f);
@@ -192,7 +201,29 @@ export function applyRouteSuppressions(
     kept.push(route);
   }
 
-  return { kept, suppressed };
+  // Allowlist arm: config-declared globs, tested against each STILL-KEPT
+  // route's file path. Each glob is compiled into its own `ignore()`
+  // instance (rather than one combined matcher) so a match can be traced
+  // back to the EXACT glob that caused it — required for the "every
+  // exclusion cited" rule (a suppression citing only "allowlist" with no
+  // glob would be a silent, unauditable exclusion).
+  const allowlist = config?.security?.allowlist ?? [];
+  if (allowlist.length === 0) {
+    return { kept, suppressed };
+  }
+
+  const matchers = allowlist.map((glob) => ({ glob, ig: ignore().add(glob) }));
+  const finalKept: RouteInfo[] = [];
+  for (const route of kept) {
+    const match = matchers.find(({ ig }) => ig.ignores(route.file));
+    if (match) {
+      suppressed.push({ path: route.file, line: route.line, reason: "allowlist", source: match.glob });
+      continue;
+    }
+    finalKept.push(route);
+  }
+
+  return { kept: finalKept, suppressed };
 }
 
 /** Marks the audit finding below so `driftFindingToFinding` (src/drift/index.ts)
@@ -249,18 +280,22 @@ export function buildSuppressionAuditFinding(suppressed: SuppressionRecord[]): D
     severity: "info",
     confidence: 1,
     countBased: true,
-    finding: `${suppressed.length} route(s) excluded from the security consistency check via @vibedrift-public: ${formatSuppressionList(suppressed)}`,
+    // Reason-agnostic: a suppression can come from an inline @vibedrift-public
+    // annotation OR a config allowlist glob, and formatCitation already spells
+    // out which one for each entry, so the header stays accurate either way
+    // (or when both reasons are mixed in the same list).
+    finding: `${suppressed.length} route(s) excluded from the security consistency check: ${formatSuppressionList(suppressed)}`,
     // Not a real dominance vote (see countBased above): dominantPattern
     // names what's being counted (mirrors phantom-scaffolding's
     // "wired-up exports"), so consistencyScore 100 reads coherently as
     // "100% of the counted items are exclusions" rather than the
     // self-contradictory "no suppression, 100% consistent."
-    dominantPattern: "route excluded via @vibedrift-public",
+    dominantPattern: "route excluded from the security consistency check",
     dominantCount: suppressed.length,
     totalRelevantFiles: suppressed.length,
     consistencyScore: 100,
     deviatingFiles,
     dominantFiles: [],
-    recommendation: "Periodically review @vibedrift-public annotations to confirm each excluded route is still intentionally public.",
+    recommendation: "Periodically review excluded routes (annotations and allowlist entries) to confirm each is still intentionally public.",
   };
 }

--- a/src/drift/security-suppression.ts
+++ b/src/drift/security-suppression.ts
@@ -22,6 +22,7 @@
 
 import type { DeviatingFile, DriftCategory, DriftFile, DriftFinding } from "./types.js";
 import type { RouteInfo } from "./security-consistency.js";
+import type { Tree } from "../core/types.js";
 
 export interface SuppressionRecord {
   path: string;
@@ -30,21 +31,90 @@ export interface SuppressionRecord {
   source: string;
 }
 
-/** JS/TS line comment: `// @vibedrift-public`. */
-const LINE_COMMENT_RE = /\/\/\s*@vibedrift-public\b/;
-/** JS/TS/CSS-style block comment: `/* @vibedrift-public *\/`. */
-const BLOCK_COMMENT_RE = /\/\*\s*@vibedrift-public\b/;
-/** Python (and shell-style) comment: `# @vibedrift-public`. */
-const HASH_COMMENT_RE = /#\s*@vibedrift-public\b/;
+/** The annotation token itself, matched only INSIDE a real comment (never a
+ *  string literal) via the AST/textual comment-awareness below. */
+const ANNOTATION_RE = /@vibedrift-public\b/;
 
-function lineHasAnnotation(line: string | undefined): boolean {
+/**
+ * Comment markers per language family. Python (and shell-style) uses `#`;
+ * the C family (JS/TS/Go/Rust) uses `//` and `/*`. Applying the wrong marker
+ * across languages is a false-positive source (Finding 2): a leading `#` in a
+ * JS/TS file is not a comment at all, so it must never suppress a JS/TS route.
+ * Unknown/absent languages default to the C family (the common case for the
+ * regex-fallback path, which only runs when no parse tree is available).
+ */
+function commentMarkersFor(language: string | null | undefined): string[] {
+  if (language === "python") return ["#"];
+  return ["//", "/*"];
+}
+
+/**
+ * Blank out string-literal spans so an annotation living INSIDE a string
+ * (`const s = "see // @vibedrift-public"`) can never be mistaken for a real
+ * comment (Finding 2). Handles double, single, and backtick quotes with
+ * escapes. Only closed spans are stripped: an unterminated quote is left in
+ * place, which at worst leaves a rare, malformed line looking comment-like —
+ * acceptable because the AST path (which is exact) handles every parseable
+ * file, and this textual path is the conservative fallback only.
+ */
+function stripStringLiterals(line: string): string {
+  return line
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``");
+}
+
+/** The comment portion of a line (everything from the earliest comment marker
+ *  onward), or null when the line carries no comment marker for its language. */
+function commentPortion(line: string, markers: string[]): string | null {
+  let earliest = -1;
+  for (const m of markers) {
+    const idx = line.indexOf(m);
+    if (idx !== -1 && (earliest === -1 || idx < earliest)) earliest = idx;
+  }
+  return earliest === -1 ? null : line.slice(earliest);
+}
+
+/** Regex-fallback (no parse tree): does this line carry the annotation inside a
+ *  real comment for its language? String literals are stripped first so a
+ *  quoted `// @vibedrift-public` never counts, and the marker set is chosen per
+ *  language so a `#` never matches a JS/TS line. */
+function lineHasAnnotationTextual(line: string | undefined, language: string | null | undefined): boolean {
   if (!line) return false;
-  return LINE_COMMENT_RE.test(line) || BLOCK_COMMENT_RE.test(line) || HASH_COMMENT_RE.test(line);
+  const comment = commentPortion(stripStringLiterals(line), commentMarkersFor(language));
+  return comment !== null && ANNOTATION_RE.test(comment);
+}
+
+/** AST path: 0-based rows on which a `comment` NODE containing the annotation
+ *  STARTS. Sourcing from comment nodes structurally excludes string literals
+ *  and cross-language marker confusion (Finding 2). */
+function annotationCommentRows(tree: Tree): Set<number> {
+  const rows = new Set<number>();
+  for (const c of tree.rootNode.descendantsOfType("comment")) {
+    if (!c) continue;
+    if (ANNOTATION_RE.test(c.text)) rows.add(c.startPosition.row);
+  }
+  return rows;
 }
 
 /**
  * Filters `routes` down to `kept` (fed into every downstream dominance vote
  * and the uniform-auth-gap fallback) plus a `suppressed` audit trail.
+ *
+ * An annotation binds to a route in exactly two ways:
+ *   (a) it is a comment on the route's OWN registration line (trailing or
+ *       full-line), or
+ *   (b) it is a STANDALONE comment on the line immediately above the route,
+ *       where "standalone" means that preceding line is NOT itself another
+ *       route's own registration line.
+ *
+ * Case (b)'s guard is the fix for the over-suppression bug (Finding 1): a
+ * trailing `// @vibedrift-public` on route N's own line also sits on the line
+ * immediately above route N+1 when they are consecutive. Without the guard,
+ * that trailing comment binds to BOTH N (correct) and N+1 (wrong), silently
+ * dropping an un-annotated route from the vote and hiding its auth drift. We
+ * reject the preceding-line match whenever the preceding line is some route's
+ * own registration line — that annotation belongs to that route, not this one.
  *
  * Only the annotation arm is implemented here (Task 4). Task 5 extends this
  * signature with a trailing config param carrying the glob allowlist arm
@@ -55,23 +125,62 @@ export function applyRouteSuppressions(
   routes: RouteInfo[],
   files: DriftFile[],
 ): { kept: RouteInfo[]; suppressed: SuppressionRecord[] } {
-  const linesByPath = new Map<string, string[]>();
-  for (const f of files) {
-    linesByPath.set(f.relativePath, f.content.split("\n"));
+  const filesByPath = new Map<string, DriftFile>();
+  for (const f of files) filesByPath.set(f.relativePath, f);
+
+  // Every route's OWN 1-based registration line, keyed `file:line`. Used to
+  // reject a preceding-line annotation that is really the PREVIOUS route's
+  // trailing comment (Finding 1).
+  const ownLineKeys = new Set<string>();
+  for (const r of routes) ownLineKeys.add(`${r.file}:${r.line}`);
+
+  // Per-file resolver: "does an annotation comment start on 0-based row X?"
+  // AST (comment nodes) when a tree is present, string-stripped textual check
+  // otherwise. Cached per file so we parse the comment set at most once.
+  const rowResolvers = new Map<string, (row: number) => boolean>();
+  function resolverFor(file: DriftFile): (row: number) => boolean {
+    const cached = rowResolvers.get(file.relativePath);
+    if (cached) return cached;
+    let resolver: (row: number) => boolean;
+    if (file.tree) {
+      const rows = annotationCommentRows(file.tree);
+      resolver = (row) => rows.has(row);
+    } else {
+      const lines = file.content.split("\n");
+      resolver = (row) => lineHasAnnotationTextual(lines[row], file.language);
+    }
+    rowResolvers.set(file.relativePath, resolver);
+    return resolver;
   }
 
   const kept: RouteInfo[] = [];
   const suppressed: SuppressionRecord[] = [];
 
   for (const route of routes) {
-    const lines = linesByPath.get(route.file);
-    // route.line is 1-based. Its own line is index (route.line - 1); the
-    // line immediately above it is index (route.line - 2), which only
-    // exists when route.line >= 2.
-    const ownLine = lines?.[route.line - 1];
-    const precedingLine = route.line - 2 >= 0 ? lines?.[route.line - 2] : undefined;
+    const file = filesByPath.get(route.file);
+    if (!file) {
+      // Can't resolve the file's content/tree — keep the route (safe default:
+      // under-matching an annotation never hides a vulnerability).
+      kept.push(route);
+      continue;
+    }
 
-    if (lineHasAnnotation(ownLine) || lineHasAnnotation(precedingLine)) {
+    const hasAnnotationOnRow = resolverFor(file);
+    // route.line is 1-based; the 0-based own row is (route.line - 1), the
+    // preceding row is (route.line - 2).
+    const ownRow = route.line - 1;
+    const precRow = route.line - 2;
+
+    const ownMatch = ownRow >= 0 && hasAnnotationOnRow(ownRow);
+    // Preceding-line match only when that line is a standalone annotation, not
+    // the previous route's own registration line (Finding 1). `route.line - 1`
+    // is the preceding line's 1-based number.
+    const precMatch =
+      precRow >= 0 &&
+      !ownLineKeys.has(`${route.file}:${route.line - 1}`) &&
+      hasAnnotationOnRow(precRow);
+
+    if (ownMatch || precMatch) {
       suppressed.push({
         path: route.file,
         line: route.line,

--- a/src/drift/security-suppression.ts
+++ b/src/drift/security-suppression.ts
@@ -1,0 +1,157 @@
+/**
+ * Denominator-removing suppression for the Security Consistency route vote.
+ *
+ * A route carrying an inline `// @vibedrift-public` annotation (or the
+ * language-appropriate comment variant) is excluded from the auth/validation/
+ * rate-limit dominance vote entirely — it never enters the numerator OR the
+ * denominator, so the ratio for the remaining routes stays honest.
+ *
+ * This is deliberately narrow: only the route's OWN registration line and the
+ * line immediately above it are checked. Scanning the whole file for the
+ * annotation would let one stray comment anywhere silently suppress every
+ * route in that file — a real vulnerability could be hidden that way.
+ * Under-matching (missing an intended annotation) is the safe failure
+ * direction; over-matching (dropping an un-annotated route) is a correctness
+ * bug and is guarded against by tests.
+ *
+ * Every suppression is recorded in `suppressed` and surfaced by the caller
+ * (security-consistency.ts) as a cited, counted, INFO-severity hygiene
+ * finding — so mass-annotating routes to silence the check leaves a visible
+ * audit trail instead of just shrinking the sample silently.
+ */
+
+import type { DeviatingFile, DriftCategory, DriftFile, DriftFinding } from "./types.js";
+import type { RouteInfo } from "./security-consistency.js";
+
+export interface SuppressionRecord {
+  path: string;
+  line: number;
+  reason: "annotation" | "allowlist";
+  source: string;
+}
+
+/** JS/TS line comment: `// @vibedrift-public`. */
+const LINE_COMMENT_RE = /\/\/\s*@vibedrift-public\b/;
+/** JS/TS/CSS-style block comment: `/* @vibedrift-public *\/`. */
+const BLOCK_COMMENT_RE = /\/\*\s*@vibedrift-public\b/;
+/** Python (and shell-style) comment: `# @vibedrift-public`. */
+const HASH_COMMENT_RE = /#\s*@vibedrift-public\b/;
+
+function lineHasAnnotation(line: string | undefined): boolean {
+  if (!line) return false;
+  return LINE_COMMENT_RE.test(line) || BLOCK_COMMENT_RE.test(line) || HASH_COMMENT_RE.test(line);
+}
+
+/**
+ * Filters `routes` down to `kept` (fed into every downstream dominance vote
+ * and the uniform-auth-gap fallback) plus a `suppressed` audit trail.
+ *
+ * Only the annotation arm is implemented here (Task 4). Task 5 extends this
+ * signature with a trailing config param carrying the glob allowlist arm
+ * (`reason: "allowlist"`); this function's `reason` is always `"annotation"`
+ * today.
+ */
+export function applyRouteSuppressions(
+  routes: RouteInfo[],
+  files: DriftFile[],
+): { kept: RouteInfo[]; suppressed: SuppressionRecord[] } {
+  const linesByPath = new Map<string, string[]>();
+  for (const f of files) {
+    linesByPath.set(f.relativePath, f.content.split("\n"));
+  }
+
+  const kept: RouteInfo[] = [];
+  const suppressed: SuppressionRecord[] = [];
+
+  for (const route of routes) {
+    const lines = linesByPath.get(route.file);
+    // route.line is 1-based. Its own line is index (route.line - 1); the
+    // line immediately above it is index (route.line - 2), which only
+    // exists when route.line >= 2.
+    const ownLine = lines?.[route.line - 1];
+    const precedingLine = route.line - 2 >= 0 ? lines?.[route.line - 2] : undefined;
+
+    if (lineHasAnnotation(ownLine) || lineHasAnnotation(precedingLine)) {
+      suppressed.push({
+        path: route.file,
+        line: route.line,
+        reason: "annotation",
+        source: "@vibedrift-public",
+      });
+      continue;
+    }
+    kept.push(route);
+  }
+
+  return { kept, suppressed };
+}
+
+/** Marks the audit finding below so `driftFindingToFinding` (src/drift/index.ts)
+ *  can route it to the distinct hygiene analyzerId instead of the usual
+ *  `drift-security_posture`. Not one of SECURITY_SUBCATEGORIES (types.ts) —
+ *  this isn't a dominance-vote sub-convention, it's an audit log entry. */
+export const SECURITY_SUPPRESSION_SUBCATEGORY = "Suppression audit";
+
+/** Hygiene-kind analyzerId for the suppression audit finding, registered in
+ *  src/scoring/categories.ts securityPosture.analyzers with kind "hygiene" —
+ *  so citing an exclusion can never move the Vibe Drift composite. */
+export const SECURITY_SUPPRESSION_ANALYZER_ID = "security-suppression";
+
+const SECURITY_POSTURE: DriftCategory = "security_posture";
+/** Cap on how many exclusions are spelled out inline in the finding message
+ *  (readability); the full list always lands in `deviatingFiles`, which
+ *  downstream rendering caps at 15 (driftFindingToFinding), same as every
+ *  other detector. The COUNT in the message is always the true total, never
+ *  truncated — mass-annotation stays visible even past the cap. */
+const MESSAGE_LIST_CAP = 10;
+
+function formatCitation(s: SuppressionRecord): string {
+  return `${s.path}:${s.line} (${s.reason}: ${s.source})`;
+}
+
+function formatSuppressionList(suppressed: SuppressionRecord[]): string {
+  const shown = suppressed.slice(0, MESSAGE_LIST_CAP).map(formatCitation);
+  const extra = suppressed.length - shown.length;
+  return extra > 0 ? `${shown.join(", ")}, +${extra} more` : shown.join(", ");
+}
+
+/**
+ * Builds the always-cited, always-counted audit finding for a non-empty
+ * `suppressed` list. Emitted by securityConsistency.detect() whenever ANY
+ * route was suppressed, independent of whether the dominance vote itself
+ * produces a finding — a suppressed route must leave a trail even when the
+ * remaining routes are perfectly consistent and nothing else fires.
+ *
+ * `countBased: true` because this measures a COUNT (how many routes were
+ * excluded), not a dominance ratio — there is no "wrong" number of
+ * suppressions for the scoring engine to weigh against a peer baseline.
+ */
+export function buildSuppressionAuditFinding(suppressed: SuppressionRecord[]): DriftFinding {
+  const deviatingFiles: DeviatingFile[] = suppressed.map((s) => ({
+    path: s.path,
+    detectedPattern: `excluded via ${s.reason} (${s.source})`,
+    evidence: [{ line: s.line, code: s.source }],
+  }));
+
+  return {
+    detector: "security_posture",
+    subCategory: SECURITY_SUPPRESSION_SUBCATEGORY,
+    driftCategory: SECURITY_POSTURE,
+    severity: "info",
+    confidence: 1,
+    countBased: true,
+    finding: `${suppressed.length} route(s) excluded from the security consistency check via @vibedrift-public: ${formatSuppressionList(suppressed)}`,
+    // Not a real dominance vote (see countBased above): dominantPattern
+    // names what's being counted (mirrors phantom-scaffolding's
+    // "wired-up exports"), so consistencyScore 100 reads coherently as
+    // "100% of the counted items are exclusions" rather than the
+    // self-contradictory "no suppression, 100% consistent."
+    dominantPattern: "route excluded via @vibedrift-public",
+    dominantCount: suppressed.length,
+    totalRelevantFiles: suppressed.length,
+    consistencyScore: 100,
+    deviatingFiles,
+    dominantFiles: [],
+    recommendation: "Periodically review @vibedrift-public annotations to confirm each excluded route is still intentionally public.",
+  };
+}

--- a/src/drift/types.ts
+++ b/src/drift/types.ts
@@ -1,4 +1,5 @@
 import type { Finding, FileGitMetadata } from "../core/types.js";
+import type { ProjectConfig } from "../core/project-config.js";
 import type { Tree } from "web-tree-sitter";
 
 export interface DriftDetector {
@@ -52,6 +53,14 @@ export interface DriftContext {
    * intent-divergence findings when code ignores a declaration.
    */
   intentHints?: import("../intent/types.js").IntentHint[];
+  /**
+   * Carried over from `AnalysisContext.projectConfig` by `buildDriftContext`.
+   * Consumed today by the Security Consistency detector's config glob
+   * allowlist (`security.allowlist`); undefined whenever the caller built
+   * its `AnalysisContext` without loading a project config (e.g. the
+   * MCP/baseline path), in which case that arm no-ops.
+   */
+  projectConfig?: ProjectConfig;
 }
 
 export interface DriftFile {

--- a/src/output/fix-prompt.ts
+++ b/src/output/fix-prompt.ts
@@ -63,6 +63,9 @@ function categoryLabel(f: Finding): string {
  * new analyzers.
  */
 const ANALYZER_RECOMMENDATIONS: Record<string, string> = {
+  // "security-floor" (src/analyzers/security.ts absolute-floor subset:
+  // committed secrets, disabled TLS) reuses this same copy via
+  // fallbackRecommendation below rather than a duplicated entry here.
   security:
     "Review each flagged line. If it's a real secret, rotate it immediately and move it to an environment variable or secret manager. If it's a test fixture (hardcoded example strings for security tests), move the string into a dedicated `.fixtures.ts` file under `test/` and reference it via import — the scanner excludes fixture files.",
   "dead-code":
@@ -90,6 +93,11 @@ const ANALYZER_RECOMMENDATIONS: Record<string, string> = {
 };
 
 function fallbackRecommendation(analyzerId: string): string | null {
+  // "security-floor" (committed secrets, disabled TLS — see
+  // src/analyzers/security.ts) is the absolute-floor subset of "security"
+  // findings; it gets the same specific "rotate the secret" guidance rather
+  // than falling through to the generic per-category fallback.
+  if (analyzerId === "security-floor") return ANALYZER_RECOMMENDATIONS.security ?? null;
   if (ANALYZER_RECOMMENDATIONS[analyzerId]) return ANALYZER_RECOMMENDATIONS[analyzerId];
   // Strip common prefixes ("drift-" etc.) and try again
   const stripped = analyzerId.replace(/^drift-/, "").replace(/^codedna-/, "");

--- a/src/output/floor-badge.ts
+++ b/src/output/floor-badge.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared floor-trip detector for the render-only "Security floor" badge
+ * (Phase 2, Task 3).
+ *
+ * Consumes two disjoint finding families that are both high-precision
+ * enough to warrant a warning regardless of the repo's overall drift
+ * consistency:
+ *   - `security-floor` (src/analyzers/security.ts): committed secrets,
+ *     disabled TLS verification. Hygiene-kind, does not touch the drift
+ *     composite.
+ *   - `codedna-taint` (src/codedna/taint-analysis.ts) findings whose sink is
+ *     `code_injection` or `command_injection`: unsanitized input reaching
+ *     eval/exec.
+ *
+ * RENDER ONLY: `hasFloorTrip` never reads or writes compositeScore/grade.
+ * Callers (src/output/terminal.ts, src/output/html.ts) use its result only
+ * to decide whether to print a warning line/chip. This is a locked
+ * constraint — see the grade-invariance test in
+ * test/unit/output/floor-badge.test.ts.
+ */
+
+import type { Finding } from "../core/types.js";
+import { INJECTION_SINK_LABELS } from "../codedna/taint-analysis.js";
+
+export interface FloorTripResult {
+  tripped: boolean;
+  reasons: string[];
+}
+
+// Known security-floor rule messages (src/analyzers/security.ts SECURITY_PATTERNS,
+// floor: true subset) mapped to a short, stable reason phrase. Matched against
+// the raw finding message since analyzerId alone ("security-floor") doesn't
+// distinguish which rule fired. Order matters: first match wins.
+const FLOOR_REASON_RULES: Array<{ test: RegExp; reason: string }> = [
+  { test: /private key/i, reason: "private key in source" },
+  { test: /AWS access key/i, reason: "AWS access key in source" },
+  { test: /hardcoded API key/i, reason: "hardcoded API key in source" },
+  { test: /hardcoded authentication token/i, reason: "hardcoded auth token in source" },
+  { test: /TLS certificate verification disabled/i, reason: "TLS certificate verification disabled" },
+];
+
+function reasonForFloorFinding(message: string): string {
+  for (const rule of FLOOR_REASON_RULES) {
+    if (rule.test.test(message)) return rule.reason;
+  }
+  // Fallback for a future floor rule this table doesn't know about yet:
+  // strip the trailing " in <file>:<line>" suffix security.ts appends to
+  // every message, and lowercase the leading word so it reads as a clause.
+  const stripped = message.replace(/\s+in\s+\S+:\d+$/, "").trim();
+  return stripped.length > 0 ? stripped.charAt(0).toLowerCase() + stripped.slice(1) : "security floor rule tripped";
+}
+
+function isInjectionTaintFinding(f: Finding): boolean {
+  if (f.analyzerId !== "codedna-taint") return false;
+  // One-hop flows (findOneHopFlows in taint-analysis.ts) embed the raw sink
+  // category string directly in the message (e.g. "reaches command_injection
+  // sink"); direct-sink flows embed the human sink label instead (e.g. "code
+  // evaluation"). Check both so neither shape is missed.
+  if (f.message.includes("code_injection") || f.message.includes("command_injection")) return true;
+  for (const label of INJECTION_SINK_LABELS) {
+    if (f.message.includes(label)) return true;
+  }
+  return false;
+}
+
+/**
+ * Scan a finding set for an absolute security floor trip. Pure and
+ * side-effect free; safe to call from any renderer.
+ */
+export function hasFloorTrip(findings: Finding[]): FloorTripResult {
+  const reasons = new Set<string>();
+  for (const f of findings) {
+    if (f.analyzerId === "security-floor") {
+      reasons.add(reasonForFloorFinding(f.message));
+    } else if (isInjectionTaintFinding(f)) {
+      reasons.add("unsanitized input reaches eval/exec");
+    }
+  }
+  return { tripped: reasons.size > 0, reasons: [...reasons] };
+}

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -6,6 +6,7 @@ import { hasMeaningfulImpact } from "./fix-plan-select.js";
 import { getAnalyzerKind, DRIFT_DISPLAY_CATEGORIES } from "../scoring/categories.js";
 import { applicableCategoryCount, compositeScopeNote } from "./terminal.js";
 import { formatCount } from "./format.js";
+import { hasFloorTrip } from "./floor-badge.js";
 
 const SCORING_CATEGORY_LABELS: Record<string, string> = {
   architecturalConsistency: "Architectural",
@@ -407,11 +408,21 @@ function buildSummaryHero(result: ScanResult, detailedUrl: string): string {
     ? `<a class="btn btn-primary" href="#fix-first">Fix the top drifts</a>`
     : "";
 
+  // Floor-gate badge (render-only): reuses the existing .badge.warn chip
+  // (yellow accent, no new color) already used in the findings library.
+  // Never changes compositeScore or g.letter above — see the grade-invariance
+  // test in test/unit/output/floor-badge.test.ts.
+  const floorTrip = hasFloorTrip(result.findings);
+  const floorBadge = floorTrip.tripped
+    ? `<span class="badge warn" title="${esc(floorTrip.reasons.join(", "))}">Security floor tripped</span>`
+    : "";
+
   return `<section class="va-hero">
     <div class="va-hero-top">
       <div class="va-scorewrap">
         <span class="va-score num" style="color:${g.color}">${compositeScore.toFixed(1)}<span class="s"> /${maxCompositeScore}</span></span>
         <span class="va-grade" style="background:${g.tint};color:${g.color}">${g.letter}</span>
+        ${floorBadge}
       </div>
       ${trend}
     </div>
@@ -430,14 +441,21 @@ function buildSummaryHero(result: ScanResult, detailedUrl: string): string {
 
 function buildCategoryBreakdown(result: ScanResult): string {
   const scores = result.scores as unknown as Record<string, { score: number; maxScore: number; applicable: boolean }>;
+  // Floor-gate badge (render-only): folded into the Security Consistency
+  // card's gloss note below. Never affects the card's score/color — see the
+  // grade-invariance test in test/unit/output/floor-badge.test.ts.
+  const floorTrip = hasFloorTrip(result.findings);
   // Dependency Health is not shown on the drift score display — it has no drift
   // detector and lives on the Hygiene track. Exclude it from the drift cards.
   const cards = SCORING_CATEGORY_ORDER.filter((cat) => cat !== "dependencyHealth").map((cat) => {
     const s = scores[cat];
     const label = esc(SCORING_CATEGORY_LABELS[cat]);
+    const floorNote = cat === "securityPosture" && floorTrip.tripped
+      ? `<div class="note"><span class="badge warn">Security floor</span> ${esc(floorTrip.reasons.join(", "))}. Fix before shipping (does not change the score).</div>`
+      : "";
     const gloss =
       cat === "securityPosture"
-        ? `<div class="note">Consistency of this repo's own auth and validation patterns, not the absence of vulnerabilities.</div>`
+        ? `<div class="note">Consistency of this repo's own auth and validation patterns, not the absence of vulnerabilities.</div>${floorNote}`
         : "";
     if (!s || !s.applicable) {
       // These drift detectors ran but found no applicable code in this repo.

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -12,6 +12,7 @@ import { CATEGORY_CONFIG, ALL_CATEGORIES, DRIFT_DISPLAY_CATEGORIES, getAnalyzerK
 import { scoreBar, padRight, formatCount } from "./format.js";
 import { scorePercentiles } from "../scoring/engine.js";
 import { isPeerGroundedEntitled, type Plan } from "../auth/plan.js";
+import { hasFloorTrip } from "./floor-badge.js";
 
 /**
  * Public GitHub repo for the post-scan "star us" CTA. Empty string keeps the
@@ -189,7 +190,7 @@ function findingConsequence(f: Finding): string | null {
   }
 
   // Static analyzers
-  if (id === "security") {
+  if (id === "security" || id === "security-floor") {
     return "Hardcoded secrets or injection risks may be in production";
   }
   if (id === "dead-code") {
@@ -237,7 +238,7 @@ function findingPriority(f: Finding): number {
   const sev = f.severity === "error" ? 3 : f.severity === "warning" ? 2 : 1;
 
   // Security — always top priority
-  if (id === "security" || tags.includes("security_posture") || id.startsWith("drift-security")) return 10 * sev;
+  if (id === "security" || id === "security-floor" || tags.includes("security_posture") || id.startsWith("drift-security")) return 10 * sev;
   // Architectural drift — competing patterns are the core VibeDrift signal
   if (tags.includes("architectural_consistency") || id.startsWith("drift-architectural") || id === "codedna-pattern" || id === "codedna-deviation") return 8 * sev;
   // Intent divergence — team said one thing, code does another
@@ -618,6 +619,19 @@ function renderCategoryBars(result: ScanResult): string[] {
   );
   const scopeSuffix = scopeNote ? `  ${chalk.dim(scopeNote)}` : "";
   lines.push(`  ${padRight("Vibe Drift Score:", 28)} ${totalColor(`${result.compositeScore.toFixed(0)}/${result.maxCompositeScore}`)}${scopeSuffix}`);
+  // Floor-gate badge (render-only): an absolute security floor trip (committed
+  // secret, disabled TLS, unsanitized input reaching eval/exec) is surfaced as
+  // a warning line but NEVER changes compositeScore or the letter grade — see
+  // src/output/floor-badge.ts and the grade-invariance test in
+  // test/unit/output/floor-badge.test.ts.
+  const floorTrip = hasFloorTrip(result.findings);
+  if (floorTrip.tripped) {
+    lines.push(
+      chalk.dim(
+        `  ${chalk.yellow("⚠")} Security floor: ${floorTrip.reasons.join(", ")}. Fix before shipping (does not change the score).`,
+      ),
+    );
+  }
   // Hygiene composite — only rendered when there's a non-zero hygiene
   // surface (some hygiene category applies). Presented as a separate
   // scalar so it's clearly NOT part of the drift score.

--- a/src/scoring/categories.ts
+++ b/src/scoring/categories.ts
@@ -114,6 +114,12 @@ export const CATEGORY_CONFIG: Record<ScoringCategory, CategoryConfig> = {
     analyzers: [
       // Generic OWASP regex checks
       { id: "security", applicableLanguages: "all", kind: "hygiene" },
+      // Absolute-floor subset of the OWASP regex checks (private-key,
+      // aws-key, hardcoded-api-key, hardcoded-token, go-tls-skip-verify),
+      // emitted under a distinct id (see security.ts) so a high-precision
+      // badge can be rendered separately. Hygiene-kind: never dents the
+      // Vibe Drift composite, same as its parent "security" analyzer.
+      { id: "security-floor", applicableLanguages: "all", kind: "hygiene" },
       // Cross-file auth/validation/rate-limiting consistency — real drift
       // (analyzerId `drift-security_posture`, from driftCategory).
       { id: "drift-security_posture", applicableLanguages: "all", kind: "drift" },

--- a/src/scoring/categories.ts
+++ b/src/scoring/categories.ts
@@ -127,6 +127,11 @@ export const CATEGORY_CONFIG: Record<ScoringCategory, CategoryConfig> = {
       // (see applySecurityMinPeerFloor). Advisory: renders on the hygiene
       // track, never touches the drift composite.
       { id: "security_posture-advisory", applicableLanguages: "all", kind: "hygiene" },
+      // Suppression audit trail: cites every route excluded from the vote via
+      // `// @vibedrift-public` (see security-suppression.ts). Hygiene-kind so
+      // an exclusion is always visible but never moves the composite — the
+      // anti-abuse property is "counted and cited," not "silently ignored."
+      { id: "security-suppression", applicableLanguages: "all", kind: "hygiene" },
       // Code DNA taint analysis
       { id: "codedna-taint", applicableLanguages: "all", kind: "drift" },
     ],

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -218,10 +218,20 @@ const AUTH_REQUIRED_HINT = "auth_required"; // intent-hint pattern (src/intent/p
 const ROUTER_CAVEAT =
   "Note: router-level middleware is not visible to this in-loop check, so this is a hint, not a verdict.";
 
+/** The peer-majority "Auth middleware applied" vote, or null when the stored
+ *  vote (if any) is a different pattern (e.g. the aspirational uniform-gap
+ *  label) or there is no vote at all. Shared by checkRouteAuthDrift (to decide
+ *  whether it has a truthful count to cite) and run() (to populate
+ *  referenceFiles from the same vote when it is the auth conflict's source). */
+function appliedAuthVote(baseline: RepoDriftBaseline) {
+  const vote = baseline.securitySubVotes?.[AUTH_SUBKEY];
+  return vote && vote.dominantPattern === AUTH_APPLIED ? vote : null;
+}
+
 /**
  * In-loop auth-drift check for a SINGLE proposed body. Emits a Conflict only
  * when the body registers a mutating route with NO visible per-route guard AND
- * the repo's own convention says auth is applied/required — either a peer
+ * the repo's own convention says auth is applied/required: either a peer
  * "Auth middleware applied" majority vote, or a declared `auth_required` intent
  * hint. Returns null (honest silence) otherwise, including the healthy case
  * where there is neither a vote nor a hint to compare against.
@@ -229,12 +239,13 @@ const ROUTER_CAVEAT =
  * Async because it parses the body (via the shared classifier, which reuses the
  * batch AST route extractor so it can never disagree with the batch detector).
  * Not folded into the pure `validateChange` for that reason. The caller forces
- * `confidence: "low"` when this fires — router-scope auth is invisible here.
+ * `confidence: "low"` when this fires, because router-scope auth is invisible
+ * here.
  */
 export async function checkRouteAuthDrift(
   baseline: RepoDriftBaseline,
-  relTarget: string,
   body: string,
+  relTarget: string,
 ): Promise<Conflict | null> {
   const cls = await classifyRouteAuth(body, relTarget);
   if (!cls || !cls.isMutatingRoute || cls.hasVisibleAuth) return null;
@@ -242,8 +253,8 @@ export async function checkRouteAuthDrift(
   // Prefer the peer-majority vote: its dominantCount/total is a truthful count
   // to cite. Reuses the exact get-dominant-pattern.ts read path (securitySubVotes
   // keyed by the Auth sub-category).
-  const vote = baseline.securitySubVotes?.[AUTH_SUBKEY];
-  if (vote && vote.dominantPattern === AUTH_APPLIED) {
+  const vote = appliedAuthVote(baseline);
+  if (vote) {
     return {
       dimension: "security_posture",
       dominantPattern: AUTH_APPLIED,
@@ -257,7 +268,7 @@ export async function checkRouteAuthDrift(
 
   // No applied-majority vote: fall back to a DECLARED auth-required rule. This
   // also covers the uniformly-unauthed-but-declared repo, whose stored vote (if
-  // any) is the aspirational rule, not the applied majority — so we cite the
+  // any) is the aspirational rule, not the applied majority, so we cite the
   // declaration rather than a misleading "0 of N" count.
   const hint = topHintFor(baseline.intentHints ?? [], "security_posture");
   if (hint && hint.pattern === AUTH_REQUIRED_HINT) {
@@ -310,14 +321,26 @@ export async function run({
   // In-loop security check (async, so it lives here rather than in the pure
   // validateChange): a proposed mutating route with no visible guard against a
   // repo that applies/declares auth. Appended to conflicts and forced to low
-  // confidence — the check cannot see router-scope middleware, so it never
-  // claims high confidence. ok recomputes false via the same rule, which is the
-  // intended signal (informative, not a hard block).
-  const authConflict = await checkRouteAuthDrift(baseline, relTarget, body);
+  // confidence, because the check cannot see router-scope middleware, so it
+  // never claims high confidence. ok recomputes false via the same rule, which
+  // is the intended signal (informative, not a hard block). Captured in a local
+  // so the deep block below can re-assert the low confidence instead of letting
+  // a cloud hit silently overstate this hedge.
+  const authConflict = await checkRouteAuthDrift(baseline, body, relTarget);
   if (authConflict) {
     out.conflicts = [...out.conflicts, authConflict];
     out.confidence = "low";
     out.ok = out.conflicts.length === 0 && out.duplicateOf.length === 0;
+    // validateChange only seeds referenceFiles from its own conflicts[0], so
+    // when the auth conflict is the sole conflict, referenceFiles is still [].
+    // Borrow the same peer-majority vote's dominantFiles the fixHint already
+    // cited (matching how the other dimensions populate referenceFiles).
+    // Stays empty when the source was the declared-hint branch, which has no
+    // file list to offer.
+    if (out.referenceFiles.length === 0) {
+      const vote = appliedAuthVote(baseline);
+      if (vote) out.referenceFiles = vote.dominantFiles.slice(0, 3);
+    }
   }
 
   if (!deep) return out;
@@ -347,7 +370,11 @@ export async function run({
   if (deepHits > 0) {
     out.ok = false; // cloud found real drift the local pass can't see
     out.status = "partial"; // local + deep both contributed
-    out.confidence = "high";
+    // The security auth-conflict hedge must win over the deep pass: the auth
+    // check cannot see router-scope middleware, so its own fixHint says "hint,
+    // not a verdict" regardless of what the cloud found. Never surface it at
+    // confidence:"high".
+    out.confidence = authConflict ? "low" : "high";
   }
   return out;
 }

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -12,9 +12,11 @@
 import { z } from "zod";
 import { relative, resolve } from "node:path";
 import type { DriftCategory } from "../../drift/types.js";
+import { SECURITY_SUBCATEGORIES } from "../../drift/types.js";
 import type { RepoDriftBaseline } from "../../core/baseline.js";
 import type { IntentHint } from "../../intent/types.js";
 import { getBaseline } from "../../mcp/baseline-provider.js";
+import { classifyRouteAuth } from "../../drift/route-auth-classify.js";
 import { classifyAsyncStyle, ASYNC_STYLE_NAMES, type AsyncStyle } from "../../drift/async-style.js";
 import { classifyReturnShapeLabel, SHAPE_NAMES } from "../../drift/return-shape-consistency.js";
 import { classifyDataAccessLabel, DATA_ACCESS_NAMES } from "../../drift/architectural-contradiction.js";
@@ -206,6 +208,73 @@ export function validateChange(
   };
 }
 
+// The auth sub-vote's key + the exact dominantPattern the security detector
+// emits for the peer-majority "routes apply auth" signal (security-consistency
+// emits `${propertyName} applied`). Derived from the shared constant so this can
+// never drift out of sync with the detector.
+const AUTH_SUBKEY = SECURITY_SUBCATEGORIES.auth; // "Auth middleware"
+const AUTH_APPLIED = `${SECURITY_SUBCATEGORIES.auth} applied`; // "Auth middleware applied"
+const AUTH_REQUIRED_HINT = "auth_required"; // intent-hint pattern (src/intent/parser.ts)
+const ROUTER_CAVEAT =
+  "Note: router-level middleware is not visible to this in-loop check, so this is a hint, not a verdict.";
+
+/**
+ * In-loop auth-drift check for a SINGLE proposed body. Emits a Conflict only
+ * when the body registers a mutating route with NO visible per-route guard AND
+ * the repo's own convention says auth is applied/required — either a peer
+ * "Auth middleware applied" majority vote, or a declared `auth_required` intent
+ * hint. Returns null (honest silence) otherwise, including the healthy case
+ * where there is neither a vote nor a hint to compare against.
+ *
+ * Async because it parses the body (via the shared classifier, which reuses the
+ * batch AST route extractor so it can never disagree with the batch detector).
+ * Not folded into the pure `validateChange` for that reason. The caller forces
+ * `confidence: "low"` when this fires — router-scope auth is invisible here.
+ */
+export async function checkRouteAuthDrift(
+  baseline: RepoDriftBaseline,
+  relTarget: string,
+  body: string,
+): Promise<Conflict | null> {
+  const cls = await classifyRouteAuth(body, relTarget);
+  if (!cls || !cls.isMutatingRoute || cls.hasVisibleAuth) return null;
+
+  // Prefer the peer-majority vote: its dominantCount/total is a truthful count
+  // to cite. Reuses the exact get-dominant-pattern.ts read path (securitySubVotes
+  // keyed by the Auth sub-category).
+  const vote = baseline.securitySubVotes?.[AUTH_SUBKEY];
+  if (vote && vote.dominantPattern === AUTH_APPLIED) {
+    return {
+      dimension: "security_posture",
+      dominantPattern: AUTH_APPLIED,
+      yourPattern: "no auth guard visible in this change",
+      fixHint:
+        `Repo applies auth on ${vote.dominantCount} of ${vote.totalRelevantFiles} mutating routes. ` +
+        `Add the guard, or annotate the route // @vibedrift-public if it is intentionally public. ` +
+        ROUTER_CAVEAT,
+    };
+  }
+
+  // No applied-majority vote: fall back to a DECLARED auth-required rule. This
+  // also covers the uniformly-unauthed-but-declared repo, whose stored vote (if
+  // any) is the aspirational rule, not the applied majority — so we cite the
+  // declaration rather than a misleading "0 of N" count.
+  const hint = topHintFor(baseline.intentHints ?? [], "security_posture");
+  if (hint && hint.pattern === AUTH_REQUIRED_HINT) {
+    return {
+      dimension: "security_posture",
+      dominantPattern: AUTH_APPLIED,
+      yourPattern: "no auth guard visible in this change",
+      fixHint:
+        `Repo declares auth is required (${hint.source}:${hint.line}). ` +
+        `Add the guard, or annotate the route // @vibedrift-public if it is intentionally public. ` +
+        ROUTER_CAVEAT,
+    };
+  }
+
+  return null; // no vote and no auth hint → nothing to compare against.
+}
+
 export interface ValidateChangeOut extends ValidateChangeResult {
   status: Status;
   message?: string;
@@ -237,6 +306,19 @@ export async function run({
   }
   const relTarget = relative(rootDir, resolve(rootDir, targetPath)).replace(/\\/g, "/");
   const out: ValidateChangeOut = { status, ...validateChange(baseline, relTarget, body) };
+
+  // In-loop security check (async, so it lives here rather than in the pure
+  // validateChange): a proposed mutating route with no visible guard against a
+  // repo that applies/declares auth. Appended to conflicts and forced to low
+  // confidence — the check cannot see router-scope middleware, so it never
+  // claims high confidence. ok recomputes false via the same rule, which is the
+  // intended signal (informative, not a hard block).
+  const authConflict = await checkRouteAuthDrift(baseline, relTarget, body);
+  if (authConflict) {
+    out.conflicts = [...out.conflicts, authConflict];
+    out.confidence = "low";
+    out.ok = out.conflicts.length === 0 && out.duplicateOf.length === 0;
+  }
 
   if (!deep) return out;
 

--- a/test/calibration/injectors.ts
+++ b/test/calibration/injectors.ts
@@ -68,11 +68,36 @@ export function injectSecurityDrift(baseline: BaselineFile[], rate: number): Bas
   );
 }
 
+/**
+ * Distinct from `injectSecurityDrift` above, which STRIPS auth from routes (a
+ * dominance-vote drift signal on `drift-security_posture`). This plants an
+ * ABSOLUTE floor violation — a committed private key literal — into
+ * otherwise-clean, non-route files. It trips the high-precision
+ * `security-floor` rule (`private-key`, src/analyzers/security.ts), which is
+ * scored on its own axis (analyzerId "security-floor") independent of any
+ * auth vote, so it calibrates a different rule family than `security` does.
+ */
+export function injectSecurityFloor(baseline: BaselineFile[], rate: number): BaselineFile[] {
+  const eligible = baseline.filter((f) => /^src\/handlers\/.+Handler\.ts$/.test(f.path)).length;
+  const count = Math.round(eligible * rate);
+  if (count === 0) return baseline;
+
+  return mutate(baseline, /^src\/handlers\/.+Handler\.ts$/, count, (content) =>
+    `${content}\n` +
+    `// Committed by mistake during a deploy debugging session (do not do this).\n` +
+    "const DEPLOY_KEY = `-----BEGIN PRIVATE KEY-----\n" +
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDU9fpAstUbeMwd\n" +
+    "Qhq3iF0vG6dGzq2Q4h8mR3jK7yN1pW5xL9tC8sV2bE6oA4uY7wZ0rD3nF1kJ5xHq\n" +
+    "-----END PRIVATE KEY-----`;\n",
+  );
+}
+
 export const INJECTORS: Record<string, (base: BaselineFile[], rate: number) => BaselineFile[]> = {
   architectural: injectArchDrift,
   error_handling: injectErrorHandlingDrift,
   naming: injectNamingDrift,
   security: injectSecurityDrift,
+  security_floor: injectSecurityFloor,
 };
 
 /**

--- a/test/calibration/precision-recall.ts
+++ b/test/calibration/precision-recall.ts
@@ -24,13 +24,29 @@ import { INJECTORS } from "./injectors.js";
 import { classify, findingCategory, type CategoryMetrics, type DriftLabel, type ScoredFinding } from "./metrics.js";
 
 // Each injector's expected detector category (what a correct detector emits).
+// security_floor -> "security-floor": the floor rules (private-key, aws-key,
+// go-tls-skip-verify, ...) are emitted under analyzerId "security-floor"
+// (src/analyzers/security.ts), tagged ["security", ...] rather than
+// ["drift", ...], so `findingCategory` (metrics.ts) falls through to the
+// analyzerId itself rather than a driftCategory tag. Verified empirically
+// against a scored injected corpus before wiring this in — see task-7-report.md.
 const INJECTOR_CATEGORY: Record<string, string> = {
   naming: "naming_conventions",
   architectural: "architectural_consistency",
   error_handling: "architectural_consistency",
   security: "security_posture",
+  security_floor: "security-floor",
 };
 const INJECT_RATE = 0.34; // ~2 of 6 eligible files — a clear minority = unambiguous drift
+
+// Absolute-floor calibration gate (Phase 2 acceptance criterion): the
+// high-precision security-floor rules (private-key, aws-key,
+// go-tls-skip-verify, ...) must hold precision >= 0.95 on the clean-baseline
+// + injected corpus, or the run fails. Do not lower this to make a run pass —
+// a drop below 0.95 means the floor rules are false-firing on clean code and
+// that is a real bug to fix, not a threshold to soften.
+const FLOOR_CATEGORY = INJECTOR_CATEGORY.security_floor;
+const FLOOR_PRECISION_GATE = 0.95;
 
 async function writeFixture(root: string, files: BaselineFile[]): Promise<void> {
   await rm(root, { recursive: true, force: true });
@@ -128,6 +144,14 @@ async function main(): Promise<void> {
     console.log(`    ${unmeasured.map((r) => `${r.category}(${r.fp})`).join(", ")}`);
   }
 
+  // Gate: the floor rules must hold >= FLOOR_PRECISION_GATE precision on the
+  // clean baseline (step 1 above, already merged into `agg`) + the injected
+  // corpus. This is the one row in `rows` this script actually enforces —
+  // everything else here is report-only. A drop below the gate means the
+  // floor rules are false-firing on clean code; fix the rule, do not lower
+  // the gate.
+  const floorRow = rows.find((r) => r.category === FLOOR_CATEGORY);
+
   const report = { generatedAt: new Date().toISOString(), injectRate: INJECT_RATE, measured: rows, unmeasured };
   const reportDir = join(process.cwd(), "test/calibration/reports");
   await mkdir(reportDir, { recursive: true });
@@ -136,6 +160,20 @@ async function main(): Promise<void> {
   await writeFile(join(reportDir, "latest.json"), JSON.stringify(report, null, 2));
   console.log(`\n  Baseline written to test/calibration/reports/latest.json`);
   await rm(root, { recursive: true, force: true });
+
+  if (!floorRow || floorRow.precision == null) {
+    throw new Error(
+      `security floor calibration gate: no measurable '${FLOOR_CATEGORY}' findings. The injector produced no signal to score.`,
+    );
+  }
+  if (floorRow.precision < FLOOR_PRECISION_GATE) {
+    throw new Error(
+      `security floor calibration gate FAILED: precision ${floorRow.precision.toFixed(3)} < ${FLOOR_PRECISION_GATE} ` +
+        `(tp=${floorRow.tp} fp=${floorRow.fp} fn=${floorRow.fn}). The security-floor rules are false-firing on the clean corpus; ` +
+        `investigate the rule, do not lower this gate.`,
+    );
+  }
+  console.log(`  \x1b[32m✓\x1b[0m security floor precision gate: ${floorRow.precision.toFixed(3)} >= ${FLOOR_PRECISION_GATE}`);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/test/unit/analyzers/security-floor.test.ts
+++ b/test/unit/analyzers/security-floor.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import { securityAnalyzer } from "../../../src/analyzers/security.js";
+import { computeScores } from "../../../src/scoring/engine.js";
+import type { AnalysisContext, Finding, SourceFile, SupportedLanguage } from "../../../src/core/types.js";
+
+function makeCtx(files: (Partial<SourceFile> & { language?: SupportedLanguage })[]): AnalysisContext {
+  const fullFiles = files.map((f) => ({
+    path: f.path ?? "/test/" + f.relativePath,
+    relativePath: f.relativePath ?? "test.ts",
+    language: f.language ?? "typescript" as const,
+    content: f.content ?? "",
+    lineCount: (f.content ?? "").split("\n").length,
+  }));
+  return {
+    rootDir: "/test",
+    files: fullFiles,
+    packageJson: null,
+    goMod: null,
+    cargoToml: null,
+    requirementsTxt: null,
+    envExample: null,
+    totalLines: fullFiles.reduce((s, f) => s + f.lineCount, 0),
+    languageBreakdown: new Map([["typescript", { files: 1, lines: 5 }]]),
+    dominantLanguage: "typescript",
+  };
+}
+
+describe("security analyzer: floor subset + demoted subset", () => {
+  describe("floor rules emit under the security-floor analyzer id (D1)", () => {
+    it("private-key finding is analyzerId 'security-floor'", async () => {
+      const ctx = makeCtx([
+        { relativePath: "key.ts", content: 'const k = "-----BEGIN RSA PRIVATE KEY-----";\n' },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /private key/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security-floor");
+    });
+
+    it("aws-key finding is analyzerId 'security-floor'", async () => {
+      const ctx = makeCtx([
+        { relativePath: "creds.ts", content: 'const awsKey = "AKIAIOSFODNN7EXAMPLE";\n' },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /AWS access key/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security-floor");
+    });
+
+    it("hardcoded-api-key finding is analyzerId 'security-floor'", async () => {
+      const ctx = makeCtx([
+        { relativePath: "a.ts", content: 'const apiKey = "abcdefghijklmnopqrstuv";\n' },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /hardcoded API key/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security-floor");
+    });
+
+    it("hardcoded-token finding is analyzerId 'security-floor'", async () => {
+      const ctx = makeCtx([
+        { relativePath: "auth.ts", content: 'const token = "abcdefghijklmnopqrstuvwxyz0123456789";\n' },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /hardcoded authentication token/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security-floor");
+    });
+
+    it("go-tls-skip-verify finding is analyzerId 'security-floor'", async () => {
+      const ctx = makeCtx([
+        {
+          relativePath: "client.go",
+          language: "go",
+          content: "tlsConfig := &tls.Config{InsecureSkipVerify: true}\n",
+        },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /TLS certificate verification disabled/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security-floor");
+    });
+  });
+
+  describe("demoted rules stay under 'security' but drop to info + 'demoted' tag", () => {
+    it("innerHTML assignment is demoted (analyzerId stays 'security')", async () => {
+      const ctx = makeCtx([
+        { relativePath: "view.ts", content: "el.innerHTML = userInput;\n" },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /innerHTML assignment/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security");
+      expect(hit!.severity).toBe("info");
+      expect(hit!.tags).toContain("demoted");
+    });
+
+    it("ssrf-risk is demoted", async () => {
+      const ctx = makeCtx([
+        { relativePath: "data.ts", content: "fetch(`/api/data/${id}`);\n" },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /URL constructed from variable/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security");
+      expect(hit!.severity).toBe("info");
+      expect(hit!.tags).toContain("demoted");
+    });
+
+    it("math-random-crypto is demoted", async () => {
+      const ctx = makeCtx([
+        {
+          relativePath: "session.ts",
+          content: "function generateSessionToken() {\n  return Math.random().toString(36).slice(2);\n}\n",
+        },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /Math\.random\(\) is not cryptographically secure/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security");
+      expect(hit!.severity).toBe("info");
+      expect(hit!.tags).toContain("demoted");
+    });
+
+    it("path-traversal is demoted", async () => {
+      const ctx = makeCtx([
+        { relativePath: "files.ts", content: "fs.readFileSync(basePath + userInput);\n" },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /path traversal/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security");
+      expect(hit!.severity).toBe("info");
+      expect(hit!.tags).toContain("demoted");
+    });
+
+    it("rust-unsafe is demoted", async () => {
+      const ctx = makeCtx([
+        {
+          relativePath: "mem.rs",
+          language: "rust",
+          content: "fn foo() {\n    unsafe { ptr::read(x) };\n}\n",
+        },
+      ]);
+      const findings = await securityAnalyzer.analyze(ctx);
+      const hit = findings.find((f) => /Unsafe block/i.test(f.message));
+      expect(hit).toBeDefined();
+      expect(hit!.analyzerId).toBe("security");
+      expect(hit!.severity).toBe("info");
+      expect(hit!.tags).toContain("demoted");
+    });
+  });
+
+  describe("composite invariance (constraint: hygiene never dents the Vibe Drift composite)", () => {
+    function driftFinding(): Finding {
+      // A real drift-kind finding so the composite starts below 100 — makes
+      // the invariance assertion meaningful rather than a vacuous 100 === 100.
+      return {
+        analyzerId: "naming",
+        severity: "error",
+        confidence: 0.9,
+        message: "naming drift",
+        locations: [{ file: "src/a.ts", line: 1 }],
+        tags: [],
+      };
+    }
+
+    function floorFinding(): Finding {
+      return {
+        analyzerId: "security-floor",
+        severity: "error",
+        confidence: 0.95,
+        message: "AWS access key ID detected in creds.ts:1",
+        locations: [{ file: "creds.ts", line: 1 }],
+        tags: ["security", "secrets", "aws"],
+      };
+    }
+
+    it("adding a security-floor finding does not change compositeScore", () => {
+      const base = [driftFinding(), driftFinding()];
+      const without = computeScores(base, 30000);
+      const withFloor = computeScores([...base, floorFinding()], 30000);
+
+      expect(without.compositeScore).toBeLessThan(without.maxCompositeScore);
+      expect(withFloor.compositeScore).toBe(without.compositeScore);
+      expect(withFloor.scores.securityPosture.score).toBe(without.scores.securityPosture.score);
+
+      // Sanity: the security-floor finding IS being processed (proves the
+      // invariance above isn't vacuous — it lands on the hygiene track).
+      expect(withFloor.hygieneScore).toBeLessThan(without.hygieneScore);
+    });
+
+    it("a security-floor-only finding set still scores 100 on the drift composite", () => {
+      const { compositeScore, maxCompositeScore } = computeScores([floorFinding()], 30000);
+      expect(compositeScore).toBe(maxCompositeScore);
+    });
+  });
+});

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -14,6 +14,15 @@ import {
 } from "../../../src/core/baseline.js";
 import { buildAnalysisContext } from "../../../src/core/discovery.js";
 import { runDriftDetection } from "../../../src/drift/index.js";
+import { parseFiles } from "../../../src/utils/ast.js";
+import { securityConsistency } from "../../../src/drift/security-consistency.js";
+import {
+  SECURITY_SUPPRESSION_SUBCATEGORY,
+  SECURITY_SUPPRESSION_ANALYZER_ID,
+} from "../../../src/drift/security-suppression.js";
+import { fileDriftFromBaseline } from "../../../src/tools-core/tools/check-file-drift.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+import type { DriftContext } from "../../../src/drift/types.js";
 import type { DriftFinding } from "../../../src/drift/types.js";
 
 function fakeFinding(overrides: Partial<DriftFinding>): DriftFinding {
@@ -84,6 +93,135 @@ describe("votesFromFindings", () => {
     expect(subVotes["Auth middleware"]!.dominantPattern).toBe("Auth middleware applied");
     expect(subVotes["Rate limiting"]!.dominantPattern).toBe("Rate limiting applied");
     expect(subVotes["Auth middleware"]!.totalRelevantFiles).toBe(5);
+  });
+});
+
+// ── Suppression-audit finding must never enter the persisted baseline votes ──
+//
+// buildSuppressionAuditFinding (security-suppression.ts) emits a hygiene audit
+// trail ("N routes excluded"), tagged driftCategory: security_posture and
+// subCategory: SECURITY_SUPPRESSION_SUBCATEGORY, so it can render in the CLI's
+// hygiene pane. Left unfiltered, it also satisfied both vote builders above:
+// it could win the widest-denominator perCategoryVote.security_posture slot
+// (worse, it was the ONLY security_posture finding when a suppression removed
+// the repo's one real deviator), and it always populated a bogus
+// securitySubVotes["Suppression audit"] entry. Either leak means
+// check_file_drift's fileDriftFromBaseline (src/tools-core/tools/check-file-drift.ts)
+// could report a nonsensical deviation ("route excluded from the security
+// consistency check") for a file that was correctly suppressed, not drifting.
+describe("suppression-audit finding excluded from persisted baseline votes", () => {
+  function mkCtx(files: Awaited<ReturnType<typeof fileWithTree>>[]): DriftContext {
+    return { files, totalLines: files.reduce((s, f) => s + f.lineCount, 0), dominantLanguage: "typescript" };
+  }
+
+  it("does not let the audit finding win securitySubVotes or displace a real security_posture vote", async () => {
+    // Mixed fixture: a trailing annotation suppresses /public, but the
+    // un-annotated /danger route on the next line still drifts (no auth) —
+    // so this scan produces BOTH the audit finding and a real "Auth
+    // middleware" dominance finding for the same security_posture category.
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+        `router.post("/public", handlePublic); // @vibedrift-public\n` +
+        `router.post("/danger", wipeEverything);\n`,
+    );
+    const findings = securityConsistency.detect(mkCtx([f]));
+    expect(findings.some((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBe(true);
+    expect(findings.some((fnd) => fnd.subCategory === "Auth middleware")).toBe(true);
+
+    const subVotes = securitySubVotesFromFindings(findings);
+    expect(subVotes[SECURITY_SUPPRESSION_SUBCATEGORY]).toBeUndefined();
+    expect(Object.keys(subVotes)).not.toContain("Suppression audit");
+
+    const votes = votesFromFindings(findings);
+    expect(votes.security_posture).toBeDefined();
+    expect(votes.security_posture!.dominantPattern).not.toBe(
+      "route excluded from the security consistency check",
+    );
+    expect(votes.security_posture!.dominantPattern).toBe("Auth middleware applied");
+  });
+
+  // The key scenario: suppression removes the repo's ONLY deviator, so no
+  // real security dominance finding fires at all. Before the fix, the audit
+  // finding was the sole security_posture finding and so WON the
+  // perCategoryVote slot by default, and check_file_drift would then report
+  // the suppressed file itself as deviating in security_posture.
+  it("when suppression removes the only deviator, no real vote fires: perCategoryVote.security_posture is ABSENT (not the audit finding), and the suppressed file gets no bogus deviation", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+        `// @vibedrift-public\n` +
+        `router.post("/public/webhook", handleWebhook);\n`,
+    );
+    const findings = securityConsistency.detect(mkCtx([f]));
+
+    // Only the audit finding fires — suppression made the remaining routes
+    // 4-of-4 authed, so no auth-drift finding exists to compete with it.
+    expect(findings).toHaveLength(1);
+    expect(findings[0].subCategory).toBe(SECURITY_SUPPRESSION_SUBCATEGORY);
+
+    const votes = votesFromFindings(findings);
+    expect(votes.security_posture).toBeUndefined();
+
+    const subVotes = securitySubVotesFromFindings(findings);
+    expect(subVotes[SECURITY_SUPPRESSION_SUBCATEGORY]).toBeUndefined();
+
+    const baseline = {
+      key: "k",
+      rootDir: "/repo",
+      ctxFiles: [],
+      perCategoryVote: votes,
+      securitySubVotes: subVotes,
+      intentHints: [],
+      minhashIndex: [],
+      builtAt: 0,
+    };
+    const { fits, deviations } = fileDriftFromBaseline(baseline, "src/routes/api.ts");
+    expect(deviations.find((d) => d.dimension === "security_posture")).toBeUndefined();
+    expect(fits).toBe(true);
+  });
+
+  // End-to-end through the real scan pipeline (buildAnalysisContext +
+  // runDriftDetection + assembleBaseline), confirming: (1) the audit finding
+  // still reaches result.findings so the CLI render is unaffected, while (2)
+  // it is excluded from the persisted baseline this same scan writes.
+  describe("end-to-end scan (buildAnalysisContext -> runDriftDetection -> assembleBaseline)", () => {
+    let repo: string;
+    beforeAll(() => {
+      repo = mkdtempSync(join(tmpdir(), "vd-baseline-suppression-"));
+      writeFileSync(
+        join(repo, "api.ts"),
+        `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+          `// @vibedrift-public\n` +
+          `router.post("/public/webhook", handleWebhook);\n`,
+      );
+    });
+    afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+    it("keeps the audit finding in result.findings but not in the persisted baseline votes", async () => {
+      const { ctx } = await buildAnalysisContext(repo);
+      await parseFiles(ctx.files);
+      const { findings, driftFindings } = runDriftDetection(ctx);
+
+      // Render path unaffected: the audit finding still lands in result.findings.
+      expect(findings.some((fnd) => fnd.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID)).toBe(true);
+
+      const baseline = assembleBaseline(repo, ctx, driftFindings);
+      expect(baseline.perCategoryVote.security_posture).toBeUndefined();
+      expect(baseline.securitySubVotes?.[SECURITY_SUPPRESSION_SUBCATEGORY]).toBeUndefined();
+
+      const { deviations } = fileDriftFromBaseline(baseline, "api.ts");
+      expect(deviations.find((d) => d.dimension === "security_posture")).toBeUndefined();
+    });
   });
 });
 

--- a/test/unit/core/project-config.test.ts
+++ b/test/unit/core/project-config.test.ts
@@ -30,4 +30,29 @@ describe("normalizeProjectConfig", () => {
   it("defaults version when missing", () => {
     expect(normalizeProjectConfig({})).toEqual({ version: PROJECT_CONFIG_VERSION });
   });
+
+  it("keeps a security.allowlist of globs", () => {
+    const cfg = normalizeProjectConfig({
+      version: 1,
+      security: { allowlist: ["src/public/**", "src/routes/webhooks/*.ts"] },
+    });
+    expect(cfg).toEqual({
+      version: 1,
+      security: { allowlist: ["src/public/**", "src/routes/webhooks/*.ts"] },
+    });
+  });
+
+  it("drops non-string entries from security.allowlist but keeps the valid ones", () => {
+    const cfg = normalizeProjectConfig({
+      security: { allowlist: ["src/public/**", 123, null, {}, "  ", "src/health/*"] },
+    });
+    expect(cfg?.security?.allowlist).toEqual(["src/public/**", "src/health/*"]);
+  });
+
+  it("omits security when allowlist is absent, not an array, or empty after filtering", () => {
+    expect(normalizeProjectConfig({})).toEqual({ version: PROJECT_CONFIG_VERSION });
+    expect(normalizeProjectConfig({ security: {} })?.security).toBeUndefined();
+    expect(normalizeProjectConfig({ security: { allowlist: "not-an-array" } })?.security).toBeUndefined();
+    expect(normalizeProjectConfig({ security: { allowlist: [1, null, "  "] } })?.security).toBeUndefined();
+  });
 });

--- a/test/unit/drift/inloop-batch-agreement.test.ts
+++ b/test/unit/drift/inloop-batch-agreement.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Pins the "in-loop can never disagree with batch" guarantee (Task 7).
+ *
+ * `classifyRouteAuth` (src/drift/route-auth-classify.ts) is the single-body,
+ * in-loop `validate_change` security check. It is documented to reuse the
+ * SAME AST route extractor the batch security detector uses
+ * (`extractJsRoutesAst`), specifically so its verdict can never contradict
+ * the batch detector for the same body. That is true "by construction" today
+ * — this test makes it executable, so a future change that makes the
+ * in-loop path re-derive auth some other way (instead of delegating to
+ * `extractJsRoutesAst`) fails a test instead of silently shipping a
+ * classifier that can disagree with the scanner.
+ *
+ * For every fixture body below, we independently recompute the same
+ * aggregate `classifyRouteAuth` is documented to compute — straight from
+ * `extractJsRoutesAst`, called with no file-level middleware (mirroring the
+ * in-loop path, which cannot see router-scope `router.use(...)`) — and
+ * assert the two agree.
+ */
+import { describe, it, expect } from "vitest";
+import { classifyRouteAuth } from "../../../src/drift/route-auth-classify.js";
+import { extractJsRoutesAst, SECURITY_AST } from "../../../src/drift/security-ast.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+import { generateBaseline } from "../../calibration/baseline.js";
+
+interface BatchVerdict {
+  isMutatingRoute: boolean;
+  hasVisibleAuth: boolean;
+}
+
+/**
+ * Independently recomputed "batch" verdict for a single body: parse it, run
+ * the batch AST route extractor with no file middleware (same invisibility
+ * constraint the in-loop check operates under), and reduce to the same shape
+ * `classifyRouteAuth` reports. This is a SEPARATE call path from
+ * `classifyRouteAuth` (a fresh parse, a fresh `extractJsRoutesAst` call) —
+ * not a call into the classifier itself — so a divergence in the classifier's
+ * internals shows up as a mismatch here.
+ */
+async function batchVerdict(body: string, relTarget: string): Promise<BatchVerdict | null> {
+  const ext = relTarget.split(".").pop() ?? "";
+  const language = ext === "js" || ext === "jsx" || ext === "mjs" || ext === "cjs" ? "javascript" : "typescript";
+  const file = await fileWithTree(relTarget, body, language);
+  if (!file.tree) return null;
+
+  const routes = extractJsRoutesAst(file.tree, relTarget, undefined);
+  if (routes.length === 0) return null;
+
+  const mutating = routes.filter((r) => SECURITY_AST.MUTATING.has(r.method.toLowerCase()));
+  return {
+    isMutatingRoute: mutating.length > 0,
+    hasVisibleAuth: mutating.every((r) => r.hasAuth === true),
+  };
+}
+
+/** Asserts classifyRouteAuth and the independently-recomputed batch verdict
+ *  agree in full (both null, or both non-null with identical fields). */
+async function assertAgreement(body: string, relTarget = "src/routes/new.ts"): Promise<void> {
+  const inLoop = await classifyRouteAuth(body, relTarget);
+  const batch = await batchVerdict(body, relTarget);
+  expect(inLoop, `classifyRouteAuth verdict for ${relTarget}`).toEqual(batch);
+}
+
+describe("in-loop classifier vs batch extractor: no-disagreement pin", () => {
+  it("agrees on an authed mutating route", async () => {
+    await assertAgreement('router.post("/x", requireAuth, (req, res) => { res.json({}); });');
+  });
+
+  it("agrees on an unauthed mutating route", async () => {
+    await assertAgreement('router.post("/x", (req, res) => { res.json({}); });');
+  });
+
+  it("agrees on a GET-only (non-mutating) route", async () => {
+    await assertAgreement('router.get("/x", (req, res) => { res.json({}); });');
+  });
+
+  it("agrees on array-literal middleware", async () => {
+    await assertAgreement('router.post("/x", [requireAuth, validate], (req, res) => { res.json({}); });');
+  });
+
+  it("agrees on a non-route body (both null)", async () => {
+    await assertAgreement("export function add(a, b) { return a + b; }");
+  });
+
+  it("agrees on a body mixing an authed and an unauthed mutating route (conservative case)", async () => {
+    const body = [
+      'router.post("/a", requireAuth, (req, res) => { res.json({}); });',
+      'router.delete("/b", (req, res) => { res.json({}); });',
+    ].join("\n");
+    await assertAgreement(body);
+  });
+
+  it("agrees on a body mixing a mutating and a read-only route", async () => {
+    const body = [
+      'router.get("/a", (req, res) => { res.json({}); });',
+      'router.put("/b", requireAuth, (req, res) => { res.json({}); });',
+    ].join("\n");
+    await assertAgreement(body);
+  });
+
+  // Reuse the calibration fixture route bodies (test/calibration/baseline.ts
+  // `route()` output) so the pin covers the SAME bodies the precision/recall
+  // corpus scores, not just hand-written cases here.
+  it("agrees on every route body in the calibration fixture corpus", async () => {
+    const baseline = generateBaseline();
+    const routeFiles = baseline.filter((f) => /^src\/routes\//.test(f.path));
+    expect(routeFiles.length).toBeGreaterThan(0); // sanity: fixture isn't empty
+    for (const f of routeFiles) {
+      await assertAgreement(f.content, f.path);
+    }
+  });
+});

--- a/test/unit/drift/security-ast.test.ts
+++ b/test/unit/drift/security-ast.test.ts
@@ -29,6 +29,18 @@ describe("extractJsRoutesAst", () => {
       `router.get("/me", passport.authenticate("jwt"), getMe);\n`);
     expect(extractJsRoutesAst(f.tree!, f.relativePath, undefined)[0].hasAuth).toBe(true);
   });
+
+  it("unpacks array-literal middleware ([requireAuth]) to detect auth", async () => {
+    const f = await fileWithTree("r.ts",
+      `router.post("/x", [requireAuth], (req,res)=>{});\n`);
+    expect(extractJsRoutesAst(f.tree!, f.relativePath, undefined)[0].hasAuth).toBe(true);
+  });
+
+  it("still reads hasAuth:false for a route with no middleware", async () => {
+    const f = await fileWithTree("r.ts",
+      `router.post("/x", (req,res)=>{});\n`);
+    expect(extractJsRoutesAst(f.tree!, f.relativePath, undefined)[0].hasAuth).toBe(false);
+  });
 });
 
 describe("extractFileMiddlewareAst", () => {

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../../src/drift/security-consistency.js";
+import { runDriftDetection } from "../../../src/drift/index.js";
 import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
-import { SECURITY_SUPPRESSION_SUBCATEGORY } from "../../../src/drift/security-suppression.js";
+import {
+  SECURITY_SUPPRESSION_SUBCATEGORY,
+  SECURITY_SUPPRESSION_ANALYZER_ID,
+} from "../../../src/drift/security-suppression.js";
 
 function mkCtx(files: DriftFile[]): DriftContext {
   return {
@@ -240,6 +244,65 @@ describe("security-consistency detector", () => {
       expect(auditFinding!.finding).toContain("src/routes/api.ts:6");
     });
 
+    // ── Finding 1 (over-suppression): the reviewer's exact end-to-end case ──
+    //
+    // A TRAILING `// @vibedrift-public` on route N's own line also sits on the
+    // line immediately above route N+1. The old preceding-line matcher bound it
+    // to BOTH, so an un-annotated unauthed route directly below an annotated
+    // public route was silently removed from the vote and its auth drift never
+    // fired. This test MUST fail before the Finding 1 fix.
+    it("a trailing annotation on the line ABOVE an un-annotated unauthed route does not suppress that route (Finding 1)", async () => {
+      const f = await fileWithTree(
+        "src/routes/api.ts",
+        `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+          `router.post("/public", handlePublic); // @vibedrift-public\n` +
+          `router.post("/danger", wipeEverything);\n`,
+      );
+      const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+      const findings = securityConsistency.detect(ctx as any);
+
+      // Only /public (line 5) is excluded — the trailing comment binds to its
+      // own route, never to /danger on the line below.
+      const auditFinding = findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+      expect(auditFinding).toBeDefined();
+      expect(auditFinding!.totalRelevantFiles).toBe(1);
+      expect(auditFinding!.deviatingFiles).toHaveLength(1);
+      expect(auditFinding!.deviatingFiles[0].evidence[0].line).toBe(5);
+
+      // The un-annotated /danger route stays in the denominator: with /public
+      // suppressed, the remaining routes are 4 authed /items + 1 unauthed
+      // /danger (ratio 4/5 = 0.8 > 0.75), so the auth-drift finding STILL fires
+      // and cites /danger on line 6.
+      const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+      expect(authFinding).toBeDefined();
+      expect(authFinding!.deviatingFiles.some((d) => d.evidence[0].line === 6)).toBe(true);
+    });
+
+    // ── Finding 2 (comment-vs-code awareness), AST path ──
+    it("does not suppress a route when @vibedrift-public sits inside a string literal on the line above (Finding 2)", async () => {
+      const f = await fileWithTree(
+        "src/routes/api.ts",
+        `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+          `const doc = "publish under // @vibedrift-public to opt out";\n` +
+          `router.post("/danger", wipeEverything);\n`,
+      );
+      const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+      const findings = securityConsistency.detect(ctx as any);
+
+      // The string literal is not a comment, so nothing is suppressed and the
+      // unauthed /danger route is flagged normally.
+      expect(findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBeUndefined();
+      const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+      expect(authFinding).toBeDefined();
+      expect(authFinding!.deviatingFiles.some((d) => d.evidence[0].line === 6)).toBe(true);
+    });
+
     it("an annotation elsewhere in the file does not suppress an unrelated, un-annotated route (precision)", async () => {
       const f = await fileWithTree(
         "src/routes/api.ts",
@@ -268,5 +331,80 @@ describe("security-consistency detector", () => {
       // still all authed, so no auth drift finding fires either.
       expect(findings.find((fnd) => fnd.subCategory === "Auth middleware")).toBeUndefined();
     });
+  });
+});
+
+// ── Finding 3: the suppression-audit finding must never be stamped with a
+//    false "code contradicts declared intent" divergence ──
+//
+// The suppression-audit finding is a COUNT of excluded routes, not a dominance
+// vote; its dominantPattern ("route excluded via @vibedrift-public") is never
+// meant to be compared against a declared convention label. Without the guard
+// in enrichWithIntentDivergence (src/drift/index.ts), any repo with a
+// security_posture intent hint would stamp the audit finding with a spurious
+// intent-divergence claim — an audit-first false statement. This pins that
+// guard while confirming a REAL auth-vote finding still diverges.
+describe("suppression-audit finding vs intent divergence (Finding 3)", () => {
+  it("does not stamp the audit finding with intent divergence, but still stamps a real auth-vote finding", async () => {
+    // Group A (src/routes/items): 4 authed + 1 annotated-public unauthed route
+    // → produces a suppression-audit finding, no auth vote (4/4 after removal).
+    const items = await fileWithTree(
+      "src/routes/items/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+        `// @vibedrift-public\n` +
+        `router.post("/public/webhook", handleWebhook);\n`,
+    );
+    // Group B (src/routes/orders): 4 authed + 1 unauthed mutating route
+    // → real auth-vote finding (ratio 4/5 = 0.8), dominantPattern differs from
+    // the declared label, so intent divergence SHOULD stamp it.
+    const orders = await fileWithTree(
+      "src/routes/orders/orders.ts",
+      `router.post("/orders", requireAuth, a);\n` +
+        `router.put("/orders/:id", requireAuth, b);\n` +
+        `router.patch("/orders/:id", requireAuth, c);\n` +
+        `router.delete("/orders/:id", requireAuth, d);\n` +
+        `router.post("/orders/export", exportOrders);\n`,
+    );
+
+    const ctx = {
+      files: [items, orders],
+      totalLines: items.lineCount + orders.lineCount,
+      dominantLanguage: "typescript",
+      intentHints: [
+        {
+          category: "security_posture",
+          pattern: "auth_required",
+          label: "auth required on all routes",
+          source: "CLAUDE.md",
+          line: 1,
+          text: "all routes require auth",
+          confidence: 0.95,
+        },
+      ],
+    };
+
+    const { driftFindings } = runDriftDetection(ctx as any);
+
+    // The audit finding exists and carries NO intent-divergence claim.
+    const audit = driftFindings.find((f) => f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+    expect(audit).toBeDefined();
+    expect(audit!.intentDivergence).toBeUndefined();
+
+    // The real auth-vote finding still diverges from the declared convention.
+    const authVote = driftFindings.find((f) => f.subCategory === "Auth middleware");
+    expect(authVote).toBeDefined();
+    expect(authVote!.intentDivergence).toBeDefined();
+    expect(authVote!.intentDivergence!.declaredPattern).toBe("auth_required");
+    expect(authVote!.intentDivergence!.source).toBe("CLAUDE.md");
+
+    // And after conversion, the audit finding lands on the hygiene analyzerId
+    // (never the drift-security_posture track) with no intent-divergence tag.
+    const { findings } = runDriftDetection(ctx as any);
+    const auditConverted = findings.find((f) => f.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID);
+    expect(auditConverted).toBeDefined();
+    expect(auditConverted!.tags).not.toContain("intent-divergence");
   });
 });

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -334,6 +334,122 @@ describe("security-consistency detector", () => {
   });
 });
 
+// ── Task 5: config glob allowlist (`security.allowlist`) ── end-to-end
+// through the detector, mirroring the @vibedrift-public suppression tests
+// above but suppressing via ctx.projectConfig instead of an inline comment.
+describe("route suppression via config allowlist (security.allowlist)", () => {
+  it("without the allowlist, 4 authed + 1 unauthed mutating routes flags the unauthed one (baseline)", async () => {
+    const items = await fileWithTree(
+      "src/routes/api/items.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+    );
+    const webhook = await fileWithTree(
+      "src/routes/api/webhook.ts",
+      `router.post("/public/webhook", handleWebhook);\n`,
+    );
+    const ctx = {
+      files: [items, webhook],
+      totalLines: items.lineCount + webhook.lineCount,
+      dominantLanguage: "typescript",
+    };
+    const findings = securityConsistency.detect(ctx as any);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    expect(findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBeUndefined();
+  });
+
+  it("a config allowlist glob removes the unauthed route from the vote (no auth finding) and the audit finding cites it", async () => {
+    const items = await fileWithTree(
+      "src/routes/api/items.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+    );
+    const webhook = await fileWithTree(
+      "src/routes/api/webhook.ts",
+      `router.post("/public/webhook", handleWebhook);\n`,
+    );
+    const ctx = {
+      files: [items, webhook],
+      totalLines: items.lineCount + webhook.lineCount,
+      dominantLanguage: "typescript",
+      projectConfig: { version: 1, security: { allowlist: ["src/routes/api/webhook.ts"] } },
+    };
+    const findings = securityConsistency.detect(ctx as any);
+
+    // The unauthed webhook route was removed from the denominator BEFORE the
+    // vote ran, so the remaining 4 /items routes are 4/4 authed and no auth
+    // drift finding fires.
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeUndefined();
+
+    // The exclusion is cited and counted, same as an annotation-based one.
+    const auditFinding = findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+    expect(auditFinding).toBeDefined();
+    expect(auditFinding!.totalRelevantFiles).toBe(1);
+    expect(auditFinding!.deviatingFiles[0].path).toBe("src/routes/api/webhook.ts");
+    expect(auditFinding!.deviatingFiles[0].evidence[0].line).toBe(1);
+    expect(auditFinding!.finding).toContain("1 route(s)");
+    expect(auditFinding!.finding).toContain("src/routes/api/webhook.ts:1");
+    expect(auditFinding!.finding).toContain("allowlist");
+    expect(auditFinding!.finding).toContain("src/routes/api/webhook.ts");
+  });
+
+  it("a non-matching allowlist glob does not suppress anything; the auth finding still fires (no over-suppression)", async () => {
+    const items = await fileWithTree(
+      "src/routes/api/items.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+    );
+    const webhook = await fileWithTree(
+      "src/routes/api/webhook.ts",
+      `router.post("/public/webhook", handleWebhook);\n`,
+    );
+    const ctx = {
+      files: [items, webhook],
+      totalLines: items.lineCount + webhook.lineCount,
+      dominantLanguage: "typescript",
+      projectConfig: { version: 1, security: { allowlist: ["src/completely/unrelated/**"] } },
+    };
+    const findings = securityConsistency.detect(ctx as any);
+
+    expect(findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBeUndefined();
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+  });
+
+  it("works with projectConfig undefined, the MCP/baseline shape (no crash, no suppression)", async () => {
+    const items = await fileWithTree(
+      "src/routes/api/items.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+    );
+    const webhook = await fileWithTree(
+      "src/routes/api/webhook.ts",
+      `router.post("/public/webhook", handleWebhook);\n`,
+    );
+    // No `projectConfig` key at all — the exact shape runDriftDetection sees
+    // when an AnalysisContext is built without loading one (e.g. baseline.ts).
+    const ctx = {
+      files: [items, webhook],
+      totalLines: items.lineCount + webhook.lineCount,
+      dominantLanguage: "typescript",
+    };
+    expect(() => securityConsistency.detect(ctx as any)).not.toThrow();
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBeUndefined();
+    expect(findings.find((fnd) => fnd.subCategory === "Auth middleware")).toBeDefined();
+  });
+});
+
 // ── Finding 3: the suppression-audit finding must never be stamped with a
 //    false "code contradicts declared intent" divergence ──
 //

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../../src/drift/security-consistency.js";
 import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
+import { SECURITY_SUPPRESSION_SUBCATEGORY } from "../../../src/drift/security-suppression.js";
 
 function mkCtx(files: DriftFile[]): DriftContext {
   return {
@@ -178,5 +179,94 @@ describe("security-consistency detector", () => {
     // Machinery-only evidence (no declared CLAUDE.md/AGENTS.md hint) -> the
     // softer 0.6 confidence tier, per analyzeUniformAuthGap.
     expect(gapFinding!.confidence).toBe(0.6);
+  });
+
+  // ── Denominator-removing suppression (@vibedrift-public annotation) ──
+  //
+  // Uses fileWithTree (AST route extraction) rather than the plain `file()`
+  // regex fixture: the regex path's per-route auth check is a sliding
+  // +/-N-line TEXT proximity window (see extractJsRoutesRegex), which in a
+  // short 5-6 line fixture sees `requireAuth` from a NEIGHBORING route's own
+  // call and marks every route in the window as authed — the AST extractor
+  // scopes auth detection to each route's own middleware arguments, which is
+  // what an annotation-suppression precision test needs.
+  describe("route suppression via @vibedrift-public", () => {
+    it("without the annotation, 4 authed + 1 unauthed mutating routes flags the unauthed one (baseline)", async () => {
+      const f = await fileWithTree(
+        "src/routes/api.ts",
+        `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+          `router.post("/public/webhook", handleWebhook);\n`,
+      );
+      const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+      const findings = securityConsistency.detect(ctx as any);
+      const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+      expect(authFinding).toBeDefined();
+      expect(authFinding!.deviatingFiles.some((d) => d.evidence[0].line === 5)).toBe(true);
+      // No suppression occurred — no audit finding either.
+      expect(findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBeUndefined();
+    });
+
+    it("suppresses the annotated unauthed route so the denominator stays honest, and cites the exclusion", async () => {
+      const f = await fileWithTree(
+        "src/routes/api.ts",
+        `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+          `// @vibedrift-public\n` +
+          `router.post("/public/webhook", handleWebhook);\n`,
+      );
+      const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+      const findings = securityConsistency.detect(ctx as any);
+
+      // The unauthed route was removed from the denominator BEFORE the vote
+      // ran, so the remaining 4 routes are 4/4 authed — ratio stays honest
+      // and no auth drift finding fires.
+      const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+      expect(authFinding).toBeUndefined();
+
+      // The exclusion is cited and counted — never silent.
+      const auditFinding = findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+      expect(auditFinding).toBeDefined();
+      expect(auditFinding!.severity).toBe("info");
+      expect(auditFinding!.totalRelevantFiles).toBe(1);
+      expect(auditFinding!.deviatingFiles).toHaveLength(1);
+      expect(auditFinding!.deviatingFiles[0].path).toBe("src/routes/api.ts");
+      expect(auditFinding!.deviatingFiles[0].evidence[0].line).toBe(6);
+      expect(auditFinding!.finding).toContain("1 route(s)");
+      expect(auditFinding!.finding).toContain("src/routes/api.ts:6");
+    });
+
+    it("an annotation elsewhere in the file does not suppress an unrelated, un-annotated route (precision)", async () => {
+      const f = await fileWithTree(
+        "src/routes/api.ts",
+        `// @vibedrift-public\n` +
+          `router.post("/public/webhook", handleWebhook);\n` +
+          `\n` +
+          `router.post("/items", requireAuth, createItem);\n` +
+          `router.put("/items/:id", requireAuth, updateItem);\n` +
+          `router.patch("/items/:id", requireAuth, patchItem);\n` +
+          `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+      );
+      const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+      const findings = securityConsistency.detect(ctx as any);
+
+      // Only the annotated webhook route (line 2) is suppressed — the 4
+      // authed /items routes below it must NOT be swept up by the same
+      // annotation two lines above them, or a real exclusion could hide
+      // routes it was never meant to touch.
+      const auditFinding = findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+      expect(auditFinding).toBeDefined();
+      expect(auditFinding!.totalRelevantFiles).toBe(1);
+      expect(auditFinding!.deviatingFiles[0].evidence[0].line).toBe(2);
+
+      // The 4 authed /items routes were NOT removed from the vote: with the
+      // webhook route suppressed out of the denominator, the remaining 4 are
+      // still all authed, so no auth drift finding fires either.
+      expect(findings.find((fnd) => fnd.subCategory === "Auth middleware")).toBeUndefined();
+    });
   });
 });

--- a/test/unit/drift/security-suppression.test.ts
+++ b/test/unit/drift/security-suppression.test.ts
@@ -6,12 +6,13 @@ import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
 } from "../../../src/drift/security-suppression.js";
 import { computeScores } from "../../../src/scoring/engine.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
 import type { DriftFile } from "../../../src/drift/types.js";
 import type { RouteInfo } from "../../../src/drift/security-consistency.js";
 import type { Finding } from "../../../src/core/types.js";
 
-function file(path: string, content: string): DriftFile {
-  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
+function file(path: string, content: string, language: DriftFile["language"] = "typescript"): DriftFile {
+  return { relativePath: path, language, content, lineCount: content.split("\n").length };
 }
 
 function route(overrides: Partial<RouteInfo> & { file: string; line: number }): RouteInfo {
@@ -68,8 +69,8 @@ describe("applyRouteSuppressions", () => {
     expect(suppressed).toHaveLength(1);
   });
 
-  it("matches a Python-style hash comment annotation", () => {
-    const files = [file("src/routes/a.py", `# @vibedrift-public\n@app.route("/x")\n`)];
+  it("matches a Python-style hash comment annotation on a python file", () => {
+    const files = [file("src/routes/a.py", `# @vibedrift-public\n@app.route("/x")\n`, "python")];
     const routes = [route({ file: "src/routes/a.py", line: 2 })];
     const { kept, suppressed } = applyRouteSuppressions(routes, files);
     expect(kept).toHaveLength(0);
@@ -144,6 +145,146 @@ describe("applyRouteSuppressions", () => {
     const { kept, suppressed } = applyRouteSuppressions(routes, []);
     expect(kept).toHaveLength(1);
     expect(suppressed).toHaveLength(0);
+  });
+
+  // ── Finding 1: a trailing annotation must bind to its OWN route only ──
+  //
+  // A trailing `// @vibedrift-public` on route N's own line ALSO sits on the
+  // line immediately above route N+1 when they are consecutive. The preceding-
+  // line arm must NOT bind that comment to N+1 (which would silently drop an
+  // un-annotated route from the vote and hide its auth drift). The comment
+  // belongs to N, whose own registration line it shares.
+  it("does NOT let a trailing annotation on route N leak onto the consecutive route N+1 (over-suppression)", () => {
+    const files = [
+      file(
+        "src/routes/api.ts",
+        `router.post("/public", h); // @vibedrift-public\n` +
+          `router.post("/danger", wipeEverything);\n`,
+      ),
+    ];
+    const routes = [
+      route({ file: "src/routes/api.ts", line: 1, path: "/public" }),
+      route({ file: "src/routes/api.ts", line: 2, path: "/danger" }),
+    ];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+
+    // Only /public (its own trailing comment) is suppressed. /danger, on the
+    // line below, is kept — its "preceding line" is /public's own route line.
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].line).toBe(1);
+    expect(kept.map((r) => r.path)).toEqual(["/danger"]);
+  });
+
+  // A genuine standalone annotation above a route still binds (regression that
+  // the Finding 1 guard didn't over-correct and break the normal case).
+  it("still binds a STANDALONE annotation on the line above (preceding line is not a route)", () => {
+    const files = [
+      file(
+        "src/routes/api.ts",
+        `router.post("/one", h1);\n` +
+          `// @vibedrift-public\n` +
+          `router.post("/two", h2);\n`,
+      ),
+    ];
+    const routes = [
+      route({ file: "src/routes/api.ts", line: 1, path: "/one" }),
+      route({ file: "src/routes/api.ts", line: 3, path: "/two" }),
+    ];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].line).toBe(3);
+    expect(kept.map((r) => r.path)).toEqual(["/one"]);
+  });
+
+  // ── Finding 2: comment-vs-code awareness (no string-literal / cross-lang FPs) ──
+  it("does NOT suppress when @vibedrift-public appears inside a STRING LITERAL on the line above (regex fallback)", () => {
+    const files = [
+      file(
+        "src/routes/api.ts",
+        `const msg = "see // @vibedrift-public docs";\n` +
+          `router.post("/x", handler);\n`,
+      ),
+    ];
+    const routes = [route({ file: "src/routes/api.ts", line: 2 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(suppressed).toHaveLength(0);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("does NOT suppress when @vibedrift-public appears inside a STRING LITERAL on the route's own line (regex fallback)", () => {
+    const files = [
+      file("src/routes/api.ts", `router.post("/x", handler, "// @vibedrift-public");\n`),
+    ];
+    const routes = [route({ file: "src/routes/api.ts", line: 1 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(suppressed).toHaveLength(0);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("does NOT apply the Python `#` comment form to a JS/TS route (regex fallback)", () => {
+    const files = [
+      file(
+        "src/routes/api.ts",
+        `# @vibedrift-public\n` + `router.post("/x", handler);\n`,
+      ),
+    ];
+    const routes = [route({ file: "src/routes/api.ts", line: 2 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(suppressed).toHaveLength(0);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("still suppresses a genuine `// @vibedrift-public` comment (trailing and standalone-above) in the regex fallback", () => {
+    const trailing = applyRouteSuppressions(
+      [route({ file: "src/routes/a.ts", line: 1 })],
+      [file("src/routes/a.ts", `router.post("/x", handler); // @vibedrift-public\n`)],
+    );
+    expect(trailing.suppressed).toHaveLength(1);
+
+    const above = applyRouteSuppressions(
+      [route({ file: "src/routes/b.ts", line: 2 })],
+      [file("src/routes/b.ts", `// @vibedrift-public\nrouter.post("/x", handler);\n`)],
+    );
+    expect(above.suppressed).toHaveLength(1);
+  });
+
+  // ── Finding 2, AST path: comment NODES only, string literals excluded ──
+  it("uses comment NODES (AST path): a string-literal `// @vibedrift-public` above a route does not suppress", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `const msg = "see // @vibedrift-public docs";\n` + `router.post("/x", handler);\n`,
+    );
+    const routes = [route({ file: "src/routes/api.ts", line: 2 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, [f]);
+    expect(suppressed).toHaveLength(0);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("uses comment NODES (AST path): a genuine trailing `// @vibedrift-public` still suppresses", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/x", handler); // @vibedrift-public\n`,
+    );
+    const routes = [route({ file: "src/routes/api.ts", line: 1 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, [f]);
+    expect(suppressed).toHaveLength(1);
+    expect(kept).toHaveLength(0);
+  });
+
+  it("AST path honors Finding 1: trailing annotation on route N does not leak onto consecutive route N+1", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/public", h); // @vibedrift-public\n` +
+        `router.post("/danger", wipeEverything);\n`,
+    );
+    const routes = [
+      route({ file: "src/routes/api.ts", line: 1, path: "/public" }),
+      route({ file: "src/routes/api.ts", line: 2, path: "/danger" }),
+    ];
+    const { kept, suppressed } = applyRouteSuppressions(routes, [f]);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].line).toBe(1);
+    expect(kept.map((r) => r.path)).toEqual(["/danger"]);
   });
 });
 

--- a/test/unit/drift/security-suppression.test.ts
+++ b/test/unit/drift/security-suppression.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyRouteSuppressions,
+  buildSuppressionAuditFinding,
+  SECURITY_SUPPRESSION_ANALYZER_ID,
+  SECURITY_SUPPRESSION_SUBCATEGORY,
+} from "../../../src/drift/security-suppression.js";
+import { computeScores } from "../../../src/scoring/engine.js";
+import type { DriftFile } from "../../../src/drift/types.js";
+import type { RouteInfo } from "../../../src/drift/security-consistency.js";
+import type { Finding } from "../../../src/core/types.js";
+
+function file(path: string, content: string): DriftFile {
+  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
+}
+
+function route(overrides: Partial<RouteInfo> & { file: string; line: number }): RouteInfo {
+  return {
+    method: "POST",
+    path: "/x",
+    hasAuth: false,
+    hasValidation: false,
+    hasRateLimit: false,
+    hasErrorHandler: false,
+    ...overrides,
+  };
+}
+
+describe("applyRouteSuppressions", () => {
+  it("filters out a route whose own line carries // @vibedrift-public", () => {
+    const files = [file("src/routes/a.ts", `router.post("/x", handler); // @vibedrift-public\n`)];
+    const routes = [route({ file: "src/routes/a.ts", line: 1 })];
+
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+
+    expect(kept).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0]).toEqual({
+      path: "src/routes/a.ts",
+      line: 1,
+      reason: "annotation",
+      source: "@vibedrift-public",
+    });
+  });
+
+  it("filters out a route annotated on the line immediately above it", () => {
+    const files = [
+      file(
+        "src/routes/a.ts",
+        `// @vibedrift-public\nrouter.post("/x", handler);\n`,
+      ),
+    ];
+    const routes = [route({ file: "src/routes/a.ts", line: 2 })];
+
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+
+    expect(kept).toHaveLength(0);
+    expect(suppressed).toEqual([
+      { path: "src/routes/a.ts", line: 2, reason: "annotation", source: "@vibedrift-public" },
+    ]);
+  });
+
+  it("matches a block comment annotation", () => {
+    const files = [file("src/routes/a.ts", `/* @vibedrift-public */\nrouter.post("/x", handler);\n`)];
+    const routes = [route({ file: "src/routes/a.ts", line: 2 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(kept).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it("matches a Python-style hash comment annotation", () => {
+    const files = [file("src/routes/a.py", `# @vibedrift-public\n@app.route("/x")\n`)];
+    const routes = [route({ file: "src/routes/a.py", line: 2 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(kept).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it("keeps a route with no annotation on its own or preceding line", () => {
+    const files = [file("src/routes/a.ts", `router.post("/x", handler);\n`)];
+    const routes = [route({ file: "src/routes/a.ts", line: 1 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(kept).toEqual(routes);
+    expect(suppressed).toHaveLength(0);
+  });
+
+  it("does NOT suppress a route just because @vibedrift-public appears elsewhere in the file (precision)", () => {
+    const files = [
+      file(
+        "src/routes/a.ts",
+        `// @vibedrift-public\nrouter.post("/annotated", h1);\n\nrouter.post("/unrelated", h2);\n`,
+      ),
+    ];
+    // /unrelated is on line 4; its own line and line 3 (blank) carry no
+    // annotation — only line 1, two lines above it, does. Scanning the whole
+    // file (instead of just the two adjacent lines) would wrongly suppress it.
+    const routes = [
+      route({ file: "src/routes/a.ts", line: 2, path: "/annotated" }),
+      route({ file: "src/routes/a.ts", line: 4, path: "/unrelated" }),
+    ];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0].path).toBe("/unrelated");
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].path).toBe("src/routes/a.ts");
+    expect(suppressed[0].line).toBe(2);
+  });
+
+  it("keeps mixed suppressed/kept routes in a multi-route file, suppressing only the annotated one", () => {
+    const files = [
+      file(
+        "src/routes/a.ts",
+        `router.post("/one", h1);\n` +
+          `router.put("/two", h2);\n` +
+          `// @vibedrift-public\n` +
+          `router.delete("/three", h3);\n`,
+      ),
+    ];
+    const routes = [
+      route({ file: "src/routes/a.ts", line: 1, path: "/one" }),
+      route({ file: "src/routes/a.ts", line: 2, path: "/two" }),
+      route({ file: "src/routes/a.ts", line: 4, path: "/three" }),
+    ];
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+
+    expect(kept.map((r) => r.path)).toEqual(["/one", "/two"]);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].path).toBe("src/routes/a.ts");
+    expect(suppressed[0].line).toBe(4);
+  });
+
+  it("does not crash and keeps the route when it has no line above it (line 1) and carries no annotation", () => {
+    const files = [file("src/routes/a.ts", `router.post("/x", handler);\n`)];
+    const routes = [route({ file: "src/routes/a.ts", line: 1 })];
+    expect(() => applyRouteSuppressions(routes, files)).not.toThrow();
+    const { kept, suppressed } = applyRouteSuppressions(routes, files);
+    expect(kept).toHaveLength(1);
+    expect(suppressed).toHaveLength(0);
+  });
+
+  it("keeps a route safely when its file cannot be found among the provided files (no crash, no over-suppression)", () => {
+    const routes = [route({ file: "src/routes/missing.ts", line: 1 })];
+    const { kept, suppressed } = applyRouteSuppressions(routes, []);
+    expect(kept).toHaveLength(1);
+    expect(suppressed).toHaveLength(0);
+  });
+});
+
+describe("buildSuppressionAuditFinding", () => {
+  it("cites every exclusion (path:line, reason, source) and counts them accurately", () => {
+    const finding = buildSuppressionAuditFinding([
+      { path: "src/routes/a.ts", line: 4, reason: "annotation", source: "@vibedrift-public" },
+      { path: "src/routes/b.ts", line: 9, reason: "annotation", source: "@vibedrift-public" },
+    ]);
+
+    expect(finding.severity).toBe("info");
+    expect(finding.driftCategory).toBe("security_posture");
+    expect(finding.subCategory).toBe(SECURITY_SUPPRESSION_SUBCATEGORY);
+    expect(finding.countBased).toBe(true);
+    expect(finding.totalRelevantFiles).toBe(2);
+    expect(finding.deviatingFiles).toHaveLength(2);
+    expect(finding.finding).toContain("2 route(s)");
+    expect(finding.finding).toContain("src/routes/a.ts:4");
+    expect(finding.finding).toContain("src/routes/b.ts:9");
+    expect(finding.finding).toContain("annotation");
+    expect(finding.finding).toContain("@vibedrift-public");
+  });
+
+  it("never truncates the reported count, even when the inline citation list is capped", () => {
+    const many = Array.from({ length: 15 }, (_, i) => ({
+      path: `src/routes/r${i}.ts`,
+      line: 1,
+      reason: "annotation" as const,
+      source: "@vibedrift-public",
+    }));
+    const finding = buildSuppressionAuditFinding(many);
+    expect(finding.totalRelevantFiles).toBe(15);
+    expect(finding.deviatingFiles).toHaveLength(15);
+    expect(finding.finding).toContain("15 route(s)");
+  });
+
+  it("has no em-dashes or double hyphens in any user-facing string", () => {
+    const finding = buildSuppressionAuditFinding([
+      { path: "src/routes/a.ts", line: 4, reason: "annotation", source: "@vibedrift-public" },
+    ]);
+    for (const text of [finding.finding, finding.recommendation]) {
+      expect(text).not.toMatch(/—|--/);
+    }
+  });
+});
+
+describe("composite invariance (constraint: a suppression-audit finding never dents the Vibe Drift composite)", () => {
+  function driftFinding(): Finding {
+    // A real drift-kind finding so the composite starts below 100 — makes
+    // the invariance assertion meaningful rather than a vacuous 100 === 100.
+    return {
+      analyzerId: "naming",
+      severity: "error",
+      confidence: 0.9,
+      message: "naming drift",
+      locations: [{ file: "src/a.ts", line: 1 }],
+      tags: [],
+    };
+  }
+
+  function suppressionAuditFinding(): Finding {
+    return {
+      analyzerId: SECURITY_SUPPRESSION_ANALYZER_ID,
+      severity: "info",
+      confidence: 1,
+      message: "3 route(s) excluded from the security consistency check via @vibedrift-public: a.ts:1, b.ts:2, c.ts:3",
+      locations: [{ file: "src/routes/a.ts", line: 1 }],
+      tags: ["drift", "security_posture", "cross-file"],
+    };
+  }
+
+  it("adding a suppression-audit finding does not change compositeScore", () => {
+    const base = [driftFinding(), driftFinding()];
+    const without = computeScores(base, 30000);
+    const withAudit = computeScores([...base, suppressionAuditFinding()], 30000);
+
+    expect(without.compositeScore).toBeLessThan(without.maxCompositeScore);
+    expect(withAudit.compositeScore).toBe(without.compositeScore);
+    expect(withAudit.scores.securityPosture.score).toBe(without.scores.securityPosture.score);
+
+    // Sanity: the suppression-audit finding IS being processed (proves the
+    // invariance above isn't vacuous — it lands on the hygiene track, not
+    // that it was silently dropped). An INFO-severity, size-normalized
+    // finding barely moves the rounded aggregate hygieneScore in a 30k-line
+    // repo (by design — same size-fairness as every other count-based
+    // hygiene signal), so assert on the deterministic finding count instead
+    // of the float-rounding-sensitive composite.
+    expect(without.hygieneScores.securityPosture.findingCount).toBe(0);
+    expect(withAudit.hygieneScores.securityPosture.findingCount).toBe(1);
+    expect(withAudit.hygieneScore).toBeLessThanOrEqual(without.hygieneScore);
+  });
+
+  it("a suppression-audit-only finding set still scores 100 on the drift composite", () => {
+    const { compositeScore, maxCompositeScore } = computeScores([suppressionAuditFinding()], 30000);
+    expect(compositeScore).toBe(maxCompositeScore);
+  });
+});

--- a/test/unit/drift/security-suppression.test.ts
+++ b/test/unit/drift/security-suppression.test.ts
@@ -271,6 +271,90 @@ describe("applyRouteSuppressions", () => {
     expect(kept).toHaveLength(0);
   });
 
+  // ── Task 5: config glob allowlist (`security.allowlist`) ──
+  describe("config glob allowlist", () => {
+    it("drops a route whose file matches an allowlist glob, recording reason: allowlist and the matching glob as source", () => {
+      const files = [file("src/public/status.ts", `router.post("/status", handler);\n`)];
+      const routes = [route({ file: "src/public/status.ts", line: 1 })];
+      const config = { version: 1, security: { allowlist: ["src/public/**"] } };
+
+      const { kept, suppressed } = applyRouteSuppressions(routes, files, config);
+
+      expect(kept).toHaveLength(0);
+      expect(suppressed).toEqual([
+        { path: "src/public/status.ts", line: 1, reason: "allowlist", source: "src/public/**" },
+      ]);
+    });
+
+    it("keeps a route whose file does NOT match any allowlist glob (no over-suppression)", () => {
+      const files = [file("src/routes/danger.ts", `router.post("/danger", handler);\n`)];
+      const routes = [route({ file: "src/routes/danger.ts", line: 1 })];
+      const config = { version: 1, security: { allowlist: ["src/public/**"] } };
+
+      const { kept, suppressed } = applyRouteSuppressions(routes, files, config);
+
+      expect(kept).toEqual(routes);
+      expect(suppressed).toHaveLength(0);
+    });
+
+    it("cites the SPECIFIC glob that matched when multiple globs are configured", () => {
+      const files = [file("src/routes/webhooks/stripe.ts", `router.post("/stripe", handler);\n`)];
+      const routes = [route({ file: "src/routes/webhooks/stripe.ts", line: 1 })];
+      const config = {
+        version: 1,
+        security: { allowlist: ["src/public/**", "src/routes/webhooks/**"] },
+      };
+
+      const { suppressed } = applyRouteSuppressions(routes, files, config);
+
+      expect(suppressed).toEqual([
+        { path: "src/routes/webhooks/stripe.ts", line: 1, reason: "allowlist", source: "src/routes/webhooks/**" },
+      ]);
+    });
+
+    it("still applies the annotation arm first, then the allowlist arm, without double-suppressing an already-annotated route", () => {
+      const files = [
+        file(
+          "src/routes/mixed.ts",
+          `router.post("/a", h1); // @vibedrift-public\n` +
+            `router.post("/b", h2);\n`,
+        ),
+      ];
+      const routes = [
+        route({ file: "src/routes/mixed.ts", line: 1, path: "/a" }),
+        route({ file: "src/routes/mixed.ts", line: 2, path: "/b" }),
+      ];
+      const config = { version: 1, security: { allowlist: ["src/routes/mixed.ts"] } };
+
+      const { kept, suppressed } = applyRouteSuppressions(routes, files, config);
+
+      expect(kept).toHaveLength(0);
+      expect(suppressed).toHaveLength(2);
+      expect(suppressed.find((s) => s.line === 1)).toEqual({
+        path: "src/routes/mixed.ts",
+        line: 1,
+        reason: "annotation",
+        source: "@vibedrift-public",
+      });
+      expect(suppressed.find((s) => s.line === 2)).toEqual({
+        path: "src/routes/mixed.ts",
+        line: 2,
+        reason: "allowlist",
+        source: "src/routes/mixed.ts",
+      });
+    });
+
+    it("is a no-op when config is undefined, null, or carries no security.allowlist (MCP/baseline path)", () => {
+      const files = [file("src/public/status.ts", `router.post("/status", handler);\n`)];
+      const routes = [route({ file: "src/public/status.ts", line: 1 })];
+
+      expect(applyRouteSuppressions(routes, files).kept).toHaveLength(1);
+      expect(applyRouteSuppressions(routes, files, null).kept).toHaveLength(1);
+      expect(applyRouteSuppressions(routes, files, { version: 1 }).kept).toHaveLength(1);
+      expect(applyRouteSuppressions(routes, files, { version: 1, security: {} }).kept).toHaveLength(1);
+    });
+  });
+
   it("AST path honors Finding 1: trailing annotation on route N does not leak onto consecutive route N+1", async () => {
     const f = await fileWithTree(
       "src/routes/api.ts",

--- a/test/unit/drift/suppression-honesty.test.ts
+++ b/test/unit/drift/suppression-honesty.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Suppression-honesty, end to end (Task 7, Step 3).
+ *
+ * `test/unit/drift/security-suppression.test.ts` and
+ * `test/unit/drift/security-consistency.test.ts` already cover
+ * `applyRouteSuppressions` / `securityConsistency.detect` in isolation (raw
+ * `DriftFinding[]`). This file adds the one level those don't reach: the REAL
+ * `runDriftDetection` entry point (the same function the CLI scan path calls),
+ * which converts drift findings to the `Finding[]` shape the CLI, MCP, and
+ * scoring engine all consume. It asserts the full chain in one place:
+ * suppressing a route removes it from the denominator (no spurious security
+ * finding survives to `Finding[]`), AND the exclusion is still cited via a
+ * `security-suppression` finding in that same `Finding[]` — suppression never
+ * means "disappears without a trace."
+ *
+ * Covers both suppression mechanisms: the inline `// @vibedrift-public`
+ * annotation and the config `security.allowlist` glob.
+ */
+import { describe, it, expect } from "vitest";
+import { runDriftDetection } from "../../../src/drift/index.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+import { SECURITY_SUPPRESSION_ANALYZER_ID } from "../../../src/drift/security-suppression.js";
+import type { AnalysisContext } from "../../../src/core/types.js";
+import type { DriftFile } from "../../../src/drift/types.js";
+
+const SECURITY_DRIFT_ANALYZER_ID = "drift-security_posture";
+
+function ctxFrom(files: DriftFile[], projectConfig?: AnalysisContext["projectConfig"]): AnalysisContext {
+  return {
+    files,
+    totalLines: files.reduce((s, f) => s + f.lineCount, 0),
+    dominantLanguage: "typescript",
+    projectConfig,
+  } as unknown as AnalysisContext;
+}
+
+// 4 authed + 1 unauthed mutating route, all in one file: without suppression,
+// the unauthed route trips the "Auth middleware" dominance vote (4/5 = 0.8 >
+// 0.75). Used by the annotation-based tests, where suppression targets a
+// single LINE within the file.
+async function fourAuthedOneUnauthed(unauthedLine: (n: string) => string): Promise<DriftFile> {
+  return fileWithTree(
+    "src/routes/api.ts",
+    `router.post("/items", requireAuth, createItem);\n` +
+      `router.put("/items/:id", requireAuth, updateItem);\n` +
+      `router.patch("/items/:id", requireAuth, patchItem);\n` +
+      `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+      unauthedLine("router.post"),
+  );
+}
+
+// Same 4-authed/1-unauthed shape, but the unauthed route lives in its OWN
+// file (src/routes/webhook.ts). The config allowlist glob suppresses at FILE
+// granularity, so it needs the unauthed route isolated from the 4 authed
+// ones to test "suppress exactly the one route" rather than "suppress the
+// whole file the 4 authed routes also live in."
+async function fourAuthedFile(): Promise<DriftFile> {
+  return fileWithTree(
+    "src/routes/items.ts",
+    `router.post("/items", requireAuth, createItem);\n` +
+      `router.put("/items/:id", requireAuth, updateItem);\n` +
+      `router.patch("/items/:id", requireAuth, patchItem);\n` +
+      `router.delete("/items/:id", requireAuth, deleteItem);\n`,
+  );
+}
+async function oneUnauthedFile(): Promise<DriftFile> {
+  return fileWithTree("src/routes/webhook.ts", `router.post("/public/webhook", handleWebhook);\n`);
+}
+
+describe("suppression honesty end to end (runDriftDetection)", () => {
+  it("sanity: WITHOUT suppression, the unauthed route trips a security_posture finding through the full pipeline", async () => {
+    const f = await fourAuthedOneUnauthed(() => `router.post("/public/webhook", handleWebhook);\n`);
+    const result = runDriftDetection(ctxFrom([f]));
+
+    const authFinding = result.findings.find((fnd) => fnd.analyzerId === SECURITY_DRIFT_ANALYZER_ID);
+    expect(authFinding, "expected the unauthed route to trip a security_posture finding").toBeDefined();
+    expect(result.findings.find((fnd) => fnd.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID)).toBeUndefined();
+  });
+
+  it("@vibedrift-public annotation: no security finding is emitted, and the suppression audit finding carries the count", async () => {
+    const f = await fourAuthedOneUnauthed(
+      () => `// @vibedrift-public\nrouter.post("/public/webhook", handleWebhook);\n`,
+    );
+    const result = runDriftDetection(ctxFrom([f]));
+
+    // Denominator stays honest: the annotated route is out, remaining 4 are
+    // 4/4 authed, so no auth-drift finding survives to Finding[].
+    const authFinding = result.findings.find((fnd) => fnd.analyzerId === SECURITY_DRIFT_ANALYZER_ID);
+    expect(authFinding, "suppressed route must not produce a security_posture finding").toBeUndefined();
+
+    // The exclusion is still cited and counted.
+    const auditFinding = result.findings.find((fnd) => fnd.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID);
+    expect(auditFinding, "expected a suppression audit finding").toBeDefined();
+    expect(auditFinding!.message).toContain("1 route(s)");
+    expect(auditFinding!.message).toContain("src/routes/api.ts:6");
+    expect(auditFinding!.message).toContain("annotation");
+  });
+
+  it("config security.allowlist: no security finding is emitted, and the suppression audit finding cites the matching glob", async () => {
+    const items = await fourAuthedFile();
+    const webhook = await oneUnauthedFile();
+    const ctx = ctxFrom([items, webhook], { version: 1, security: { allowlist: ["src/routes/webhook.ts"] } });
+    const result = runDriftDetection(ctx);
+
+    const authFinding = result.findings.find((fnd) => fnd.analyzerId === SECURITY_DRIFT_ANALYZER_ID);
+    expect(authFinding, "allowlisted route must not produce a security_posture finding").toBeUndefined();
+
+    const auditFinding = result.findings.find((fnd) => fnd.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID);
+    expect(auditFinding, "expected a suppression audit finding").toBeDefined();
+    expect(auditFinding!.message).toContain("1 route(s)");
+    expect(auditFinding!.message).toContain("allowlist");
+    expect(auditFinding!.message).toContain("src/routes/webhook.ts");
+  });
+
+  it("a non-matching allowlist glob does not suppress: the security finding still fires and no audit finding appears", async () => {
+    const items = await fourAuthedFile();
+    const webhook = await oneUnauthedFile();
+    const ctx = ctxFrom([items, webhook], { version: 1, security: { allowlist: ["src/completely/unrelated/**"] } });
+    const result = runDriftDetection(ctx);
+
+    expect(result.findings.find((fnd) => fnd.analyzerId === SECURITY_DRIFT_ANALYZER_ID)).toBeDefined();
+    expect(result.findings.find((fnd) => fnd.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID)).toBeUndefined();
+  });
+});

--- a/test/unit/mcp/tools/validate-change-security.test.ts
+++ b/test/unit/mcp/tools/validate-change-security.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { classifyRouteAuth } from "../../../../src/drift/route-auth-classify.js";
+
+// The deep path (unused here, but run() imports it) is stubbed so nothing hits
+// the network if a stray deep:true ever reaches it.
+vi.mock("../../../../src/mcp/deep-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../src/mcp/deep-client.js")>();
+  return { ...actual, deepAnalyze: vi.fn() };
+});
+vi.mock("../../../../src/mcp/deep-index.js", () => ({ deepDuplicatesViaIndex: vi.fn() }));
+
+import { checkRouteAuthDrift, run } from "../../../../src/mcp/tools/validate-change.js";
+import { buildBaseline, writeBaseline, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
+import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
+
+// ── Shared classifier ───────────────────────────────────────────────────────
+// classifyRouteAuth reuses the SAME AST route extractor the batch security
+// detector uses, so its verdict can never contradict the batch detector for the
+// same body (Task 7 asserts that agreement across fixtures).
+describe("classifyRouteAuth", () => {
+  it("flags a mutating route with no visible auth guard", async () => {
+    const r = await classifyRouteAuth('router.post("/x", (req, res) => { res.json({}); });', "a.ts");
+    expect(r).toEqual({ isMutatingRoute: true, hasVisibleAuth: false });
+  });
+
+  it("reports a visible auth guard on a mutating route", async () => {
+    const r = await classifyRouteAuth('router.post("/x", requireAuth, (req, res) => { res.json({}); });', "a.ts");
+    expect(r).toEqual({ isMutatingRoute: true, hasVisibleAuth: true });
+  });
+
+  it("is conservative: a partly guarded body (one mutating route unguarded) is hasVisibleAuth:false", async () => {
+    const body = [
+      'router.post("/a", requireAuth, (req, res) => { res.json({}); });',
+      'router.delete("/b", (req, res) => { res.json({}); });',
+    ].join("\n");
+    const r = await classifyRouteAuth(body, "a.ts");
+    expect(r).toEqual({ isMutatingRoute: true, hasVisibleAuth: false });
+  });
+
+  it("returns a non-mutating verdict for a read-only (GET) route body", async () => {
+    const r = await classifyRouteAuth('router.get("/x", (req, res) => { res.json({}); });', "a.ts");
+    expect(r).toEqual({ isMutatingRoute: false, hasVisibleAuth: true });
+  });
+
+  it("returns null for a body with no route at all", async () => {
+    const r = await classifyRouteAuth("export function add(a, b) { return a + b; }", "a.ts");
+    expect(r).toBeNull();
+  });
+
+  it("returns null for a non JS/TS language (Python)", async () => {
+    const r = await classifyRouteAuth('@app.post("/x")\ndef handler():\n    return {}', "a.py");
+    expect(r).toBeNull();
+  });
+});
+
+// ── Security path (checkRouteAuthDrift) ──────────────────────────────────────
+// Pure-ish: takes a hand-built baseline so every branch is deterministic and
+// offline. Emits a Conflict only when the proposed body has a mutating route
+// with no visible guard AND the repo's own convention (vote or declared hint)
+// is to apply auth. Otherwise honest silence (null).
+const UNAUTHED_POST = 'router.post("/x", (req, res) => { res.json({}); });';
+const GUARDED_POST = 'router.post("/x", requireAuth, (req, res) => { res.json({}); });';
+const PLAIN_FN = "export function add(a, b) { return a + b; }";
+const PY_ROUTE = '@app.post("/x")\ndef handler():\n    return {}';
+
+function baseWith(
+  securitySubVotes: RepoDriftBaseline["securitySubVotes"],
+  intentHints: RepoDriftBaseline["intentHints"] = [],
+): RepoDriftBaseline {
+  return {
+    key: "k",
+    rootDir: "/r",
+    ctxFiles: [{ path: "x.ts", hash: "h" }],
+    perCategoryVote: {},
+    securitySubVotes,
+    intentHints,
+    minhashIndex: [],
+    builtAt: 0,
+  };
+}
+
+const AUTH_APPLIED_VOTE: RepoDriftBaseline["securitySubVotes"] = {
+  "Auth middleware": {
+    driftCategory: "security_posture",
+    dominantPattern: "Auth middleware applied",
+    dominantCount: 8,
+    totalRelevantFiles: 9,
+    consistencyScore: 89,
+    dominantFiles: ["routes/users.ts"],
+    deviators: [],
+  },
+};
+
+const AUTH_REQUIRED_HINT = {
+  category: "security_posture" as const,
+  pattern: "auth_required",
+  label: "auth required on all routes",
+  source: "CLAUDE.md",
+  line: 42,
+  text: "all routes require auth",
+  confidence: 0.9,
+};
+
+describe("checkRouteAuthDrift", () => {
+  it("emits a low-confidence conflict for an unauthed mutating route vs an 'Auth middleware' vote", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.ts", UNAUTHED_POST);
+    expect(c).not.toBeNull();
+    expect(c!.dimension).toBe("security_posture");
+    expect(c!.dominantPattern).toBe("Auth middleware applied");
+    expect(c!.yourPattern).toBe("no auth guard visible in this change");
+    expect(c!.fixHint).toContain("8 of 9");
+    expect(c!.fixHint).toContain("router-level middleware is not visible");
+    // Honest phrasing: no em-dashes or double hyphens anywhere in the message.
+    expect(c!.fixHint).not.toMatch(/—|--/);
+  });
+
+  it("cites the declaration when there is no vote but an auth_required hint exists", async () => {
+    const c = await checkRouteAuthDrift(baseWith({}, [AUTH_REQUIRED_HINT]), "new.ts", UNAUTHED_POST);
+    expect(c).not.toBeNull();
+    expect(c!.dimension).toBe("security_posture");
+    expect(c!.dominantPattern).toBe("Auth middleware applied");
+    expect(c!.yourPattern).toBe("no auth guard visible in this change");
+    expect(c!.fixHint).toContain("CLAUDE.md:42");
+    expect(c!.fixHint).not.toMatch(/—|--/);
+  });
+
+  it("stays silent when there is neither a vote nor an auth hint (healthy 100%-authed repo)", async () => {
+    const c = await checkRouteAuthDrift(baseWith({}, []), "new.ts", UNAUTHED_POST);
+    expect(c).toBeNull();
+  });
+
+  it("does not flag a guarded mutating route even with an auth vote", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.ts", GUARDED_POST);
+    expect(c).toBeNull();
+  });
+
+  it("does not flag a non-route body", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.ts", PLAIN_FN);
+    expect(c).toBeNull();
+  });
+
+  it("does not flag a Python body (JS/TS-only gate)", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.py", PY_ROUTE);
+    expect(c).toBeNull();
+  });
+
+  it("stays silent when the auth vote is not the applied-majority signal and no hint is declared", async () => {
+    // Uniformly-unauthed baseline w/ machinery stores dominantPattern
+    // "auth on mutating routes" (aspirational), not "Auth middleware applied".
+    // Without a declared rule, the in-loop check has no truthful count to cite.
+    const machineryVote: RepoDriftBaseline["securitySubVotes"] = {
+      "Auth middleware": {
+        driftCategory: "security_posture",
+        dominantPattern: "auth on mutating routes",
+        dominantCount: 0,
+        totalRelevantFiles: 3,
+        consistencyScore: 0,
+        dominantFiles: [],
+        deviators: [],
+      },
+    };
+    const c = await checkRouteAuthDrift(baseWith(machineryVote), "new.ts", UNAUTHED_POST);
+    expect(c).toBeNull();
+  });
+});
+
+// ── run() wiring (real baseline) ─────────────────────────────────────────────
+// Proves the check is appended to the result in the async run() wrapper: ok
+// flips false, confidence is forced low, and the security conflict is present.
+// The baseline is built from a real repo whose auth sub-vote is "Auth middleware
+// applied", so this doubles as a no-disagreement smoke test against the batch
+// extractor.
+describe("validate_change security check (run wiring)", () => {
+  let repo: string;
+  let authVote: string | undefined;
+  beforeAll(async () => {
+    repo = mkdtempSync(join(tmpdir(), "vd-vc-sec-"));
+    mkdirSync(join(repo, "routes"), { recursive: true });
+    // 4 guarded + 1 unguarded mutating route → ratio 0.8 > 0.75 → the security
+    // detector votes "Auth middleware applied" (dominantCount 4 of 5).
+    writeFileSync(
+      join(repo, "routes", "api.ts"),
+      [
+        'router.post("/a", requireAuth, (req, res) => { res.json({}); });',
+        'router.put("/b", requireAuth, (req, res) => { res.json({}); });',
+        'router.patch("/c", requireAuth, (req, res) => { res.json({}); });',
+        'router.delete("/d", requireAuth, (req, res) => { res.json({}); });',
+        'router.post("/e", (req, res) => { res.json({}); });',
+        "",
+      ].join("\n"),
+    );
+    const built = await buildBaseline(repo);
+    await writeBaseline(built);
+    authVote = built.securitySubVotes?.["Auth middleware"]?.dominantPattern;
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+  beforeEach(() => __clearBaselineCache());
+
+  it("fixture establishes an 'Auth middleware applied' vote", () => {
+    expect(authVote).toBe("Auth middleware applied");
+  });
+
+  it("appends a low-confidence security conflict for an unauthed mutating route change", async () => {
+    const out = await run({ rootDir: repo, targetPath: join(repo, "routes", "new.ts"), body: UNAUTHED_POST });
+    expect(["ok", "stale"]).toContain(out.status);
+    expect(out.ok).toBe(false);
+    expect(out.confidence).toBe("low");
+    const sec = out.conflicts.find((c) => c.dimension === "security_posture");
+    expect(sec, "expected a security_posture conflict").toBeTruthy();
+    expect(sec!.yourPattern).toBe("no auth guard visible in this change");
+  });
+
+  it("does not append a security conflict for a guarded route change", async () => {
+    const out = await run({ rootDir: repo, targetPath: join(repo, "routes", "new.ts"), body: GUARDED_POST });
+    expect(out.conflicts.some((c) => c.dimension === "security_posture")).toBe(false);
+  });
+});

--- a/test/unit/mcp/tools/validate-change-security.test.ts
+++ b/test/unit/mcp/tools/validate-change-security.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../../../src/mcp/deep-index.js", () => ({ deepDuplicatesViaIndex: vi
 import { checkRouteAuthDrift, run } from "../../../../src/mcp/tools/validate-change.js";
 import { buildBaseline, writeBaseline, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
 import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
+import { deepDuplicatesViaIndex } from "../../../../src/mcp/deep-index.js";
 
 // ── Shared classifier ───────────────────────────────────────────────────────
 // classifyRouteAuth reuses the SAME AST route extractor the batch security
@@ -106,7 +107,7 @@ const AUTH_REQUIRED_HINT = {
 
 describe("checkRouteAuthDrift", () => {
   it("emits a low-confidence conflict for an unauthed mutating route vs an 'Auth middleware' vote", async () => {
-    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.ts", UNAUTHED_POST);
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), UNAUTHED_POST, "new.ts");
     expect(c).not.toBeNull();
     expect(c!.dimension).toBe("security_posture");
     expect(c!.dominantPattern).toBe("Auth middleware applied");
@@ -118,7 +119,7 @@ describe("checkRouteAuthDrift", () => {
   });
 
   it("cites the declaration when there is no vote but an auth_required hint exists", async () => {
-    const c = await checkRouteAuthDrift(baseWith({}, [AUTH_REQUIRED_HINT]), "new.ts", UNAUTHED_POST);
+    const c = await checkRouteAuthDrift(baseWith({}, [AUTH_REQUIRED_HINT]), UNAUTHED_POST, "new.ts");
     expect(c).not.toBeNull();
     expect(c!.dimension).toBe("security_posture");
     expect(c!.dominantPattern).toBe("Auth middleware applied");
@@ -128,22 +129,22 @@ describe("checkRouteAuthDrift", () => {
   });
 
   it("stays silent when there is neither a vote nor an auth hint (healthy 100%-authed repo)", async () => {
-    const c = await checkRouteAuthDrift(baseWith({}, []), "new.ts", UNAUTHED_POST);
+    const c = await checkRouteAuthDrift(baseWith({}, []), UNAUTHED_POST, "new.ts");
     expect(c).toBeNull();
   });
 
   it("does not flag a guarded mutating route even with an auth vote", async () => {
-    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.ts", GUARDED_POST);
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), GUARDED_POST, "new.ts");
     expect(c).toBeNull();
   });
 
   it("does not flag a non-route body", async () => {
-    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.ts", PLAIN_FN);
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), PLAIN_FN, "new.ts");
     expect(c).toBeNull();
   });
 
   it("does not flag a Python body (JS/TS-only gate)", async () => {
-    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), "new.py", PY_ROUTE);
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), PY_ROUTE, "new.py");
     expect(c).toBeNull();
   });
 
@@ -162,7 +163,7 @@ describe("checkRouteAuthDrift", () => {
         deviators: [],
       },
     };
-    const c = await checkRouteAuthDrift(baseWith(machineryVote), "new.ts", UNAUTHED_POST);
+    const c = await checkRouteAuthDrift(baseWith(machineryVote), UNAUTHED_POST, "new.ts");
     expect(c).toBeNull();
   });
 });
@@ -176,6 +177,7 @@ describe("checkRouteAuthDrift", () => {
 describe("validate_change security check (run wiring)", () => {
   let repo: string;
   let authVote: string | undefined;
+  let authVoteFiles: string[] | undefined;
   beforeAll(async () => {
     repo = mkdtempSync(join(tmpdir(), "vd-vc-sec-"));
     mkdirSync(join(repo, "routes"), { recursive: true });
@@ -195,6 +197,7 @@ describe("validate_change security check (run wiring)", () => {
     const built = await buildBaseline(repo);
     await writeBaseline(built);
     authVote = built.securitySubVotes?.["Auth middleware"]?.dominantPattern;
+    authVoteFiles = built.securitySubVotes?.["Auth middleware"]?.dominantFiles;
   });
   afterAll(() => rmSync(repo, { recursive: true, force: true }));
   beforeEach(() => __clearBaselineCache());
@@ -203,7 +206,7 @@ describe("validate_change security check (run wiring)", () => {
     expect(authVote).toBe("Auth middleware applied");
   });
 
-  it("appends a low-confidence security conflict for an unauthed mutating route change", async () => {
+  it("appends a low-confidence security conflict for an unauthed mutating route change, with referenceFiles from the vote", async () => {
     const out = await run({ rootDir: repo, targetPath: join(repo, "routes", "new.ts"), body: UNAUTHED_POST });
     expect(["ok", "stale"]).toContain(out.status);
     expect(out.ok).toBe(false);
@@ -211,10 +214,69 @@ describe("validate_change security check (run wiring)", () => {
     const sec = out.conflicts.find((c) => c.dimension === "security_posture");
     expect(sec, "expected a security_posture conflict").toBeTruthy();
     expect(sec!.yourPattern).toBe("no auth guard visible in this change");
+    // FINDING 2: the auth conflict is the only conflict, so validateChange's own
+    // referenceFiles computation never runs. run() must backfill it from the
+    // SAME auth vote the fixHint already cites (dominantFiles, capped at 3).
+    expect(authVoteFiles?.length, "fixture vote should carry dominantFiles").toBeGreaterThan(0);
+    expect(out.referenceFiles).toEqual((authVoteFiles ?? []).slice(0, 3));
   });
 
   it("does not append a security conflict for a guarded route change", async () => {
     const out = await run({ rootDir: repo, targetPath: join(repo, "routes", "new.ts"), body: GUARDED_POST });
     expect(out.conflicts.some((c) => c.dimension === "security_posture")).toBe(false);
+  });
+
+  // ── FINDING 1: deep path must never override the security-forced low
+  // confidence ────────────────────────────────────────────────────────────────
+  // The auth conflict's own fixHint says "this is a hint, not a verdict"
+  // because router-level middleware is invisible to the in-loop check. A cloud
+  // deep hit is genuinely high-confidence on ITS OWN finding, but must not
+  // launder the hedged auth conflict up to confidence:"high" just because it
+  // rode along in the same result.
+  describe("deep path vs. the security-forced low confidence", () => {
+    beforeEach(() => {
+      (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockReset();
+    });
+
+    it("a deep hit does NOT override confidence when an auth conflict also fired", async () => {
+      (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockResolvedValue({
+        degraded: false,
+        intentMismatches: [],
+        duplicates: [
+          { kind: "duplicate", detail: "new.ts::x ~ a.ts::twin", confidence: 0.93, verdict: "semantic_duplicate" },
+        ],
+      });
+      const out = await run({
+        rootDir: repo,
+        targetPath: join(repo, "routes", "new.ts"),
+        body: UNAUTHED_POST,
+        deep: true,
+      });
+      // The deep hit genuinely fired (proves this isn't a vacuous test)...
+      expect(out.deep?.duplicates).toHaveLength(1);
+      const sec = out.conflicts.find((c) => c.dimension === "security_posture");
+      expect(sec, "expected a security_posture conflict").toBeTruthy();
+      // ...but the auth conflict's hedge still wins at the result level.
+      expect(out.confidence).toBe("low");
+    });
+
+    it("a deep hit DOES set confidence high when there is no auth conflict (regression)", async () => {
+      (deepDuplicatesViaIndex as ReturnType<typeof vi.fn>).mockResolvedValue({
+        degraded: false,
+        intentMismatches: [],
+        duplicates: [
+          { kind: "duplicate", detail: "new.ts::x ~ a.ts::twin", confidence: 0.93, verdict: "semantic_duplicate" },
+        ],
+      });
+      const out = await run({
+        rootDir: repo,
+        targetPath: join(repo, "routes", "new.ts"),
+        body: GUARDED_POST,
+        deep: true,
+      });
+      expect(out.deep?.duplicates).toHaveLength(1);
+      expect(out.conflicts.some((c) => c.dimension === "security_posture")).toBe(false);
+      expect(out.confidence).toBe("high");
+    });
   });
 });

--- a/test/unit/output/floor-badge.test.ts
+++ b/test/unit/output/floor-badge.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect } from "vitest";
+import { hasFloorTrip } from "../../../src/output/floor-badge.js";
+import { renderTerminalOutput, renderConciseSummary } from "../../../src/output/terminal.js";
+import { renderHtmlReport, buildEmbeddedPrompts } from "../../../src/output/html.js";
+import { buildFixPromptMarkdown } from "../../../src/output/fix-prompt.js";
+import { computeScores } from "../../../src/scoring/engine.js";
+import type { Finding, ScanResult } from "../../../src/core/types.js";
+
+// ──── Fixture findings ────
+
+function driftFinding(): Finding {
+  // A real drift-kind finding so the composite starts below 100 — makes the
+  // grade-invariance assertion meaningful rather than a vacuous 100 === 100.
+  return {
+    analyzerId: "naming",
+    severity: "error",
+    confidence: 0.9,
+    message: "naming drift",
+    locations: [{ file: "src/a.ts", line: 1 }],
+    tags: [],
+  };
+}
+
+function securityFinding(): Finding {
+  // A plain (non-floor) security finding — must NOT trip the badge.
+  return {
+    analyzerId: "security",
+    severity: "info",
+    confidence: 0.5,
+    message: "URL constructed from variable in src/data.ts:1",
+    locations: [{ file: "src/data.ts", line: 1 }],
+    tags: ["security", "ssrf", "demoted"],
+  };
+}
+
+function privateKeyFloorFinding(): Finding {
+  return {
+    analyzerId: "security-floor",
+    severity: "error",
+    confidence: 0.98,
+    message: "Private key embedded in source code in src/key.ts:1",
+    locations: [{ file: "src/key.ts", line: 1 }],
+    tags: ["security", "secrets", "critical"],
+  };
+}
+
+function awsKeyFloorFinding(): Finding {
+  return {
+    analyzerId: "security-floor",
+    severity: "error",
+    confidence: 0.95,
+    message: "AWS access key ID detected in creds.ts:1",
+    locations: [{ file: "creds.ts", line: 1 }],
+    tags: ["security", "secrets", "aws"],
+  };
+}
+
+function tlsFloorFinding(): Finding {
+  return {
+    analyzerId: "security-floor",
+    severity: "error",
+    confidence: 0.95,
+    message: "TLS certificate verification disabled in client.go:4",
+    locations: [{ file: "client.go", line: 4 }],
+    tags: ["security", "tls"],
+  };
+}
+
+function evalTaintFinding(): Finding {
+  // Shaped like taintFindings() in src/codedna/taint-analysis.ts for a
+  // direct eval() sink (category code_injection, label "code evaluation").
+  return {
+    analyzerId: "codedna-taint",
+    severity: "error",
+    confidence: 0.75,
+    message:
+      "Unsanitized URL parameter reaches code evaluation in handleInput(): input (line 3) → code evaluation (line 5)",
+    locations: [
+      { file: "src/handler.ts", line: 3, snippet: "input = c.Param(...)" },
+      { file: "src/handler.ts", line: 5, snippet: "eval(input)" },
+    ],
+    tags: ["codedna", "taint", "security"],
+  };
+}
+
+function execTaintFinding(): Finding {
+  // Direct command_injection sink (execSync).
+  return {
+    analyzerId: "codedna-taint",
+    severity: "error",
+    confidence: 0.75,
+    message:
+      "Unsanitized request body reaches sync command execution in runCmd(): body (line 8) → sync command execution (line 10)",
+    locations: [
+      { file: "src/runner.ts", line: 8, snippet: "body = req.body.cmd" },
+      { file: "src/runner.ts", line: 10, snippet: "execSync(body)" },
+    ],
+    tags: ["codedna", "taint", "security"],
+  };
+}
+
+function oneHopInjectionTaintFinding(): Finding {
+  // Shaped like the one-hop finding in findOneHopFlows(), whose sink.type
+  // embeds the raw category string (not the human label).
+  return {
+    analyzerId: "codedna-taint",
+    severity: "warning",
+    confidence: 0.75,
+    message:
+      "Unsanitized URL parameter reaches runShell() reaches command_injection sink in handler(): id (line 2) → runShell() reaches command_injection sink (line 6)",
+    locations: [
+      { file: "src/handler.ts", line: 2 },
+      { file: "src/handler.ts", line: 6 },
+    ],
+    tags: ["codedna", "taint", "security"],
+  };
+}
+
+function sqlTaintFinding(): Finding {
+  // codedna-taint, but sql_injection — must NOT trip the badge.
+  return {
+    analyzerId: "codedna-taint",
+    severity: "error",
+    confidence: 0.75,
+    message:
+      "Unsanitized query parameter reaches SQL query in getUser(): id (line 2) → SQL query (line 4)",
+    locations: [
+      { file: "src/db.ts", line: 2 },
+      { file: "src/db.ts", line: 4 },
+    ],
+    tags: ["codedna", "taint", "security"],
+  };
+}
+
+// ──── hasFloorTrip ────
+
+describe("hasFloorTrip", () => {
+  it("is not tripped for an empty finding set", () => {
+    expect(hasFloorTrip([])).toEqual({ tripped: false, reasons: [] });
+  });
+
+  it("is not tripped by a demoted (non-floor) 'security' finding", () => {
+    const result = hasFloorTrip([securityFinding()]);
+    expect(result.tripped).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it("is not tripped by a codedna-taint finding whose sink is sql_injection", () => {
+    const result = hasFloorTrip([sqlTaintFinding()]);
+    expect(result.tripped).toBe(false);
+  });
+
+  it("trips on a security-floor private-key finding with reason 'private key in source'", () => {
+    const result = hasFloorTrip([privateKeyFloorFinding()]);
+    expect(result.tripped).toBe(true);
+    expect(result.reasons).toContain("private key in source");
+  });
+
+  it("trips on a security-floor AWS-key finding", () => {
+    const result = hasFloorTrip([awsKeyFloorFinding()]);
+    expect(result.tripped).toBe(true);
+    expect(result.reasons.length).toBe(1);
+  });
+
+  it("trips on a security-floor TLS finding", () => {
+    const result = hasFloorTrip([tlsFloorFinding()]);
+    expect(result.tripped).toBe(true);
+    expect(result.reasons[0]).toMatch(/TLS certificate verification disabled/i);
+  });
+
+  it("trips on a codedna-taint eval() (code_injection) finding with reason 'unsanitized input reaches eval/exec'", () => {
+    const result = hasFloorTrip([evalTaintFinding()]);
+    expect(result.tripped).toBe(true);
+    expect(result.reasons).toContain("unsanitized input reaches eval/exec");
+  });
+
+  it("trips on a codedna-taint execSync() (command_injection) finding", () => {
+    const result = hasFloorTrip([execTaintFinding()]);
+    expect(result.tripped).toBe(true);
+    expect(result.reasons).toContain("unsanitized input reaches eval/exec");
+  });
+
+  it("trips on a one-hop codedna-taint finding whose message embeds the raw command_injection category", () => {
+    const result = hasFloorTrip([oneHopInjectionTaintFinding()]);
+    expect(result.tripped).toBe(true);
+    expect(result.reasons).toContain("unsanitized input reaches eval/exec");
+  });
+
+  it("dedupes reasons across multiple floor findings of the same kind", () => {
+    const result = hasFloorTrip([awsKeyFloorFinding(), awsKeyFloorFinding(), evalTaintFinding()]);
+    expect(result.reasons.length).toBe(2);
+  });
+
+  it("never emits an em-dash or double hyphen in any reason string", () => {
+    const result = hasFloorTrip([
+      privateKeyFloorFinding(),
+      awsKeyFloorFinding(),
+      tlsFloorFinding(),
+      evalTaintFinding(),
+    ]);
+    for (const reason of result.reasons) {
+      expect(reason).not.toContain("—");
+      expect(reason).not.toContain("--");
+    }
+  });
+});
+
+// ──── Terminal render site ────
+
+describe("terminal render: Security floor badge", () => {
+  function terminalResult(findings: Finding[]): ScanResult {
+    const { scores, hygieneScores, hygieneScore, maxHygieneScore, compositeScore, maxCompositeScore } =
+      computeScores(findings, 30000);
+    return {
+      context: {
+        rootDir: "/tmp/proj",
+        dominantLanguage: "typescript",
+        languageBreakdown: new Map([["typescript", { files: 1, lines: 100 }]]),
+        totalLines: 30000,
+        files: [],
+        intentHints: [],
+      },
+      compositeScore,
+      maxCompositeScore,
+      percentile: null,
+      peerLanguage: "typescript",
+      scores,
+      hygieneScore,
+      maxHygieneScore,
+      hygieneScores,
+      findings,
+      driftFindings: [],
+      driftScores: {},
+      perFileScores: new Map(),
+      teaseMessages: [],
+      deepInsights: [],
+      scanTimeMs: 5,
+    } as unknown as ScanResult;
+  }
+
+  it("shows the floor badge line when a security-floor finding is present", () => {
+    const out = renderTerminalOutput(terminalResult([driftFinding(), privateKeyFloorFinding()]));
+    expect(out).toContain("Security floor:");
+    expect(out).toContain("private key in source");
+    expect(out).toContain("does not change the score");
+  });
+
+  it("does not show the floor badge line when there is no floor trip", () => {
+    const out = renderTerminalOutput(terminalResult([driftFinding(), securityFinding()]));
+    expect(out).not.toContain("Security floor:");
+  });
+});
+
+// ──── HTML render site ────
+
+describe("html render: Security floor badge", () => {
+  function htmlResult(findings: Finding[]): ScanResult {
+    const { scores, hygieneScores, hygieneScore, maxHygieneScore, compositeScore, maxCompositeScore } =
+      computeScores(findings, 30000);
+    return {
+      context: {
+        rootDir: "/tmp/proj",
+        dominantLanguage: "typescript",
+        languageBreakdown: new Map([["typescript", { files: 1, lines: 100 }]]),
+        totalLines: 30000,
+        files: [],
+        intentHints: [],
+      },
+      compositeScore,
+      maxCompositeScore,
+      percentile: null,
+      peerLanguage: "typescript",
+      scores,
+      hygieneScore,
+      maxHygieneScore,
+      hygieneScores,
+      findings,
+      driftFindings: [],
+      driftScores: {},
+      perFileScores: new Map(),
+      teaseMessages: [],
+      deepInsights: [],
+      scanTimeMs: 5,
+    } as unknown as ScanResult;
+  }
+
+  it("renders a floor-trip chip reusing the existing .badge.warn class when tripped", () => {
+    const html = renderHtmlReport(htmlResult([driftFinding(), privateKeyFloorFinding()]), "summary");
+    expect(html).toContain("Security floor");
+    expect(html).toMatch(/class="badge warn"/);
+  });
+
+  it("does not render a floor-trip chip when there is no floor trip", () => {
+    const html = renderHtmlReport(htmlResult([driftFinding(), securityFinding()]), "summary");
+    expect(html).not.toContain("Security floor tripped");
+  });
+
+  it("introduces no new CSS color token — only reuses existing --warn/--warn-tint", () => {
+    const html = renderHtmlReport(htmlResult([driftFinding(), privateKeyFloorFinding()]), "summary");
+    // Sanity: the stylesheet's badge.warn rule (pre-existing, reused) is present.
+    expect(html).toContain(".badge.warn{background:var(--warn-tint);color:var(--warn)}");
+  });
+});
+
+// ──── Grade invariance (locked constraint) ────
+
+describe("grade invariance: the badge never changes compositeScore or the letter grade", () => {
+  function extractGradeLetter(html: string): string {
+    const m = html.match(/class="va-grade"[^>]*>([A-F])</);
+    expect(m).not.toBeNull();
+    return m![1];
+  }
+
+  it("compositeScore and the rendered letter grade are identical with vs without a security-floor finding", () => {
+    const base = [driftFinding(), driftFinding()];
+    const without = computeScores(base, 30000);
+    const withFloor = computeScores([...base, awsKeyFloorFinding()], 30000);
+
+    expect(withFloor.compositeScore).toBe(without.compositeScore);
+
+    function toScanResult(scored: ReturnType<typeof computeScores>, findings: Finding[]): ScanResult {
+      return {
+        context: {
+          rootDir: "/tmp/proj",
+          dominantLanguage: "typescript",
+          languageBreakdown: new Map([["typescript", { files: 1, lines: 100 }]]),
+          totalLines: 30000,
+          files: [],
+          intentHints: [],
+        },
+        compositeScore: scored.compositeScore,
+        maxCompositeScore: scored.maxCompositeScore,
+        percentile: null,
+        peerLanguage: "typescript",
+        scores: scored.scores,
+        hygieneScore: scored.hygieneScore,
+        maxHygieneScore: scored.maxHygieneScore,
+        hygieneScores: scored.hygieneScores,
+        findings,
+        driftFindings: [],
+        driftScores: {},
+        perFileScores: new Map(),
+        teaseMessages: [],
+        deepInsights: [],
+        scanTimeMs: 5,
+      } as unknown as ScanResult;
+    }
+
+    const htmlWithout = renderHtmlReport(toScanResult(without, base), "summary");
+    const htmlWithFloor = renderHtmlReport(toScanResult(withFloor, [...base, awsKeyFloorFinding()]), "summary");
+
+    expect(extractGradeLetter(htmlWithFloor)).toBe(extractGradeLetter(htmlWithout));
+    // Sanity: the floor badge IS present in the "with" render (proves this
+    // isn't a vacuous comparison where the badge never showed up).
+    expect(htmlWithFloor).toContain("Security floor");
+    expect(htmlWithout).not.toContain("Security floor tripped");
+  });
+});
+
+// ──── Consumer-guidance fixes (Task 2 review fold-in) ────
+//
+// security-floor findings are hygiene-kind, so computeScores never populates
+// their `consistencyImpact` (see src/scoring/engine.ts: "Hygiene track: ...
+// never mutates consistencyImpact"). These tests set consistencyImpact
+// directly on the fixture, matching how test/unit/output/fix-plan-widget.test.ts
+// builds Fix Plan fixtures, so the terminal.ts Fix Plan path (which is
+// impact-gated) can be exercised for a security-floor finding.
+
+function minimalScanResult(findings: Finding[]): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  // renderHygienePane (terminal.ts) reads result.hygieneScores[cat].applicable for
+  // every ScoringCategory key; applicable:false makes it a no-op skip so it
+  // doesn't crash or interfere with the Fix Plan assertions below.
+  const naCat = { score: 0, maxScore: 20, locked: false, findingCount: 0, applicable: false };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map(),
+      totalLines: 1000,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 90,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...naCat },
+      redundancy: { ...naCat },
+      dependencyHealth: { ...naCat },
+      securityPosture: { ...naCat },
+      intentClarity: { ...naCat },
+    },
+    findings,
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+  } as unknown as ScanResult;
+}
+
+describe("terminal: findingConsequence recognizes security-floor (terminal.ts ~L193)", () => {
+  it("shows the security 'why it matters' line for a security-floor Fix Plan item", () => {
+    const floor: Finding = {
+      ...privateKeyFloorFinding(),
+      consistencyImpact: 1.0, // manually set — see comment above
+    };
+    const out = renderTerminalOutput(minimalScanResult([floor]));
+    expect(out).toContain("Hardcoded secrets or injection risks may be in production");
+  });
+});
+
+describe("terminal: findingPriority treats security-floor as top priority (terminal.ts ~L241)", () => {
+  it("ranks a security-floor item ahead of a lower-priority, higher-impact naming item in the drift-first Fix Plan", () => {
+    // Same severity ("error") on both so the default (non-security) priority
+    // tier ties at 2*3=6 for each — without the fix, findingPriority would not
+    // recognize "security-floor" and this pair would tie, falling through to
+    // the consistencyImpact tie-break (naming's 5.0 > floor's 1.0), putting
+    // naming FIRST. With the fix, security-floor jumps to the top tier
+    // (10*3=30) and wins outright. This makes the test a real regression
+    // guard, not a vacuous pass.
+    const floor: Finding = {
+      analyzerId: "security-floor",
+      severity: "error",
+      confidence: 0.98,
+      message: "SECURITY_FLOOR_ITEM: private key embedded in source",
+      locations: [{ file: "src/key.ts", line: 1 }],
+      tags: ["security", "secrets", "critical"],
+      consistencyImpact: 1.0,
+    };
+    const naming: Finding = {
+      analyzerId: "naming",
+      severity: "error",
+      confidence: 0.8,
+      message: "NAMING_ITEM: inconsistent casing",
+      locations: [{ file: "src/b.ts", line: 1 }],
+      tags: [],
+      consistencyImpact: 5.0, // much higher impact, but lower priority tier
+    };
+    const out = renderConciseSummary(minimalScanResult([naming, floor]));
+    const floorIdx = out.indexOf("SECURITY_FLOOR_ITEM");
+    const namingIdx = out.indexOf("NAMING_ITEM");
+    expect(floorIdx).toBeGreaterThan(-1);
+    expect(namingIdx).toBeGreaterThan(-1);
+    expect(floorIdx).toBeLessThan(namingIdx);
+  });
+});
+
+describe("fix-prompt: security-floor gets the specific 'rotate the secret' recommendation, not the generic fallback", () => {
+  it("buildFixPromptMarkdown for a security-floor finding surfaces the security-specific recommendation", () => {
+    const md = buildFixPromptMarkdown(privateKeyFloorFinding());
+    expect(md).toContain("rotate it immediately");
+    expect(md).not.toContain("Address the finding described above");
+  });
+
+  it("html buildEmbeddedPrompts (paid) surfaces the specific recommendation for a security-floor finding", () => {
+    const html = buildEmbeddedPrompts(minimalScanResult([privateKeyFloorFinding()]), true);
+    expect(html).toContain("rotate it immediately");
+  });
+});

--- a/test/unit/output/security-advisory-render.test.ts
+++ b/test/unit/output/security-advisory-render.test.ts
@@ -6,7 +6,13 @@ import { renderCsvReport } from "../../../src/output/csv.js";
 import { renderDocxReport } from "../../../src/output/docx.js";
 import { applySecurityMinPeerFloor, MIN_SECURITY_PEERS, computeScores } from "../../../src/scoring/engine.js";
 import { scoredDriftView, driftFindingToFinding, attachEngineComposite } from "../../../src/drift/index.js";
+import {
+  buildSuppressionAuditFinding,
+  SECURITY_SUPPRESSION_SUBCATEGORY,
+  SECURITY_SUPPRESSION_ANALYZER_ID,
+} from "../../../src/drift/security-suppression.js";
 import type { DriftFinding } from "../../../src/drift/types.js";
+import type { SuppressionRecord } from "../../../src/drift/security-suppression.js";
 import type { ScanResult, PerFileScore } from "../../../src/core/types.js";
 
 /**
@@ -328,6 +334,78 @@ describe("min-peer-floor render consistency (root fix)", () => {
       const html = renderHtmlReport(result, "detailed");
       const library = htmlSection(html, "Drift findings", "File ranking");
       expect(library).toContain("1 mutating route(s) lack auth (at floor)");
+    });
+  });
+
+  // The suppression-audit finding (security-suppression.ts) is a hygiene audit
+  // trail, not a dominance vote, so it must never appear in the DRIFT
+  // representation regardless of how many routes were suppressed. Its
+  // `totalRelevantFiles` is just the suppressed-route count, so at
+  // n >= MIN_SECURITY_PEERS the below-floor check alone does not exclude it
+  // (it only excludes n < MIN_SECURITY_PEERS) — scoredDriftView must also
+  // filter on subCategory. These tests cover both sides of that boundary.
+  describe("suppression-audit finding stays out of the DRIFT view at any suppression count", () => {
+    function suppressedRoutes(n: number): SuppressionRecord[] {
+      return Array.from({ length: n }, (_, i) => ({
+        path: `src/routes/r${i}.ts`,
+        line: 1,
+        reason: "annotation" as const,
+        source: "@vibedrift-public",
+      }));
+    }
+
+    it.each([1, MIN_SECURITY_PEERS, MIN_SECURITY_PEERS + 6])(
+      "scoredDriftView excludes the audit finding at n=%i suppressed routes (below and at/above the peer floor)",
+      (n) => {
+        const audit = buildSuppressionAuditFinding(suppressedRoutes(n));
+        expect(audit.totalRelevantFiles).toBe(n);
+
+        const { driftFindings } = scoredDriftView([audit, rawArch()], TOTAL_LINES);
+
+        expect(driftFindings.some((d) => d.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBe(false);
+        expect(
+          driftFindings.some((d) => d.dominantPattern === "route excluded from the security consistency check"),
+        ).toBe(false);
+        // The unrelated arch finding still comes through — only the audit
+        // finding is excluded, not the whole set.
+        expect(driftFindings.map((d) => d.driftCategory)).toContain("architectural_consistency");
+      },
+    );
+
+    it("stays present in result.findings (hygiene pane) at n>=MIN_SECURITY_PEERS even though it is dropped from result.driftFindings", () => {
+      const n = MIN_SECURITY_PEERS + 6; // 10: past the floor, the leak case before the fix
+      const audit = buildSuppressionAuditFinding(suppressedRoutes(n));
+      const result = mkPipelineResult([audit, rawArch()]);
+
+      expect(result.findings.some((f) => f.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID)).toBe(true);
+      expect(result.driftFindings.some((d) => d.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY)).toBe(false);
+    });
+
+    it("html: no DRIFT security row for the audit finding at n>=MIN_SECURITY_PEERS, but it still renders in the hygiene section", () => {
+      const n = MIN_SECURITY_PEERS + 6;
+      const audit = buildSuppressionAuditFinding(suppressedRoutes(n));
+      const result = mkPipelineResult([audit, rawArch()]);
+
+      const html = renderHtmlReport(result, "detailed");
+      const library = htmlSection(html, "Drift findings", "File ranking");
+      expect(library).not.toContain("route excluded from the security consistency check");
+      expect(html).toContain(`${n} route(s) excluded from the security consistency check`);
+    });
+
+    it("csv: DRIFT FINDINGS omits the audit finding, ALL FINDINGS still surfaces it under its hygiene analyzerId", () => {
+      const n = MIN_SECURITY_PEERS + 6;
+      const audit = buildSuppressionAuditFinding(suppressedRoutes(n));
+      const result = mkPipelineResult([audit, rawArch()]);
+
+      const csv = renderCsvReport(result);
+      const driftFindingsStart = csv.indexOf("DRIFT FINDINGS");
+      const allFindingsStart = csv.indexOf("ALL FINDINGS");
+      const driftFindingsSection = csv.slice(driftFindingsStart, allFindingsStart);
+      expect(driftFindingsSection).not.toContain("route excluded from the security consistency check");
+
+      const allFindingsSection = csv.slice(allFindingsStart);
+      expect(allFindingsSection).toContain(SECURITY_SUPPRESSION_ANALYZER_ID);
+      expect(allFindingsSection).toContain("route(s) excluded from the security consistency check");
     });
   });
 });

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,14 @@
 # CLI backlog
 
+- **Security floor precision gate only covers `private-key`.** The calibration
+  floor-precision gate (`test/calibration/precision-recall.ts`) exercises only the
+  `private-key` floor rule because the fixture corpus has no `.go` files, so
+  `go-tls-skip-verify`'s false-positive rate is unmeasured (not just under-weighted).
+  Add a Go fixture to the calibration corpus so the "floor precision >= 0.95" claim
+  covers all five floor rules, not one. (The composite `calibrate:monotonic`
+  non-responsiveness at low injection rates is pre-existing and tracked with the
+  scoring-formula responsiveness work, not here.)
+
 - **Security suppression: regex-fallback over-suppression on unterminated strings.**
   In `src/drift/security-suppression.ts`, the AST comment-node path is immune, but
   the textual regex fallback's `stripStringLiterals` only blanks CLOSED quote spans.

--- a/todo.md
+++ b/todo.md
@@ -80,6 +80,13 @@
   match the rendered (scored) view, feed `scoredDriftView(...).driftFindings` to
   both the diff digest (buildScanResult) and `saveScanResult` together (keep the
   two sources identical or a spurious per-scan diff reappears).
+  Same root cause covers the suppression-audit finding (subCategory
+  `SECURITY_SUPPRESSION_SUBCATEGORY`, `security-suppression.ts`): the diff
+  digest also reads raw `driftFindings`, so adding or removing a
+  `@vibedrift-public` annotation or allowlist entry can show up as a "new" or
+  "resolved" drift finding in the diff banner and get committed into
+  `.vibedrift/context.md`. The same fix (feed the diff digest source from
+  `scoredDriftView(...).driftFindings`) would exclude it too.
 - **`watch` renderer shows signed-out copy while authenticated** (v0.14.8): watch
   output includes the "Sign in with `vibedrift login`…" hint and free-tier deep
   tease even on a logged-in session. Fix the auth-state branch in the renderer.

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,17 @@
 # CLI backlog
 
+- **Security suppression: regex-fallback over-suppression on unterminated strings.**
+  In `src/drift/security-suppression.ts`, the AST comment-node path is immune, but
+  the textual regex fallback's `stripStringLiterals` only blanks CLOSED quote spans.
+  An unterminated string containing `// @vibedrift-public` therefore survives and is
+  read as a comment, dropping the route from the security denominator (over-suppression
+  hides a route). Only reachable in a global no-parser degraded mode (tree-sitter WASM
+  fails to init), so low risk. Two fixes: (1) correct the inverted safe-direction code
+  comment at `security-suppression.ts:55-58` (it wrongly says under-strip is safe);
+  (2) strip an unterminated quote to end-of-line before scanning for a comment marker,
+  so the fallback fails to the safe under-match side. Never-over-suppress is the
+  dominating invariant.
+
 - **Security Consistency is not at parity across supported languages.** The
   route/auth consistency detector (`extractRoutes`, `security-consistency.ts`)
   covers 3 of the 5 supported languages, at uneven precision, and the AST

--- a/todo.md
+++ b/todo.md
@@ -35,13 +35,6 @@
   and attribute a guard only on a single exact-path match. Security-critical (a
   false attribution is a missed vulnerability) — design deliberately.
 
-- **AST route middleware: unpack array-literal middleware.** `middlewareNames`
-  in `src/drift/security-ast.ts` doesn't unpack `router.post("/x", [requireAuth],
-  handler)` (middleware passed as an array), so a genuinely-authed route reads as
-  an unauthed deviator. Safe direction (over-flags, never falsely blesses) and
-  narrow, but a ~3-line fix: when a middleware arg is an `array` node, recurse
-  over its `namedChildren`.
-
 - **Security calibration: exercise the primary dominance vote.** The `security`
   calibration injector strips auth at the shared `INJECT_RATE` (0.34), which puts
   the authed ratio below the 0.75 dominance-vote gate, so calibration only

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,27 @@
 # CLI backlog
 
+- **Security Consistency is not at parity across supported languages.** The
+  route/auth consistency detector (`extractRoutes`, `security-consistency.ts`)
+  covers 3 of the 5 supported languages, at uneven precision, and the AST
+  precision upgrade from the Phase 1 wedge is JS/TS-only:
+  - **Rust: zero coverage.** There is no Rust route extractor at all — the
+    `extractRoutes` dispatch silently skips Rust, so Axum/Actix/Rocket services
+    produce no security-consistency signal. (The Phase 1 plan text claiming a
+    "regex fallback for Go/Python/Rust" was wrong; no Rust extractor ever
+    existed. Corrected in the plan.)
+  - **Python/Go: still line-window regex, un-upgraded and unverified.**
+    `extractPythonRoutes` / `extractGoRoutes` read auth/validation/rate-limit
+    from a ±10–30 line proximity window, not from parsed middleware args, so
+    they both false-positive (auth keyword nearby but not applied) and
+    false-negate (auth applied via a pattern not in the regex). They did NOT get
+    the receiver whitelist, `router.use()` inheritance, or the over-capture fix
+    (`cache.get`) the JS/TS AST path got, and were not smoke-tested on the latest
+    build (only JS was exercised in the Phase 1 verification).
+  Full remediation is drafted as a dedicated phase:
+  `PLAN-security-conformance-phase-multilang.md` (port the AST extractor to
+  Python + Go, add a first Rust extractor, per-language calibration). Warrants
+  its own branch, not a fold into the current work.
+
 - **Mounted-router middleware resolution needs proper module resolution.** The
   Security Consistency detector should resolve `app.use('/api', apiRouter)`
   cross-file so a router-level guard propagates to the mounted routes. A


### PR DESCRIPTION
## Security Consistency: floor, route suppression, and an in-loop auth check

Builds on the AST route detection from #35. Three additions, all local and free, none of which move the Vibe Drift composite (the score keeps measuring drift, not security).

### 1. Security floor
A curated set of absolute, high confidence checks (a private key committed in source, an AWS key, a hardcoded API key or token, disabled TLS verification) now carry a `floor` tag and surface a floor-gate badge in the terminal and HTML report. These are bad regardless of what the rest of the repo does, so the badge shows up independently of the drift number and never changes the grade. The badge also lights up when the existing taint analysis finds unsanitized input reaching `eval`/`exec`. The noisiest low confidence rules are demoted so they stop dominating the hygiene output.

### 2. Route suppression that keeps the ratio honest
Two ways to exclude a genuinely public route from the Security Consistency check, so it does not count against the repo's own auth convention:
- an inline `// @vibedrift-public` comment on the route (detected via the parsed comment nodes, so it never matches inside a string), and
- a `security.allowlist` glob list in `.vibedrift/config.json`.

Every exclusion is cited and counted in the report, so silently annotating routes away is visible rather than hidden.

### 3. In-loop auth check in `validate_change`
When an agent proposes a mutating route with no visible auth guard, and the repo's own convention is to apply auth, the `validate_change` MCP tool now returns a low confidence, hedged note: "no auth guard visible in this change." It reuses the same route extractor the batch scan uses, so it can never disagree with a full scan, and it states plainly that router-level middleware is not visible to a single-change check, so it reads as a hint rather than a verdict. It stays silent when there is no basis to compare.

### Notes
- JavaScript and TypeScript only for the in-loop check and the AST route work; other languages are unaffected here.
- Fully tested, including a calibration gate on the floor's precision, a check that the in-loop and batch paths agree, and end-to-end suppression-honesty coverage. Build, type check, and the full suite are green.
- Remaining precision and coverage follow-ups are tracked in `todo.md`.
