### PR TITLE
test: fix 13 Windows-incompatible test assumptions

### DIFF
--- a/test/integration/mcp.test.ts
+++ b/test/integration/mcp.test.ts
@@ -33,7 +33,7 @@ async function connect(home: string): Promise<Client> {
   const transport = new StdioClientTransport({
     command: "node",
     args: [CLI, "mcp"],
-    env: { ...process.env, HOME: home },
+    env: { ...process.env, HOME: home, USERPROFILE: home },
   });
   const client = new Client({ name: "test-client", version: "0.0.0" });
   await client.connect(transport);

--- a/test/integration/mcp.test.ts
+++ b/test/integration/mcp.test.ts
@@ -56,7 +56,7 @@ describe("MCP integration — Pro plan (tools serve)", () => {
     // Build the baseline the real way: a scan under the SAME HOME the server reads
     // (the cache dir is derived from HOME, so this writes to home/.vibedrift).
     execFileSync("node", [CLI, repo, "--local-only", "--format", "terminal"], {
-      env: { ...process.env, HOME: home },
+      env: { ...process.env, HOME: home, USERPROFILE: home },
       stdio: "ignore",
     });
     client = await connect(home);
@@ -155,7 +155,7 @@ describe("MCP integration — deep-scan nudge piggybacks on a write-time tool", 
     }
     writeFileSync(join(repo, "then0.ts"), "export function then0(){\n  return a().then(r => r);\n}\n");
     execFileSync("node", [CLI, repo, "--local-only", "--format", "terminal"], {
-      env: { ...process.env, HOME: home },
+      env: { ...process.env, HOME: home, USERPROFILE: home },
       stdio: "ignore",
     });
     client = await connect(home);

--- a/test/integration/temporal-pivot.test.ts
+++ b/test/integration/temporal-pivot.test.ts
@@ -17,13 +17,13 @@ async function gitInit(dir: string): Promise<void> {
   await run(dir, "git init -q");
   await run(dir, 'git config user.email "test@example.com"');
   await run(dir, 'git config user.name "Test"');
-  await run(dir, "git config core.hooksPath /dev/null");
+  await run(dir, "git config core.hooksPath .git/hooks-disabled");
 }
 
 async function commit(dir: string, isoDate: string, msg: string): Promise<void> {
-  const env = `GIT_AUTHOR_DATE="${isoDate}" GIT_COMMITTER_DATE="${isoDate}"`;
-  await run(dir, `${env} git add -A`);
-  await run(dir, `${env} git commit -q -m "${msg}"`);
+  const env = { ...process.env, GIT_AUTHOR_DATE: isoDate, GIT_COMMITTER_DATE: isoDate };
+  await execP("git add -A", { cwd: dir, env });
+  await execP(`git commit -q -m "${msg}"`, { cwd: dir, env });
 }
 
 /**

--- a/test/unit/cli/hook.test.ts
+++ b/test/unit/cli/hook.test.ts
@@ -48,7 +48,10 @@ describe("runHook in a temp git repo", () => {
     const content = readFileSync(hookPath, "utf8");
     expect(content).toContain(HOOK_MARKER);
     expect(content).toContain("--fail-on-score 80");
-    expect(statSync(hookPath).mode & 0o100).toBeTruthy(); // owner-executable
+    // Unix file permissions don't exist on Windows — skip this check there
+    if (process.platform !== "win32") {
+      expect(statSync(hookPath).mode & 0o100).toBeTruthy(); // owner-executable
+    }
   });
 
   it("uninstall removes a VibeDrift-created hook", async () => {

--- a/test/unit/core/embedding-index.test.ts
+++ b/test/unit/core/embedding-index.test.ts
@@ -73,14 +73,20 @@ describe("isIndexStale", () => {
 describe("write/load round-trip", () => {
   let home: string;
   let prevHome: string | undefined;
+  let prevUserProfile: string | undefined;
   beforeAll(() => {
     // Redirect homedir() to a temp dir so the test never touches the real ~/.vibedrift
     home = mkdtempSync(join(tmpdir(), "vd-eidx-"));
     prevHome = process.env.HOME;
+    prevUserProfile = process.env.USERPROFILE;
     process.env.HOME = home;
+    process.env.USERPROFILE = home;
   });
   afterAll(() => {
     if (prevHome !== undefined) process.env.HOME = prevHome;
+    else delete process.env.HOME;
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = prevUserProfile;
+    else delete process.env.USERPROFILE;
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/test/unit/core/git-metadata.test.ts
+++ b/test/unit/core/git-metadata.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { exec } from "child_process";
 import { promisify } from "util";
-import { collectGitMetadata } from "../../../src/core/git-metadata.js";
 
 const execP = promisify(exec);
 
@@ -18,24 +17,46 @@ async function initRepo(dir: string): Promise<void> {
   await run(dir, 'git config user.name "Test"');
   // Suppress any pre-commit/prepare-commit-msg hooks the user may have
   // configured globally — we want hermetic, fast commits.
-  await run(dir, "git config core.hooksPath /dev/null");
+  await run(dir, "git config core.hooksPath .git/hooks-disabled");
 }
 
 async function commitWithDate(dir: string, isoDate: string, msg: string): Promise<void> {
-  const env = `GIT_AUTHOR_DATE="${isoDate}" GIT_COMMITTER_DATE="${isoDate}"`;
-  await run(dir, `${env} git add -A`);
-  await run(dir, `${env} git commit -q -m "${msg}"`);
+  const env = { ...process.env, GIT_AUTHOR_DATE: isoDate, GIT_COMMITTER_DATE: isoDate };
+  await execP("git add -A", { cwd: dir, env });
+  await execP(`git commit -q -m "${msg}"`, { cwd: dir, env });
 }
 
 describe("collectGitMetadata", () => {
   let dir: string;
+  let fakeHome: string;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
+
+  /** Dynamic import so vi.resetModules() forces CACHE_DIR to re-evaluate. */
+  async function collectGitMetadata(rootDir: string) {
+    const mod = await import("../../../src/core/git-metadata.js");
+    return mod.collectGitMetadata(rootDir);
+  }
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "vibedrift-git-test-"));
+    fakeHome = await mkdtemp(join(tmpdir(), "vibedrift-git-home-"));
+    // Redirect homedir() so the git-metadata cache goes to a temp dir
+    // (CACHE_DIR is evaluated at module load time, so we must resetModules)
+    origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    vi.resetModules();
   });
 
   afterEach(async () => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserProfile !== undefined) process.env.USERPROFILE = origUserProfile;
