### PR TITLE
fix(security): close the four #34 release blockers with method-resolved auth vote + scoring migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ vibedrift-*.html
 
 # Calibration / eval run outputs (generated)
 test/calibration/reports/pr-*.json
+test/calibration/reports/latest.json
 eval/reports/
 
 # Score-discrimination harness clone cache (cloned upstream repos)

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -23,6 +23,7 @@ import { parseFiles } from "../utils/ast.js";
 import { extractAllFunctions } from "../codedna/function-extractor.js";
 import { buildSignature } from "../codedna/minhash.js";
 import { SECURITY_SUPPRESSION_SUBCATEGORY } from "../drift/security-suppression.js";
+import { isBelowSecurityPeerFloor } from "../scoring/engine.js";
 import type { AnalysisContext } from "./types.js";
 import type { DriftFinding, DriftCategory } from "../drift/types.js";
 import type { IntentHint } from "../intent/types.js";
@@ -41,6 +42,10 @@ export interface CategoryVote {
   /** Files that drift in this category + the pattern each uses instead — lets
    *  check_file_drift report "your file does X, the repo does Y". */
   deviators: Array<{ path: string; detectedPattern: string }>;
+  /** True when this is a security_posture vote below MIN_SECURITY_PEERS relevant
+   *  routes: too thin to dent the score, so MCP tools surface it as advisory
+   *  rather than authoritative. Single source of truth: isBelowSecurityPeerFloor. */
+  belowPeerFloor?: boolean;
 }
 
 export interface MinhashEntry {
@@ -131,6 +136,7 @@ export function toCategoryVote(f: DriftFinding): CategoryVote {
     consistencyScore: f.consistencyScore,
     dominantFiles: f.dominantFiles ?? [],
     deviators: f.deviatingFiles.map((d) => ({ path: d.path, detectedPattern: d.detectedPattern })),
+    belowPeerFloor: isBelowSecurityPeerFloor({ driftCategory: f.driftCategory, totalRelevantFiles: f.totalRelevantFiles }),
   };
 }
 

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -30,7 +30,7 @@ import type { IntentHint } from "../intent/types.js";
 
 const CACHE_DIR = join(homedir(), ".vibedrift", "baseline-cache");
 /** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
-export const BASELINE_VERSION = 2;
+export const BASELINE_VERSION = 3;
 
 export interface CategoryVote {
   driftCategory: DriftCategory;
@@ -70,6 +70,11 @@ export interface RepoDriftBaseline {
   intentHints: IntentHint[];
   minhashIndex: MinhashEntry[];
   builtAt: number;
+  /** BASELINE_VERSION at build time. A mismatch against the current
+   *  BASELINE_VERSION means the persisted vote shape may be stale (e.g.
+   *  missing securitySubVotes) and forces a one-time rebuild; see
+   *  getBaseline in src/mcp/baseline-provider.ts. */
+  version: number;
 }
 
 /** On-disk shape: signatures degrade to number[] (JSON has no typed arrays). */
@@ -200,6 +205,7 @@ export function assembleBaseline(
     intentHints: ctx.intentHints ?? [],
     minhashIndex,
     builtAt: Date.now(),
+    version: BASELINE_VERSION,
   };
 }
 

--- a/src/drift/route-auth-classify.ts
+++ b/src/drift/route-auth-classify.ts
@@ -4,8 +4,9 @@
  * It deliberately reuses the SAME AST route extractor the batch security
  * detector uses (`extractJsRoutesAst`), so its verdict can never contradict the
  * batch detector for the same body. Given a single proposed function body, it
- * reports whether that body registers a mutating route (POST/PUT/PATCH/DELETE)
- * and whether EVERY such route carries a visible per-route auth guard.
+ * reports whether that body registers a mutating route (POST/PUT/PATCH/DELETE
+ * and Express `.all()`) and whether EVERY such route carries a visible
+ * per-route auth guard.
  *
  * Router-scope middleware (`router.use(requireAuth)`) is intentionally NOT
  * consulted here: a single proposed body cannot see its router's setup, so we
