### PR TITLE
fix(deps): use AST to extract imports, eliminating false positives from comments/strings

### DIFF
--- a/src/analyzers/dependencies.ts
+++ b/src/analyzers/dependencies.ts
@@ -1,5 +1,6 @@
 import type { Analyzer } from "./base.js";
-import type { AnalysisContext, Finding } from "../core/types.js";
+import type { AnalysisContext, Finding, SourceFile } from "../core/types.js";
+import { parseImportsAst } from "../core/import-graph-ast.js";
 
 const NODE_BUILTINS = new Set([
   "assert", "buffer", "child_process", "cluster", "console", "constants",
@@ -108,24 +109,39 @@ export const dependenciesAnalyzer: Analyzer = {
 };
 
 function collectImportedPackages(
-  files: { content: string; relativePath: string }[],
+  files: SourceFile[],
 ): { imported: Set<string>; importLocations: Map<string, { file: string; line: number }[]> } {
   const imported = new Set<string>();
   const importLocations = new Map<string, { file: string; line: number }[]>();
 
   for (const file of files) {
-    for (const pattern of JS_IMPORT_PATTERNS) {
-      const regex = new RegExp(pattern.source, pattern.flags);
-      let match;
-      while ((match = regex.exec(file.content)) !== null) {
-        const pkg = extractJsPackageName(match[1]);
+    // Use AST when available — immune to matching inside comments/strings
+    if (file.tree) {
+      const { sources } = parseImportsAst(file.tree);
+      for (const source of sources) {
+        // Only care about bare package imports (not relative ./.. paths)
+        if (source.startsWith(".") || source.startsWith("/")) continue;
+        const pkg = extractJsPackageName(source);
         if (NODE_BUILTINS.has(pkg) || pkg.startsWith("node:") || pkg.startsWith("@/") || pkg.startsWith("~")) continue;
         imported.add(pkg);
+        // AST doesn't give us line numbers for sources cheaply, so omit location
         if (!importLocations.has(pkg)) importLocations.set(pkg, []);
-        importLocations.get(pkg)!.push({
-          file: file.relativePath,
-          line: file.content.slice(0, match.index).split("\n").length,
-        });
+      }
+    } else {
+      // Fallback to regex for files without a parsed tree
+      for (const pattern of JS_IMPORT_PATTERNS) {
+        const regex = new RegExp(pattern.source, pattern.flags);
+        let match;
+        while ((match = regex.exec(file.content)) !== null) {
+          const pkg = extractJsPackageName(match[1]);
+          if (NODE_BUILTINS.has(pkg) || pkg.startsWith("node:") || pkg.startsWith("@/") || pkg.startsWith("~")) continue;
+          imported.add(pkg);
+          if (!importLocations.has(pkg)) importLocations.set(pkg, []);
+          importLocations.get(pkg)!.push({
+            file: file.relativePath,
+            line: file.content.slice(0, match.index).split("\n").length,
+          });
+        }
       }
     }
   }
@@ -230,6 +246,9 @@ function analyzeJsDeps(ctx: AnalysisContext): Finding[] {
     ...Object.keys(pkg.peerDependencies ?? {}),
     ...Object.keys((pkg as any).optionalDependencies ?? {}),
   ]);
+
+  // Self-references (importing your own package name) are not missing deps
+  if (pkg.name) declared.add(pkg.name);
 
   // Detect monorepo workspace packages (workspace:* protocol, or packages
   // whose versions are "workspace:*", "workspace:^", "workspace:~", "*")

--- a/test/unit/analyzers/dependencies.test.ts
+++ b/test/unit/analyzers/dependencies.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { dependenciesAnalyzer } from "../../../src/analyzers/dependencies.js";
-import type { AnalysisContext } from "../../../src/core/types.js";
+import type { AnalysisContext, SourceFile } from "../../../src/core/types.js";
 
 const BASE: Omit<AnalysisContext, "files" | "packageJson" | "totalLines"> = {
   rootDir: "/test",
@@ -106,5 +106,73 @@ describe("dependencies analyzer", () => {
     };
     const findings = await dependenciesAnalyzer.analyze(ctx);
     expect(findings.find((f) => f.tags.includes("missing"))).toBeDefined();
+  });
+
+  it("does NOT flag import-like text inside comments or JSDoc as missing deps (AST path)", async () => {
+    const { parseFile } = await import("../../../src/utils/ast.js");
+
+    // This file has "import" patterns in comments and strings that the regex
+    // would match, but the AST path should ignore them.
+    const fileContent = `/**
+ * Usage:
+ *   import { renderReport } from "@vibedrift/cli/render";
+ */
+import { readFile } from "fs";
+
+// require('lodash') is mentioned here as documentation
+const msg = 'the shift from "interesting" to "I should fix this"';
+export function run() { return readFile("./x"); }
+`;
+    const file: SourceFile = {
+      path: "/test/src/example.ts",
+      relativePath: "src/example.ts",
+      language: "typescript" as const,
+      content: fileContent,
+      lineCount: fileContent.split("\n").length,
+    };
+    // Parse to get a real tree so the AST path is exercised
+    file.tree = (await parseFile(file)) ?? undefined;
+
+    const ctx: AnalysisContext = {
+      ...BASE,
+      files: [file],
+      packageJson: { name: "@vibedrift/cli", dependencies: {} },
+      totalLines: file.lineCount,
+    };
+    const findings = await dependenciesAnalyzer.analyze(ctx);
+    const missing = findings.find((f) => f.tags.includes("missing"));
+
+    // Should NOT report @vibedrift/cli (self-reference), lodash (in comment),
+    // or "interesting" (prose in a string) as missing
+    expect(missing).toBeUndefined();
+  });
+
+  it("still detects genuinely missing packages via AST", async () => {
+    const { parseFile } = await import("../../../src/utils/ast.js");
+
+    const fileContent = `import chalk from "chalk";\nimport { z } from "zod";\n`;
+    const file: SourceFile = {
+      path: "/test/src/real.ts",
+      relativePath: "src/real.ts",
+      language: "typescript" as const,
+      content: fileContent,
+      lineCount: 2,
+    };
+    file.tree = (await parseFile(file)) ?? undefined;
+
+    const ctx: AnalysisContext = {
+      ...BASE,
+      files: [file],
+      packageJson: { dependencies: { chalk: "^5.0.0" } }, // zod is NOT declared
+      totalLines: 2,
+    };
+    const findings = await dependenciesAnalyzer.analyze(ctx);
+    const missing = findings.find((f) => f.tags.includes("missing"));
+
+    // Should detect zod as missing (it's a real import, not in package.json)
+    expect(missing).toBeDefined();
+    expect(missing!.message).toContain("zod");
+    // chalk should NOT be flagged (it's declared)
+    expect(missing!.message).not.toContain("chalk");
   });
 });


### PR DESCRIPTION
## Summary

The dependency analyzer's `collectImportedPackages` runs regex patterns over raw file content, which matches import-like text inside JSDoc comments, documentation strings, and regex literals. Was producing false "missing package" reports. On VibeDrift's own repo, this created 12 false positives (`lodash` from a doc comment, `@vibedrift/cli` from a JSDoc usage example, `interesting` from prose, etc.).

**Fix:** Use `parseImportsAst(file.tree)` when the AST is available (always for JS/TS after `parseFiles` runs). The tree-sitter parser inherently knows what's a real import statement vs. text inside comments/strings, no matching edge cases. Falls back to regex for files without a parsed tree.

Also adds self-reference handling: the package's own name (`pkg.name`) is added to the declared set so importing yourself (e.g., `@vibedrift/cli/tools` in a skill script) isn't flagged as missing.

**Before (self-scan):** "12 packages imported but not in package.json: @vibedrift/cli, pkg, lodash, interesting, no surface..."  
**After:** Finding eliminated entirely. All 12 were false positives.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Closes #28