+    else delete process.env.USERPROFILE;
     await rm(dir, { recursive: true, force: true });
+    await rm(fakeHome, { recursive: true, force: true });
   });
 
   it("returns null when the directory is not a git repo", async () => {

--- a/test/unit/core/update-check.test.ts
+++ b/test/unit/core/update-check.test.ts
@@ -37,11 +37,14 @@ describe("checkForUpdate (cache + fetch behavior)", () => {
   // Redirect HOME to a temp dir so cache writes are isolated per test.
   let tmpHome: string;
   let origHome: string | undefined;
+  let origUserProfile: string | undefined;
 
   beforeEach(async () => {
     tmpHome = await mkdtemp(join(tmpdir(), "vd-update-check-"));
     origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
     process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
     // Reset the module registry so the cache-path constant re-resolves
     // against the new HOME (the module reads homedir() at import).
     vi.resetModules();
@@ -50,6 +53,8 @@ describe("checkForUpdate (cache + fetch behavior)", () => {
   afterEach(async () => {
     if (origHome !== undefined) process.env.HOME = origHome;
     else delete process.env.HOME;
+    if (origUserProfile !== undefined) process.env.USERPROFILE = origUserProfile;
+    else delete process.env.USERPROFILE;
     await rm(tmpHome, { recursive: true, force: true });
   });
 

--- a/test/unit/ml-client/build-embedding-index.test.ts
+++ b/test/unit/ml-client/build-embedding-index.test.ts
@@ -14,6 +14,7 @@ describe("buildEmbeddingIndex", () => {
   let repo: string;
   let home: string;
   let prevHome: string | undefined;
+  let prevUserProfile: string | undefined;
 
   beforeAll(() => {
     repo = mkdtempSync(join(tmpdir(), "vd-bei-repo-"));
@@ -21,10 +22,15 @@ describe("buildEmbeddingIndex", () => {
     writeFileSync(join(repo, "b.ts"), "export function addNumbers(a, b){ const total = a + b; return total; }\n");
     home = mkdtempSync(join(tmpdir(), "vd-bei-home-"));
     prevHome = process.env.HOME;
+    prevUserProfile = process.env.USERPROFILE;
     process.env.HOME = home; // redirect ~/.vibedrift to a temp dir
+    process.env.USERPROFILE = home;
   });
   afterAll(() => {
     if (prevHome !== undefined) process.env.HOME = prevHome;
+    else delete process.env.HOME;
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = prevUserProfile;
+    else delete process.env.USERPROFILE;
     rmSync(repo, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

13 tests fail on Windows due to platform-specific assumptions in the test harness. This fixes all 13 without changing any product code.

**Root causes:**
1. `GIT_AUTHOR_DATE="..." git add` is Unix inline env var syntax — doesn't work on Windows cmd/PowerShell (7 tests)
2. `process.env.HOME = tmpDir` doesn't redirect `os.homedir()` on Windows which uses `USERPROFILE` — tests read stale cache from real home dir (5 tests)
3. `statSync(path).mode & 0o100` checks Unix execute permission bits which don't exist on Windows (1 test)

**Fixes:**
- Use Node's `execP` with `{ env }` option instead of shell inline vars — works on all platforms
- Set both `HOME` and `USERPROFILE` when redirecting home — Linux/macOS reads `HOME`, Windows reads `USERPROFILE`, setting both is harmless
- Skip the permission bit assertion on Windows (`process.platform !== "win32"`) — content assertions still run
- Replace `/dev/null` hooksPath with `.git/hooks-disabled` (nonexistent dir on all platforms)
- Use separate `fakeHome` dir for git-metadata cache isolation (prevents cache files from being tracked by git inside the test repo)
- Add `vi.resetModules()` + dynamic import for `collectGitMetadata` since `CACHE_DIR` is evaluated at module load time

**Before:** 13 failures on Windows, 0 on CI (Ubuntu)
**After:** 0 failures on all platforms

### Score verification

Verified on Windows 11 (Node 24) that the CLI scan score is unchanged:

```
Base commit (d89137f — the main this PR branches from): 90.8
This branch (fix/windows-test-compat):                  90.8
```

Score is identical — only test files are modified, zero product code touched.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

No tracked issue — discovered while contributing on Windows.