@@ -33,7 +34,8 @@ const JS_TS_EXT: Record<string, SupportedLanguage> = {
 };
 
 export interface RouteAuthClassification {
-  /** At least one route in the body uses a mutating method (POST/PUT/PATCH/DELETE). */
+  /** At least one route in the body uses a mutating method (POST/PUT/PATCH/DELETE
+   *  and Express `.all()`). */
   isMutatingRoute: boolean;
   /** EVERY mutating route in the body carries a visible per-route auth guard.
    *  Conservative: a single unguarded mutating route makes this false. */

--- a/src/drift/security-ast.ts
+++ b/src/drift/security-ast.ts
@@ -24,7 +24,13 @@ import type { Tree, SyntaxNode } from "../core/types.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 
 const ROUTE_METHODS = new Set(["get", "post", "put", "patch", "delete", "all"]);
-const MUTATING = new Set(["post", "put", "patch", "delete"]);
+// State-changing methods: POST/PUT/PATCH/DELETE and Express `.all()` (a
+// wildcard handler that matches every verb on the path, so an unauthed
+// `.all()` route is exactly as unsafe as an unauthed POST). Canonical for
+// both the batch detector (security-consistency.ts derives its upper-cased
+// MUTATION_METHODS from this) and the in-loop classifier
+// (route-auth-classify.ts), so the two can never disagree.
+const MUTATING = new Set(["post", "put", "patch", "delete", "all"]);
 
 // Receiver identifiers that plausibly register routes. Combined with the
 // "first arg is a string path starting with /" gate below, this excludes the

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -34,10 +34,16 @@
 import type { DriftDetector, DriftContext, DriftFinding, DriftFile } from "./types.js";
 import { SECURITY_SUBCATEGORIES } from "./types.js";
 import { pickIntentHint } from "./utils.js";
-import { extractJsRoutesAst, extractFileMiddlewareAst } from "./security-ast.js";
+import { extractJsRoutesAst, extractFileMiddlewareAst, SECURITY_AST } from "./security-ast.js";
 import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
 
-const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
+// Canonical mutating set (upper-cased), shared with the in-loop classifier via
+// SECURITY_AST.MUTATING so batch and in-loop can never disagree. Includes ALL
+// (Express .all() handles every verb) so an unauthed .all() route is not
+// silently excluded from the auth vote.
+const MUTATION_METHODS = [...SECURITY_AST.MUTATING].map((m) => m.toUpperCase());
+// Body-bearing methods for the validation vote (DELETE usually has no body).
+const BODY_METHODS = ["POST", "PUT", "PATCH", "ALL"];
 
 // Does the codebase use auth machinery anywhere? If it does, a mutating route
 // with no auth is drift ("you know how to auth — this route forgot"), not an
@@ -256,7 +262,21 @@ function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<s
     const match = lines[i].match(routePattern);
     if (!match) continue;
     const path = match[1];
-    const method = lines[i].match(/\.(get|post|put|patch|delete)/)?.[1]?.toUpperCase() ?? "ANY";
+    // Flask's @app.route defaults to GET when no methods= kwarg is present, NOT an
+    // unknown "ANY". Decorator-verb style (@app.post) resolves directly; the
+    // methods=[...] kwarg (Flask/others) is parsed so a mutating verb classifies
+    // the route as mutating. Scan the decorator + up to 2 continuation lines,
+    // since the kwarg can wrap.
+    const decoratorVerb = lines[i].match(/\.(get|post|put|patch|delete)\s*\(/)?.[1]?.toUpperCase();
+    let method = decoratorVerb ?? "GET";
+    const decoratorWindow = lines.slice(i, Math.min(lines.length, i + 3)).join(" ");
+    const methodsKw = decoratorWindow.match(/methods\s*=\s*\[([^\]]*)\]/i);
+    if (methodsKw) {
+      const verbs = (methodsKw[1].match(/["'](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["']/gi) ?? [])
+        .map((v) => v.replace(/["']/g, "").toUpperCase());
+      const mutating = verbs.find((v) => MUTATION_METHODS.includes(v));
+      method = mutating ?? verbs[0] ?? method;
+    }
     const context = lines.slice(i, Math.min(lines.length, i + 30)).join("\n");
 
     const perAuth = /login_required|jwt_required|@requires|permission|token/.test(context);
@@ -404,7 +424,7 @@ export const securityConsistency: DriftDetector = {
     }
 
     for (const group of groups) {
-      const groupMutationRoutes = group.filter((r) => ["POST", "PUT", "PATCH"].includes(r.method));
+      const groupMutationRoutes = group.filter((r) => BODY_METHODS.includes(r.method));
       const valFinding = analyzeSecurityProperty(groupMutationRoutes, SECURITY_SUBCATEGORIES.validation, (r) => r.hasValidation, healthPaths);
       if (valFinding) findings.push(valFinding);
     }

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -256,13 +256,35 @@ function extractJsRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddlewa
 /** Text inside a Python route decorator's parentheses: from the first "(" on
  *  line `start` to its matching ")", spanning continuation lines. Bounded by
  *  paren depth so `methods=` is read from THIS decorator only and can never
- *  bleed into an adjacent route's decorator. */
+ *  bleed into an adjacent route's decorator. Parens inside string literals
+ *  (e.g. a route path like "/weird(path") are skipped, so an unbalanced literal
+ *  paren cannot throw off the depth count and leak into the next route. */
 function balancedDecoratorArgs(lines: string[], start: number): string {
   let depth = 0;
   let started = false;
   let out = "";
+  let quote: string | null = null; // active string-literal quote char, or null
   for (let j = start; j < lines.length; j++) {
-    for (const ch of lines[j]) {
+    const line = lines[j];
+    for (let k = 0; k < line.length; k++) {
+      const ch = line[k];
+      if (quote) {
+        // Inside a string literal: only a matching unescaped quote ends it;
+        // parens here are path/text, not structure.
+        if (ch === "\\") {
+          if (started) out += ch + (line[k + 1] ?? "");
+          k++; // skip the escaped char
+          continue;
+        }
+        if (ch === quote) quote = null;
+        if (started) out += ch;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        if (started) out += ch;
+        continue;
+      }
       if (ch === "(") {
         depth++;
         started = true;

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -253,6 +253,31 @@ function extractJsRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddlewa
   }
 }
 
+/** Text inside a Python route decorator's parentheses: from the first "(" on
+ *  line `start` to its matching ")", spanning continuation lines. Bounded by
+ *  paren depth so `methods=` is read from THIS decorator only and can never
+ *  bleed into an adjacent route's decorator. */
+function balancedDecoratorArgs(lines: string[], start: number): string {
+  let depth = 0;
+  let started = false;
+  let out = "";
+  for (let j = start; j < lines.length; j++) {
+    for (const ch of lines[j]) {
+      if (ch === "(") {
+        depth++;
+        started = true;
+      } else if (ch === ")") {
+        depth--;
+      }
+      if (started) out += ch;
+      if (started && depth === 0) return out;
+    }
+    out += " ";
+    if (j - start > 6) return out; // defensive cap for a malformed decorator
+  }
+  return out;
+}
+
 function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
   const lines = file.content.split("\n");
   const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
@@ -265,12 +290,13 @@ function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<s
     // Flask's @app.route defaults to GET when no methods= kwarg is present, NOT an
     // unknown "ANY". Decorator-verb style (@app.post) resolves directly; the
     // methods=[...] kwarg (Flask/others) is parsed so a mutating verb classifies
-    // the route as mutating. Scan the decorator + up to 2 continuation lines,
-    // since the kwarg can wrap.
+    // the route as mutating. The kwarg is read from the route's own decorator
+    // via balanced paren scanning, so it can never bleed into an adjacent
+    // route's decorator even when routes sit right next to each other.
     const decoratorVerb = lines[i].match(/\.(get|post|put|patch|delete)\s*\(/)?.[1]?.toUpperCase();
     let method = decoratorVerb ?? "GET";
-    const decoratorWindow = lines.slice(i, Math.min(lines.length, i + 3)).join(" ");
-    const methodsKw = decoratorWindow.match(/methods\s*=\s*\[([^\]]*)\]/i);
+    const decoratorArgs = balancedDecoratorArgs(lines, i);
+    const methodsKw = decoratorArgs.match(/methods\s*=\s*\[([^\]]*)\]/i);
     if (methodsKw) {
       const verbs = (methodsKw[1].match(/["'](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["']/gi) ?? [])
         .map((v) => v.replace(/["']/g, "").toUpperCase());

--- a/src/mcp/baseline-provider.ts
+++ b/src/mcp/baseline-provider.ts
@@ -28,6 +28,12 @@ const memCache = new Map<string, RepoDriftBaseline>();
 // In-flight lazy builds, keyed by rootDir, so simultaneous first-call tools
 // share ONE build instead of each kicking off a 3-8s scan.
 const building = new Map<string, Promise<RepoDriftBaseline | null>>();
+// rootDirs whose version-triggered rebuild failed. Guards against re-paying the
+// full scan on every call for a repo whose rebuild keeps failing (a version bump
+// plus a build error): the rebuild is attempted once, then the old baseline is
+// served. Cleared on invalidateBaselineMem/init and in tests, so recovery needs
+// no process restart.
+const failedVersionRebuild = new Set<string>();
 
 /**
  * Build a baseline for a repo that has never been scanned, persist it, and
@@ -63,6 +69,7 @@ async function buildAndCacheBaseline(rootDir: string): Promise<RepoDriftBaseline
 /** Test-only: drop the in-process cache so disk-load paths are exercised. */
 export function __clearBaselineCache(): void {
   memCache.clear();
+  failedVersionRebuild.clear();
 }
 
 /**
@@ -73,6 +80,7 @@ export function __clearBaselineCache(): void {
  */
 export function invalidateBaselineMem(rootDir: string): void {
   memCache.delete(rootDir);
+  failedVersionRebuild.delete(rootDir);
 }
 
 /**
@@ -115,13 +123,19 @@ export async function getBaseline(
   // shape (e.g. securitySubVotes) and would serve wrong answers forever; the
   // stale tag alone never rebuilds. A version mismatch forces a one-time rebuild
   // (same lazy path as a never-scanned repo). Content-only drift stays "stale"
-  // (cheap re-hash, no rebuild) as before.
-  if (baseline && baseline.version !== BASELINE_VERSION) {
-    memCache.delete(rootDir);
+  // (cheap re-hash, no rebuild) as before. A rebuild that fails is remembered so
+  // we do not pay the full scan on every later call: the old baseline is served
+  // until an init or a successful scan writes a current-version one.
+  if (baseline.version !== BASELINE_VERSION && !failedVersionRebuild.has(rootDir)) {
     const rebuilt = await buildAndCacheBaseline(rootDir);
-    if (rebuilt) return { baseline: rebuilt, status: "ok" };
-    // Rebuild failed (e.g. files vanished): fall through and serve the old one
-    // rather than returning no_baseline, so the tool still answers.
+    if (rebuilt) {
+      failedVersionRebuild.delete(rootDir);
+      return { baseline: rebuilt, status: "ok" };
+    }
+    // Rebuild failed: remember it so later calls short-circuit the retry, keep
+    // the old baseline mem-cached, and serve it below (the tool still answers).
+    failedVersionRebuild.add(rootDir);
+    memCache.set(rootDir, baseline);
   }
 
   const fresh = (await liveKey(rootDir, baseline)) === baseline.key;

--- a/src/mcp/baseline-provider.ts
+++ b/src/mcp/baseline-provider.ts
@@ -20,6 +20,7 @@ import {
   writeBaseline,
   computeBaselineKey,
   loadBaselineUnchecked,
+  BASELINE_VERSION,
   type RepoDriftBaseline,
 } from "../core/baseline.js";
 
@@ -108,6 +109,19 @@ export async function getBaseline(
     baseline = await buildAndCacheBaseline(rootDir);
     if (!baseline) return { baseline: null, status: "no_baseline" };
     return { baseline, status: "ok" };
+  }
+
+  // A baseline built under an older BASELINE_VERSION is missing current vote
+  // shape (e.g. securitySubVotes) and would serve wrong answers forever; the
+  // stale tag alone never rebuilds. A version mismatch forces a one-time rebuild
+  // (same lazy path as a never-scanned repo). Content-only drift stays "stale"
+  // (cheap re-hash, no rebuild) as before.
+  if (baseline && baseline.version !== BASELINE_VERSION) {
+    memCache.delete(rootDir);
+    const rebuilt = await buildAndCacheBaseline(rootDir);
+    if (rebuilt) return { baseline: rebuilt, status: "ok" };
+    // Rebuild failed (e.g. files vanished): fall through and serve the old one
+    // rather than returning no_baseline, so the tool still answers.
   }
 
   const fresh = (await liveKey(rootDir, baseline)) === baseline.key;

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -49,12 +49,18 @@ import {
  *        analyzer in computeScores. Sparse reimplementation stays informational.
  *        Deep-scan scores move for repos with concentrated reimplementation;
  *        local / free scores are unchanged.
+ *   v10: security route classification. Express `.all()` and Flask
+ *        `@app.route(methods=[...])` mutating routes now enter the security
+ *        auth/validation votes, so a repo with previously-uncounted unauthed
+ *        mutating routes reflects the security_posture drift it always had.
+ *        Only repos with those route shapes move; every other repo is byte
+ *        identical, and the bundled calibration corpus is unchanged.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v9";
+export const SCORING_VERSION = "v10";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;

--- a/src/tools-core/tools/check-file-drift.ts
+++ b/src/tools-core/tools/check-file-drift.ts
@@ -10,7 +10,7 @@
 import { z } from "zod";
 import { relative, resolve } from "node:path";
 import type { DriftCategory } from "../../drift/types.js";
-import type { RepoDriftBaseline } from "../../core/baseline.js";
+import type { CategoryVote, RepoDriftBaseline } from "../../core/baseline.js";
 import { getBaseline } from "../../mcp/baseline-provider.js";
 import { noBaselineData, type Status } from "../result.js";
 
@@ -36,22 +36,50 @@ export function fileDriftFromBaseline(
   relativePath: string,
 ): { fits: boolean; deviations: Deviation[] } {
   const deviations: Deviation[] = [];
+  const subVotes = baseline.securitySubVotes;
   for (const cat of Object.keys(baseline.perCategoryVote) as DriftCategory[]) {
+    // Security is read from the granular sub-votes below, not the collapsed
+    // widest-denominator security_posture slot (which hides auth deviators
+    // behind whichever sub-convention had the most routes). Fall through to the
+    // collapsed slot only for older baselines that predate securitySubVotes.
+    if (cat === "security_posture" && subVotes) continue;
     const vote = baseline.perCategoryVote[cat]!;
     const dev = vote.deviators.find((d) => d.path === relativePath);
     if (!dev) continue;
-    const exemplar = vote.dominantFiles[0];
-    const pct = Math.round(vote.consistencyScore);
-    deviations.push({
-      dimension: cat,
-      deviates: true,
-      yourPattern: dev.detectedPattern,
-      dominantPattern: vote.dominantPattern,
-      consistency: `${vote.dominantCount} of ${vote.totalRelevantFiles} files (${pct}%)`,
-      fixHint: `Match the repo: use ${vote.dominantPattern}${exemplar ? `; see ${exemplar}` : ""}.`,
-    });
+    deviations.push(deviationFrom(cat, vote, dev, "files"));
+  }
+  if (subVotes) {
+    for (const vote of Object.values(subVotes)) {
+      if (!vote) continue;
+      const dev = vote.deviators.find((d) => d.path === relativePath);
+      if (!dev) continue;
+      deviations.push(deviationFrom("security_posture", vote, dev, "routes"));
+    }
   }
   return { fits: deviations.length === 0, deviations };
+}
+
+/** Build one Deviation from a matched vote. `unit` is "routes" for the security
+ *  dimension (sub-convention votes count routes) and "files" everywhere else. A
+ *  below-peer-floor vote (thin sample) is hedged as advisory but still counts as
+ *  a non-fit, so callers never bless a file the granular vote flagged. */
+function deviationFrom(
+  dimension: DriftCategory,
+  vote: CategoryVote,
+  dev: { path: string; detectedPattern: string },
+  unit: "files" | "routes",
+): Deviation {
+  const exemplar = vote.dominantFiles[0];
+  const pct = Math.round(vote.consistencyScore);
+  const advisory = vote.belowPeerFloor ? " (thin sample - advisory)" : "";
+  return {
+    dimension,
+    deviates: true,
+    yourPattern: dev.detectedPattern,
+    dominantPattern: vote.dominantPattern,
+    consistency: `${vote.dominantCount} of ${vote.totalRelevantFiles} ${unit} (${pct}%)${advisory}`,
+    fixHint: `Match the repo: use ${vote.dominantPattern}${exemplar ? `; see ${exemplar}` : ""}.${advisory}`,
+  };
 }
 
 export interface CheckFileDriftOut {

--- a/src/tools-core/tools/check-file-drift.ts
+++ b/src/tools-core/tools/check-file-drift.ts
@@ -37,18 +37,26 @@ export function fileDriftFromBaseline(
 ): { fits: boolean; deviations: Deviation[] } {
   const deviations: Deviation[] = [];
   const subVotes = baseline.securitySubVotes;
+  // Non-empty is the load-bearing test, not mere presence: only skip the
+  // collapsed security_posture slot when there are actual sub-votes to read
+  // instead. An EMPTY securitySubVotes ({}) must NOT suppress a real collapsed
+  // deviator, or we would silently bless a security drift the collapsed slot
+  // caught. This keeps never-false-bless enforced HERE, not dependent on a
+  // cross-file guarantee that every security finding always carries a subCategory.
+  const hasSecuritySubVotes = !!subVotes && Object.keys(subVotes).length > 0;
   for (const cat of Object.keys(baseline.perCategoryVote) as DriftCategory[]) {
     // Security is read from the granular sub-votes below, not the collapsed
     // widest-denominator security_posture slot (which hides auth deviators
     // behind whichever sub-convention had the most routes). Fall through to the
-    // collapsed slot only for older baselines that predate securitySubVotes.
-    if (cat === "security_posture" && subVotes) continue;
+    // collapsed slot for older baselines that predate securitySubVotes (or the
+    // defensive empty-map case above).
+    if (cat === "security_posture" && hasSecuritySubVotes) continue;
     const vote = baseline.perCategoryVote[cat]!;
     const dev = vote.deviators.find((d) => d.path === relativePath);
     if (!dev) continue;
     deviations.push(deviationFrom(cat, vote, dev, "files"));
   }
-  if (subVotes) {
+  if (hasSecuritySubVotes && subVotes) {
     for (const vote of Object.values(subVotes)) {
       if (!vote) continue;
       const dev = vote.deviators.find((d) => d.path === relativePath);

--- a/src/tools-core/tools/get-dominant-pattern.ts
+++ b/src/tools-core/tools/get-dominant-pattern.ts
@@ -61,10 +61,15 @@ export function dominantPatternFor(
     };
   }
   const pct = Math.round(vote.consistencyScore);
+  const unit = SECURITY_SUB_DIM[dimension] ? "routes" : "files";
+  const base = `${vote.dominantCount} of ${vote.totalRelevantFiles} ${unit} (${pct}%)`;
+  const consistency = vote.belowPeerFloor
+    ? `${base} - thin sample (below the reliable-sample floor), treat as advisory`
+    : base;
   return {
     dimension,
     dominantPattern: vote.dominantPattern,
-    consistency: `${vote.dominantCount} of ${vote.totalRelevantFiles} files (${pct}%)`,
+    consistency,
     examples: vote.dominantFiles.slice(0, 3),
   };
 }

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -255,12 +255,19 @@ export async function checkRouteAuthDrift(
   // keyed by the Auth sub-category).
   const vote = appliedAuthVote(baseline);
   if (vote) {
+    // Below MIN_SECURITY_PEERS relevant routes, the vote is too thin to move
+    // the composite score (isBelowSecurityPeerFloor), so the in-loop check must
+    // hedge it the same way rather than citing it as a confident verdict.
+    const thin = vote.belowPeerFloor
+      ? "This is a thin sample (below the reliable-sample floor), so treat it as advisory. "
+      : "";
     return {
       dimension: "security_posture",
       dominantPattern: AUTH_APPLIED,
       yourPattern: "no auth guard visible in this change",
       fixHint:
         `Repo applies auth on ${vote.dominantCount} of ${vote.totalRelevantFiles} mutating routes. ` +
+        thin +
         `Add the guard, or annotate the route // @vibedrift-public if it is intentionally public. ` +
         ROUTER_CAVEAT,
     };

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -12,6 +12,7 @@ import {
   votesFromFindings,
   securitySubVotesFromFindings,
   toCategoryVote,
+  BASELINE_VERSION,
 } from "../../../src/core/baseline.js";
 import { buildAnalysisContext } from "../../../src/core/discovery.js";
 import { runDriftDetection } from "../../../src/drift/index.js";
@@ -327,6 +328,13 @@ describe("buildBaseline + persistence round-trip", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.key).toBe(built.key);
     expect(loaded!.rootDir).toBe(repo);
+  });
+
+  it("assembleBaseline stamps the baseline with the current BASELINE_VERSION", async () => {
+    const { ctx } = await buildAnalysisContext(repo);
+    const { driftFindings } = runDriftDetection(ctx);
+    const assembled = assembleBaseline(repo, ctx, driftFindings);
+    expect(assembled.version).toBe(BASELINE_VERSION);
   });
 
   it("assembleBaseline (the scan side-effect path) agrees with standalone buildBaseline", async () => {

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -11,6 +11,7 @@ import {
   computeBaselineKey,
   votesFromFindings,
   securitySubVotesFromFindings,
+  toCategoryVote,
 } from "../../../src/core/baseline.js";
 import { buildAnalysisContext } from "../../../src/core/discovery.js";
 import { runDriftDetection } from "../../../src/drift/index.js";
@@ -93,6 +94,38 @@ describe("votesFromFindings", () => {
     expect(subVotes["Auth middleware"]!.dominantPattern).toBe("Auth middleware applied");
     expect(subVotes["Rate limiting"]!.dominantPattern).toBe("Rate limiting applied");
     expect(subVotes["Auth middleware"]!.totalRelevantFiles).toBe(5);
+  });
+});
+
+// ── belowPeerFloor: thin-sample security votes flagged advisory ─────────────
+//
+// A security_posture vote below MIN_SECURITY_PEERS (4) relevant routes is too
+// thin a sample to move the composite score (applySecurityMinPeerFloor /
+// isBelowSecurityPeerFloor in src/scoring/engine.ts), yet the same vote is
+// persisted into securitySubVotes and served by get_dominant_pattern /
+// validate_change as if it were an ordinary dominance vote. toCategoryVote
+// reuses isBelowSecurityPeerFloor (the single source of truth for the
+// below-floor test) to flag it so those tools can hedge instead of asserting.
+describe("toCategoryVote: belowPeerFloor flag", () => {
+  it("flags a security_posture vote below MIN_SECURITY_PEERS (4) relevant routes", () => {
+    const vote = toCategoryVote(
+      fakeFinding({ driftCategory: "security_posture", totalRelevantFiles: 3 }),
+    );
+    expect(vote.belowPeerFloor).toBe(true);
+  });
+
+  it("does not flag a security_posture vote at or above MIN_SECURITY_PEERS relevant routes", () => {
+    const vote = toCategoryVote(
+      fakeFinding({ driftCategory: "security_posture", totalRelevantFiles: 5 }),
+    );
+    expect(vote.belowPeerFloor).toBeFalsy();
+  });
+
+  it("does not flag a non-security-posture vote even with a thin sample", () => {
+    const vote = toCategoryVote(
+      fakeFinding({ driftCategory: "async_patterns", totalRelevantFiles: 1 }),
+    );
+    expect(vote.belowPeerFloor).toBeFalsy();
   });
 });
 

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -613,4 +613,97 @@ describe("canonical mutating methods (Task B1)", () => {
       authFinding!.deviatingFiles.some((d) => d.evidence[0].line === 25),
     ).toBe(false);
   });
+
+  // ── Adjacent-decorator regression: the methods= lookahead must never bleed
+  // into a neighboring route's decorator when routes sit immediately next to
+  // each other with one-line bodies (no blank line in between). ──
+  it("does not bleed an adjacent route's methods=[...] into an unauthed POST route's own classification", () => {
+    const pyRoutes = file(
+      "src/routes/orders.py",
+      [
+        `@app.post("/orders")`,
+        `@requires_auth`,
+        `def create_order(): return {}`,
+        `@app.post("/orders/<id>")`,
+        `@requires_auth`,
+        `def update_order(): return {}`,
+        `@app.post("/orders/<id>/cancel")`,
+        `@requires_auth`,
+        `def cancel_order(): return {}`,
+        `@app.post("/orders/<id>/ship")`,
+        `@requires_auth`,
+        `def ship_order(): return {}`,
+        `@app.post("/orders/danger")`,
+        `def danger(): return {}`,
+        `@app.route("/read", methods=["GET"])`,
+        `def read_only(): return {}`,
+      ].join("\n"),
+      "python",
+    );
+    const ctx = mkCtx([pyRoutes]);
+    const findings = securityConsistency.detect(ctx);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    // The unauthed POST route at line 13 must still be classified as
+    // mutating (POST from its own decorator), not as GET bled in from the
+    // immediately-adjacent /read route's methods=["GET"] on line 15.
+    expect(authFinding).toBeDefined();
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 13),
+    ).toBe(true);
+  });
+
+  it("does not bleed an adjacent route's methods=[...] into a bare GET route's own classification", () => {
+    // 7 authed POST routes keep the auth-vote ratio above the 75% dominance
+    // threshold even while both trailing routes (the misclassified /read
+    // under the old bug, and the genuinely-unauthed /danger) count against
+    // it — so the vote actually fires and the bug's false-positive on /read
+    // is observable, rather than the vote going silent.
+    const pyRoutes = file(
+      "src/routes/orders.py",
+      [
+        `@app.post("/orders/1")`,
+        `@requires_auth`,
+        `def r1(): return {}`,
+        `@app.post("/orders/2")`,
+        `@requires_auth`,
+        `def r2(): return {}`,
+        `@app.post("/orders/3")`,
+        `@requires_auth`,
+        `def r3(): return {}`,
+        `@app.post("/orders/4")`,
+        `@requires_auth`,
+        `def r4(): return {}`,
+        `@app.post("/orders/5")`,
+        `@requires_auth`,
+        `def r5(): return {}`,
+        `@app.post("/orders/6")`,
+        `@requires_auth`,
+        `def r6(): return {}`,
+        `@app.post("/orders/7")`,
+        `@requires_auth`,
+        `def r7(): return {}`,
+        `@app.route("/read")`,
+        `def read_only(): return {}`,
+        `@app.route("/danger", methods=["POST"])`,
+        `def danger(): return {}`,
+      ].join("\n"),
+      "python",
+    );
+    const ctx = mkCtx([pyRoutes]);
+    const findings = securityConsistency.detect(ctx);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    // The bare @app.route("/read") on line 22 defaults to GET and must never
+    // be reported as a missing-auth mutating route, even though the
+    // immediately-adjacent /danger route's methods=["POST"] on line 24 sits
+    // within the old 3-line lookahead window.
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 22),
+    ).toBe(false);
+    // /danger (line 24) is a genuine unauthed mutating route and should
+    // still be correctly flagged.
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 24),
+    ).toBe(true);
+  });
 });

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -16,8 +16,8 @@ function mkCtx(files: DriftFile[]): DriftContext {
   };
 }
 
-function file(path: string, content: string): DriftFile {
-  return { relativePath: path, language: "typescript", content, lineCount: content.split("\n").length };
+function file(path: string, content: string, language: DriftFile["language"] = "typescript"): DriftFile {
+  return { relativePath: path, language, content, lineCount: content.split("\n").length };
 }
 
 describe("security-consistency detector", () => {
@@ -522,5 +522,95 @@ describe("suppression-audit finding vs intent divergence (Finding 3)", () => {
     const auditConverted = findings.find((f) => f.analyzerId === SECURITY_SUPPRESSION_ANALYZER_ID);
     expect(auditConverted).toBeDefined();
     expect(auditConverted!.tags).not.toContain("intent-divergence");
+  });
+});
+
+// ── Task B1: canonical mutating-method classification ──────────────────────
+//
+// MUTATION_METHODS previously excluded Express `.all()` ("ALL") and unresolved
+// Flask routes ("ANY"), so those routes were silently dropped from BOTH the
+// auth dominance vote and its uniform-auth-gap fallback. These tests pin the
+// fix: `.all()` and a Flask `methods=[...]` mutating verb now enter the vote;
+// a bare `@app.route` (which defaults to GET, not "ANY") still does not.
+describe("canonical mutating methods (Task B1)", () => {
+  it("includes an unauthed Express .all() route in the auth vote as a deviator", async () => {
+    const f = await fileWithTree(
+      "src/routes/admin.ts",
+      `router.post("/users", requireAuth, createUser);\n` +
+        `router.put("/users/:id", requireAuth, updateUser);\n` +
+        `router.patch("/users/:id", requireAuth, patchUser);\n` +
+        `router.delete("/users/:id", requireAuth, deleteUser);\n` +
+        `router.all("/admin", handleAdmin);\n`,
+    );
+    const authMachinery = file(
+      "src/middleware/auth.ts",
+      `export function requireAuth(req, res, next) { verifyToken(req); next(); }`,
+    );
+    const ctx = {
+      files: [f, authMachinery],
+      totalLines: f.lineCount + authMachinery.lineCount,
+      dominantLanguage: "typescript",
+    };
+    const findings = securityConsistency.detect(ctx as any);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === f.relativePath && d.evidence[0].line === 5),
+    ).toBe(true);
+  });
+
+  it("includes a Flask methods=['POST'] mutating route in the auth vote as a deviator; a bare @app.route (GET) is not flagged", () => {
+    // Deliberately NOT @login_required / @jwt_required here: those decorators
+    // also trip buildFileMiddlewareIndex's FILE-LEVEL Python auth regex
+    // (pyAuth), which would inherit hasAuth:true onto every route in the
+    // file, masking the very per-route gap this test targets. @requires_auth
+    // still matches the per-route perAuth regex (`@requires`) without
+    // matching the file-level one.
+    const pyRoutes = file(
+      "src/routes/orders.py",
+      [
+        `@app.post("/orders")`,
+        `@requires_auth`,
+        `def create_order():`,
+        `    return {}`,
+        ``,
+        `@app.post("/orders/<id>")`,
+        `@requires_auth`,
+        `def update_order():`,
+        `    return {}`,
+        ``,
+        `@app.post("/orders/<id>")`,
+        `@requires_auth`,
+        `def cancel_order():`,
+        `    return {}`,
+        ``,
+        `@app.post("/orders/<id>/ship")`,
+        `@requires_auth`,
+        `def ship_order():`,
+        `    return {}`,
+        ``,
+        `@app.route("/orders/danger", methods=["POST"])`,
+        `def danger():`,
+        `    return {}`,
+        ``,
+        `@app.route("/read")`,
+        `def read_only():`,
+        `    return {}`,
+      ].join("\n"),
+      "python",
+    );
+    const ctx = mkCtx([pyRoutes]);
+    const findings = securityConsistency.detect(ctx);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    // The unauthed methods=['POST'] route (line 21) is named as the deviator...
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 21),
+    ).toBe(true);
+    // ...and the bare, GET-only @app.route('/read') (line 25, no auth) is not:
+    // it never enters the mutating-route denominator at all.
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.evidence[0].line === 25),
+    ).toBe(false);
   });
 });

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -656,7 +656,7 @@ describe("canonical mutating methods (Task B1)", () => {
     // 7 authed POST routes keep the auth-vote ratio above the 75% dominance
     // threshold even while both trailing routes (the misclassified /read
     // under the old bug, and the genuinely-unauthed /danger) count against
-    // it — so the vote actually fires and the bug's false-positive on /read
+    // it, so the vote actually fires and the bug's false-positive on /read
     // is observable, rather than the vote going silent.
     const pyRoutes = file(
       "src/routes/orders.py",
@@ -702,6 +702,60 @@ describe("canonical mutating methods (Task B1)", () => {
     ).toBe(false);
     // /danger (line 24) is a genuine unauthed mutating route and should
     // still be correctly flagged.
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 24),
+    ).toBe(true);
+  });
+
+  it("does not let an unbalanced literal paren in a route path bleed an adjacent route's methods=[...]", () => {
+    // A route path string can legitimately contain a "(". The decorator-arg
+    // scanner must skip parens inside string literals, otherwise the unbalanced
+    // "(" in "/weird(path" keeps the paren depth open and the scan leaks into
+    // the immediately-adjacent /danger route's methods=["POST"], misclassifying
+    // this bare GET route as a mutating route (a false positive).
+    const pyRoutes = file(
+      "src/routes/orders.py",
+      [
+        `@app.post("/orders/1")`,
+        `@requires_auth`,
+        `def r1(): return {}`,
+        `@app.post("/orders/2")`,
+        `@requires_auth`,
+        `def r2(): return {}`,
+        `@app.post("/orders/3")`,
+        `@requires_auth`,
+        `def r3(): return {}`,
+        `@app.post("/orders/4")`,
+        `@requires_auth`,
+        `def r4(): return {}`,
+        `@app.post("/orders/5")`,
+        `@requires_auth`,
+        `def r5(): return {}`,
+        `@app.post("/orders/6")`,
+        `@requires_auth`,
+        `def r6(): return {}`,
+        `@app.post("/orders/7")`,
+        `@requires_auth`,
+        `def r7(): return {}`,
+        `@app.route("/weird(path")`,
+        `def weird(): return {}`,
+        `@app.route("/danger", methods=["POST"])`,
+        `def danger(): return {}`,
+      ].join("\n"),
+      "python",
+    );
+    const ctx = mkCtx([pyRoutes]);
+    const findings = securityConsistency.detect(ctx);
+    const authFinding = findings.find((fnd) => fnd.subCategory === "Auth middleware");
+    expect(authFinding).toBeDefined();
+    // The bare @app.route("/weird(path") on line 22 defaults to GET and must
+    // never be reported as a missing-auth mutating route, even though the
+    // unbalanced literal "(" would, without string skipping, leak the adjacent
+    // /danger route's methods=["POST"] into its classification.
+    expect(
+      authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 22),
+    ).toBe(false);
+    // /danger (line 24) is a genuine unauthed mutating route and stays flagged.
     expect(
       authFinding!.deviatingFiles.some((d) => d.path === pyRoutes.relativePath && d.evidence[0].line === 24),
     ).toBe(true);

--- a/test/unit/mcp/baseline-provider.test.ts
+++ b/test/unit/mcp/baseline-provider.test.ts
@@ -1,9 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// Wrap buildBaseline in a spy that forwards to the real implementation by
+// default, so every existing setup call in this file (and inside
+// baseline-provider.ts) behaves exactly as before. One test below overrides a
+// single call with mockImplementationOnce to simulate a persistently-failing
+// rebuild, without touching any other test.
+vi.mock("../../../src/core/baseline.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/core/baseline.js")>();
+  return { ...actual, buildBaseline: vi.fn(actual.buildBaseline) };
+});
+
 import { buildBaseline, writeBaseline, BASELINE_VERSION } from "../../../src/core/baseline.js";
-import { getBaseline, __clearBaselineCache } from "../../../src/mcp/baseline-provider.js";
+import { getBaseline, __clearBaselineCache, invalidateBaselineMem } from "../../../src/mcp/baseline-provider.js";
 
 describe("baseline provider", () => {
   let repo: string;
@@ -125,6 +136,57 @@ describe("baseline provider", () => {
       // originally-persisted baseline.
       expect(baseline!.version).toBe(BASELINE_VERSION);
       expect(baseline!.builtAt).toBe(originalBuiltAt);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("attempts a version-mismatch rebuild AT MOST ONCE when the rebuild persistently fails, then serves the old baseline until invalidateBaselineMem clears the failure memory", async () => {
+    const fresh = mkdtempSync(join(tmpdir(), "vd-version-failrebuild-"));
+    try {
+      writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
+      const built = await buildBaseline(fresh);
+      // Simulate a baseline persisted under an older BASELINE_VERSION.
+      await writeBaseline({ ...built, version: 1 });
+      __clearBaselineCache();
+      // Isolate the call-count assertions below to just the calls made by
+      // getBaseline in this test (buildBaseline is a module-scoped spy that
+      // also gets called by earlier tests' fixture setup in this file).
+      vi.mocked(buildBaseline).mockClear();
+
+      // The next call to buildBaseline (the version-triggered rebuild) fails,
+      // as if the version bump also introduced a build error for this repo's
+      // content, or the repo is transiently unreadable. Rejects asynchronously
+      // (not a synchronous throw) to match the real buildBaseline, which is a
+      // genuinely async function whose internal errors surface as an async
+      // rejection through its own await chain.
+      vi.mocked(buildBaseline).mockImplementationOnce(async () => {
+        throw new Error("simulated persistent rebuild failure");
+      });
+
+      const first = await getBaseline(fresh);
+      expect(first.status).not.toBe("no_baseline");
+      expect(first.baseline).not.toBeNull();
+      expect(first.baseline!.version).toBe(1); // old baseline served, not the (failed) rebuild
+
+      const second = await getBaseline(fresh);
+      expect(second.status).not.toBe("no_baseline");
+      expect(second.baseline).not.toBeNull();
+      expect(second.baseline!.version).toBe(1);
+
+      // Two getBaseline calls after the failure must have attempted the
+      // rebuild only once total, not once per call.
+      expect(vi.mocked(buildBaseline)).toHaveBeenCalledTimes(1);
+
+      // invalidateBaselineMem clears the failure memory, so the next call
+      // attempts the rebuild again (this time it succeeds via the default
+      // forwarding implementation).
+      invalidateBaselineMem(fresh);
+      const third = await getBaseline(fresh);
+      expect(third.status).toBe("ok");
+      expect(third.baseline).not.toBeNull();
+      expect(third.baseline!.version).toBe(BASELINE_VERSION);
+      expect(vi.mocked(buildBaseline)).toHaveBeenCalledTimes(2);
     } finally {
       rmSync(fresh, { recursive: true, force: true });
     }

--- a/test/unit/mcp/baseline-provider.test.ts
+++ b/test/unit/mcp/baseline-provider.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildBaseline, writeBaseline } from "../../../src/core/baseline.js";
+import { buildBaseline, writeBaseline, BASELINE_VERSION } from "../../../src/core/baseline.js";
 import { getBaseline, __clearBaselineCache } from "../../../src/mcp/baseline-provider.js";
 
 describe("baseline provider", () => {
@@ -73,5 +73,60 @@ describe("baseline provider", () => {
     const { baseline, status } = await getBaseline(repo);
     expect(status).toBe("stale");
     expect(baseline).not.toBeNull(); // serve cached + tag, never hang/rebuild in-call
+  });
+
+  it("rebuilds once when the on-disk baseline predates BASELINE_VERSION, then serves the rebuilt baseline without rebuilding again", async () => {
+    const fresh = mkdtempSync(join(tmpdir(), "vd-version-"));
+    try {
+      writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
+      writeFileSync(join(fresh, "y.ts"), "export async function y(){ return await fetch('/b'); }\n");
+      const built = await buildBaseline(fresh);
+      // Simulate a baseline persisted under an older BASELINE_VERSION (e.g.
+      // missing securitySubVotes / the belowPeerFloor vote shape).
+      await writeBaseline({ ...built, version: 1 });
+      __clearBaselineCache();
+
+      const rebuiltResult = await getBaseline(fresh);
+      expect(rebuiltResult.status).toBe("ok");
+      expect(rebuiltResult.baseline).not.toBeNull();
+      expect(rebuiltResult.baseline!.version).toBe(BASELINE_VERSION);
+      const firstBuiltAt = rebuiltResult.baseline!.builtAt;
+
+      // Content is unchanged and the on-disk baseline is now at the current
+      // version, so a second call (after dropping the mem cache, forcing a
+      // disk load) must be SERVED, not rebuilt again: builtAt is identical.
+      __clearBaselineCache();
+      const servedResult = await getBaseline(fresh);
+      expect(servedResult.status).toBe("ok");
+      expect(servedResult.baseline).not.toBeNull();
+      expect(servedResult.baseline!.version).toBe(BASELINE_VERSION);
+      expect(servedResult.baseline!.builtAt).toBe(firstBuiltAt);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("a current-version baseline with content-only drift still returns 'stale' (cheap re-hash), not a rebuild", async () => {
+    const fresh = mkdtempSync(join(tmpdir(), "vd-version-content-"));
+    try {
+      writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
+      await writeBaseline(await buildBaseline(fresh));
+      __clearBaselineCache();
+      const first = await getBaseline(fresh);
+      expect(first.status).toBe("ok");
+      const originalBuiltAt = first.baseline!.builtAt;
+
+      __clearBaselineCache();
+      writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/CHANGED'); }\n");
+      const { baseline, status } = await getBaseline(fresh);
+      expect(status).toBe("stale");
+      expect(baseline).not.toBeNull();
+      // Content-only drift never rebuilds: same version, same builtAt as the
+      // originally-persisted baseline.
+      expect(baseline!.version).toBe(BASELINE_VERSION);
+      expect(baseline!.builtAt).toBe(originalBuiltAt);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
   });
 });

--- a/test/unit/mcp/tools/check-file-drift.test.ts
+++ b/test/unit/mcp/tools/check-file-drift.test.ts
@@ -50,6 +50,120 @@ describe("fileDriftFromBaseline (pure)", () => {
   });
 });
 
+describe("fileDriftFromBaseline (security sub-votes)", () => {
+  // A baseline whose collapsed security_posture slot is the RATE-LIMIT vote
+  // (widest denominator) that does NOT list orders.ts, while the granular
+  // "Auth middleware" sub-vote DOES flag orders.ts as an auth deviator.
+  function securityBaseline(): RepoDriftBaseline {
+    return {
+      key: "k",
+      rootDir: "/repo",
+      ctxFiles: [{ path: "orders.ts", hash: "h" }],
+      perCategoryVote: {
+        security_posture: {
+          driftCategory: "security_posture",
+          dominantPattern: "rate_limit_present",
+          dominantCount: 9,
+          totalRelevantFiles: 10,
+          consistencyScore: 90,
+          dominantFiles: ["users.ts"],
+          deviators: [{ path: "other.ts", detectedPattern: "no_rate_limit" }],
+        },
+      },
+      securitySubVotes: {
+        "Auth middleware": {
+          driftCategory: "security_posture",
+          dominantPattern: "requireAuth",
+          dominantCount: 5,
+          totalRelevantFiles: 6,
+          consistencyScore: 83,
+          dominantFiles: ["users.ts"],
+          deviators: [{ path: "orders.ts", detectedPattern: "no_auth" }],
+        },
+      },
+      intentHints: [],
+      minhashIndex: [],
+      builtAt: 0,
+    };
+  }
+
+  it("flags an unauthed route as fits:false via securitySubVotes even when the collapsed rate-limit slot does not list it", () => {
+    const r = fileDriftFromBaseline(securityBaseline(), "orders.ts");
+    expect(r.fits).toBe(false);
+    expect(r.deviations).toHaveLength(1);
+    const d = r.deviations[0];
+    expect(d.dimension).toBe("security_posture");
+    expect(d.yourPattern).toBe("no_auth");
+    expect(d.dominantPattern).toBe("requireAuth");
+    // security dimension consistency counts routes, not files
+    expect(d.consistency).toMatch(/routes/);
+    expect(d.consistency).not.toMatch(/files/);
+    expect(d.fixHint).toMatch(/requireAuth/);
+  });
+
+  it("does not double-count a file that is a deviator in BOTH the collapsed slot and its sub-vote", () => {
+    const b = securityBaseline();
+    // orders.ts is now a rate-limit deviator in the collapsed slot AND in the
+    // "Rate limiting" sub-vote for the same underlying sub-convention.
+    b.perCategoryVote.security_posture!.deviators = [
+      { path: "orders.ts", detectedPattern: "no_rate_limit" },
+    ];
+    b.securitySubVotes = {
+      "Rate limiting": {
+        driftCategory: "security_posture",
+        dominantPattern: "rate_limit_present",
+        dominantCount: 9,
+        totalRelevantFiles: 10,
+        consistencyScore: 90,
+        dominantFiles: ["users.ts"],
+        deviators: [{ path: "orders.ts", detectedPattern: "no_rate_limit" }],
+      },
+    };
+    const r = fileDriftFromBaseline(b, "orders.ts");
+    const sec = r.deviations.filter((d) => d.dimension === "security_posture");
+    expect(sec).toHaveLength(1);
+    // proves it came from the sub-vote path (routes), not the collapsed slot (files)
+    expect(sec[0].consistency).toMatch(/routes/);
+  });
+
+  it("renders a below-floor sub-vote as advisory but still counts it as a non-fit", () => {
+    const b = securityBaseline();
+    b.perCategoryVote = {}; // isolate the sub-vote path
+    b.securitySubVotes = {
+      "Auth middleware": {
+        driftCategory: "security_posture",
+        dominantPattern: "requireAuth",
+        dominantCount: 2,
+        totalRelevantFiles: 3,
+        consistencyScore: 67,
+        dominantFiles: ["users.ts"],
+        deviators: [{ path: "orders.ts", detectedPattern: "no_auth" }],
+        belowPeerFloor: true,
+      },
+    };
+    const r = fileDriftFromBaseline(b, "orders.ts");
+    expect(r.fits).toBe(false); // hedge, never bless
+    expect(r.deviations).toHaveLength(1);
+    const d = r.deviations[0];
+    expect(d.consistency).toMatch(/advisory/i);
+    expect(d.fixHint).toMatch(/advisory/i);
+  });
+
+  it("falls back to the collapsed security_posture slot when securitySubVotes is absent (older baseline)", () => {
+    const b = securityBaseline();
+    delete b.securitySubVotes;
+    b.perCategoryVote.security_posture!.deviators = [
+      { path: "orders.ts", detectedPattern: "no_rate_limit" },
+    ];
+    const r = fileDriftFromBaseline(b, "orders.ts");
+    expect(r.fits).toBe(false);
+    expect(r.deviations).toHaveLength(1);
+    expect(r.deviations[0].dimension).toBe("security_posture");
+    // legacy path keeps the file-unit wording
+    expect(r.deviations[0].consistency).toMatch(/files/);
+  });
+});
+
 describe("check_file_drift (integration on the messy-project fixture)", () => {
   const repo = resolve("test/fixtures/messy-project");
   let built: RepoDriftBaseline;

--- a/test/unit/mcp/tools/check-file-drift.test.ts
+++ b/test/unit/mcp/tools/check-file-drift.test.ts
@@ -162,6 +162,22 @@ describe("fileDriftFromBaseline (security sub-votes)", () => {
     // legacy path keeps the file-unit wording
     expect(r.deviations[0].consistency).toMatch(/files/);
   });
+
+  it("falls back to the collapsed slot when securitySubVotes is present but EMPTY (never silently drops a real security deviator)", () => {
+    // Defensive: an empty {} securitySubVotes must not suppress a real collapsed
+    // security_posture deviator. Mere presence is not enough to skip the slot;
+    // there must be actual sub-votes to read instead, or never-false-bless breaks.
+    const b = securityBaseline();
+    b.securitySubVotes = {};
+    b.perCategoryVote.security_posture!.deviators = [
+      { path: "orders.ts", detectedPattern: "no_rate_limit" },
+    ];
+    const r = fileDriftFromBaseline(b, "orders.ts");
+    expect(r.fits).toBe(false);
+    expect(r.deviations).toHaveLength(1);
+    expect(r.deviations[0].dimension).toBe("security_posture");
+    expect(r.deviations[0].consistency).toMatch(/files/);
+  });
 });
 
 describe("check_file_drift (integration on the messy-project fixture)", () => {

--- a/test/unit/mcp/tools/get-dominant-pattern.test.ts
+++ b/test/unit/mcp/tools/get-dominant-pattern.test.ts
@@ -6,12 +6,17 @@ import { dominantPatternFor, run, DIMENSIONS } from "../../../../src/mcp/tools/g
 import { buildBaseline, writeBaseline, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
 import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
 
-function baselineWith(vote: Partial<RepoDriftBaseline["perCategoryVote"]>, fileCount = 5): RepoDriftBaseline {
+function baselineWith(
+  vote: Partial<RepoDriftBaseline["perCategoryVote"]>,
+  fileCount = 5,
+  securitySubVotes?: RepoDriftBaseline["securitySubVotes"],
+): RepoDriftBaseline {
   return {
     key: "k",
     rootDir: "/x",
     ctxFiles: Array.from({ length: fileCount }, (_, i) => ({ path: `f${i}.ts`, hash: "h" })),
     perCategoryVote: vote,
+    securitySubVotes,
     intentHints: [],
     minhashIndex: [],
     builtAt: 0,
@@ -51,6 +56,55 @@ describe("dominantPatternFor (pure projection)", () => {
     for (const dim of DIMENSIONS) {
       expect(() => dominantPatternFor(baselineWith({}), dim)).not.toThrow();
     }
+  });
+
+  // A security_posture sub-vote below MIN_SECURITY_PEERS relevant routes is too
+  // thin to move the composite score, yet is served here as an ordinary vote.
+  // belowPeerFloor must make the consistency string read as advisory, not a
+  // confident verdict, and must denominate in "routes" (auth is route-scoped).
+  it("caveats a below-peer-floor auth vote as a thin sample, denominated in routes", () => {
+    const b = baselineWith(
+      {},
+      5,
+      {
+        "Auth middleware": {
+          driftCategory: "security_posture",
+          dominantPattern: "Auth middleware applied",
+          dominantCount: 2,
+          totalRelevantFiles: 3,
+          consistencyScore: 67,
+          dominantFiles: ["routes/a.ts"],
+          deviators: [],
+          belowPeerFloor: true,
+        },
+      },
+    );
+    const r = dominantPatternFor(b, "auth");
+    expect(r.consistency).toMatch(/thin sample/i);
+    expect(r.consistency).toContain("routes");
+    expect(r.consistency).not.toContain("files");
+  });
+
+  it("does not caveat an at-or-above-floor auth vote", () => {
+    const b = baselineWith(
+      {},
+      5,
+      {
+        "Auth middleware": {
+          driftCategory: "security_posture",
+          dominantPattern: "Auth middleware applied",
+          dominantCount: 4,
+          totalRelevantFiles: 5,
+          consistencyScore: 80,
+          dominantFiles: ["routes/a.ts"],
+          deviators: [],
+          belowPeerFloor: false,
+        },
+      },
+    );
+    const r = dominantPatternFor(b, "auth");
+    expect(r.consistency).not.toMatch(/thin sample/i);
+    expect(r.consistency).toContain("routes");
   });
 });
 

--- a/test/unit/mcp/tools/validate-change-security.test.ts
+++ b/test/unit/mcp/tools/validate-change-security.test.ts
@@ -99,6 +99,23 @@ const AUTH_APPLIED_VOTE: RepoDriftBaseline["securitySubVotes"] = {
   },
 };
 
+// Below MIN_SECURITY_PEERS (4) relevant routes: 2 of 3 mutating routes authed.
+// Too thin a sample to move the composite score (isBelowSecurityPeerFloor),
+// so the in-loop check must hedge this as advisory, not cite it as a
+// confident verdict.
+const AUTH_APPLIED_VOTE_THIN: RepoDriftBaseline["securitySubVotes"] = {
+  "Auth middleware": {
+    driftCategory: "security_posture",
+    dominantPattern: "Auth middleware applied",
+    dominantCount: 2,
+    totalRelevantFiles: 3,
+    consistencyScore: 67,
+    dominantFiles: ["routes/users.ts"],
+    deviators: [],
+    belowPeerFloor: true,
+  },
+};
+
 const AUTH_REQUIRED_HINT = {
   category: "security_posture" as const,
   pattern: "auth_required",
@@ -159,6 +176,22 @@ describe("checkRouteAuthDrift", () => {
   it("does not flag a Python body (JS/TS-only gate)", async () => {
     const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), PY_ROUTE, "new.py");
     expect(c).toBeNull();
+  });
+
+  it("adds a thin-sample advisory note when the applied-auth vote is below the peer floor", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE_THIN), UNAUTHED_POST, "new.ts");
+    expect(c).not.toBeNull();
+    expect(c!.fixHint).toContain("2 of 3");
+    expect(c!.fixHint).toMatch(/thin sample/i);
+    // Both caveats present: thin-sample AND the existing router-scope caveat.
+    expect(c!.fixHint).toContain("router-level middleware is not visible");
+    expect(c!.fixHint).not.toMatch(/—|--/);
+  });
+
+  it("does not add the thin-sample note when the applied-auth vote is at or above the peer floor", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), UNAUTHED_POST, "new.ts");
+    expect(c).not.toBeNull();
+    expect(c!.fixHint).not.toMatch(/thin sample/i);
   });
 
   it("stays silent when the auth vote is not the applied-majority signal and no hint is declared", async () => {

--- a/test/unit/mcp/tools/validate-change-security.test.ts
+++ b/test/unit/mcp/tools/validate-change-security.test.ts
@@ -64,6 +64,10 @@ describe("classifyRouteAuth", () => {
 // is to apply auth. Otherwise honest silence (null).
 const UNAUTHED_POST = 'router.post("/x", (req, res) => { res.json({}); });';
 const GUARDED_POST = 'router.post("/x", requireAuth, (req, res) => { res.json({}); });';
+// Task B1: Express .all() is a mutating method (it handles every verb), so an
+// unauthed .all() route must be caught by the same in-loop classifier as
+// .post()/.put()/.patch()/.delete(). It previously was not.
+const UNAUTHED_ALL = 'router.all("/orders", (req, res) => { res.json({}); });';
 const PLAIN_FN = "export function add(a, b) { return a + b; }";
 const PY_ROUTE = '@app.post("/x")\ndef handler():\n    return {}';
 
@@ -136,6 +140,15 @@ describe("checkRouteAuthDrift", () => {
   it("does not flag a guarded mutating route even with an auth vote", async () => {
     const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), GUARDED_POST, "new.ts");
     expect(c).toBeNull();
+  });
+
+  it("emits a low-confidence conflict for an unauthed Express .all() route vs an 'Auth middleware' vote (Task B1)", async () => {
+    const c = await checkRouteAuthDrift(baseWith(AUTH_APPLIED_VOTE), UNAUTHED_ALL, "new.ts");
+    expect(c).not.toBeNull();
+    expect(c!.dimension).toBe("security_posture");
+    expect(c!.dominantPattern).toBe("Auth middleware applied");
+    expect(c!.yourPattern).toBe("no auth guard visible in this change");
+    expect(c!.fixHint).toContain("8 of 9");
   });
 
   it("does not flag a non-route body", async () => {

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,15 @@
 # CLI backlog
 
+- **Landing-page release notes for SCORING_VERSION v10 (cross-repo).** The
+  security release bumps `SCORING_VERSION` v9 -> v10 (Express `.all()` + Flask
+  `@app.route(methods=[...])` mutating routes now enter the security auth vote,
+  so repos with those shapes reflect security_posture drift they always had).
+  The one-time scoring-refined notice (`src/core/scoring-notice.ts`) points
+  users to `https://vibedrift.ai/releases`, so that page must describe the v10
+  change before/at publish. Calibration corpus is byte-identical (no percentile
+  regeneration needed). Belongs in `vibedrift-landing-page`, tracked here so the
+  CLI publish does not ship a notice pointing at an undocumented change.
+
 - **Gin `.Any()` / Chi `.Method()` routes are not extracted at all.** Task B1
   (2026-07-08, canonical mutating-method classification) fixed the
   vote-exclusion bug for Express `.all()` and Flask `methods=[...]`, but Go's
@@ -84,9 +94,16 @@
   text into the committed `.vibedrift/context.md` in the same scenario (a more
   durable surface than the ephemeral terminal line).
   This is deliberate for now: the baseline (`assembleBaseline`) and diff track
-  the raw representation for continuity, and the first-scan-after-upgrade case is
-  already silenced by the SCORING_VERSION-mismatch guard. If we want the diff to
-  match the rendered (scored) view, feed `scoredDriftView(...).driftFindings` to
+  the raw representation for continuity. CORRECTION (2026-07-08 audit, issue #34
+  item C1): the claim below that the first-scan-after-upgrade case is "already
+  silenced by the SCORING_VERSION-mismatch guard" is FALSE — verified against
+  source. `diffScans` (`src/output/history-diff.ts`) only gates on
+  `previous.schemaVersion`, never on `scoringVersion`; `previousScoresMismatch`
+  (the actual guard, set in `scan.ts`) is never read by `diffScans` or
+  `src/output/context-md.ts`. A scan taken right after a `SCORING_VERSION` bump
+  WILL diff its `compositeScore` against the prior version's and can commit a
+  cross-version "Vibe Drift Score delta" into `.vibedrift/context.md`. If we
+  want the diff to match the rendered (scored) view, feed `scoredDriftView(...).driftFindings` to
   both the diff digest (buildScanResult) and `saveScanResult` together (keep the
   two sources identical or a spurious per-scan diff reappears).
   Same root cause covers the suppression-audit finding (subCategory
@@ -104,3 +121,37 @@
   coherence audit, AI-validated findings, and intent-mismatch checks only
   appear with `--format terminal`. Add a short AI summary (coherence grade +
   top finding) to the default deep render.
+
+- **Issue #34 audit findings (2026-07-08). B1-B4 RELEASE BLOCKERS + D2 are
+  FIXED on branch `security-blockers-34` (2026-07-08); the items below are
+  correctness/polish, NOT release blockers:**
+  - **C2 — `computeDriftScores` credits an empty security_posture category
+    full health** (`drift/index.ts:115-154`, `categoryHealth([...], ...)`
+    returns 1 for an empty array with no "not measured" branch, unlike
+    `computeCategoryScore`). Produces `{score:14, maxScore:14, findings:0}`,
+    uploaded as-is in `result_json.driftScores` next to the composite's N/A.
+  - **C4 — `applyReimplementationConcentrationGate` re-tag never propagates
+    out of `computeScores`** (`engine.ts:88-103,732`; re-tags a local copy of
+    `findings`, not returned). Same "local copy" bug class already fixed once
+    for the security floor (see `scan.ts:405-420`'s comment) but never
+    hoisted here — a concentrated reimplementation finding correctly dents the
+    score but still renders/labels as hygiene everywhere (CSV/HTML/DOCX/context.md).
+  - **C5 — per-file Drift/Static tallies still tag-based, headline is
+    kind-based (mismatch)** (`docx.ts:398-399`, `html.ts:285-286` use
+    `f.tags?.includes("drift")`; the headline sections
+    (`docx.ts:424-427`, `html.ts:827-829`) were fixed to use
+    `getAnalyzerKind`). A demoted `security_posture-advisory` finding tallies
+    as "Drift" in the per-file table but lists under "Static"/"Hygiene" in the
+    headline.
+  - **D1 — N/A category card says "No findings in this repo"**
+    (`html.ts:462`, `terminal.ts:588`) even when a demoted advisory finding
+    exists and its actual message renders further down the same output
+    (hygiene section, `html.ts:827-829` / `terminal.ts:512-533`).
+  - **D3 — "consistent, not safe" gloss omits rate limiting**
+    (`terminal.ts:604`, `html.ts:458` say "auth and validation patterns" only;
+    `SECURITY_SUBCATEGORIES` has a third sub-convention, `rateLimit`).
+  - **E1 — `allFindings.push(...flooredFindings)` spreads a whole array as
+    call args** (`scan.ts:419`, also `:363`) — RangeError risk on very large
+    finding sets.
+  Full file:line evidence + quotes: see `LOGBOOK.md` "2026-07-08 (later 4)"
+  at the workspace root.

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,14 @@
 # CLI backlog
 
+- **Gin `.Any()` / Chi `.Method()` routes are not extracted at all.** Task B1
+  (2026-07-08, canonical mutating-method classification) fixed the
+  vote-exclusion bug for Express `.all()` and Flask `methods=[...]`, but Go's
+  `extractGoRoutes` (`src/drift/security-consistency.ts`) never recognizes
+  `r.Any(...)` (Gin) or `r.Method(...)` (Chi) as route registrations in the
+  first place, so these routes are missing from the route list entirely, not
+  just excluded from the mutating-method vote. Separate coverage gap, not a
+  vote-exclusion bug.
+
 - **Security floor precision gate only covers `private-key`.** The calibration
   floor-precision gate (`test/calibration/precision-recall.ts`) exercises only the
   `private-key` floor rule because the fixture corpus has no `.go` files, so


### PR DESCRIPTION
## Close the four Security Consistency release blockers

Four correctness fixes to the Security Consistency detector and the MCP tools it powers, so the security release does not ship lost-detection or wrong-answer paths.

### Auth vote now covers catch-all and Flask routes
Express `.all()` routes and Flask `@app.route(..., methods=[...])` routes were silently excluded from the auth-consistency vote, so a repo could carry unauthed mutating routes that produced no finding at all. The detector now resolves each route's real method: `.all()` is treated as mutating, Flask `methods=` is parsed, and a bare `@app.route` correctly stays GET so read-only routes are never flagged. The batch detector and the in-loop `validate_change` check share one method definition, so they can never disagree on the same route.

### MCP tools no longer serve stale or misleading answers
- `check_file_drift` reads the per-convention security votes (auth, validation, rate limit) instead of a single collapsed slot, so it can no longer report `fits: true` for a file whose only issue is an unauthed route.
- The MCP baseline is rebuilt when it was persisted under an older vote version, instead of serving pre-upgrade data indefinitely.
- A security vote drawn from too small a sample is surfaced as advisory rather than stated as an established convention.

### Scoring
Because the auth vote now counts routes it previously missed, a repo with those route shapes reflects the security drift it always had. This is a scoring refinement handled by the normal version migration: existing scores are preserved and the change applies to new scans, with a one-time notice.

Addresses the four release blockers tracked in #34. Supersedes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkqH9w2pU7b7Hctbe45h2t
