### PR TITLE
fix(security): close the four #34 release blockers (auth peer group, baseline version gate, sub-vote floor, check_file_drift)

### DIFF
--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -53,6 +53,12 @@ export interface MinhashEntry {
 
 export interface RepoDriftBaseline {
   key: string;
+  /** BASELINE_VERSION this baseline was built with. Optional because baselines
+   *  persisted before the field shipped carry none; loaders treat absence as
+   *  pre-current and rebuild rather than serve (getBaseline's version gate).
+   *  assembleBaseline always sets it, so every newly persisted baseline is
+   *  versioned. */
+  version?: number;
   rootDir: string;
   ctxFiles: Array<{ path: string; hash: string }>;
   perCategoryVote: Partial<Record<DriftCategory, CategoryVote>>;
@@ -187,6 +193,7 @@ export function assembleBaseline(
 
   return {
     key: computeBaselineKey(ctxFiles),
+    version: BASELINE_VERSION,
     rootDir,
     ctxFiles,
     perCategoryVote: votesFromFindings(driftFindings),

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -23,13 +23,18 @@ import { parseFiles } from "../utils/ast.js";
 import { extractAllFunctions } from "../codedna/function-extractor.js";
 import { buildSignature } from "../codedna/minhash.js";
 import { SECURITY_SUPPRESSION_SUBCATEGORY } from "../drift/security-suppression.js";
+import { MIN_SECURITY_PEERS } from "../scoring/engine.js";
 import type { AnalysisContext } from "./types.js";
 import type { DriftFinding, DriftCategory } from "../drift/types.js";
 import type { IntentHint } from "../intent/types.js";
 
 const CACHE_DIR = join(homedir(), ".vibedrift", "baseline-cache");
-/** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
-export const BASELINE_VERSION = 2;
+/** Bump when vote logic / detector set / signature format changes (invalidates
+ *  all caches). v3: method-ANY/ALL routes joined the auth peer group and
+ *  securitySubVotes gained the MIN_SECURITY_PEERS floor, so v2 baselines carry
+ *  votes the current logic would not produce. getBaseline rebuilds any
+ *  persisted baseline whose version differs. */
+export const BASELINE_VERSION = 3;
 
 export interface CategoryVote {
   driftCategory: DriftCategory;
@@ -148,6 +153,12 @@ export function toCategoryVote(f: DriftFinding): CategoryVote {
  * subCategory is excluded for the same reason as in votesFromFindings above:
  * it is an audit trail, not a sub-convention vote, so it must not leave a
  * bogus "Suppression audit" entry in the persisted securitySubVotes.
+ *
+ * Findings whose route sample is below MIN_SECURITY_PEERS are also dropped:
+ * the scoring engine demotes those same findings to advisory (too thin a
+ * sample to trust, see applySecurityMinPeerFloor), so persisting them here
+ * would let the MCP serve a 2-of-3-routes vote as the authoritative
+ * convention while the scan refuses to score it. One floor, one boundary.
  */
 export function securitySubVotesFromFindings(
   findings: DriftFinding[],
@@ -156,6 +167,7 @@ export function securitySubVotesFromFindings(
   for (const f of findings) {
     if (f.driftCategory !== "security_posture" || !f.subCategory) continue;
     if (f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY) continue;
+    if (f.totalRelevantFiles < MIN_SECURITY_PEERS) continue;
     const key = f.subCategory;
     const existing = out[key];
     if (existing && existing.totalRelevantFiles >= f.totalRelevantFiles) continue;

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -39,6 +39,23 @@ import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security
 
 const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
+// The auth vote's peer group: every state-changing method, PLUS "ANY" (a route
+// whose method the extractor could not pin down, e.g. Flask `@app.route(...)`)
+// and "ALL" (Express `.all()`, which handles every verb including the mutating
+// ones). Filtering the peer group to MUTATION_METHODS alone dropped both
+// silently, losing auth-consistency detection for whole frameworks: a Flask
+// repo with 9 authed + 1 unauthed routes produced no finding at all. The
+// validation vote deliberately keeps the narrower POST/PUT/PATCH set
+// (body-carrying methods only), so it must NOT use this constant.
+const AUTH_VOTE_METHODS = [...MUTATION_METHODS, "ANY", "ALL"];
+
+/** Copy helper: "ANY" means the method is unresolved, so a message counting
+ *  such routes must not assert they all mutate. "ALL" routes genuinely handle
+ *  the mutating verbs, so they keep the plain "mutating" label. */
+function authRoutesNoun(routes: RouteInfo[]): string {
+  return routes.some((r) => r.method === "ANY") ? "mutating or unresolved-method route(s)" : "mutating route(s)";
+}
+
 // Does the codebase use auth machinery anywhere? If it does, a mutating route
 // with no auth is drift ("you know how to auth — this route forgot"), not an
 // intentionally-public API. Specific symbols only, to keep false positives low.
@@ -51,8 +68,9 @@ function repoHasAuthMachinery(files: DriftFile[]): boolean {
  * Absolute baseline for the uniform-wrongness blind spot: the dominance vote
  * (analyzeSecurityProperty) goes SILENT when 0% of routes have auth (ratio=0
  * fails the ratio>0.75 gate), so an AI that wrote every mutating endpoint
- * without auth produced a clean grade. This fires on uniformly-unauthed
- * MUTATING routes — but only with a baseline reason: either the repo uses auth
+ * without auth produced a clean grade. This fires on uniformly-unauthed routes
+ * in the auth peer group (AUTH_VOTE_METHODS: mutating, method-ANY, and .all()
+ * routes) — but only with a baseline reason: either the repo uses auth
  * elsewhere, or a CLAUDE.md/AGENTS.md hint declares auth required. With neither,
  * we stay silent (could be an intentionally-public API).
  */
@@ -60,8 +78,10 @@ function analyzeUniformAuthGap(
   routes: RouteInfo[],
   opts: { hasMachinery: boolean; hint: ReturnType<typeof pickIntentHint>; healthPaths: RegExp },
 ): DriftFinding | null {
-  const mutating = routes.filter((r) => MUTATION_METHODS.includes(r.method) && !opts.healthPaths.test(r.path));
-  const unauthed = mutating.filter((r) => !r.hasAuth);
+  // Same peer group as the primary dominance vote (AUTH_VOTE_METHODS), so the
+  // vote and its fallback can never disagree about which routes are judged.
+  const authPeers = routes.filter((r) => AUTH_VOTE_METHODS.includes(r.method) && !opts.healthPaths.test(r.path));
+  const unauthed = authPeers.filter((r) => !r.hasAuth);
   if (unauthed.length === 0) return null;
   if (!opts.hasMachinery && !opts.hint) return null; // no baseline → maybe intentionally public
 
@@ -69,7 +89,8 @@ function analyzeUniformAuthGap(
   // Evidence-driven confidence: a declared rule is strong; "uses auth elsewhere"
   // is a softer signal.
   const confidence = declared ? 0.9 : 0.6;
-  const have = mutating.length - unauthed.length;
+  const have = authPeers.length - unauthed.length;
+  const noun = authRoutesNoun(unauthed);
 
   return {
     detector: "security_posture",
@@ -78,12 +99,12 @@ function analyzeUniformAuthGap(
     severity: unauthed.length > 2 ? "error" : "warning",
     confidence,
     finding: declared
-      ? `${unauthed.length} mutating route(s) lack auth, but ${opts.hint!.source} declares authentication is required`
-      : `${unauthed.length} mutating route(s) lack auth while the codebase uses auth elsewhere`,
+      ? `${unauthed.length} ${noun} lack auth, but ${opts.hint!.source} declares authentication is required`
+      : `${unauthed.length} ${noun} lack auth while the codebase uses auth elsewhere`,
     dominantPattern: declared ? `${opts.hint!.label}` : "auth on mutating routes",
     dominantCount: have,
-    totalRelevantFiles: mutating.length,
-    consistencyScore: mutating.length ? Math.round((have / mutating.length) * 100) : 0,
+    totalRelevantFiles: authPeers.length,
+    consistencyScore: authPeers.length ? Math.round((have / authPeers.length) * 100) : 0,
     deviatingFiles: unauthed.map((r) => ({
       path: r.file,
       detectedPattern: `${r.method} ${r.path} — no auth`,
@@ -91,8 +112,8 @@ function analyzeUniformAuthGap(
     })),
     dominantFiles: [],
     recommendation: declared
-      ? `${opts.hint!.source}:${opts.hint!.line} declares auth is required. Add auth middleware to these ${unauthed.length} mutating route(s), or mark them explicitly public.`
-      : `These ${unauthed.length} mutating route(s) have no auth while the codebase authenticates elsewhere. Add auth middleware, or confirm they are intentionally public.`,
+      ? `${opts.hint!.source}:${opts.hint!.line} declares auth is required. Add auth middleware to these ${unauthed.length} ${noun}, or mark them explicitly public.`
+      : `These ${unauthed.length} ${noun} have no auth while the codebase authenticates elsewhere. Add auth middleware, or confirm they are intentionally public.`,
   };
 }
 
@@ -375,11 +396,15 @@ export const securityConsistency: DriftDetector = {
     const groups = groupRoutes(routes);
 
     for (const group of groups) {
-      // Auth applies to every state-changing route (POST/PUT/PATCH/DELETE).
-      // Rescoped from `group`: counting read-only GETs put intentionally-public
-      // reads in the denominator and made the "X of Y mutating routes" line false.
-      // Same set as analyzeUniformAuthGap so the primary vote and its fallback agree.
-      const groupAuthRoutes = group.filter((r) => MUTATION_METHODS.includes(r.method));
+      // Auth applies to every state-changing route (POST/PUT/PATCH/DELETE)
+      // plus method-ANY/ALL routes (see AUTH_VOTE_METHODS). Rescoped from
+      // `group`: counting read-only GETs put intentionally-public reads in the
+      // denominator and made the "X of Y routes" line false. Same set as
+      // analyzeUniformAuthGap so the primary vote and its fallback agree.
+      // Runs on post-suppression routes only: `group` descends from the
+      // applyRouteSuppressions `kept` set above, so a suppressed ANY/ALL route
+      // never re-enters the vote through this filter.
+      const groupAuthRoutes = group.filter((r) => AUTH_VOTE_METHODS.includes(r.method));
       const authFinding = analyzeSecurityProperty(groupAuthRoutes, SECURITY_SUBCATEGORIES.auth, (r) => r.hasAuth, healthPaths);
       if (authFinding) {
         findings.push(authFinding);

--- a/src/mcp/baseline-provider.ts
+++ b/src/mcp/baseline-provider.ts
@@ -2,9 +2,13 @@
  * In-memory baseline holder for the long-lived MCP server.
  *
  * Loads a repo's RepoDriftBaseline from disk ONCE and caches it in process.
- * For a repo that already has a baseline it never rebuilds synchronously (a
- * rebuild is 3–8s and would blow the <500ms budget) — instead it re-hashes the
- * working tree to decide `ok` vs `stale` and always serves the cached baseline.
+ * For a repo that already has a CURRENT-version baseline it never rebuilds
+ * synchronously (a rebuild is 3–8s and would blow the <500ms budget) — instead
+ * it re-hashes the working tree to decide `ok` vs `stale` and always serves
+ * the cached baseline. A baseline persisted under an older BASELINE_VERSION is
+ * the one exception: it is rebuilt like the never-scanned case (see the
+ * version gate in getBaseline), because its shape/votes predate the current
+ * logic and its key can never read fresh again.
  *
  * For a repo that has NEVER been scanned, the first tool call builds the
  * baseline lazily (a one-time 3–8s), persists it, and returns it — so the MCP
@@ -20,6 +24,7 @@ import {
   writeBaseline,
   computeBaselineKey,
   loadBaselineUnchecked,
+  BASELINE_VERSION,
   type RepoDriftBaseline,
 } from "../core/baseline.js";
 
@@ -99,12 +104,25 @@ export async function getBaseline(
 ): Promise<{ baseline: RepoDriftBaseline | null; status: "ok" | "stale" | "no_baseline" }> {
   let baseline = memCache.get(rootDir) ?? null;
   if (!baseline) {
-    baseline = await loadBaselineUnchecked(rootDir);
-    if (baseline) memCache.set(rootDir, baseline);
+    const loaded = await loadBaselineUnchecked(rootDir);
+    // Version gate: a baseline persisted under an older BASELINE_VERSION
+    // predates the current vote logic (pre-v2 files, for example, carry no
+    // securitySubVotes, so auth projections would answer the no-vote
+    // "consistent" shape even when the stale vote recorded deviators), and
+    // because the version is baked into the cache key, its freshness check
+    // could never read "ok" again. Treat it exactly like a missing baseline:
+    // rebuild lazily once below, persist, and serve fresh. Absence of the
+    // field means the baseline predates versioned persistence, which is
+    // equally out of date.
+    if (loaded && loaded.version === BASELINE_VERSION) {
+      baseline = loaded;
+      memCache.set(rootDir, baseline);
+    }
   }
   if (!baseline) {
-    // Never scanned: build it lazily instead of failing the tool. The freshly
-    // built baseline matches the working tree, so it is "ok".
+    // Never scanned (or the persisted baseline failed the version gate):
+    // build it lazily instead of failing the tool. The freshly built
+    // baseline matches the working tree, so it is "ok".
     baseline = await buildAndCacheBaseline(rootDir);
     if (!baseline) return { baseline: null, status: "no_baseline" };
     return { baseline, status: "ok" };

--- a/src/tools-core/tools/check-file-drift.ts
+++ b/src/tools-core/tools/check-file-drift.ts
@@ -1,7 +1,8 @@
 /**
  * check_file_drift — does a file match the repo's established patterns?
  *
- * Reads the cached baseline's per-category votes and surfaces every category in
+ * Reads the cached baseline's per-category votes (and, for security_posture,
+ * the per-sub-convention securitySubVotes) and surfaces every category in
  * which the target file is a recorded deviator, with the file's own pattern, the
  * repo's dominant, and a fix hint citing an exemplar. v1 reads the frozen
  * baseline (no per-call re-derivation); a file changed since the scan is
@@ -36,7 +37,25 @@ export function fileDriftFromBaseline(
   relativePath: string,
 ): { fits: boolean; deviations: Deviation[] } {
   const deviations: Deviation[] = [];
+  const subVotes = baseline.securitySubVotes ?? {};
+  // Field PRESENCE (not entry count) decides authority: a baseline built with
+  // sub-votes always carries the field, and an EMPTY record means every
+  // security vote fell below the scoring min-peer floor, so no security
+  // convention is authoritative (the same scan reports the category N/A).
+  // Only a baseline that predates the field falls back to the collided slot.
+  const subVotesAuthoritative = baseline.securitySubVotes !== undefined;
+
   for (const cat of Object.keys(baseline.perCategoryVote) as DriftCategory[]) {
+    // security_posture's perCategoryVote slot collapses the auth/validation/
+    // rate-limit sub-conventions into ONE widest-denominator vote (rate
+    // limiting usually wins, since it votes over all routes), so a file that
+    // deviates only in a narrower sub-convention (e.g. the repo's one
+    // unauthed mutating route) would read as fitting. The sub-votes are the
+    // complete, uncollided, floor-respecting record for this category, so
+    // they are consulted below instead; skipping the collided slot also
+    // avoids double-reporting the widest sub-vote and never resurrects a
+    // below-floor vote the sub-vote builder dropped.
+    if (cat === "security_posture" && subVotesAuthoritative) continue;
     const vote = baseline.perCategoryVote[cat]!;
     const dev = vote.deviators.find((d) => d.path === relativePath);
     if (!dev) continue;
@@ -51,6 +70,27 @@ export function fileDriftFromBaseline(
       fixHint: `Match the repo: use ${vote.dominantPattern}${exemplar ? `; see ${exemplar}` : ""}.`,
     });
   }
+
+  // Security sub-conventions: a file deviating in ANY of them does not fit,
+  // and the deviation cites which sub-convention (Auth middleware / Input
+  // validation / Rate limiting). These votes are route-denominated, so the
+  // consistency count says routes, not files.
+  for (const [subConvention, vote] of Object.entries(subVotes)) {
+    if (!vote) continue;
+    const dev = vote.deviators.find((d) => d.path === relativePath);
+    if (!dev) continue;
+    const exemplar = vote.dominantFiles[0];
+    const pct = Math.round(vote.consistencyScore);
+    deviations.push({
+      dimension: "security_posture",
+      deviates: true,
+      yourPattern: dev.detectedPattern,
+      dominantPattern: vote.dominantPattern,
+      consistency: `${vote.dominantCount} of ${vote.totalRelevantFiles} routes (${pct}%)`,
+      fixHint: `Match the repo's ${subConvention} convention: use ${vote.dominantPattern}${exemplar ? `; see ${exemplar}` : ""}.`,
+    });
+  }
+
   return { fits: deviations.length === 0, deviations };
 }
 

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -21,6 +21,7 @@ import {
   SECURITY_SUPPRESSION_ANALYZER_ID,
 } from "../../../src/drift/security-suppression.js";
 import { fileDriftFromBaseline } from "../../../src/tools-core/tools/check-file-drift.js";
+import { MIN_SECURITY_PEERS } from "../../../src/scoring/engine.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import type { DriftContext } from "../../../src/drift/types.js";
 import type { DriftFinding } from "../../../src/drift/types.js";
@@ -93,6 +94,59 @@ describe("votesFromFindings", () => {
     expect(subVotes["Auth middleware"]!.dominantPattern).toBe("Auth middleware applied");
     expect(subVotes["Rate limiting"]!.dominantPattern).toBe("Rate limiting applied");
     expect(subVotes["Auth middleware"]!.totalRelevantFiles).toBe(5);
+  });
+
+  // ── Issue #34 blocker 4: sub-votes must respect the scoring min-peer floor ──
+  //
+  // Sub-votes were built from RAW drift findings with no MIN_SECURITY_PEERS
+  // floor, so the MCP served a 2-of-3-routes auth vote as the authoritative
+  // convention while the same scan demoted that finding as too thin to score.
+  it("drops a security sub-vote whose route sample is below MIN_SECURITY_PEERS", () => {
+    const subVotes = securitySubVotesFromFindings([
+      fakeFinding({
+        driftCategory: "security_posture",
+        subCategory: "Auth middleware",
+        dominantPattern: "Auth middleware applied",
+        dominantCount: MIN_SECURITY_PEERS - 2,
+        totalRelevantFiles: MIN_SECURITY_PEERS - 1,
+      }),
+    ]);
+    expect(subVotes["Auth middleware"]).toBeUndefined();
+    expect(Object.keys(subVotes)).toHaveLength(0);
+  });
+
+  it("keeps a security sub-vote at exactly MIN_SECURITY_PEERS (same boundary as the scoring floor)", () => {
+    const subVotes = securitySubVotesFromFindings([
+      fakeFinding({
+        driftCategory: "security_posture",
+        subCategory: "Auth middleware",
+        dominantPattern: "Auth middleware applied",
+        dominantCount: MIN_SECURITY_PEERS - 1,
+        totalRelevantFiles: MIN_SECURITY_PEERS,
+      }),
+    ]);
+    expect(subVotes["Auth middleware"]).toBeDefined();
+    expect(subVotes["Auth middleware"]!.totalRelevantFiles).toBe(MIN_SECURITY_PEERS);
+  });
+
+  // End-to-end with real detector output: a 3-route repo's uniform-auth-gap
+  // finding (the exact thin sample the scoring engine demotes to advisory)
+  // must not become the MCP's authoritative auth convention.
+  it("a real thin (3-route) detector finding produces no persisted auth sub-vote", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/a", requireAuth, createA);\n` +
+        `router.put("/b", requireAuth, updateB);\n` +
+        `router.post("/c", createC);\n`,
+    );
+    const ctx: DriftContext = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+    const findings = securityConsistency.detect(ctx);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding, "detector should still fire (advisory recall is kept)").toBeDefined();
+    expect(authFinding!.totalRelevantFiles).toBeLessThan(MIN_SECURITY_PEERS);
+
+    const subVotes = securitySubVotesFromFindings(findings);
+    expect(subVotes["Auth middleware"]).toBeUndefined();
   });
 });
 

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -7,6 +7,7 @@ import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
   SECURITY_SUPPRESSION_ANALYZER_ID,
 } from "../../../src/drift/security-suppression.js";
+import { MIN_SECURITY_PEERS, isBelowSecurityPeerFloor } from "../../../src/scoring/engine.js";
 
 function mkCtx(files: DriftFile[]): DriftContext {
   return {
@@ -331,6 +332,113 @@ describe("security-consistency detector", () => {
       // still all authed, so no auth drift finding fires either.
       expect(findings.find((fnd) => fnd.subCategory === "Auth middleware")).toBeUndefined();
     });
+  });
+});
+
+// ── Issue #34 blocker 1: method-ANY/ALL routes must stay in the auth peer group ──
+//
+// Route extractors default an unparseable method to "ANY" (Flask
+// `@app.route(...)` never matches the .get/.post method regex) and Express
+// `.all()` maps to "ALL". Filtering the auth peer group to MUTATION_METHODS
+// silently dropped both, so whole frameworks lost auth-consistency detection:
+// a Flask repo with 9 authed + 1 unauthed routes produced NO finding.
+describe("method-ANY/ALL routes stay in the auth peer group", () => {
+  function pyFile(path: string, content: string): DriftFile {
+    return { relativePath: path, language: "python", content, lineCount: content.split("\n").length };
+  }
+
+  // Flask-style: `@app.route(...)` extracts as method "ANY".
+  // Auth evidence lives in a separate file from the unauthed route because the
+  // file-level middleware regex treats ANY `login_required` in a file as
+  // file-scope auth, which would mark the unauthed route authed too.
+  it("flags the one unauthed Flask ANY route when 9 peers in the same directory are authed", () => {
+    const authedRoutes = Array.from({ length: 9 }, (_, i) =>
+      `@app.route("/r${i}")\n@login_required\ndef handler_${i}():\n    return respond()\n`,
+    ).join("\n");
+    const files = [
+      pyFile("src/routes/app_a.py", authedRoutes),
+      pyFile("src/routes/app_b.py", `@app.route("/exports")\ndef run_exports():\n    return respond()\n`),
+    ];
+    const findings = securityConsistency.detect(mkCtx(files));
+    const authFinding = findings.find((f) => f.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    expect(authFinding!.totalRelevantFiles).toBe(10); // all 10 ANY routes are in the denominator
+    expect(authFinding!.deviatingFiles).toHaveLength(1);
+    expect(authFinding!.deviatingFiles[0].path).toBe("src/routes/app_b.py");
+  });
+
+  // Express `.all()` extracts as method "ALL" (AST path).
+  it("flags an unauthed router.all() route against authed mutating peers", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+        `router.all("/hooks", handleHook);\n`,
+    );
+    const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+    const findings = securityConsistency.detect(ctx as any);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    expect(authFinding!.totalRelevantFiles).toBe(5); // the ALL route counts as an auth peer
+    expect(authFinding!.deviatingFiles.some((d) => d.evidence[0].line === 5)).toBe(true);
+  });
+
+  // GET is a KNOWN method and read-only: it must stay OUT of the auth peer
+  // group. A GET-only repo (some authed, some not) produces no auth finding.
+  it("still produces no auth finding for a GET-only Express repo", async () => {
+    const f = await fileWithTree(
+      "src/routes/reads.ts",
+      `router.get("/a", requireAuth, getA);\n` +
+        `router.get("/b", requireAuth, getB);\n` +
+        `router.get("/c", requireAuth, getC);\n` +
+        `router.get("/d", requireAuth, getD);\n` +
+        `router.get("/catalog", listCatalog);\n`,
+    );
+    const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.find((fnd) => fnd.subCategory === "Auth middleware")).toBeUndefined();
+  });
+
+  // The inclusion must land AFTER the suppression chokepoint: an annotated
+  // ALL route stays out of the vote (compare the un-annotated fixture above,
+  // where the same route IS flagged).
+  it("a @vibedrift-public annotation still suppresses an ALL route from the auth vote", async () => {
+    const f = await fileWithTree(
+      "src/routes/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+        `router.put("/items/:id", requireAuth, updateItem);\n` +
+        `router.patch("/items/:id", requireAuth, patchItem);\n` +
+        `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+        `// @vibedrift-public\n` +
+        `router.all("/hooks", handleHook);\n`,
+    );
+    const ctx = { files: [f], totalLines: f.lineCount, dominantLanguage: "typescript" };
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.find((fnd) => fnd.subCategory === "Auth middleware")).toBeUndefined();
+    const auditFinding = findings.find((fnd) => fnd.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+    expect(auditFinding).toBeDefined();
+    expect(auditFinding!.deviatingFiles[0].evidence[0].line).toBe(6);
+  });
+
+  // A thin ANY-route sample still hits the scoring min-peer floor: the
+  // uniform-auth-gap finding fires (recall), but its 3-route sample stays
+  // below MIN_SECURITY_PEERS so the composite never moves from it.
+  it("a thin (3-route) ANY sample produces a finding that the min-peer floor still demotes", () => {
+    const files = [
+      pyFile("src/routes/app_a.py", `@app.route("/a")\n@login_required\ndef a():\n    return respond()\n\n@app.route("/b")\n@login_required\ndef b():\n    return respond()\n`),
+      pyFile("src/routes/app_b.py", `@app.route("/exports")\ndef run_exports():\n    return respond()\n`),
+    ];
+    const findings = securityConsistency.detect(mkCtx(files));
+    const authFinding = findings.find((f) => f.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    expect(authFinding!.totalRelevantFiles).toBe(3);
+    expect(authFinding!.totalRelevantFiles).toBeLessThan(MIN_SECURITY_PEERS);
+    expect(isBelowSecurityPeerFloor(authFinding!)).toBe(true);
+    // Copy stays honest: an ANY route's method is unresolved, so the message
+    // must not assert that every counted route mutates.
+    expect(authFinding!.finding).toContain("unresolved-method");
   });
 });
 

--- a/test/unit/mcp/baseline-provider.test.ts
+++ b/test/unit/mcp/baseline-provider.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildBaseline, writeBaseline } from "../../../src/core/baseline.js";
+import { buildBaseline, writeBaseline, BASELINE_VERSION, type RepoDriftBaseline } from "../../../src/core/baseline.js";
 import { getBaseline, __clearBaselineCache } from "../../../src/mcp/baseline-provider.js";
+import { dominantPatternFor } from "../../../src/tools-core/tools/get-dominant-pattern.js";
 
 describe("baseline provider", () => {
   let repo: string;
@@ -73,5 +74,68 @@ describe("baseline provider", () => {
     const { baseline, status } = await getBaseline(repo);
     expect(status).toBe("stale");
     expect(baseline).not.toBeNull(); // serve cached + tag, never hang/rebuild in-call
+  });
+});
+
+// ── Issue #34 blocker 2: a persisted baseline from an older BASELINE_VERSION
+// must be rebuilt, not served forever. Pre-v2 baselines carry no
+// securitySubVotes, so serving one makes get_dominant_pattern("auth") answer
+// the no-vote projection ("consistent, no deviations detected") even when the
+// stale vote recorded deviators; and its version-prefixed key can never match
+// the working tree again, so the status read "stale" on every call.
+describe("baseline version gate", () => {
+  let repo: string;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "vd-vergate-"));
+    // 4 authed + 1 unauthed mutating routes: a real "Auth middleware applied"
+    // sub-vote (5 peers, at/above the scoring floor) with one recorded deviator.
+    writeFileSync(
+      join(repo, "api.ts"),
+      [
+        'router.post("/a", requireAuth, (req, res) => { res.json({}); });',
+        'router.put("/b", requireAuth, (req, res) => { res.json({}); });',
+        'router.patch("/c", requireAuth, (req, res) => { res.json({}); });',
+        'router.delete("/d", requireAuth, (req, res) => { res.json({}); });',
+        'router.post("/e", (req, res) => { res.json({}); });',
+        "",
+      ].join("\n"),
+    );
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+  beforeEach(() => __clearBaselineCache());
+
+  it("rebuilds a pre-versioned (v1-shaped) on-disk baseline instead of serving it", async () => {
+    const built = await buildBaseline(repo);
+    // Doctor the persisted shape into a faithful v1 baseline: no version
+    // field, no securitySubVotes, and a key computed under the old version
+    // prefix (any value the current computeBaselineKey can't reproduce).
+    const v1 = { ...built, key: "0".repeat(64), builtAt: 12345 } as RepoDriftBaseline;
+    delete v1.version;
+    delete v1.securitySubVotes;
+    await writeBaseline(v1);
+    __clearBaselineCache();
+
+    const { baseline, status } = await getBaseline(repo);
+    expect(baseline).not.toBeNull();
+    expect(baseline!.builtAt).not.toBe(12345); // rebuilt, not served
+    expect(baseline!.version).toBe(BASELINE_VERSION);
+    expect(status).toBe("ok"); // no perpetual "stale" from the version-prefixed key
+
+    // The rebuilt baseline serves the auth sub-vote again: the projection is
+    // the real vote, not the no-vote "consistent" answer the stale file gave.
+    expect(baseline!.securitySubVotes?.["Auth middleware"]).toBeDefined();
+    const projection = dominantPatternFor(baseline!, "auth");
+    expect(projection.dominantPattern).toBe("Auth middleware applied");
+  });
+
+  it("serves an up-to-date on-disk baseline without rebuilding", async () => {
+    const built = await buildBaseline(repo);
+    await writeBaseline({ ...built, builtAt: 424242 }); // marker survives only if served from disk
+    __clearBaselineCache();
+
+    const { baseline, status } = await getBaseline(repo);
+    expect(status).toBe("ok");
+    expect(baseline!.builtAt).toBe(424242);
+    expect(baseline!.version).toBe(BASELINE_VERSION);
   });
 });

--- a/test/unit/mcp/tools/check-file-drift.test.ts
+++ b/test/unit/mcp/tools/check-file-drift.test.ts
@@ -50,6 +50,98 @@ describe("fileDriftFromBaseline (pure)", () => {
   });
 });
 
+// ── Issue #34 blocker 3: security deviations must be read from securitySubVotes ──
+//
+// perCategoryVote.security_posture keeps only the widest-denominator security
+// finding (rate limiting usually wins, since it votes over ALL routes), so a
+// file recorded as a deviator only in securitySubVotes["Auth middleware"] (the
+// repo's one unauthed mutating route) read as fitting the repo's patterns.
+describe("fileDriftFromBaseline — security sub-vote deviators", () => {
+  function subVote(pattern: string, dom: number, total: number, deviators: Array<{ path: string; detectedPattern: string }>) {
+    return {
+      driftCategory: "security_posture" as const,
+      dominantPattern: pattern,
+      dominantCount: dom,
+      totalRelevantFiles: total,
+      consistencyScore: Math.round((dom / total) * 100),
+      dominantFiles: ["routes/a.ts"],
+      deviators,
+    };
+  }
+
+  function securityBaseline(): RepoDriftBaseline {
+    return {
+      key: "k",
+      rootDir: "/repo",
+      ctxFiles: [{ path: "routes/danger.ts", hash: "h" }, { path: "routes/ok.ts", hash: "h" }],
+      perCategoryVote: {
+        // The collided slot: rate limiting won the widest-denominator
+        // tie-break, so the auth deviator is invisible here.
+        security_posture: subVote("Rate limiting applied", 9, 12, [
+          { path: "routes/slow.ts", detectedPattern: "POST /slow — no Rate limiting" },
+        ]),
+      },
+      securitySubVotes: {
+        "Auth middleware": subVote("Auth middleware applied", 4, 5, [
+          { path: "routes/danger.ts", detectedPattern: "POST /danger — no Auth middleware" },
+        ]),
+        "Rate limiting": subVote("Rate limiting applied", 9, 12, [
+          { path: "routes/slow.ts", detectedPattern: "POST /slow — no Rate limiting" },
+        ]),
+      },
+      intentHints: [],
+      minhashIndex: [],
+      builtAt: 0,
+    };
+  }
+
+  it("reports fits:false citing Auth middleware for the unauthed route even when rate limiting holds the collided slot", () => {
+    const r = fileDriftFromBaseline(securityBaseline(), "routes/danger.ts");
+    expect(r.fits).toBe(false);
+    expect(r.deviations).toHaveLength(1);
+    const d = r.deviations[0];
+    expect(d.dimension).toBe("security_posture");
+    expect(d.dominantPattern).toBe("Auth middleware applied");
+    expect(d.yourPattern).toBe("POST /danger — no Auth middleware");
+    expect(d.fixHint).toContain("Auth middleware"); // cites WHICH sub-convention
+    // Security sub-votes are route-denominated, so the count says routes.
+    expect(d.consistency).toBe("4 of 5 routes (80%)");
+  });
+
+  it("a file deviating in no sub-vote still fits", () => {
+    const r = fileDriftFromBaseline(securityBaseline(), "routes/ok.ts");
+    expect(r.fits).toBe(true);
+    expect(r.deviations).toEqual([]);
+  });
+
+  it("a rate-limit deviator is still flagged (via its sub-vote, no coverage lost from the collided slot)", () => {
+    const r = fileDriftFromBaseline(securityBaseline(), "routes/slow.ts");
+    expect(r.fits).toBe(false);
+    expect(r.deviations).toHaveLength(1);
+    expect(r.deviations[0].dominantPattern).toBe("Rate limiting applied");
+  });
+
+  it("falls back to the collided perCategoryVote slot when securitySubVotes is absent (pre-upgrade baseline shape)", () => {
+    const b = securityBaseline();
+    b.securitySubVotes = undefined;
+    const r = fileDriftFromBaseline(b, "routes/slow.ts");
+    expect(r.fits).toBe(false);
+    expect(r.deviations[0].dominantPattern).toBe("Rate limiting applied");
+  });
+
+  it("does not resurrect the collided slot when securitySubVotes is present but empty (every vote below the scoring floor)", () => {
+    const b = securityBaseline();
+    // The sub-vote builder floors thin votes out, so an empty (but present)
+    // record means no security convention is authoritative; the same scan
+    // reports the category N/A, and this surface must agree with it rather
+    // than cite the below-floor vote still sitting in the collided slot.
+    b.securitySubVotes = {};
+    const r = fileDriftFromBaseline(b, "routes/slow.ts");
+    expect(r.deviations.find((d) => d.dimension === "security_posture")).toBeUndefined();
+    expect(r.fits).toBe(true);
+  });
+});
+
 describe("check_file_drift (integration on the messy-project fixture)", () => {
   const repo = resolve("test/fixtures/messy-project");
   let built: RepoDriftBaseline;

--- a/test/unit/mcp/tools/validate-change-security.test.ts
+++ b/test/unit/mcp/tools/validate-change-security.test.ts
@@ -13,9 +13,11 @@ vi.mock("../../../../src/mcp/deep-client.js", async (importOriginal) => {
 vi.mock("../../../../src/mcp/deep-index.js", () => ({ deepDuplicatesViaIndex: vi.fn() }));
 
 import { checkRouteAuthDrift, run } from "../../../../src/mcp/tools/validate-change.js";
-import { buildBaseline, writeBaseline, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
+import { buildBaseline, writeBaseline, securitySubVotesFromFindings, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
 import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
 import { deepDuplicatesViaIndex } from "../../../../src/mcp/deep-index.js";
+import { MIN_SECURITY_PEERS } from "../../../../src/scoring/engine.js";
+import type { DriftFinding } from "../../../../src/drift/types.js";
 
 // ── Shared classifier ───────────────────────────────────────────────────────
 // classifyRouteAuth reuses the SAME AST route extractor the batch security
@@ -145,6 +147,32 @@ describe("checkRouteAuthDrift", () => {
 
   it("does not flag a Python body (JS/TS-only gate)", async () => {
     const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), PY_ROUTE, "new.py");
+    expect(c).toBeNull();
+  });
+
+  // ── Issue #34 blocker 4: a below-floor auth vote must not drive the in-loop
+  // check. securitySubVotesFromFindings drops sub-votes whose sample is under
+  // MIN_SECURITY_PEERS, so the baseline carries no auth vote at all and the
+  // check goes honest-silent (nothing authoritative to compare against).
+  it("goes honest-silent when the repo's only auth vote is below the min-peer floor", async () => {
+    const thinFinding: DriftFinding = {
+      detector: "security_posture",
+      subCategory: "Auth middleware",
+      driftCategory: "security_posture",
+      severity: "warning",
+      confidence: 0.75,
+      finding: "Auth middleware missing on 1 of 3 routes",
+      dominantPattern: "Auth middleware applied",
+      dominantCount: MIN_SECURITY_PEERS - 2,
+      totalRelevantFiles: MIN_SECURITY_PEERS - 1,
+      consistencyScore: 67,
+      deviatingFiles: [{ path: "routes/c.ts", detectedPattern: "POST /c — no Auth middleware", evidence: [] }],
+      dominantFiles: ["routes/a.ts"],
+      recommendation: "add auth",
+    };
+    const subVotes = securitySubVotesFromFindings([thinFinding]);
+    expect(subVotes["Auth middleware"]).toBeUndefined(); // floored out at build time
+    const c = await checkRouteAuthDrift(baseWith(subVotes), UNAUTHED_POST, "new.ts");
     expect(c).toBeNull();
   });
 


### PR DESCRIPTION
Fixes the four release blockers from #34, on top of merged Phase 2 (#37).

1. **Method-`ANY`/`ALL` routes stay in the auth peer group.** The auth consistency vote and the uniform-auth-gap fallback now share `AUTH_VOTE_METHODS` (mutating + unresolved-method + `.all()` routes), restoring auth detection for Flask-style decorators and Express `.all()`. Validation and rate-limit votes are unchanged. Messages counting unresolved-method routes no longer claim they all mutate.

2. **Persisted baselines carry a version, and the MCP rebuilds stale ones.** `getBaseline` treats a baseline from an older `BASELINE_VERSION` exactly like the never-scanned case: one lazy rebuild, persisted, served fresh — instead of serving pre-v2 votes forever with a permanent "stale" status.

3. **`check_file_drift` consults the security sub-votes.** A file deviating in any of Auth middleware / Input validation / Rate limiting is `fits:false` citing that sub-convention, route-denominated — instead of reading the collided widest-denominator slot that rate limiting usually wins.

4. **`securitySubVotes` respect the min-peer floor.** Sub-votes below `MIN_SECURITY_PEERS` are no longer persisted, so the MCP never serves a thin sample as the repo's authoritative convention while the same scan demotes it as too small to score. The in-loop auth check goes honest-silent on such repos.

`BASELINE_VERSION` bumps 2 → 3 so already-scanned repos rebuild their votes lazily (blockers 1 and 4 change what the votes contain).

16 new tests, red-first; 894 passing total; tsc and lint clean.

Remaining #34 checklist items (consistency + copy fixes) are follow-ups, not blockers.

