### PR TITLE
Security Consistency: Python AST route and auth extraction

### DIFF
--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -58,9 +58,53 @@ const ROUTER_RECEIVER =
 // ROUTER_RECEIVER remain a documented recall gap, measured in Task 7 (S0) and
 // whole-phase gate item 7.
 const ROUTER_CONSTRUCTORS = new Set(["Blueprint", "APIRouter", "Flask", "FastAPI"]);
+// Auth decorators, matched by EXACT final name segment (never substring, so
+// @author_stats can never match). Flask-Login, flask-jwt-extended, flask-httpauth,
+// Django, DRF, and common custom names. Bare "requires" is deliberately NOT here:
+// it is a generic English verb whose final-segment match collides with
+// feature-flag / DI / marker decorators (@feature.requires("new_ui"),
+// @pytest.mark.requires). The bare-identifier call form @requires("admin") is
+// special-cased in isAuthDecorator; @anything.requires never matches.
+const AUTH_DECORATORS = new Set([
+  "login_required", "fresh_login_required", "jwt_required", "token_required",
+  "auth_required", "requires_auth", "require_auth", "permission_required",
+  "roles_required", "roles_accepted", "admin_required", "staff_required",
+  "superuser_required", "verify_token", "authenticated",
+]);
+// FastAPI Depends(...)/Security(...) auth recognition is SEGMENT-based, applied to
+// the dependency's RESOLVED NAME only (identifier, dotted attribute, or a class
+// dependency's callee: Depends(JWTBearer())), never to raw expression text. The
+// name is split on underscore AND CamelCase boundaries (nameSegments), lowercased,
+// then:
+//   hit  = any single segment in DEPENDS_AUTH_SEGMENTS, or any ADJACENT segment
+//          pair in DEPENDS_AUTH_PAIRS. Whole segments make substring blessing
+//          structurally impossible: get_author_stats is [get, author, stats] and
+//          "author" is not "auth"; JWTBearer is [jwt, bearer] and hits.
+//   veto = any segment in DEPENDS_VETO_SEGMENTS cancels a hit and resolves FALSE:
+//          optional-auth dependencies (get_current_user_optional,
+//          get_current_user_or_none) admit anonymous requests, and settings /
+//          config / stats / url dependencies (get_jwt_settings,
+//          get_api_key_usage_stats) are not auth enforcement. Ambiguity resolves
+//          to false, per the invariant.
+const DEPENDS_AUTH_SEGMENTS = new Set([
+  "auth", "authenticate", "authenticated", "jwt", "oauth", "oauth2", "bearer",
+]);
+const DEPENDS_AUTH_PAIRS = new Set([
+  "current user", "active user", "api key", "verify token", "validate token",
+  "require auth", "requires auth", "require admin", "require user", "require login",
+  "auth required", "check auth", "logged in",
+]);
+const DEPENDS_VETO_SEGMENTS = new Set([
+  "optional", "maybe", "anonymous", "none", "settings", "setting", "config",
+  "params", "options", "url", "urls", "stats", "metrics", "usage",
+]);
+const VAL_NAMES = /(?:pydantic|validate|validator|schema|serializer|marshmallow)/i;
+const RATE_NAMES = /(?:rate_?limit|throttle|limiter|slowapi|slowdown)/i;
 
 export const SECURITY_AST_PY = {
   ROUTE_METHODS, HTTP_VERBS, MUTATING_VERBS, ROUTER_RECEIVER, ROUTER_CONSTRUCTORS,
+  AUTH_DECORATORS, DEPENDS_AUTH_SEGMENTS, DEPENDS_AUTH_PAIRS, DEPENDS_VETO_SEGMENTS,
+  VAL_NAMES, RATE_NAMES,
 };
 
 /** Value of a Python string-ish path argument with quotes AND prefixes stripped.
@@ -197,6 +241,140 @@ function resolveMethod(attr: string, args: SyntaxNode): string {
   return verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0];
 }
 
+/** Final name segment of a decorator expression: "login_required" for
+ *  @login_required, @auth.login_required, @flask_login.login_required. */
+function decoratorName(expr: SyntaxNode): string | null {
+  if (expr.type === "identifier") return expr.text;
+  if (expr.type === "attribute") return expr.childForFieldName("attribute")?.text ?? null;
+  return null;
+}
+
+/** Lowercase segments of an identifier, split on underscore/non-alphanumeric AND
+ *  CamelCase boundaries (digits stay attached to their run):
+ *  "get_author_stats" -> [get, author, stats]; "JWTBearer" -> [jwt, bearer];
+ *  "OAuth2PasswordBearer" -> [o, auth2, password, bearer]. Whole-segment matching
+ *  makes substring blessing structurally impossible. */
+function nameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((s) => s.length > 0);
+}
+
+/** Segment-matched auth verdict for a resolved dependency name (see the constants
+ *  block): hit on a single DEPENDS_AUTH_SEGMENTS segment or an adjacent
+ *  DEPENDS_AUTH_PAIRS pair; ANY DEPENDS_VETO_SEGMENTS segment cancels the hit
+ *  (optional / settings / stats flavored dependencies resolve false). */
+function dependsNameIsAuth(name: string): boolean {
+  const segs = nameSegments(name);
+  if (segs.some((s) => DEPENDS_VETO_SEGMENTS.has(s))) return false;
+  if (segs.some((s) => DEPENDS_AUTH_SEGMENTS.has(s))) return true;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (DEPENDS_AUTH_PAIRS.has(`${segs[i]} ${segs[i + 1]}`)) return true;
+  }
+  return false;
+}
+
+/** The NAME a Depends/Security argument resolves to: an identifier's text, an
+ *  attribute's dotted text, or, for a class dependency Depends(JWTBearer()), the
+ *  call's OWN callee name (never its arguments). Anything else (lambda, subscript,
+ *  literal) resolves null: matching raw expression text would let a nested string
+ *  or kwarg bless (Depends(make_client("oauth2_url")) must stay false). */
+function dependencyTargetName(target: SyntaxNode): string | null {
+  if (target.type === "identifier" || target.type === "attribute") return target.text;
+  if (target.type === "call") {
+    const fn = target.childForFieldName("function");
+    if (fn && (fn.type === "identifier" || fn.type === "attribute")) return fn.text;
+  }
+  return null;
+}
+
+/** The value node of a `name=` kwarg on a call, or null when absent. */
+function kwargValue(call: SyntaxNode, kwarg: string): SyntaxNode | null {
+  const args = call.childForFieldName("arguments");
+  if (!args) return null;
+  for (const n of args.namedChildren) {
+    if (
+      n !== null &&
+      n.type === "keyword_argument" &&
+      n.childForFieldName("name")?.text === kwarg
+    ) {
+      return n.childForFieldName("value");
+    }
+  }
+  return null;
+}
+
+function isAuthDecorator(dec: SyntaxNode): boolean {
+  const expr = dec.namedChild(0);
+  if (!expr) return false;
+  if (expr.type === "identifier" || expr.type === "attribute") {
+    const name = decoratorName(expr);
+    return name !== null && AUTH_DECORATORS.has(name);
+  }
+  if (expr.type === "call") {
+    const fn = expr.childForFieldName("function");
+    if (!fn) return false;
+    const name = decoratorName(fn);
+    // Bare "requires" counts ONLY in its bare-identifier form @requires(...):
+    // @feature.requires("new_ui") / @pytest.mark.requires are feature-flag and
+    // marker decorators, not auth.
+    const recognized =
+      (name !== null && AUTH_DECORATORS.has(name)) ||
+      (fn.type === "identifier" && fn.text === "requires");
+    if (!recognized) return false;
+    // flask-jwt-extended: @jwt_required(optional=True) admits anonymous requests.
+    // ANY optional= value other than the literal False counts as optional
+    // (optional=SOME_FLAG is statically unknowable; ambiguity resolves to false,
+    // never toward a bless).
+    const optional = kwargValue(expr, "optional");
+    return optional === null || optional.text === "False";
+  }
+  return false;
+}
+
+/** Any Depends(...)/Security(...) call under `scope` whose RESOLVED dependency
+ *  name matches the segment lexicon. Bare Depends(), an unresolvable target, or a
+ *  vetoed name resolves false. */
+function callsWithAuthDependency(scope: SyntaxNode): boolean {
+  for (const call of scope.descendantsOfType("call")) {
+    if (!call) continue;
+    const fn = call.childForFieldName("function");
+    if (!fn || fn.type !== "identifier") continue;
+    if (fn.text !== "Depends" && fn.text !== "Security") continue;
+    const target = call.childForFieldName("arguments")?.namedChild(0);
+    const name = target ? dependencyTargetName(target) : null;
+    if (name !== null && dependsNameIsAuth(name)) return true;
+  }
+  return false;
+}
+
+/** FastAPI parameter dependencies: one descendant-call walk over the parameters
+ *  node covers plain defaults (default_parameter), typed defaults
+ *  (typed_default_parameter), and Annotated[T, Depends(...)] (typed_parameter,
+ *  where the call nests under the TYPE field's generic_type). */
+function paramsHaveAuthDependency(definition: SyntaxNode): boolean {
+  const params = definition.childForFieldName("parameters");
+  return params ? callsWithAuthDependency(params) : false;
+}
+
+/** Route-decorator-level dependencies kwarg:
+ *  @router.post("/x", dependencies=[Depends(verify_token)]). */
+function routeCallHasAuthDependency(call: SyntaxNode): boolean {
+  const args = call.childForFieldName("arguments");
+  if (!args) return false;
+  const kw = args.namedChildren.find(
+    (n) =>
+      n !== null &&
+      n.type === "keyword_argument" &&
+      n.childForFieldName("name")?.text === "dependencies",
+  );
+  const value = kw?.childForFieldName("value");
+  return value ? callsWithAuthDependency(value) : false;
+}
+
 export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectRouterNames(tree.rootNode);
@@ -209,12 +387,31 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const decorators = dd.namedChildren.filter(
       (n): n is SyntaxNode => n !== null && n.type === "decorator",
     );
-    // Per-route signals land in Task 3; receiver-scoped middleware inheritance
-    // lands in Task 4. Task 1 emits structurally-correct routes with the
-    // never-false-bless default.
-    const perAuth = false;
-    const perVal = false;
-    const perRate = false;
+    // Auth decorators bind POSITIONALLY. Python decorators apply bottom-up, so an
+    // auth decorator protects a route only when it is applied BEFORE the route
+    // decorator registers the handler, i.e. only when it sits BELOW that route
+    // decorator (strictly greater start row). @login_required stacked ABOVE
+    // @app.route leaves the url_map holding the unwrapped handler: genuinely
+    // unauthed at runtime, so it must not bless.
+    const authDecoratorRows = decorators
+      .filter(isAuthDecorator)
+      .map((d) => d.startPosition.row);
+    const paramAuth = paramsHaveAuthDependency(definition);
+    // Validation / rate-limit lanes match NON-ROUTE decorator CALLEE NAMES only
+    // (@limiter.limit -> "limiter.limit", @validate_schema -> "validate_schema"),
+    // never argument or path text: @app.post("/validate") is a path, not
+    // validation middleware, and must not bless its lane.
+    const laneNames = decorators
+      .filter((d) => asRouteDecorator(d, routerNames) === null)
+      .map((d) => {
+        const expr = d.namedChild(0);
+        if (!expr) return "";
+        if (expr.type === "call") return expr.childForFieldName("function")?.text ?? "";
+        return expr.text;
+      })
+      .filter((t) => t.length > 0);
+    const perVal = laneNames.some((t) => VAL_NAMES.test(t));
+    const perRate = laneNames.some((t) => RATE_NAMES.test(t));
     for (const dec of decorators) {
       const route = asRouteDecorator(dec, routerNames);
       if (!route) continue;
@@ -226,7 +423,10 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
         // not the def line): regex parity, and the @vibedrift-public suppression
         // binding depends on it.
         line: dec.startPosition.row + 1,
-        hasAuth: perAuth,
+        hasAuth:
+          authDecoratorRows.some((row) => row > dec.startPosition.row) ||
+          paramAuth ||
+          routeCallHasAuthDependency(route.call),
         hasValidation: perVal,
         hasRateLimit: perRate,
         hasErrorHandler: false, // write-only field; JS AST extractor hard-codes false too

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -32,6 +32,10 @@
  * vote (matching how an Express `.all()` route is treated). This is a real,
  * user-visible behavior change from today's regex path, not a bug fix; it is
  * called out here for explicit sign-off rather than shipped silently.
+ * `asApiViewDecorator` follows the SAME ALL-on-unresolvable convention: an
+ * `@api_view([METHOD])` / `@api_view([*BASE])` list whose only verbs are hidden
+ * behind a variable resolves to "ALL", not GET. Same open question, same
+ * pending sign-off.
  *
  * DJANGO REST SCOPE (best-effort, function views only): `@api_view(["POST"])`
  * routes are recognized; the URL lives in `urls.py` and cross-file resolution
@@ -117,6 +121,14 @@ const RATE_NAMES = /(?:rate_?limit|throttle|limiter|slowapi|slowdown)/i;
 // hooks that do not authenticate. Whole-segment matching makes substring blessing
 // structurally impossible.
 const AUTH_CORE_SEGMENTS = new Set(["auth", "authenticate", "authenticated"]);
+// LEXICON NOTE (pending owner lexicon sign-off): these two sets are broader than
+// the plan's Integration contract. Beyond the contract, ENFORCE adds
+// verify/verified, protect/protected, restrict/restricted, and SUBJECT adds
+// users, jwt, role(s), admin, credentials. The additions expand the two-tier
+// (ENFORCE + SUBJECT) bless surface, so the closest non-auth neighbors are pinned
+// FALSE by boundary tests (restricted_zone_redirect, track_user_metrics,
+// role_labels, protect_branch) to keep the surface explicit. The sets are left
+// UNCHANGED here; any narrowing waits on the owner's lexicon decision.
 const AUTH_ENFORCE_SEGMENTS = new Set([
   "require", "required", "requires", "verify", "verified", "ensure",
   "protect", "protected", "restrict", "restricted",
@@ -125,6 +137,14 @@ const AUTH_SUBJECT_SEGMENTS = new Set([
   "login", "token", "user", "users", "session", "jwt", "permission",
   "permissions", "role", "roles", "admin", "credentials",
 ]);
+// Optionality-flavored veto, the subset of DEPENDS_VETO_SEGMENTS that signals an
+// auth check which ADMITS unauthenticated requests. Applied to before_request
+// HOOK names (nameHasAuthToken) and add_middleware CLASS names so an
+// optional_authenticate hook or an OptionalAuthMiddleware never blesses, exactly
+// as Depends(optional_auth) already does not. Only the optionality members are
+// carried here: the settings/config/stats/url vetoes are Depends-argument-shape
+// specific and do not generalize to hook/middleware names.
+const OPTIONAL_AUTH_VETO = new Set(["optional", "maybe", "anonymous", "none"]);
 // Middleware CLASS-NAME auth segments for app.add_middleware(X). Matched by WHOLE
 // CamelCase/underscore segment on the class name ONLY (never the whole arg text):
 // AuthMiddleware and AuthenticationMiddleware bless, AuthorTrackingMiddleware does
@@ -146,7 +166,7 @@ export const SECURITY_AST_PY = {
   ROUTE_METHODS, HTTP_VERBS, MUTATING_VERBS, ROUTER_RECEIVER, ROUTER_CONSTRUCTORS,
   AUTH_DECORATORS, DEPENDS_AUTH_SEGMENTS, DEPENDS_AUTH_PAIRS, DEPENDS_VETO_SEGMENTS,
   VAL_NAMES, RATE_NAMES, AUTH_CORE_SEGMENTS, AUTH_ENFORCE_SEGMENTS,
-  AUTH_SUBJECT_SEGMENTS, MIDDLEWARE_AUTH_SEGMENTS, PERMISSION_AUTH,
+  AUTH_SUBJECT_SEGMENTS, OPTIONAL_AUTH_VETO, MIDDLEWARE_AUTH_SEGMENTS, PERMISSION_AUTH,
 };
 
 /** Value of a Python string-ish path argument with quotes AND prefixes stripped.
@@ -296,11 +316,24 @@ function asApiViewDecorator(dec: SyntaxNode, definition: SyntaxNode): PyRoute | 
   const list = expr.childForFieldName("arguments")?.namedChild(0);
   let method = "GET"; // DRF default when @api_view() has no args
   if (list && ["list", "tuple", "set"].includes(list.type)) {
-    const verbs = list.namedChildren
-      .filter((n): n is SyntaxNode => n !== null && n.type === "string")
+    const children = list.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    const verbs = children
+      .filter((n) => n.type === "string")
       .map((s) => (pyStringText(s) ?? "").toUpperCase())
       .filter((v) => HTTP_VERBS.has(v));
-    method = verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0] ?? "GET";
+    // A non-string element (a variable verb: @api_view([METHOD]) or
+    // @api_view([*BASE])) is statically unresolvable. Following the module's
+    // ALL-on-unresolvable convention (resolveMethod, pending the owner sign-off
+    // in the header OPEN QUESTION), an unresolvable list with no visible literal
+    // verb resolves ALL so the route STAYS in the mutating vote rather than
+    // silently defaulting GET; a visible literal still resolves it normally.
+    const hidden = children.some((n) => n.type !== "string");
+    method =
+      verbs.length === 0
+        ? hidden
+          ? "ALL"
+          : "GET"
+        : (verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0]);
   } else if (list) {
     method = "ALL"; // verbs behind a variable: keep the route in the mutating vote
   }
@@ -359,6 +392,9 @@ function nameSegments(name: string): string[] {
  *  authenticate. Substring blessing is structurally impossible (segments). */
 function nameHasAuthToken(name: string): boolean {
   const segs = nameSegments(name);
+  // Optional-auth veto first: optional_authenticate / maybe_require_login admit
+  // anonymous requests, so they never bless (mirrors the Depends path).
+  if (segs.some((s) => OPTIONAL_AUTH_VETO.has(s))) return false;
   if (segs.some((s) => AUTH_CORE_SEGMENTS.has(s))) return true;
   return (
     segs.some((s) => AUTH_ENFORCE_SEGMENTS.has(s)) &&
@@ -554,8 +590,14 @@ function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
       // Middleware CLASS NAME only (never the whole arg text), matched by WHOLE
       // CamelCase/underscore segment: AuthMiddleware and AuthenticationMiddleware
       // bless, AuthorTrackingMiddleware does not (the segment "author" is not
-      // "auth"; same discipline as decorators and Depends targets).
-      if (nameSegments(mwName).some((s) => MIDDLEWARE_AUTH_SEGMENTS.has(s))) {
+      // "auth"; same discipline as decorators and Depends targets). The
+      // optional-auth veto cancels a hit: OptionalAuthMiddleware admits anonymous
+      // requests, so it must not bless (mirrors the Depends path).
+      const mwSegs = nameSegments(mwName);
+      if (
+        mwSegs.some((s) => MIDDLEWARE_AUTH_SEGMENTS.has(s)) &&
+        !mwSegs.some((s) => OPTIONAL_AUTH_VETO.has(s))
+      ) {
         mark(receiver, false, "hasAuth");
       }
       if (/[Ll]imit/.test(mwName) || RATE_NAMES.test(mwName)) mark(receiver, false, "hasRateLimit");
@@ -619,11 +661,16 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const authDecoratorRows = decorators
       .filter(isAuthDecorator)
       .map((d) => d.startPosition.row);
-    // @permission_classes([IsAuthenticated]) is a POSITIONAL auth decorator too
-    // (DRF: it must sit BELOW @api_view or it is never enforced), so it folds
-    // into the same rows array and the same "row > dec.startPosition.row" check
-    // below.
-    authDecoratorRows.push(...decorators.filter(isAuthPermissionClasses).map((d) => d.startPosition.row));
+    // @permission_classes([IsAuthenticated]) is DRF-only and runtime-inert when
+    // stacked under a Flask (@app.route) or FastAPI (@router.post) route
+    // decorator, so its rows are collected SEPARATELY and may bless ONLY an
+    // api_view-derived route (never a co-located @app/@router route in the same
+    // decorated_definition). DRF's own positional rule still applies: a
+    // permission_classes decorator counts only when it sits BELOW @api_view
+    // (row > the api_view decorator's row), enforced by the same check below.
+    const permissionClassRows = decorators
+      .filter(isAuthPermissionClasses)
+      .map((d) => d.startPosition.row);
     const paramAuth = paramsHaveAuthDependency(definition);
     // Validation / rate-limit lanes match NON-ROUTE decorator CALLEE NAMES only
     // (@limiter.limit -> "limiter.limit", @validate_schema -> "validate_schema"),
@@ -641,8 +688,14 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const perVal = laneNames.some((t) => VAL_NAMES.test(t));
     const perRate = laneNames.some((t) => RATE_NAMES.test(t));
     for (const dec of decorators) {
-      const route = asRouteDecorator(dec, routerNames) ?? asApiViewDecorator(dec, definition);
+      const routeFromDecorator = asRouteDecorator(dec, routerNames);
+      // asApiViewDecorator is only consulted when the decorator is not already a
+      // router/app route, so the api_view-only permission_classes bless below can
+      // key off apiViewRoute !== null.
+      const apiViewRoute = routeFromDecorator ? null : asApiViewDecorator(dec, definition);
+      const route = routeFromDecorator ?? apiViewRoute;
       if (!route) continue;
+      const fromApiView = apiViewRoute !== null;
       routes.push({
         method: route.method,
         path: route.path,
@@ -653,6 +706,8 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
         line: dec.startPosition.row + 1,
         hasAuth:
           authDecoratorRows.some((row) => row > dec.startPosition.row) ||
+          (fromApiView &&
+            permissionClassRows.some((row) => row > dec.startPosition.row)) ||
           paramAuth ||
           routeCallHasAuthDependency(route.call) ||
           scopes.global.hasAuth ||

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -121,14 +121,23 @@ const RATE_NAMES = /(?:rate_?limit|throttle|limiter|slowapi|slowdown)/i;
 // hooks that do not authenticate. Whole-segment matching makes substring blessing
 // structurally impossible.
 const AUTH_CORE_SEGMENTS = new Set(["auth", "authenticate", "authenticated"]);
-// LEXICON NOTE (pending owner lexicon sign-off): these two sets are broader than
-// the plan's Integration contract. Beyond the contract, ENFORCE adds
-// verify/verified, protect/protected, restrict/restricted, and SUBJECT adds
-// users, jwt, role(s), admin, credentials. The additions expand the two-tier
-// (ENFORCE + SUBJECT) bless surface, so the closest non-auth neighbors are pinned
-// FALSE by boundary tests (restricted_zone_redirect, track_user_metrics,
-// role_labels, protect_branch) to keep the surface explicit. The sets are left
-// UNCHANGED here; any narrowing waits on the owner's lexicon decision.
+// KNOWN FALSE-BLESS EXPOSURE (owner decision required): the ENFORCE+SUBJECT
+// two-tier match blesses attributive non-auth hook names such as
+// verify_user_email (email-confirmation flow) and protect_user_data (data
+// scrubbing): ENFORCE verb + SUBJECT noun both match even though the hook
+// does not authenticate. This shape exists in the plan's pinned sets as well
+// (verify + user), so it is inherent to the two-tier design, not only to the
+// additions. Resolution options for the owner: narrow the ENFORCE x SUBJECT
+// cross-product, add attributive vetoes (subject followed by an object noun
+// like email/data/profile), or accept as documented risk. Blessing suppresses
+// findings, so this is the false-bless direction, never a safe over-flag.
+// Also note: verify_token in AUTH_DECORATORS matches flask-httpauth's
+// @auth.verify_token registration decorator, which is not a route wrapper;
+// if stacked on a route handler it would leak-bless (non-idiomatic, low
+// risk). The closest non-auth neighbors are pinned FALSE by boundary tests
+// (restricted_zone_redirect, track_user_metrics, role_labels, protect_branch)
+// to keep the surface explicit. The sets are left UNCHANGED here; any
+// narrowing waits on the owner's lexicon decision.
 const AUTH_ENFORCE_SEGMENTS = new Set([
   "require", "required", "requires", "verify", "verified", "ensure",
   "protect", "protected", "restrict", "restricted",

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -1,0 +1,187 @@
+/**
+ * AST-based route extraction for Python (Flask, FastAPI), used by
+ * security-consistency.ts in place of the regex line-window extractor
+ * whenever a parsed tree is available and clean. Mirrors the shipped JS/TS
+ * design in src/drift/security-ast.ts.
+ *
+ * A find-replace port from that file fails silently on four Python grammar
+ * traps:
+ *   1. Node names differ: a Python call is `call`, not `call_expression`;
+ *      a Python member access is `attribute`, not `member_expression`.
+ *      Both JS names are simply absent from the Python grammar.
+ *   2. The member-name field on `attribute` is called `attribute`, not
+ *      `property`.
+ *   3. String prefixes (`f"`, `r"`, `"""`) live in the `string_start` token,
+ *      not a fixed one-character slice; `text.slice(1, -1)` corrupts
+ *      f-strings, raw strings, and triple-quoted strings.
+ *   4. `typed_parameter` (an `Annotated[...]` parameter) has NO `name`
+ *      field; the name is `namedChild(0)`.
+ *
+ * INVARIANT SCOPE: the never-false-bless guarantee (never mark an unauthed
+ * route as authed) holds on THIS AST path only. A file with a parse error
+ * anywhere (`tree.rootNode.hasError`) is routed whole to the existing regex
+ * extractor, which keeps its legacy over-blesses (the 30-line token/
+ * permission window and the file-level login_required bless) unchanged.
+ */
+
+import type { Tree, SyntaxNode } from "../core/types.js";
+import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
+
+// Route-registration attribute names on a router-like receiver.
+const ROUTE_METHODS = new Set(["route", "get", "post", "put", "patch", "delete", "api_route"]);
+// Verbs a methods=[...] kwarg may contribute (same set the regex extractor accepts).
+const HTTP_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
+const MUTATING_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+// Receivers that plausibly register routes. Python conventions differ from JS:
+// Flask blueprints are *_bp / *_blueprint, FastAPI routers *_router, versioned
+// registrars v1 / api_v1. ASCII only (a unicode receiver is a recognition miss,
+// never a bless). This is the NAME-CONVENTION FALLBACK only: receivers are first
+// resolved STRUCTURALLY via ROUTER_CONSTRUCTORS below, so bare-name blueprints
+// (main, auth, admin: the flasky layout) extract whenever their constructor is
+// visible in the file.
+const ROUTER_RECEIVER =
+  /^(?:app|application|server|router|api|bp|blueprint|v\d+|api_v\d+|[a-z][a-z0-9_]*_(?:bp|blueprint|router|api))$/;
+// Structural receiver resolution: any identifier assigned from one of these
+// constructors ANYWHERE in the file is a route receiver regardless of spelling
+// (main = Blueprint("main", __name__) makes @main.route extractable, matching the
+// shipped regex's recall on bare names). Imported receivers whose name also misses
+// ROUTER_RECEIVER remain a documented recall gap, measured in Task 7 (S0) and
+// whole-phase gate item 7.
+const ROUTER_CONSTRUCTORS = new Set(["Blueprint", "APIRouter", "Flask", "FastAPI"]);
+
+export const SECURITY_AST_PY = {
+  ROUTE_METHODS, HTTP_VERBS, MUTATING_VERBS, ROUTER_RECEIVER, ROUTER_CONSTRUCTORS,
+};
+
+/** Value of a Python string-ish path argument with quotes AND prefixes stripped.
+ *  - string: node.text minus string_start/string_end token lengths (handles plain,
+ *    raw, f-strings, triple quotes). Interpolation braces survive in .text, so an
+ *    f-string whose FIRST piece is dynamic yields a value starting "{" and fails
+ *    the caller's leading-slash gate naturally.
+ *  - concatenated_string ("/api" "/x"): joined values of its string children.
+ *  - anything else (binary_operator, identifier): null (statically unresolvable;
+ *    the route is skipped: a miss is safe, a guessed path is not). */
+function pyStringText(node: SyntaxNode): string | null {
+  if (node.type === "concatenated_string") {
+    const parts = node.namedChildren
+      .filter((n): n is SyntaxNode => n !== null && n.type === "string")
+      .map(pyStringText);
+    if (parts.length === 0 || parts.some((p) => p === null)) return null;
+    return parts.join("");
+  }
+  if (node.type !== "string") return null;
+  const named = node.namedChildren.filter((n): n is SyntaxNode => n !== null);
+  const start = named.find((n) => n.type === "string_start");
+  const end = named.find((n) => n.type === "string_end");
+  if (!start || !end) return null;
+  return node.text.slice(start.text.length, node.text.length - end.text.length);
+}
+
+/** Receiver identifier of `X.method(...)`: "app" for app.route, and the NEAREST
+ *  attribute name for nested receivers (self.app.route resolves to "app"),
+ *  mirroring the JS receiverName. */
+function receiverName(objNode: SyntaxNode | null): string | null {
+  if (!objNode) return null;
+  if (objNode.type === "identifier") return objNode.text;
+  if (objNode.type === "attribute") return objNode.childForFieldName("attribute")?.text ?? null;
+  return null;
+}
+
+/** Path from the first positional string arg, or the path= kwarg when no positional
+ *  string leads (FastAPI allows @router.post(path="/items")). */
+function routePath(argList: SyntaxNode): string | null {
+  const named = argList.namedChildren.filter((n): n is SyntaxNode => n !== null);
+  const first = named[0];
+  if (first && (first.type === "string" || first.type === "concatenated_string")) {
+    return pyStringText(first);
+  }
+  const pathKw = named.find(
+    (n) => n.type === "keyword_argument" && n.childForFieldName("name")?.text === "path",
+  );
+  const value = pathKw?.childForFieldName("value");
+  return value && (value.type === "string" || value.type === "concatenated_string")
+    ? pyStringText(value)
+    : null;
+}
+
+interface PyRoute { method: string; path: string; call: SyntaxNode; receiver: string; }
+
+/** Identifiers assigned (anywhere in the file) from a router constructor:
+ *  main = Blueprint("main", __name__), router = APIRouter(), app = Flask(__name__).
+ *  Structural resolution first, spelling-convention fallback second: bare-name
+ *  blueprints (main/auth/admin, the flasky layout the shipped regex extracts)
+ *  must not silently drop out of the vote because their name misses
+ *  ROUTER_RECEIVER. */
+function collectRouterNames(root: SyntaxNode): Set<string> {
+  const names = new Set<string>();
+  for (const asn of root.descendantsOfType("assignment")) {
+    if (!asn) continue;
+    const left = asn.childForFieldName("left");
+    const right = asn.childForFieldName("right");
+    if (!left || left.type !== "identifier" || !right || right.type !== "call") continue;
+    const fn = right.childForFieldName("function");
+    if (fn && fn.type === "identifier" && ROUTER_CONSTRUCTORS.has(fn.text)) names.add(left.text);
+  }
+  return names;
+}
+
+function asRouteDecorator(dec: SyntaxNode, routerNames: Set<string>): PyRoute | null {
+  const expr = dec.namedChild(0);
+  if (!expr || expr.type !== "call") return null;
+  const fn = expr.childForFieldName("function");
+  const args = expr.childForFieldName("arguments");
+  // Identifier callees (@api_view) get their own branch in Task 5; the receiver
+  // gate below applies only to app/router-style attribute callees.
+  if (!fn || !args || fn.type !== "attribute") return null;
+  const attr = fn.childForFieldName("attribute")?.text ?? "";
+  if (!ROUTE_METHODS.has(attr)) return null;
+  const receiver = receiverName(fn.childForFieldName("object"));
+  if (!receiver || !(routerNames.has(receiver) || ROUTER_RECEIVER.test(receiver))) return null;
+  const path = routePath(args);
+  if (path === null || !path.startsWith("/")) return null; // leading-slash gate, same as JS
+  return { method: resolveMethod(attr, args), path, call: expr, receiver };
+}
+
+function resolveMethod(attr: string, _args: SyntaxNode): string {
+  if (attr !== "route" && attr !== "api_route") return attr.toUpperCase();
+  return "GET"; // Flask default; the methods= kwarg lands in Task 2
+}
+
+export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
+  const routes: RouteInfo[] = [];
+  const routerNames = collectRouterNames(tree.rootNode);
+  for (const dd of tree.rootNode.descendantsOfType("decorated_definition")) {
+    // Error recovery can merge adjacent handlers' decorators into one dd;
+    // blessing (or even extracting) across that boundary is forbidden.
+    if (!dd || dd.hasError) continue;
+    const definition = dd.childForFieldName("definition");
+    if (!definition || definition.type !== "function_definition") continue; // @dataclass wraps class_definition
+    const decorators = dd.namedChildren.filter(
+      (n): n is SyntaxNode => n !== null && n.type === "decorator",
+    );
+    // Per-route signals land in Task 3; receiver-scoped middleware inheritance
+    // lands in Task 4. Task 1 emits structurally-correct routes with the
+    // never-false-bless default.
+    const perAuth = false;
+    const perVal = false;
+    const perRate = false;
+    for (const dec of decorators) {
+      const route = asRouteDecorator(dec, routerNames);
+      if (!route) continue;
+      routes.push({
+        method: route.method,
+        path: route.path,
+        file: filePath,
+        // 1-based, the route decorator's OWN line (not the dd's first decorator,
+        // not the def line): regex parity, and the @vibedrift-public suppression
+        // binding depends on it.
+        line: dec.startPosition.row + 1,
+        hasAuth: perAuth,
+        hasValidation: perVal,
+        hasRateLimit: perRate,
+        hasErrorHandler: false, // write-only field; JS AST extractor hard-codes false too
+      });
+    }
+  }
+  return routes;
+}

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -32,6 +32,13 @@
  * vote (matching how an Express `.all()` route is treated). This is a real,
  * user-visible behavior change from today's regex path, not a bug fix; it is
  * called out here for explicit sign-off rather than shipped silently.
+ *
+ * DJANGO REST SCOPE (best-effort, function views only): `@api_view(["POST"])`
+ * routes are recognized; the URL lives in `urls.py` and cross-file resolution
+ * is an explicit non-goal, so the path is synthesized as `"/" + handler name`.
+ * Class-based `APIView`/`ViewSet` and `urls.py` `path(...)` registrations emit
+ * ZERO routes in Sub-Phase A. DRF settings-level default permissions are
+ * unknowable statically and never bless.
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
@@ -126,12 +133,20 @@ const AUTH_SUBJECT_SEGMENTS = new Set([
 const MIDDLEWARE_AUTH_SEGMENTS = new Set([
   "auth", "authentication", "authenticate", "authenticated", "jwt", "oauth", "oauth2", "bearer",
 ]);
+// DRF @permission_classes([...]) EXACT class names that unconditionally require
+// an authenticated request. Deliberately narrow: AllowAny never requires auth;
+// IsAuthenticatedOrReadOnly and DjangoModelPermissionsOrAnonReadOnly only require
+// auth for unsafe (write) methods, which is a per-method condition this
+// route-level check cannot statically resolve, so they are NOT here; any other
+// built-in or custom permission class is unrecognized. Per the never-false-bless
+// invariant, ambiguity and the unrecognized case both resolve to false.
+const PERMISSION_AUTH = new Set(["IsAuthenticated"]);
 
 export const SECURITY_AST_PY = {
   ROUTE_METHODS, HTTP_VERBS, MUTATING_VERBS, ROUTER_RECEIVER, ROUTER_CONSTRUCTORS,
   AUTH_DECORATORS, DEPENDS_AUTH_SEGMENTS, DEPENDS_AUTH_PAIRS, DEPENDS_VETO_SEGMENTS,
   VAL_NAMES, RATE_NAMES, AUTH_CORE_SEGMENTS, AUTH_ENFORCE_SEGMENTS,
-  AUTH_SUBJECT_SEGMENTS, MIDDLEWARE_AUTH_SEGMENTS,
+  AUTH_SUBJECT_SEGMENTS, MIDDLEWARE_AUTH_SEGMENTS, PERMISSION_AUTH,
 };
 
 /** Value of a Python string-ish path argument with quotes AND prefixes stripped.
@@ -266,6 +281,51 @@ function resolveMethod(attr: string, args: SyntaxNode): string {
   const hidden = children.some((n) => n.type !== "string");
   if (verbs.length === 0) return hidden ? "ALL" : "GET"; // [*BASE] vs literal []
   return verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0];
+}
+
+/** Django REST function views: @api_view(["POST"]). Identifier callee, NOT an
+ *  attribute, so the router-receiver gate does not apply here. Path is
+ *  synthesized from the handler name (urls.py resolution is a non-goal). */
+function asApiViewDecorator(dec: SyntaxNode, definition: SyntaxNode): PyRoute | null {
+  const expr = dec.namedChild(0);
+  if (!expr || expr.type !== "call") return null;
+  const fn = expr.childForFieldName("function");
+  if (!fn || fn.type !== "identifier" || fn.text !== "api_view") return null;
+  const fnName = definition.childForFieldName("name")?.text;
+  if (!fnName) return null;
+  const list = expr.childForFieldName("arguments")?.namedChild(0);
+  let method = "GET"; // DRF default when @api_view() has no args
+  if (list && ["list", "tuple", "set"].includes(list.type)) {
+    const verbs = list.namedChildren
+      .filter((n): n is SyntaxNode => n !== null && n.type === "string")
+      .map((s) => (pyStringText(s) ?? "").toUpperCase())
+      .filter((v) => HTTP_VERBS.has(v));
+    method = verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0] ?? "GET";
+  } else if (list) {
+    method = "ALL"; // verbs behind a variable: keep the route in the mutating vote
+  }
+  // No receiver: DRF function views register via urls.py, not on a router
+  // variable. The empty string matches no byReceiver scope, so only global
+  // (app-scoped) middleware can ever inherit onto these routes.
+  return { method, path: `/${fnName}`, call: expr, receiver: "" };
+}
+
+/** @permission_classes([IsAuthenticated]) as a POSITIONAL auth decorator.
+ *  AllowAny, an empty list, or an unrecognized class resolves false. Position
+ *  matters (DRF: it must sit BELOW @api_view or it is never enforced), so this is
+ *  a per-decorator predicate feeding the same authDecoratorRows mechanism as the
+ *  Flask auth decorators. */
+function isAuthPermissionClasses(dec: SyntaxNode): boolean {
+  const expr = dec.namedChild(0);
+  if (!expr || expr.type !== "call") return false;
+  const fn = expr.childForFieldName("function");
+  if (!fn || fn.type !== "identifier" || fn.text !== "permission_classes") return false;
+  const list = expr.childForFieldName("arguments")?.namedChild(0);
+  if (!list) return false;
+  const names = list.namedChildren
+    .filter((n): n is SyntaxNode => n !== null)
+    .map((n) => (n.type === "attribute" ? (n.childForFieldName("attribute")?.text ?? "") : n.text));
+  return names.some((n) => PERMISSION_AUTH.has(n));
 }
 
 /** Final name segment of a decorator expression: "login_required" for
@@ -559,6 +619,11 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const authDecoratorRows = decorators
       .filter(isAuthDecorator)
       .map((d) => d.startPosition.row);
+    // @permission_classes([IsAuthenticated]) is a POSITIONAL auth decorator too
+    // (DRF: it must sit BELOW @api_view or it is never enforced), so it folds
+    // into the same rows array and the same "row > dec.startPosition.row" check
+    // below.
+    authDecoratorRows.push(...decorators.filter(isAuthPermissionClasses).map((d) => d.startPosition.row));
     const paramAuth = paramsHaveAuthDependency(definition);
     // Validation / rate-limit lanes match NON-ROUTE decorator CALLEE NAMES only
     // (@limiter.limit -> "limiter.limit", @validate_schema -> "validate_schema"),
@@ -576,7 +641,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const perVal = laneNames.some((t) => VAL_NAMES.test(t));
     const perRate = laneNames.some((t) => RATE_NAMES.test(t));
     for (const dec of decorators) {
-      const route = asRouteDecorator(dec, routerNames);
+      const route = asRouteDecorator(dec, routerNames) ?? asApiViewDecorator(dec, definition);
       if (!route) continue;
       routes.push({
         method: route.method,

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -22,10 +22,20 @@
  * anywhere (`tree.rootNode.hasError`) is routed whole to the existing regex
  * extractor, which keeps its legacy over-blesses (the 30-line token/
  * permission window and the file-level login_required bless) unchanged.
+ *
+ * OPEN QUESTION FOR SIGN-OFF: `resolveMethod`'s handling of a Flask `methods=`
+ * kwarg that is not a statically readable list/tuple/set of string literals
+ * (a variable, `**kwargs`, or a `*splat` with no visible literal verb)
+ * deliberately diverges from the regex extractor. The regex silently defaults
+ * such a route to GET, which excludes it from the mutating vote. This AST
+ * path instead resolves it to "ALL", which keeps the route IN the mutating
+ * vote (matching how an Express `.all()` route is treated). This is a real,
+ * user-visible behavior change from today's regex path, not a bug fix; it is
+ * called out here for explicit sign-off rather than shipped silently.
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
-import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
+import type { RouteInfo } from "./security-consistency.js";
 
 // Route-registration attribute names on a router-like receiver.
 const ROUTE_METHODS = new Set(["route", "get", "post", "put", "patch", "delete", "api_route"]);
@@ -142,9 +152,49 @@ function asRouteDecorator(dec: SyntaxNode, routerNames: Set<string>): PyRoute | 
   return { method: resolveMethod(attr, args), path, call: expr, receiver };
 }
 
-function resolveMethod(attr: string, _args: SyntaxNode): string {
+/** Resolves the HTTP method(s) a route decorator registers.
+ *
+ *  Verb-shorthand decorators (`@app.post`, `@app.delete`, ...) are unambiguous:
+ *  the attribute name IS the method. Only `route`/`api_route` need a `methods=`
+ *  kwarg read.
+ *
+ *  DELIBERATE DIVERGENCE from the regex extractor: the regex silently defaults
+ *  to GET whenever `methods=` isn't a literal list it can pattern-match (a
+ *  variable, a set, a splat), which quietly excludes that route from the
+ *  mutating vote. This AST path instead emits "ALL" for every statically
+ *  unresolvable form (variable value, **kwargs splat, a *splat with no visible
+ *  literal verb), so the route STAYS in the mutating vote ("ALL" is a member of
+ *  both MUTATION_METHODS and BODY_METHODS), the same way Express's `.all()` is
+ *  treated. This is a real behavior change from the regex path and is flagged
+ *  as an open question for sign-off, not a silent fix.
+ *
+ *  A fully visible, empty `methods=[]` is NOT ambiguous: Flask's own default is
+ *  GET, so an empty literal resolves to GET rather than ALL. */
+function resolveMethod(attr: string, args: SyntaxNode): string {
   if (attr !== "route" && attr !== "api_route") return attr.toUpperCase();
-  return "GET"; // Flask default; the methods= kwarg lands in Task 2
+  const named = args.namedChildren.filter((n): n is SyntaxNode => n !== null);
+  const kw = named.find(
+    (n) => n.type === "keyword_argument" && n.childForFieldName("name")?.text === "methods",
+  );
+  if (!kw) {
+    // No methods kwarg. A **splat may hide one: statically unresolvable, so the
+    // route must STAY in the mutating vote ("ALL" is in MUTATION_METHODS and
+    // BODY_METHODS). Silently defaulting GET would drop an unknown-verb route
+    // out of the auth vote, which is the bless-adjacent direction the
+    // never-false-bless invariant forbids.
+    const hasSplat = named.some((n) => n.type.endsWith("splat"));
+    return hasSplat ? "ALL" : "GET";
+  }
+  const value = kw.childForFieldName("value");
+  if (!value || !["list", "tuple", "set"].includes(value.type)) return "ALL"; // methods=VARIABLE
+  const children = value.namedChildren.filter((n): n is SyntaxNode => n !== null);
+  const verbs = children
+    .filter((n) => n.type === "string")
+    .map((s) => (pyStringText(s) ?? "").toUpperCase())
+    .filter((v) => HTTP_VERBS.has(v));
+  const hidden = children.some((n) => n.type !== "string");
+  if (verbs.length === 0) return hidden ? "ALL" : "GET"; // [*BASE] vs literal []
+  return verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0];
 }
 
 export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -35,7 +35,7 @@
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
-import type { RouteInfo } from "./security-consistency.js";
+import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 
 // Route-registration attribute names on a router-like receiver.
 const ROUTE_METHODS = new Set(["route", "get", "post", "put", "patch", "delete", "api_route"]);
@@ -101,10 +101,37 @@ const DEPENDS_VETO_SEGMENTS = new Set([
 const VAL_NAMES = /(?:pydantic|validate|validator|schema|serializer|marshmallow)/i;
 const RATE_NAMES = /(?:rate_?limit|throttle|limiter|slowapi|slowdown)/i;
 
+// Two-tier segment lexicon for before_request / before_app_request HOOK HANDLER
+// names (see nameHasAuthToken). Deliberately stricter than the file-level regex,
+// which blesses ANY before_request. tier 1: a CORE segment alone (an unambiguous
+// authn word). tier 2: an ENFORCEMENT verb segment AND a SUBJECT segment anywhere
+// in the name. A lone SUBJECT (login / token / user) or a lone ENFORCE verb never
+// blesses: track_login_metrics, verify_content_type, and set_csrf_token are real
+// hooks that do not authenticate. Whole-segment matching makes substring blessing
+// structurally impossible.
+const AUTH_CORE_SEGMENTS = new Set(["auth", "authenticate", "authenticated"]);
+const AUTH_ENFORCE_SEGMENTS = new Set([
+  "require", "required", "requires", "verify", "verified", "ensure",
+  "protect", "protected", "restrict", "restricted",
+]);
+const AUTH_SUBJECT_SEGMENTS = new Set([
+  "login", "token", "user", "users", "session", "jwt", "permission",
+  "permissions", "role", "roles", "admin", "credentials",
+]);
+// Middleware CLASS-NAME auth segments for app.add_middleware(X). Matched by WHOLE
+// CamelCase/underscore segment on the class name ONLY (never the whole arg text):
+// AuthMiddleware and AuthenticationMiddleware bless, AuthorTrackingMiddleware does
+// not (the segment "author" is not "auth"). Same discipline as the decorators and
+// Depends targets.
+const MIDDLEWARE_AUTH_SEGMENTS = new Set([
+  "auth", "authentication", "authenticate", "authenticated", "jwt", "oauth", "oauth2", "bearer",
+]);
+
 export const SECURITY_AST_PY = {
   ROUTE_METHODS, HTTP_VERBS, MUTATING_VERBS, ROUTER_RECEIVER, ROUTER_CONSTRUCTORS,
   AUTH_DECORATORS, DEPENDS_AUTH_SEGMENTS, DEPENDS_AUTH_PAIRS, DEPENDS_VETO_SEGMENTS,
-  VAL_NAMES, RATE_NAMES,
+  VAL_NAMES, RATE_NAMES, AUTH_CORE_SEGMENTS, AUTH_ENFORCE_SEGMENTS,
+  AUTH_SUBJECT_SEGMENTS, MIDDLEWARE_AUTH_SEGMENTS,
 };
 
 /** Value of a Python string-ish path argument with quotes AND prefixes stripped.
@@ -263,6 +290,22 @@ function nameSegments(name: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+/** Two-tier segment auth check for hook handler names (see the constants block):
+ *  tier 1 = a CORE segment alone (check_auth, authenticate); tier 2 = an
+ *  ENFORCEMENT verb segment plus a SUBJECT segment anywhere in the name
+ *  (require_login, login_required, verify_token, ensure_user). Standalone
+ *  login/token/verify segments stay FALSE: track_login_metrics,
+ *  verify_content_type, and set_csrf_token are real hooks that do not
+ *  authenticate. Substring blessing is structurally impossible (segments). */
+function nameHasAuthToken(name: string): boolean {
+  const segs = nameSegments(name);
+  if (segs.some((s) => AUTH_CORE_SEGMENTS.has(s))) return true;
+  return (
+    segs.some((s) => AUTH_ENFORCE_SEGMENTS.has(s)) &&
+    segs.some((s) => AUTH_SUBJECT_SEGMENTS.has(s))
+  );
+}
+
 /** Segment-matched auth verdict for a resolved dependency name (see the constants
  *  block): hit on a single DEPENDS_AUTH_SEGMENTS segment or an adjacent
  *  DEPENDS_AUTH_PAIRS pair; ANY DEPENDS_VETO_SEGMENTS segment cancels the hit
@@ -375,9 +418,129 @@ function routeCallHasAuthDependency(call: SyntaxNode): boolean {
   return value ? callsWithAuthDependency(value) : false;
 }
 
+/** Middleware scopes for one python file. Python file-level middleware attaches
+ *  to a RECEIVER (an app/blueprint/router variable), so inheritance must be
+ *  receiver-scoped: `global` holds app-scoped middleware (receivers named
+ *  app/application, plus before_app_request hooks, which Flask runs app-wide);
+ *  `byReceiver` holds named blueprint/router scopes keyed by the exact
+ *  receiver/variable name. A file-granular OR would bless a public blueprint
+ *  co-located with a guarded admin blueprint: a false bless that also silences
+ *  both vote layers for the file. */
+interface PyMiddlewareScopes {
+  global: FileMiddleware;
+  byReceiver: Map<string, FileMiddleware>;
+}
+
+const APP_SCOPED_RECEIVER = /^(?:app|application)$/;
+
+function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
+  const scopes: PyMiddlewareScopes = {
+    global: { hasAuth: false, hasValidation: false, hasRateLimit: false },
+    byReceiver: new Map(),
+  };
+  const mark = (receiver: string, appWide: boolean, lane: keyof FileMiddleware) => {
+    if (appWide || APP_SCOPED_RECEIVER.test(receiver)) {
+      scopes.global[lane] = true;
+      return;
+    }
+    const entry =
+      scopes.byReceiver.get(receiver) ??
+      { hasAuth: false, hasValidation: false, hasRateLimit: false };
+    entry[lane] = true;
+    scopes.byReceiver.set(receiver, entry);
+  };
+  const routerNames = collectRouterNames(tree.rootNode);
+  const gated = (r: string | null): r is string =>
+    r !== null && (routerNames.has(r) || ROUTER_RECEIVER.test(r));
+
+  for (const dd of tree.rootNode.descendantsOfType("decorated_definition")) {
+    if (!dd || dd.hasError) continue;
+    const definition = dd.childForFieldName("definition");
+    if (!definition || definition.type !== "function_definition") continue;
+    const fnName = definition.childForFieldName("name")?.text ?? "";
+    for (const dec of dd.namedChildren) {
+      if (!dec || dec.type !== "decorator") continue;
+      const expr = dec.namedChild(0);
+      // @app.before_request is a bare attribute decorator; @app.before_request()
+      // with parens is a call whose function is the attribute. Handle both.
+      const attr =
+        expr?.type === "attribute"
+          ? expr
+          : expr?.type === "call" && expr.childForFieldName("function")?.type === "attribute"
+            ? expr.childForFieldName("function")
+            : null;
+      if (!attr) continue;
+      const hook = attr.childForFieldName("attribute")?.text ?? "";
+      if (hook !== "before_request" && hook !== "before_app_request") continue;
+      const receiver = receiverName(attr.childForFieldName("object"));
+      if (!gated(receiver)) continue;
+      const appWide = hook === "before_app_request";
+      if (nameHasAuthToken(fnName)) mark(receiver, appWide, "hasAuth");
+      if (RATE_NAMES.test(fnName)) mark(receiver, appWide, "hasRateLimit");
+      if (VAL_NAMES.test(fnName)) mark(receiver, appWide, "hasValidation");
+    }
+  }
+
+  for (const call of tree.rootNode.descendantsOfType("call")) {
+    if (!call || call.hasError) continue;
+    const fn = call.childForFieldName("function");
+    if (!fn) continue;
+    if (fn.type === "attribute" && fn.childForFieldName("attribute")?.text === "add_middleware") {
+      const receiver = receiverName(fn.childForFieldName("object"));
+      if (!gated(receiver)) continue;
+      const first = call.childForFieldName("arguments")?.namedChild(0);
+      const mwName =
+        first && (first.type === "identifier" || first.type === "attribute") ? first.text : "";
+      // Middleware CLASS NAME only (never the whole arg text), matched by WHOLE
+      // CamelCase/underscore segment: AuthMiddleware and AuthenticationMiddleware
+      // bless, AuthorTrackingMiddleware does not (the segment "author" is not
+      // "auth"; same discipline as decorators and Depends targets).
+      if (nameSegments(mwName).some((s) => MIDDLEWARE_AUTH_SEGMENTS.has(s))) {
+        mark(receiver, false, "hasAuth");
+      }
+      if (/[Ll]imit/.test(mwName) || RATE_NAMES.test(mwName)) mark(receiver, false, "hasRateLimit");
+      if (/[Vv]alid/.test(mwName)) mark(receiver, false, "hasValidation");
+    }
+  }
+
+  // Constructor dependencies scope to the ASSIGNED variable name
+  // (admin_router = APIRouter(dependencies=[...])). An unassigned or destructured
+  // constructor has no resolvable scope and blesses NOTHING (never-false-bless: a
+  // miss is safe). app = FastAPI(dependencies=[...]) lands in the global scope via
+  // APP_SCOPED_RECEIVER. Cross-receiver app.include_router() inheritance is a
+  // documented recall gap (over-flag, never a bless).
+  for (const asn of tree.rootNode.descendantsOfType("assignment")) {
+    if (!asn || asn.hasError) continue;
+    const left = asn.childForFieldName("left");
+    const right = asn.childForFieldName("right");
+    if (!left || left.type !== "identifier" || !right || right.type !== "call") continue;
+    const fn = right.childForFieldName("function");
+    if (!fn || fn.type !== "identifier") continue;
+    if (fn.text !== "APIRouter" && fn.text !== "FastAPI") continue;
+    const value = kwargValue(right, "dependencies");
+    if (value && callsWithAuthDependency(value)) mark(left.text, false, "hasAuth");
+  }
+  return scopes;
+}
+
+/** File-level OR of every scope: the seam-2 index entry (public FileMiddleware
+ *  shape, unchanged) and the regex fallback's inheritance input. Route-level
+ *  inheritance on the AST path does NOT read this OR; extractPythonRoutesAst
+ *  consumes collectPyMiddleware directly (receiver-scoped). */
+export function extractPythonFileMiddlewareAst(tree: Tree): FileMiddleware {
+  const scopes = collectPyMiddleware(tree);
+  const all = [scopes.global, ...scopes.byReceiver.values()];
+  return {
+    hasAuth: all.some((s) => s.hasAuth),
+    hasValidation: all.some((s) => s.hasValidation),
+    hasRateLimit: all.some((s) => s.hasRateLimit),
+  };
+}
+
 export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectRouterNames(tree.rootNode);
+  const scopes = collectPyMiddleware(tree);
   for (const dd of tree.rootNode.descendantsOfType("decorated_definition")) {
     // Error recovery can merge adjacent handlers' decorators into one dd;
     // blessing (or even extracting) across that boundary is forbidden.
@@ -426,9 +589,17 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
         hasAuth:
           authDecoratorRows.some((row) => row > dec.startPosition.row) ||
           paramAuth ||
-          routeCallHasAuthDependency(route.call),
-        hasValidation: perVal,
-        hasRateLimit: perRate,
+          routeCallHasAuthDependency(route.call) ||
+          scopes.global.hasAuth ||
+          (scopes.byReceiver.get(route.receiver)?.hasAuth ?? false),
+        hasValidation:
+          perVal ||
+          scopes.global.hasValidation ||
+          (scopes.byReceiver.get(route.receiver)?.hasValidation ?? false),
+        hasRateLimit:
+          perRate ||
+          scopes.global.hasRateLimit ||
+          (scopes.byReceiver.get(route.receiver)?.hasRateLimit ?? false),
         hasErrorHandler: false, // write-only field; JS AST extractor hard-codes false too
       });
     }

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -35,6 +35,7 @@ import type { DriftDetector, DriftContext, DriftFinding, DriftFile } from "./typ
 import { SECURITY_SUBCATEGORIES } from "./types.js";
 import { pickIntentHint } from "./utils.js";
 import { extractJsRoutesAst, extractFileMiddlewareAst, SECURITY_AST } from "./security-ast.js";
+import { extractPythonRoutesAst, extractPythonFileMiddlewareAst } from "./security-ast-python.js";
 import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
 
 // Canonical mutating set (upper-cased), shared with the in-loop classifier via
@@ -127,6 +128,15 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
     if (!file.language) continue;
     const c = file.content;
 
+    // Python: Flask / FastAPI. AST when a clean parsed tree is available; regex
+    // fallback otherwise. Byte-compat: for every non-(python-with-clean-tree)
+    // file, ALL regex arms (js/go/py) keep running on the raw content exactly as
+    // today. For a python file WITH a clean tree the js and go arms are forced
+    // false: on python content they are pure cross-language noise (a docstring
+    // mentioning app.use(authMiddleware) matches the jsAuth regex), and noise in
+    // this index is a file-wide bless.
+    const pythonAst = file.language === "python" && !!file.tree && !file.tree.rootNode.hasError;
+
     // JS/TS — Express / Hono / Fastify / Koa. AST when a parsed tree is
     // available (structural: gated on a router/app receiver, not just
     // proximity of the keyword); regex fallback otherwise.
@@ -136,6 +146,13 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       jsAuth = mw.hasAuth;
       jsRateLimit = mw.hasRateLimit;
       jsValidation = mw.hasValidation;
+    } else if (pythonAst) {
+      // Cross-language noise: on a clean-parsed python file the js regex arms are
+      // pure noise (they match app.use(...) text inside docstrings/comments), so
+      // force them false rather than let them file-wide-bless a python route.
+      jsAuth = false;
+      jsRateLimit = false;
+      jsValidation = false;
     } else {
       // router.use(requireAuth) | app.use(passport.authenticate(...)) | router.use(authMiddleware)
       jsAuth = /(?:router|app|router\w*|api\w*)\s*\.\s*use\s*\(\s*[^,)]*?(?:auth|requireAuth|isAuthenticated|passport|verifyToken|jwt)/i.test(c);
@@ -145,15 +162,25 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
 
     // Go — Echo / Gin / Chi
     // e.Use(AuthMiddleware) | r.Use(authMiddleware) | g := e.Group(...); g.Use(...)
-    const goAuth = /\.\s*Use\s*\(\s*[^,)]*?(?:[Aa]uth|RequireAuth|VerifyToken|JWT|Bearer)/.test(c);
-    const goRateLimit = /\.\s*Use\s*\(\s*[^,)]*?(?:[Rr]ateLimit|[Tt]hrottle|[Ll]imiter)/.test(c);
-    const goValidation = /\.\s*Use\s*\(\s*[^,)]*?(?:[Vv]alidate|[Vv]alidator)/.test(c);
+    // Forced false on a clean-parsed python file for the same cross-language
+    // noise reason as the js arms above.
+    const goAuth = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Aa]uth|RequireAuth|VerifyToken|JWT|Bearer)/.test(c);
+    const goRateLimit = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Rr]ateLimit|[Tt]hrottle|[Ll]imiter)/.test(c);
+    const goValidation = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Vv]alidate|[Vv]alidator)/.test(c);
 
     // Python — Flask / FastAPI
     // @app.before_request def f() | @blueprint.before_request | app.add_middleware(AuthMW)
-    const pyAuth = /(?:@\w+\.before_request|@blueprint\.before_request|add_middleware\s*\([^,)]*[Aa]uth|@?\bjwt_required\b|@?\blogin_required\b)/.test(c);
-    const pyRateLimit = /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
-    const pyValidation = /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
+    let pyAuth: boolean, pyRateLimit: boolean, pyValidation: boolean;
+    if (pythonAst) {
+      const mw = extractPythonFileMiddlewareAst(file.tree!);
+      pyAuth = mw.hasAuth;
+      pyRateLimit = mw.hasRateLimit;
+      pyValidation = mw.hasValidation;
+    } else {
+      pyAuth = /(?:@\w+\.before_request|@blueprint\.before_request|add_middleware\s*\([^,)]*[Aa]uth|@?\bjwt_required\b|@?\blogin_required\b)/.test(c);
+      pyRateLimit = /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
+      pyValidation = /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
+    }
 
     index.set(file.relativePath, {
       hasAuth: jsAuth || goAuth || pyAuth,
@@ -301,9 +328,26 @@ function balancedDecoratorArgs(lines: string[], start: number): string {
 }
 
 function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
+  // AST only on a CLEAN parse: tree-sitter always returns a tree for broken
+  // Python (with ERROR nodes), and error recovery can erase the whole file's
+  // decorator structure or merge adjacent handlers' decorators into one
+  // decorated_definition (a cross-bless hazard). Any parse error routes the
+  // whole file to the regex, byte-identical to today's behavior INCLUDING the
+  // regex path's known over-blesses (see the pinned-legacy test, Task 6).
+  if (file.tree && !file.tree.rootNode.hasError) {
+    // No FileMiddleware argument: the AST path computes receiver-scoped
+    // inheritance from the tree itself (a file-level OR would false-bless
+    // mixed-receiver files, and the index entry may carry cross-language noise
+    // for non-python files).
+    routes.push(...extractPythonRoutesAst(file.tree, file.relativePath));
+    return;
+  }
+  extractPythonRoutesRegex(file, routes, fileMw.get(file.relativePath));
+}
+
+function extractPythonRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddleware: FileMiddleware | undefined) {
   const lines = file.content.split("\n");
   const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
-  const fileMiddleware = fileMw.get(file.relativePath);
 
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(routePattern);

--- a/test/calibration/README.md
+++ b/test/calibration/README.md
@@ -87,6 +87,50 @@ monotonicity: ✓  (composite + drift both strictly decrease)
 responsiveness: ✓  (each +25% drift yields ≥5pt score drop)
 ```
 
+## Python security fixture (the multilang calibration gate)
+
+`python-security-fixture.ts` + `security-python.test.ts` are the enforced
+precision/recall gate for the Python AST security extractor
+(`src/drift/security-ast-python.ts`). Unlike the harness above, this one runs
+as a normal vitest file (`test/**/*.test.ts`), so it is checked on every
+`npm test`, not just `npm run calibrate`.
+
+The corpus is realistic Flask/FastAPI multi-file code (real Blueprint/
+APIRouter idioms, `login_required` decorators, `Depends(get_current_user)`),
+not minimal stubs, split into three independent roots:
+
+- `pysrv/` — 8 Flask blueprints, one mutating route each, receiver names
+  deliberately mixed between convention-gated (`users_bp`, `orders_bp`,
+  `payments_router`, `api`) and bare names resolved only structurally via
+  their `Blueprint(...)` assignment (`main`, `carts`, `auth`, `admin`).
+- `fastsrv/` — 5 FastAPI routers, one mutating route each, guarded via
+  `Depends(get_current_user)`.
+- `hooks/` — 5 uniformly PUBLIC webhook receivers (Stripe, GitHub, Slack,
+  Twilio, SendGrid). This is the negative control and lives in its own root
+  so it never shares `repoHasAuthMachinery` evidence with the authed corpora
+  (that check is repo-global over whatever files are in `ctx.files`, not
+  scoped to a route group).
+
+Five scenarios, each computing precision/recall explicitly against planted
+ground truth:
+
+- **S0** recognition self-check — every route file in the Flask/FastAPI
+  corpora yields exactly one route (13 total), and the negative control
+  yields exactly 5. A receiver-gate recall regression fails here with a
+  count, instead of silently vanishing from a vote several layers down.
+- **S1 / S2** the primary dominance vote (`analyzeSecurityProperty`) on
+  Flask and FastAPI respectively: one planted deviator among an authed
+  majority, precision 1.0 / recall 1.0.
+- **S3** the uniform-auth-gap fallback (`analyzeUniformAuthGap`): all 8
+  Flask routes stripped at once, so the primary vote goes silent (ratio 0)
+  and the gap must fire instead, precision 1.0 / recall 1.0.
+- **S4** the negative control: route extraction is asserted BEFORE
+  zero-findings (non-vacuity), because zero findings is also what you get
+  when zero routes are recognized — silence only proves something once the
+  routes were actually seen.
+- **S5** the uniformly-authed control: zero findings on every axis (auth,
+  validation, rate-limit).
+
 ## Adding a new injection type
 
 Drop a generator in `generators/`. Signature:

--- a/test/calibration/precision-recall.ts
+++ b/test/calibration/precision-recall.ts
@@ -126,7 +126,7 @@ async function main(): Promise<void> {
 
   // 3. Python security corpus (own root, own row label). This exercises the
   // AST extractor's realistic Flask fixture through the FULL on-disk scan
-  // pipeline (not the direct detector call test/calibration/security-python.ts
+  // pipeline (not the direct detector call test/calibration/security-python.test.ts
   // uses), and is kept out of the TS baseline/injector loop above by design:
   // merging Python files into generateBaseline() would contaminate the
   // naming/architecture rows and shift the clean-scan FP floor, and merging

--- a/test/calibration/precision-recall.ts
+++ b/test/calibration/precision-recall.ts
@@ -21,6 +21,7 @@ import { runDriftDetection } from "../../src/drift/index.js";
 import type { Finding } from "../../src/core/types.js";
 import { generateBaseline, type BaselineFile } from "./baseline.js";
 import { INJECTORS } from "./injectors.js";
+import { flaskAuthedGroup, pyAuthFile, pyAppFile, stripFlaskAuth } from "./python-security-fixture.js";
 import { classify, findingCategory, type CategoryMetrics, type DriftLabel, type ScoredFinding } from "./metrics.js";
 
 // Each injector's expected detector category (what a correct detector emits).
@@ -123,13 +124,31 @@ async function main(): Promise<void> {
     mergeInto(agg, classify(scored(await scan(dir)), labels));
   }
 
+  // 3. Python security corpus (own root, own row label). This exercises the
+  // AST extractor's realistic Flask fixture through the FULL on-disk scan
+  // pipeline (not the direct detector call test/calibration/security-python.ts
+  // uses), and is kept out of the TS baseline/injector loop above by design:
+  // merging Python files into generateBaseline() would contaminate the
+  // naming/architecture rows and shift the clean-scan FP floor, and merging
+  // this row's counts into the JS "security_posture" category would let a
+  // Python precision regression hide behind good JS numbers.
+  const pyBase = [...flaskAuthedGroup(), pyAuthFile, pyAppFile];
+  const pyVariant = stripFlaskAuth(pyBase, 3); // 3 of 8 unauthed -> ratio 5/8 <= 0.75: primary vote silent, gap path
+  const pyLabels = diffLabels(pyBase, pyVariant, "security_posture_py");
+  const pyDir = join(root, "security_python");
+  await writeFixture(pyDir, pyVariant);
+  const pyScored = scored(await scan(pyDir))
+    .filter((s) => s.category === "security_posture")
+    .map((s) => ({ ...s, category: "security_posture_py" }));
+  mergeInto(agg, classify(pyScored, pyLabels));
+
   const allRows = finalize(agg);
   // Only the INJECTED categories have synthetic ground truth — those are the
   // ones we can fairly score. Other categories that fire on the templated
   // baseline (semantic_duplication, dead-code, phantom_scaffolding — the 6
   // near-identical, consumer-less handlers legitimately trip them) have no
   // ground truth here and are reported separately as un-measured.
-  const injectedCats = new Set(Object.values(INJECTOR_CATEGORY));
+  const injectedCats = new Set([...Object.values(INJECTOR_CATEGORY), "security_posture_py"]);
   const rows = allRows.filter((r) => injectedCats.has(r.category));
   const unmeasured = allRows.filter((r) => !injectedCats.has(r.category) && (r.fp ?? 0) > 0);
 

--- a/test/calibration/python-security-fixture.ts
+++ b/test/calibration/python-security-fixture.ts
@@ -1,0 +1,275 @@
+/**
+ * Calibration fixture for the Python AST security extractor (Task 7): a
+ * realistic Flask + FastAPI multi-file corpus with planted ground truth, used
+ * by test/calibration/security-python.test.ts to measure BOTH the primary
+ * dominance vote (analyzeSecurityProperty) and the uniform-auth-gap fallback
+ * (analyzeUniformAuthGap) on real framework idioms, plus a negative control
+ * that must produce zero findings.
+ *
+ * Directory layout mirrors three independent "repos" so each corpus roots its
+ * own `repoHasAuthMachinery` evidence (that check is repo-global over
+ * whatever files are in ctx.files, not scoped to a route group):
+ *   pysrv/routes/*_routes.py   8 Flask blueprints, one mutating route each
+ *   pysrv/auth.py              the shared @login_required decorator
+ *   pysrv/app.py                factory that registers blueprints, no routes
+ *   fastsrv/routes/*_api.py    5 FastAPI routers, one mutating route each
+ *   fastsrv/deps.py            the shared get_current_user dependency
+ *   hooks/routes/*_hook.py     5 uniformly PUBLIC webhook receivers (negative control)
+ *
+ * Receiver names in the Flask group deliberately mix two recognition paths so
+ * the fixture measures recall across BOTH: four convention-gated names
+ * (users_bp, orders_bp, payments_router, api — recognized by ROUTER_RECEIVER)
+ * and four bare names resolved only structurally via their `Blueprint(...)`
+ * assignment (main, carts, auth, admin — the "flasky" tutorial layout).
+ */
+import type { BaselineFile } from "./baseline.js";
+
+interface FlaskEntity {
+  name: string;
+  receiver: string;
+  blueprintName: string;
+}
+
+// 8 entities: 4 convention-gated receivers, 4 bare receivers resolved only
+// structurally via their Blueprint(...) assignment (never-false-bless: a
+// route-loss regression on the structural path must show up here, not just
+// on the convention-gated one).
+const FLASK_ENTITIES: FlaskEntity[] = [
+  { name: "users", receiver: "users_bp", blueprintName: "users" },
+  { name: "orders", receiver: "orders_bp", blueprintName: "orders" },
+  { name: "payments", receiver: "payments_router", blueprintName: "payments" },
+  { name: "products", receiver: "api", blueprintName: "catalog" },
+  { name: "invoices", receiver: "main", blueprintName: "main" },
+  { name: "carts", receiver: "carts", blueprintName: "carts" },
+  { name: "sessions", receiver: "auth", blueprintName: "auth" },
+  { name: "notifications", receiver: "admin", blueprintName: "admin" },
+];
+
+// 5 FastAPI routers, one mutating route each, all guarded via the same
+// Depends(get_current_user) idiom. 5 files so one deviator gives 4/5 = 0.8 >
+// 0.75 (n=4 would never clear the strict > 0.75 gate).
+const FASTAPI_ENTITIES = ["items", "accounts", "subscriptions", "tickets", "shipments"];
+
+interface HookProvider {
+  name: string;
+  header: string;
+}
+
+// 5 uniformly public webhook receivers: signature checking (if any) happens
+// INSIDE the handler body via a helper named check_signature, never as a
+// before_request hook and never under an auth-lexicon name. This is the
+// negative control corpus and lives in its own directory root so it never
+// shares repoHasAuthMachinery evidence with the authed corpora.
+const HOOK_PROVIDERS: HookProvider[] = [
+  { name: "stripe", header: "Stripe-Signature" },
+  { name: "github", header: "X-Hub-Signature-256" },
+  { name: "slack", header: "X-Slack-Signature" },
+  { name: "twilio", header: "X-Twilio-Signature" },
+  { name: "sendgrid", header: "X-Sendgrid-Signature" },
+];
+
+function flaskRouteFile(entity: FlaskEntity): BaselineFile {
+  return {
+    path: `pysrv/routes/${entity.name}_routes.py`,
+    content:
+`"""POST /${entity.name}: create a ${entity.name} record."""
+from flask import Blueprint, jsonify, request
+from ..auth import login_required
+
+${entity.receiver} = Blueprint("${entity.blueprintName}", __name__)
+
+@${entity.receiver}.route("/${entity.name}", methods=["POST"])
+@login_required
+def create_${entity.name}():
+    payload = request.get_json()
+    return jsonify(payload), 201
+`,
+  };
+}
+
+function fastapiRouteFile(name: string): BaselineFile {
+  return {
+    path: `fastsrv/routes/${name}_api.py`,
+    content:
+`"""POST /${name}: create a ${name} record."""
+from fastapi import APIRouter, Depends
+from ..deps import get_current_user
+
+router = APIRouter()
+
+@router.post("/${name}")
+async def create_${name}(payload: dict, user=Depends(get_current_user)):
+    return {"ok": True}
+`,
+  };
+}
+
+function hookFile(provider: HookProvider): BaselineFile {
+  return {
+    path: `hooks/routes/${provider.name}_hook.py`,
+    content:
+`"""${provider.name} webhook receiver. Requests are verified via payload
+signature checking inside the handler, never via a gate that runs before it."""
+from flask import Blueprint, jsonify, request
+
+${provider.name}_bp = Blueprint("${provider.name}_webhooks", __name__)
+
+
+def check_signature(payload, header):
+    if not header:
+        return False
+    return len(header) > 8
+
+
+@${provider.name}_bp.route("/webhooks/${provider.name}", methods=["POST"])
+def handle_${provider.name}_event():
+    if not check_signature(request.get_data(), request.headers.get("${provider.header}")):
+        return jsonify({"error": "bad signature"}), 400
+    event = request.get_json()
+    return jsonify({"received": True, "type": event.get("type")})
+`,
+  };
+}
+
+export function flaskAuthedGroup(): BaselineFile[] {
+  return FLASK_ENTITIES.map(flaskRouteFile);
+}
+
+export function fastapiAuthedGroup(): BaselineFile[] {
+  return FASTAPI_ENTITIES.map(fastapiRouteFile);
+}
+
+export function publicByDesignControl(): BaselineFile[] {
+  return HOOK_PROVIDERS.map(hookFile);
+}
+
+// Support files: kept OUT of flaskAuthedGroup()/fastapiAuthedGroup() so those
+// two functions stay "one route per file" exactly (S0's route-loss guard
+// requires every element to yield exactly one route). Callers add these
+// explicitly, matching how they carry repoHasAuthMachinery evidence.
+export const pyAuthFile: BaselineFile = {
+  path: "pysrv/auth.py",
+  content:
+`"""Shared login-required decorator for Flask blueprints."""
+import functools
+
+from flask import g, jsonify, request
+
+
+def login_required(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        token = request.headers.get("Authorization")
+        if not token:
+            return jsonify({"error": "unauthorized"}), 401
+        g.user_id = token.removeprefix("Bearer ")
+        return f(*args, **kwargs)
+
+    return wrapper
+`,
+};
+
+export const pyAppFile: BaselineFile = {
+  path: "pysrv/app.py",
+  content:
+`"""Application factory: wires blueprints together, registers no routes of its own."""
+from flask import Flask
+
+from .routes.users_routes import users_bp
+from .routes.orders_routes import orders_bp
+from .routes.payments_routes import payments_router
+from .routes.products_routes import api
+from .routes.invoices_routes import main
+from .routes.carts_routes import carts
+from .routes.sessions_routes import auth
+from .routes.notifications_routes import admin
+
+
+def create_app():
+    app = Flask(__name__)
+    app.register_blueprint(users_bp)
+    app.register_blueprint(orders_bp)
+    app.register_blueprint(payments_router)
+    app.register_blueprint(api)
+    app.register_blueprint(main)
+    app.register_blueprint(carts)
+    app.register_blueprint(auth)
+    app.register_blueprint(admin)
+    return app
+`,
+};
+
+export const pyDepsFile: BaselineFile = {
+  path: "fastsrv/deps.py",
+  content:
+`"""Shared FastAPI dependencies."""
+from fastapi import HTTPException, Request
+
+
+async def get_current_user(request: Request):
+    token = request.headers.get("Authorization")
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return {"id": token.removeprefix("Bearer ")}
+`,
+};
+
+/** uniformly-authed control: the full Flask + FastAPI corpus, unchanged. */
+export function uniformlyAuthed(): BaselineFile[] {
+  return [...flaskAuthedGroup(), pyAuthFile, pyAppFile, ...fastapiAuthedGroup(), pyDepsFile];
+}
+
+function sortedEligiblePaths(files: BaselineFile[], predicate: (path: string) => boolean): string[] {
+  return files
+    .map((f) => f.path)
+    .filter(predicate)
+    .sort();
+}
+
+/** Sorted pysrv/routes/*_routes.py paths in `files` — the deterministic
+ *  strip order stripFlaskAuth uses, exposed so tests can compute which
+ *  path(s) got stripped without duplicating the sort/filter logic. */
+export function sortedFlaskRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith("pysrv/routes/") && p.endsWith("_routes.py"));
+}
+
+/** Sorted fastsrv/routes/*_api.py paths in `files`, same purpose as
+ *  sortedFlaskRoutePaths above. */
+export function sortedFastapiRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith("fastsrv/routes/") && p.endsWith("_api.py"));
+}
+
+/** Deterministically strips @login_required (decorator line AND its import)
+ *  from the first `count` Flask route files, sorted by path. The route
+ *  decorator and its methods=["POST"] kwarg are untouched, so every stripped
+ *  file remains a valid, still-mutating route with hasAuth: false. */
+export function stripFlaskAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedFlaskRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const lines = f.content
+      .split("\n")
+      .filter(
+        (line) =>
+          line.trim() !== "from ..auth import login_required" && line.trim() !== "@login_required",
+      );
+    return { path: f.path, content: lines.join("\n") };
+  });
+}
+
+/** Deterministically strips `, user=Depends(get_current_user)` (and its
+ *  import) from the first `count` FastAPI route files, sorted by path. The
+ *  route decorator is untouched, so every stripped file remains a valid,
+ *  still-mutating route with hasAuth: false. */
+export function stripFastapiAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedFastapiRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const content = f.content
+      .split("\n")
+      .filter((line) => line.trim() !== "from ..deps import get_current_user")
+      .join("\n")
+      .replace(", user=Depends(get_current_user)", "");
+    return { path: f.path, content };
+  });
+}

--- a/test/calibration/security-python.test.ts
+++ b/test/calibration/security-python.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Task 7: the enforced precision/recall calibration gate for the Python
+ * security extractor (vitest discovers test/**\/*.test.ts, so this runs as
+ * part of `npm test`, not just `npm run calibrate`).
+ *
+ * Five scenarios against test/calibration/python-security-fixture.ts's
+ * realistic Flask/FastAPI corpus, each computing precision/recall explicitly
+ * against planted ground truth (not just checking the finding fired):
+ *   S0  recognition self-check — the route-loss guard. Regresses with a
+ *       COUNT, not silent disappearance from the votes below.
+ *   S1  primary dominance vote, Flask (8 files, 1 planted deviator).
+ *   S2  primary dominance vote, FastAPI (5 files, 1 planted deviator).
+ *   S3  uniform-auth-gap fallback (all 8 Flask routes stripped at once).
+ *   S4  negative control — uniformly public webhook receivers. Non-vacuity
+ *       (routes ARE extracted) is asserted BEFORE zero-findings, per
+ *       NEVER-FALSE-BLESS: silence only proves something once we know the
+ *       routes were actually seen.
+ *   S5  uniformly-authed control — zero findings on every axis.
+ */
+import { describe, it, expect } from "vitest";
+import { securityConsistency } from "../../src/drift/security-consistency.js";
+import { SECURITY_SUBCATEGORIES } from "../../src/drift/types.js";
+import type { DriftFile } from "../../src/drift/types.js";
+import { extractPythonRoutesAst } from "../../src/drift/security-ast-python.js";
+import { fileWithTree } from "../helpers/drift-tree.js";
+import type { BaselineFile } from "./baseline.js";
+import {
+  flaskAuthedGroup,
+  fastapiAuthedGroup,
+  publicByDesignControl,
+  uniformlyAuthed,
+  pyAuthFile,
+  pyAppFile,
+  sortedFlaskRoutePaths,
+  sortedFastapiRoutePaths,
+  stripFlaskAuth,
+  stripFastapiAuth,
+} from "./python-security-fixture.js";
+
+async function toDriftFiles(files: BaselineFile[]): Promise<DriftFile[]> {
+  return Promise.all(files.map((f) => fileWithTree(f.path, f.content, "python")));
+}
+
+async function ctxFor(files: BaselineFile[]) {
+  const driftFiles = await toDriftFiles(files);
+  return {
+    files: driftFiles,
+    totalLines: driftFiles.reduce((s, f) => s + f.lineCount, 0),
+    dominantLanguage: "python",
+  };
+}
+
+function authFindings(findings: ReturnType<typeof securityConsistency.detect>) {
+  return findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.auth);
+}
+
+describe("Python calibration: S0 recognition self-check (route-loss guard)", () => {
+  it("extracts exactly one route per file across all 13 Flask + FastAPI route files, mixed receiver-naming conventions", async () => {
+    const routeFiles = [...flaskAuthedGroup(), ...fastapiAuthedGroup()];
+    let total = 0;
+    for (const f of routeFiles) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      // A receiver-gate recall regression (structural OR convention-gated)
+      // fails HERE with the offending file's path, instead of just silently
+      // vanishing from a vote count several layers down.
+      expect(routes, f.path).toHaveLength(1);
+      total += routes.length;
+    }
+    expect(total).toBe(13);
+  });
+
+  it("extracts exactly 5 routes from the negative control", async () => {
+    let total = 0;
+    for (const f of publicByDesignControl()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+});
+
+describe("Python calibration: S1 primary dominance vote, Flask", () => {
+  it("flags exactly the one stripped file among 8 Flask blueprints (dominantCount 7, consistencyScore 88)", async () => {
+    const strippedPath = sortedFlaskRoutePaths(flaskAuthedGroup())[0];
+    const files = [...stripFlaskAuth(flaskAuthedGroup(), 1), pyAuthFile, pyAppFile];
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(7);
+    expect(finding.totalRelevantFiles).toBe(8);
+    expect(finding.consistencyScore).toBe(88);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Python calibration: S2 primary dominance vote, FastAPI", () => {
+  it("flags exactly the one stripped file among 5 FastAPI routers (dominantCount 4, consistencyScore 80)", async () => {
+    const strippedPath = sortedFastapiRoutePaths(fastapiAuthedGroup())[0];
+    const files = stripFastapiAuth(fastapiAuthedGroup(), 1);
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Python calibration: S3 uniform-auth-gap fallback", () => {
+  it("flags all 8 mutating Flask routes when the primary vote goes silent but the repo uses auth elsewhere", async () => {
+    const plantedPaths = sortedFlaskRoutePaths(flaskAuthedGroup());
+    // pysrv/auth.py retained (carries the repoHasAuthMachinery evidence);
+    // pysrv/app.py deliberately NOT included here — the gap must fire from
+    // auth.py's login_required token alone.
+    const files = [...stripFlaskAuth(flaskAuthedGroup(), 8), pyAuthFile];
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.finding).toContain(
+      "8 mutating route(s) lack auth while the codebase uses auth elsewhere",
+    );
+    expect(finding.severity).toBe("error");
+    expect(finding.confidence).toBe(0.6);
+    expect(finding.deviatingFiles.map((d) => d.path).sort()).toEqual(plantedPaths);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set(plantedPaths);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Python calibration: S4 negative control (uniformly public by design)", () => {
+  const MACHINERY =
+    /\b(requireAuth|isAuthenticated|verifyToken|authMiddleware|ensureAuth|withAuth|jwt_required|login_required|AuthMiddleware|passport)\b/;
+
+  it("negative control contains no repo auth-machinery token (self-check)", () => {
+    for (const f of publicByDesignControl()) {
+      expect(MACHINERY.test(f.content), f.path).toBe(false);
+    }
+  });
+
+  it("non-vacuity FIRST: extracts exactly 5 mutating, unauthed routes before silence can mean anything", async () => {
+    let total = 0;
+    for (const f of publicByDesignControl()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(["POST", "PUT", "PATCH", "DELETE", "ALL"], f.path).toContain(routes[0].method);
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("THEN: produces zero security_posture findings", async () => {
+    const ctx = await ctxFor(publicByDesignControl());
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+});
+
+describe("Python calibration: S5 uniformly-authed control", () => {
+  it("produces zero security_posture findings across the whole Flask + FastAPI corpus, incl. validation and rate-limit", async () => {
+    const ctx = await ctxFor(uniformlyAuthed());
+    const findings = securityConsistency.detect(ctx as any);
+
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+    expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.validation)).toEqual([]);
+    expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.rateLimit)).toEqual([]);
+  });
+});

--- a/test/calibration/security-python.test.ts
+++ b/test/calibration/security-python.test.ts
@@ -194,6 +194,23 @@ describe("Python calibration: S4 negative control (uniformly public by design)",
 });
 
 describe("Python calibration: S5 uniformly-authed control", () => {
+  it("non-vacuity FIRST: extracts 13 routes across the corpus, every one authed, before silence can mean anything", async () => {
+    // Self-contained guard: zero findings below only means "uniform auth" once we
+    // know the routes were actually seen AND recognized as authed. 8 Flask + 5
+    // FastAPI route files, one route each; the auth/app/deps support files carry
+    // no routes.
+    let total = 0;
+    for (const f of uniformlyAuthed()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      for (const r of routes) {
+        expect(r.hasAuth, `${f.path} ${r.method} ${r.path}`).toBe(true);
+        total += 1;
+      }
+    }
+    expect(total).toBe(13);
+  });
+
   it("produces zero security_posture findings across the whole Flask + FastAPI corpus, incl. validation and rate-limit", async () => {
     const ctx = await ctxFor(uniformlyAuthed());
     const findings = securityConsistency.detect(ctx as any);

--- a/test/helpers/drift-tree.ts
+++ b/test/helpers/drift-tree.ts
@@ -4,7 +4,7 @@ import type { DriftFile } from "../../src/drift/types.js";
 export async function fileWithTree(
   path: string,
   content: string,
-  language: "javascript" | "typescript" = "typescript",
+  language: "javascript" | "typescript" | "python" = "typescript",
 ): Promise<DriftFile> {
   const tree = await parseFile({
     path, relativePath: path, language, content, lineCount: content.split("\n").length,

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect } from "vitest";
+import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+
+const py = (path: string, src: string) => fileWithTree(path, src, "python");
+
+describe("py() test helper (harness prerequisites)", () => {
+  it("parses a Python source file into a usable, error-free tree", async () => {
+    const f = await py("hello.py", `def hello():\n    return "hi"\n`);
+    expect(f.tree).toBeDefined();
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(f.language).toBe("python");
+  });
+});
+
+describe("extractPythonRoutesAst: Flask route recognition", () => {
+  it("extracts a FastAPI-style verb decorator with method, path, and decorator line", async () => {
+    const f = await py("routes.py",
+      `@app.post("/orders")\n` +
+      `def create_order():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=false",
+    ]);
+    expect(routes[0].line).toBe(1);
+    expect(routes[0].file).toBe("routes.py");
+  });
+
+  it("defaults a bare @app.route to GET (Flask semantics, not ANY)", async () => {
+    const f = await py("r.py", `@bp.route("/orders")\ndef list_orders():\n    return []\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /orders"]);
+  });
+
+  it("recognizes blueprint receivers: users_bp, blueprint, api, admin_blueprint", async () => {
+    const f = await py("bps.py",
+      `@users_bp.route("/users")\ndef a():\n    return []\n\n` +
+      `@blueprint.route("/x")\ndef b():\n    return []\n\n` +
+      `@api.route("/y")\ndef c():\n    return []\n\n` +
+      `@admin_blueprint.route("/z")\ndef d():\n    return []\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toHaveLength(4);
+  });
+
+  it("extracts a multiline decorator (the regex path's blind spot)", async () => {
+    const f = await py("m.py",
+      `@app.route(\n` +
+      `    "/orders",\n` +
+      `)\n` +
+      `def create():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual(["GET /orders"]);
+    expect(routes[0].line).toBe(1);
+  });
+
+  it("emits two RouteInfos for two stacked route decorators on one handler", async () => {
+    const f = await py("s.py",
+      `@app.post("/a")\n` +
+      `@app.post("/b")\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path}:${r.line}`)).toEqual(["/a:1", "/b:2"]);
+  });
+
+  it("extracts a route registered inside an app factory (nested decorated_definition)", async () => {
+    const f = await py("factory.py",
+      `def create_app():\n` +
+      `    app = Flask(__name__)\n` +
+      `    @app.post("/inner")\n` +
+      `    def inner():\n` +
+      `        return {}\n` +
+      `    return app\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/inner"]);
+  });
+
+  it("ignores app.route calls that are not in decorator position", async () => {
+    const f = await py("n.py", `r = app.route("/x")\nclient.post("/x")\nrequests.get("/y")\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("recognizes the Flask verb-shorthand decorator @app.delete", async () => {
+    const f = await py("d.py",
+      `@app.delete("/orders/<int:id>")\ndef delete_order(id):\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["DELETE /orders/<int:id>"]);
+  });
+});
+
+describe("extractPythonRoutesAst: FastAPI route recognition", () => {
+  it("recognizes @router.post on an async def handler", async () => {
+    const f = await py("i.py",
+      `@router.post("/items")\nasync def create_item():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /items"]);
+  });
+
+  it("recognizes @app.get", async () => {
+    const f = await py("i2.py", `@app.get("/items")\ndef list_items():\n    return []\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /items"]);
+  });
+
+  it("recognizes @api_router and @v1 (versioned registrar) receivers", async () => {
+    const f = await py("v.py",
+      `@api_router.put("/items/{id}")\n` +
+      `def update_item(id):\n` +
+      `    return {}\n\n` +
+      `@v1.post("/x")\n` +
+      `def create_x():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["PUT /items/{id}", "POST /x"]);
+  });
+
+  it("does not recognize @router.websocket (not a route-registration attribute)", async () => {
+    const f = await py("ws.py",
+      `@router.websocket("/ws")\nasync def ws_handler():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("accepts a keyword-only path= argument", async () => {
+    const f = await py("kw.py",
+      `@router.post(path="/items")\ndef create_item():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /items"]);
+  });
+
+  it("ignores trailing kwarg noise after the path (response_model, status_code)", async () => {
+    const f = await py("noise.py",
+      `@router.post("/items", response_model=Item, status_code=201)\n` +
+      `def create_item():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /items"]);
+  });
+});
+
+describe("extractPythonRoutesAst: receiver-gate negatives", () => {
+  it("ignores @property/@staticmethod/@classmethod method decorators", async () => {
+    const f = await py("cls.py",
+      `class Foo:\n` +
+      `    @property\n` +
+      `    def bar(self):\n` +
+      `        return 1\n\n` +
+      `    @staticmethod\n` +
+      `    def baz():\n` +
+      `        return 2\n\n` +
+      `    @classmethod\n` +
+      `    def qux(cls):\n` +
+      `        return 3\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("ignores @lru_cache and @functools.lru_cache(...) decorators", async () => {
+    const f = await py("cache.py",
+      `@lru_cache\n` +
+      `def get_config():\n` +
+      `    return {}\n\n` +
+      `@functools.lru_cache(maxsize=128)\n` +
+      `def get_settings():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not capture non-router receivers (cache.get, celery.task over-capture)", async () => {
+    const f = await py("svc.py",
+      `@cache.get("user:1")\n` +
+      `def get_user():\n` +
+      `    return {}\n\n` +
+      `@celery.task\n` +
+      `def process():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("ignores non-route decorators with attribute names outside ROUTE_METHODS", async () => {
+    const f = await py("misc.py",
+      `@pytest.mark.parametrize("p", ["/x"])\n` +
+      `def test_thing(p):\n` +
+      `    return p\n\n` +
+      `@app.errorhandler(404)\n` +
+      `def not_found(e):\n` +
+      `    return {}, 404\n\n` +
+      `@app.teardown_appcontext\n` +
+      `def teardown(exception=None):\n` +
+      `    pass\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not extract @ns.route when ns is never assigned from a ROUTER_CONSTRUCTORS name (flask-restx)", async () => {
+    // Documented under-recognition: flask-restx Namespace objects are not one
+    // of ROUTER_CONSTRUCTORS, and "ns" does not match ROUTER_RECEIVER by
+    // convention either, so this route is a measured, not silent, recall gap.
+    const f = await py("restx.py", `@ns.route("/x")\ndef get_order():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("ignores in-body route-shaped calls (TestClient(app).post, session.get)", async () => {
+    const f = await py("body.py",
+      `def test_create_order():\n` +
+      `    TestClient(app).post("/x")\n\n` +
+      `def test_get_session():\n` +
+      `    session.get("/z")\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractPythonRoutesAst: structural receiver resolution", () => {
+  // These fixtures deliberately use verb-decorator forms (@main.post) rather
+  // than the plan's illustrative `methods=["POST"]` kwarg form: Task 1's
+  // resolveMethod always returns "GET" for route/api_route (methods= parsing
+  // is Task 2's job per the edge-case-groups scope note), so a methods=
+  // fixture here would assert an output this task's code cannot produce.
+  // What's under test is receiver resolution, not method resolution, so the
+  // verb-decorator form isolates that cleanly and needs no rewrite in Task 2.
+
+  it("recognizes a bare-name blueprint receiver resolved structurally via Blueprint() (main)", async () => {
+    const f = await py("main.py",
+      `main = Blueprint("main", __name__)\n\n` +
+      `@main.post("/orders")\n` +
+      `def create_order():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("recognizes a bare-name blueprint receiver resolved structurally via Blueprint() (auth)", async () => {
+    const f = await py("auth.py",
+      `auth = Blueprint("auth", __name__)\n\n` +
+      `@auth.post("/login")\n` +
+      `def login():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /login"]);
+  });
+
+  it("recognizes a bare-name blueprint receiver resolved structurally via Blueprint() (admin)", async () => {
+    const f = await py("admin.py",
+      `admin = Blueprint("admin", __name__)\n\n` +
+      `@admin.delete("/purge")\n` +
+      `def purge():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["DELETE /purge"]);
+  });
+
+  it("recognizes a custom-named receiver resolved structurally via APIRouter() (views)", async () => {
+    const f = await py("views.py",
+      `views = APIRouter()\n\n` +
+      `@views.post("/x")\n` +
+      `def create_x():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("emits nothing for a bare receiver with no in-file constructor assignment, outside ROUTER_RECEIVER", async () => {
+    const f = await py("orphan.py",
+      `@main.route("/x", methods=["POST"])\ndef do_thing():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("resolves a nested self.app receiver to the nearest attribute name", async () => {
+    const f = await py("server.py",
+      `class Server:\n` +
+      `    def setup(self):\n` +
+      `        @self.app.route("/x")\n` +
+      `        def handler():\n` +
+      `            return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/x"]);
+  });
+});
+
+describe("extractPythonRoutesAst: path-string forms", () => {
+  it("accepts single and double quoted path strings", async () => {
+    const f = await py("q.py",
+      `@app.get('/single')\ndef a():\n    return []\n\n` +
+      `@app.get("/double")\ndef b():\n    return []\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /single", "GET /double"]);
+  });
+
+  it("keeps Flask/FastAPI path-parameter syntax verbatim", async () => {
+    const f = await py("params.py",
+      `@app.get("/users/<int:user_id>")\ndef get_user(user_id):\n    return {}\n\n` +
+      `@router.get("/items/{item_id}")\ndef get_item(item_id: int):\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/users/<int:user_id>", "/items/{item_id}"]);
+  });
+
+  it("accepts the root path", async () => {
+    const f = await py("root.py", `@app.get("/")\ndef index():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/"]);
+  });
+
+  it("skips a path with no leading slash and an empty path string", async () => {
+    const f = await py("noleading.py",
+      `@app.get("orders")\ndef a():\n    return []\n\n` +
+      `@app.get("")\ndef b():\n    return []\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("accepts an f-string path with a static leading piece, preserving interpolation braces verbatim", async () => {
+    const f = await py("fstr.py",
+      `@app.get(f"/api/{version}/x")\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/api/{version}/x"]);
+  });
+
+  it("skips an f-string path whose leading piece is dynamic", async () => {
+    const f = await py("fstr2.py", `@app.get(f"{base}/x")\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("strips the r prefix from a raw string path", async () => {
+    const f = await py("raw.py", `@app.get(r"/raw")\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /raw"]);
+  });
+
+  it("strips triple quotes from a path", async () => {
+    const f = await py("triple.py", `@app.get("""/x""")\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /x"]);
+  });
+
+  it("joins an implicitly concatenated path string", async () => {
+    const f = await py("concat.py", `@app.get("/api" "/x")\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /api/x"]);
+  });
+
+  it("skips a path built with + concatenation (statically unresolvable)", async () => {
+    const f = await py("plus.py", `@app.get("/a" + suffix)\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a route whose path is a bare identifier variable", async () => {
+    const f = await py("var.py", `PATH = "/x"\n\n@app.route(PATH)\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("accepts a unicode path", async () => {
+    const f = await py("unicode.py", `@app.get("/café")\ndef a():\n    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /café"]);
+  });
+});

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -1071,3 +1071,99 @@ describe("receiver-scoped middleware inheritance (via extractPythonRoutesAst)", 
     expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
   });
 });
+
+describe("extractPythonRoutesAst: Django REST function views", () => {
+  it("extracts @api_view([\"POST\"]) as one route, line = the @api_view decorator line", async () => {
+    const f = await py("views.py",
+      `@api_view(["POST"])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /create_thing auth=false",
+    ]);
+    expect(routes[0].line).toBe(1);
+  });
+
+  it("prefers the mutating verb: @api_view([\"GET\", \"POST\"]) -> POST", async () => {
+    const f = await py("views.py",
+      `@api_view(["GET", "POST"])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual(["POST /create_thing"]);
+  });
+
+  it("defaults @api_view() with no arguments to GET (DRF documented default)", async () => {
+    const f = await py("views.py",
+      `@api_view()\n` +
+      `def list_things(request):\n` +
+      `    return Response([])\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual(["GET /list_things"]);
+  });
+
+  it("blesses @permission_classes([IsAuthenticated]) BELOW @api_view (applied first, enforced)", async () => {
+    const f = await py("views.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([IsAuthenticated])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=true"]);
+  });
+
+  it("does NOT bless @permission_classes([IsAuthenticated]) ABOVE @api_view: decorators apply bottom-up, so api_view builds the wrapped view before the permission attribute is set", async () => {
+    const f = await py("views.py",
+      `@permission_classes([IsAuthenticated])\n` +
+      `@api_view(["POST"])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=false"]);
+  });
+
+  it("does not bless @permission_classes([AllowAny])", async () => {
+    const f = await py("views.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([AllowAny])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=false"]);
+  });
+
+  it("does not bless @permission_classes([IsAuthenticatedOrReadOnly]): conditional per-method permission is ambiguous, resolves false", async () => {
+    const f = await py("views.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([IsAuthenticatedOrReadOnly])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=false"]);
+  });
+
+  it("does not bless @api_view([\"POST\"]) with no permission_classes at all", async () => {
+    const f = await py("views.py",
+      `@api_view(["POST"])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=false"]);
+  });
+
+  it("class-based views (APIView/ViewSet) are pinned OUT: zero routes even with permission_classes set", async () => {
+    const f = await py("views.py",
+      `class MyView(APIView):\n` +
+      `    permission_classes = [IsAuthenticated]\n\n` +
+      `    def post(self, request):\n` +
+      `        return Response({})\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("urls.py path(...) registrations emit zero routes: cross-file resolution is a non-goal", async () => {
+    const f = await py("urls.py",
+      `urlpatterns = [path("things/", views.create_thing)]\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -1273,6 +1273,7 @@ describe("malformed and adversarial input", () => {
 
   it("does not extract @app.route(...) decorating a CLASS (definition.type gate)", async () => {
     const f = await py("routeclass.py", `@app.route("/x")\nclass Foo:\n    pass\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
     expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
   });
 
@@ -1417,6 +1418,133 @@ describe("documented trade-offs (task-review pins)", () => {
       "/a auth=false",
       "/b auth=false",
     ]);
+  });
+});
+
+// ─── Final review Fix 1: permission_classes blesses ONLY api_view routes ────
+//
+// @permission_classes([IsAuthenticated]) is DRF machinery. It is runtime-inert
+// when stacked under a Flask (@app.route) or FastAPI (@router.post) route
+// decorator, so it must never bless those routes; it may bless only a route
+// derived from @api_view, and only when it sits BELOW @api_view (DRF's own
+// positional rule).
+describe("permission_classes is api_view-scoped (never blesses Flask/FastAPI routes)", () => {
+  it("does NOT bless a Flask @app.post route with @permission_classes([IsAuthenticated]) below it", async () => {
+    const f = await py("flaskperm.py",
+      `@app.post("/x")\n` +
+      `@permission_classes([IsAuthenticated])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("does NOT bless a FastAPI @router.post route with @permission_classes([IsAuthenticated]) below it", async () => {
+    const f = await py("routerperm.py",
+      `@router.post("/x")\n` +
+      `@permission_classes([IsAuthenticated])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("still blesses an @api_view route with @permission_classes([IsAuthenticated]) below it (unchanged)", async () => {
+    const f = await py("apiviewperm.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([IsAuthenticated])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=true"]);
+  });
+});
+
+// ─── Final review Fix 2: optional-auth veto for hooks and middleware classes ─
+//
+// The optional-flavored veto that the Depends path already applies (an
+// optional/anonymous dependency admits unauthenticated requests, so it must not
+// bless) was missing from the before_request hook-name check and the
+// add_middleware class-name check. Both now veto on the optionality segments.
+describe("optional-auth veto: hook names and middleware class names", () => {
+  it("does NOT bless @app.before_request def optional_authenticate() (optional veto)", async () => {
+    const f = await py("opthook.py", `@app.before_request\ndef optional_authenticate():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("optional_authenticate before_request hook does not bless its receiver's routes", async () => {
+    const f = await py("opthookroute.py",
+      `@app.before_request\n` +
+      `def optional_authenticate():\n` +
+      `    return None\n\n` +
+      `@app.route("/x", methods=["POST"])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("does NOT bless app.add_middleware(OptionalAuthMiddleware) (optional veto)", async () => {
+    const f = await py("optmw.py", `app.add_middleware(OptionalAuthMiddleware)\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+});
+
+// ─── Final review Fix 3: @api_view hidden-verb list resolves ALL, not GET ────
+//
+// Aligns asApiViewDecorator with resolveMethod's ALL-on-unresolvable
+// convention: a list holding a non-string element (a variable verb) is
+// statically unresolvable, so it stays in the mutating vote as ALL rather than
+// silently defaulting GET.
+describe("@api_view hidden-verb list resolves ALL", () => {
+  it("resolves @api_view([METHOD]) to ALL (hidden non-string element, unresolvable)", async () => {
+    const f = await py("apiviewvar.py",
+      `@api_view([METHOD])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("resolves @api_view([*BASE, \"POST\"]) to POST (a visible literal still resolves it)", async () => {
+    const f = await py("apiviewsplat.py",
+      `@api_view([*BASE, "POST"])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+});
+
+// ─── Final review Fix 4: lexicon boundary pins (sets unchanged) ──────────────
+//
+// The shipped AUTH_ENFORCE_SEGMENTS / AUTH_SUBJECT_SEGMENTS sets are broader
+// than the plan's Integration contract (they add protect(ed)/restrict(ed)/
+// verified and users/jwt/role(s)/admin/credentials). The sets are deliberately
+// left unchanged pending owner lexicon sign-off; these tests pin the closest
+// non-auth neighbors that must stay FALSE so the broadened surface has an
+// explicit boundary.
+describe("hook-name lexicon boundary pins (Fix 4)", () => {
+  it("does NOT bless restricted_zone_redirect (ENFORCE restricted, no SUBJECT)", async () => {
+    const f = await py("h1.py", `@app.before_request\ndef restricted_zone_redirect():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("does NOT bless track_user_metrics (SUBJECT user, no ENFORCE/CORE)", async () => {
+    const f = await py("h2.py", `@app.before_request\ndef track_user_metrics():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("does NOT bless role_labels (SUBJECT role, no ENFORCE)", async () => {
+    const f = await py("h3.py", `@app.before_request\ndef role_labels():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("does NOT bless protect_branch (ENFORCE protect, no SUBJECT)", async () => {
+    const f = await py("h4.py", `@app.before_request\ndef protect_branch():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
   });
 });
 
@@ -1644,6 +1772,23 @@ const NEVER_FALSE_BLESS_SWEEP: Array<{
       { path: "/a", method: "POST", authed: false },
       { path: "/b", method: "POST", authed: false },
     ],
+  },
+  // permission_classes is DRF-only and runtime-inert under a Flask route
+  // decorator: it must never bless an @app/@router route (Fix 1).
+  {
+    name: "flask-perm",
+    source:
+      `@app.post("/x")\n@permission_classes([IsAuthenticated])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  // A before_request hook with a non-auth name (SUBJECT login, no ENFORCE/CORE)
+  // must not bless the routes on its receiver (two-tier negative, route level).
+  {
+    name: "before-request-nonauth-hook",
+    source:
+      `@app.before_request\ndef track_login_metrics():\n    return None\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
   },
   // ── Broken-parse fixtures (emit nothing; nothing can be blessed) ──
   {

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -1167,3 +1167,516 @@ describe("extractPythonRoutesAst: Django REST function views", () => {
     expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
   });
 });
+
+// ─── Task 6: adversarial hardening ──────────────────────────────────────────
+//
+// Every fixture here is fed straight to extractPythonRoutesAst on whatever tree
+// tree-sitter produces (error-recovered or clean). The bar is twofold: the
+// extractor must never THROW on hostile input, and it must never emit a route
+// with hasAuth:true that the source does not actually protect. The
+// security-critical member of this group is the merged decorated_definition
+// (a syntax error fusing two handlers' decorators into one node): blessing, or
+// even extracting, across that boundary would let one handler inherit another's
+// auth decorators.
+describe("malformed and adversarial input", () => {
+  const dds = (f: { tree?: unknown }) =>
+    (f as { tree: { rootNode: { descendantsOfType(t: string): unknown[] } } }).tree.rootNode
+      .descendantsOfType("decorated_definition")
+      .filter((n): n is { hasError: boolean } => n !== null) as Array<{ hasError: boolean }>;
+
+  it("does not throw and finds zero routes when an unclosed decorator paren erases the file's decorator structure", async () => {
+    // Unclosed paren early, a fully valid @app.route("/still-good") later. Error
+    // recovery does not produce a decorated_definition for either route (the
+    // whole decorator structure is erased), so the AST path finds nothing. Recall
+    // on this file is preserved at the DETECT level, where rootNode.hasError routes
+    // the file to the regex extractor (see security-consistency.test.ts, Task 6).
+    const f = await py("unclosed.py",
+      `@app.route("/broken"\n` +
+      `@app.route("/still-good")\n` +
+      `def good():\n` +
+      `    return {}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true);
+    expect(() => extractPythonRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("CROSS-BLESS GUARD: a missing def colon fuses both handlers into one errored dd, which emits ZERO routes", async () => {
+    // PINNED EXACT SOURCE (the merged-dd shape is variant-sensitive): the missing
+    // colon after `def bad()` makes tree-sitter fuse everything from /bad through
+    // /good into a SINGLE decorated_definition holding
+    // [decorator, decorator, ERROR, decorator, function_definition] with
+    // dd.hasError === true. The dd.hasError skip means /good can never inherit
+    // /bad's @login_required and /bad can never be silently dropped as authed —
+    // the extractor emits nothing at all from the fused node. This is the
+    // security-critical guard of Task 6.
+    const f = await py("mergedcolon.py",
+      `@app.post("/bad")\n` +
+      `@login_required\n` +
+      `def bad()\n` +
+      `    return 1\n` +
+      `@app.post("/good")\n` +
+      `def good():\n` +
+      `    return 2\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true);
+    const errored = dds(f);
+    expect(errored).toHaveLength(1);
+    expect(errored[0].hasError).toBe(true);
+    expect(() => extractPythonRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("extracts a clean sibling dd's route while skipping a dd whose handler body has a parse error", async () => {
+    // The error is confined to /bad's body (`x = = 1`), so /bad's dd carries
+    // hasError and is skipped, but /good parses into its own clean dd and IS
+    // extracted. rootNode.hasError is cumulative (true for the whole file), which
+    // is why DETECT routes this file to the regex path; the extractor is exercised
+    // directly here to prove the per-dd skip is surgical, not file-wide.
+    const f = await py("bodyerror.py",
+      `@app.post("/bad")\n` +
+      `def bad():\n` +
+      `    x = = 1\n\n` +
+      `@app.post("/good")\n` +
+      `def good():\n` +
+      `    return 2\n`);
+    expect(() => extractPythonRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual(["POST /good auth=false"]);
+  });
+
+  it("returns [] with no throw for garbled binary-ish content; middleware is all-false", async () => {
+    const f = await py("garbled.py", ` ÿþ garbage   def ( ) : :`);
+    expect(() => extractPythonRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual({
+      hasAuth: false, hasValidation: false, hasRateLimit: false,
+    });
+  });
+
+  it("returns [] for an empty file and a comments-only file", async () => {
+    const empty = await py("empty.py", ``);
+    const comments = await py("comments.py", `# just a comment\n# @app.route("/x")\n`);
+    expect(extractPythonRoutesAst(empty.tree!, empty.relativePath)).toEqual([]);
+    expect(extractPythonRoutesAst(comments.tree!, comments.relativePath)).toEqual([]);
+  });
+
+  it("does not extract a route from a module docstring or an assigned multiline string that contains route text", async () => {
+    const f = await py("strings.py",
+      `"""\n` +
+      `@app.route("/fake", methods=["POST"])\n` +
+      `"""\n` +
+      `x = """\n` +
+      `@app.route("/fake2", methods=["POST"])\n` +
+      `"""\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not extract @app.route(...) decorating a CLASS (definition.type gate)", async () => {
+    const f = await py("routeclass.py", `@app.route("/x")\nclass Foo:\n    pass\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("extracts a route-decorated method inside a class body (recursive descendant walk)", async () => {
+    const f = await py("methodroute.py",
+      `class Foo:\n` +
+      `    @app.route("/x")\n` +
+      `    def handler(self):\n` +
+      `        return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /x"]);
+  });
+
+  it("extracts a route-decorated nested function (no false leak, no drop)", async () => {
+    const f = await py("nested.py",
+      `def outer():\n` +
+      `    @app.post("/inner")\n` +
+      `    def inner():\n` +
+      `        return {}\n` +
+      `    return inner\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /inner"]);
+  });
+
+  it("emits two RouteInfos for an identical route decorator duplicated on two functions (no dedup, pinned deliberate)", async () => {
+    const f = await py("dup.py",
+      `@app.post("/x")\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/x")\n` +
+      `def b():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x", "POST /x"]);
+  });
+
+  it("resolves a kwarg flood to POST /x (path first, methods read, other kwargs ignored)", async () => {
+    const f = await py("flood.py",
+      `@app.route("/x", methods=["POST"], strict_slashes=False, endpoint="e", defaults={"a": 1})\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("does not throw on a conditional decorator and does not bless it: @(login_required if PROD else noop)", async () => {
+    // The conditional expression is neither an identifier, an attribute, nor a
+    // recognized auth call, so it can never bless; the sibling @app.post route is
+    // still extracted, unauthed.
+    const f = await py("conditional.py",
+      `@(login_required if PROD else noop)\n` +
+      `@app.post("/x")\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    expect(() => extractPythonRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual(["POST /x auth=false"]);
+  });
+
+  it("ignores getattr(app, \"route\")(\"/x\") — the callee is a call, not an app/router attribute", async () => {
+    const f = await py("getattr.py",
+      `@getattr(app, "route")("/x")\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  // ── Unicode ──
+  it("handles a unicode path and a unicode handler name, blessing @login_required stacked BELOW the route decorator", async () => {
+    const f = await py("unicode.py",
+      `@app.route("/café", methods=["POST"])\n` +
+      `@login_required\n` +
+      `def crée_commande():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual(["POST /café auth=true"]);
+  });
+
+  it("does not bless a unicode auth-decorator name (@認証必須): recognition is an ASCII lexicon", async () => {
+    const f = await py("unicodeauth.py",
+      `@app.post("/x")\n` +
+      `@認証必須\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("does not extract a unicode receiver (@ルーター.route): a non-ASCII receiver is a recognition miss, never a bless", async () => {
+    const f = await py("unicoderecv.py",
+      `@ルーター.route("/x")\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not bless body-only auth (if not g.user: abort(401) inside the handler)", async () => {
+    // In-body enforcement is invisible to a decorator/parameter-level check;
+    // resolving it to false is the correct never-false-bless direction (an
+    // over-flag, never an over-bless).
+    const f = await py("bodyauth.py",
+      `@app.post("/x")\n` +
+      `def h():\n` +
+      `    if not g.user:\n` +
+      `        abort(401)\n` +
+      `    return {}\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+});
+
+// ─── Task 6: task-review pins (documenting existing behavior; NOT changing it) ──
+describe("documented trade-offs (task-review pins)", () => {
+  it("a fully-literal methods list of only unrecognized verbs resolves GET and exits the mutating vote", async () => {
+    // methods=["MKCOL"] is fully visible but holds no HTTP_VERBS member, so it is
+    // treated like an empty literal list: GET (Flask's default), which keeps the
+    // route OUT of the mutating auth vote. Documented trade from the Task 2
+    // review: an exotic-but-real WebDAV verb is not surfaced as mutating. Not
+    // ambiguity (the list is fully readable), so "ALL" would be wrong here.
+    const f = await py("mkcol.py", `@app.route("/x", methods=["MKCOL"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("does not bless custom or non-IsAuthenticated permission classes: permission_classes([IsAdminUser]) and ([FooPermission])", async () => {
+    // Only IsAuthenticated is in PERMISSION_AUTH. IsAdminUser is a real DRF class
+    // that requires staff, but it is not in the narrow whitelist, and FooPermission
+    // is an unknown custom class; both resolve hasAuth:false per never-false-bless
+    // (an unrecognized permission class is ambiguity, which never blesses).
+    const f = await py("custcompermclass.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([IsAdminUser])\n` +
+      `def a(request):\n` +
+      `    return Response({})\n\n` +
+      `@api_view(["POST"])\n` +
+      `@permission_classes([FooPermission])\n` +
+      `def b(request):\n` +
+      `    return Response({})\n`);
+    expect(extractPythonRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=false",
+      "/b auth=false",
+    ]);
+  });
+});
+
+// ─── Task 6: the systematic never-false-bless sweep ─────────────────────────
+//
+// A single registry of every ambiguity / "cannot determine" branch the Python
+// extractor has, restated as a fixture with ground truth. ONE table-driven test
+// asserts the invariant that matters: no route whose ground truth is
+// authed:false is ever emitted with hasAuth:true. Positive (authed:true) entries
+// are documentation only — the assertion filters to the negatives. Any NEW
+// python fixture added in a later task MUST be registered here so the invariant
+// keeps whole-module coverage. Broken-parse fixtures are included too: they emit
+// nothing, and `emitted?.hasAuth ?? false` treats "not emitted" as not-blessed.
+const NEVER_FALSE_BLESS_SWEEP: Array<{
+  name: string;
+  source: string;
+  groundTruth: Array<{ path: string; method: string; authed: boolean }>;
+}> = [
+  // ── Decorator-order (positional auth binding) ──
+  {
+    name: "auth-above-route",
+    source:
+      `@login_required\n@app.post("/orders")\ndef create_order():\n    return {}\n`,
+    groundTruth: [{ path: "/orders", method: "POST", authed: false }],
+  },
+  {
+    name: "mixed-stack-a-b",
+    source:
+      `@app.post("/a")\n@login_required\n@app.post("/b")\ndef h():\n    return {}\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: true },
+      { path: "/b", method: "POST", authed: false },
+    ],
+  },
+  // ── flask-jwt-extended optional auth ──
+  {
+    name: "jwt-optional-true",
+    source:
+      `@app.post("/x")\n@jwt_required(optional=True)\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "jwt-optional-flag",
+    source:
+      `@app.post("/x")\n@jwt_required(optional=OPTIONAL_AUTH)\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  // ── Decorator lexicon near-misses ──
+  {
+    name: "feature-requires",
+    source:
+      `@app.post("/a")\n@feature.requires("new_ui")\ndef a():\n    return {}\n\n` +
+      `@app.post("/b")\n@pytest.mark.requires\ndef b():\n    return {}\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: false },
+      { path: "/b", method: "POST", authed: false },
+    ],
+  },
+  {
+    name: "author-stats-substring",
+    source: `@app.post("/x")\n@author_stats\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "track-metrics-and-guard",
+    source:
+      `@app.post("/a")\n@track_metrics\ndef a():\n    return {}\n\n` +
+      `@app.post("/b")\n@guard\ndef b():\n    return {}\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: false },
+      { path: "/b", method: "POST", authed: false },
+    ],
+  },
+  {
+    name: "adjacent-noleak",
+    source:
+      `@app.post("/a")\n@login_required\ndef a():\n    return {}\n\n` +
+      `@app.post("/b")\ndef b():\n    return {}\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: true },
+      { path: "/b", method: "POST", authed: false },
+    ],
+  },
+  // ── Unrecognized / invisible auth signals (all resolve false) ──
+  {
+    name: "unicode-auth-decorator",
+    source: `@app.post("/x")\n@認証必須\ndef h():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "conditional-decorator",
+    source:
+      `@(login_required if PROD else noop)\n@app.post("/x")\ndef h():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "body-only-auth",
+    source:
+      `@app.post("/x")\ndef h():\n    if not g.user:\n        abort(401)\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  // ── FastAPI Depends: non-auth dependencies ──
+  {
+    name: "depends-nonauth",
+    source:
+      `@router.post("/db")\ndef h1(db=Depends(get_db)):\n    return {}\n\n` +
+      `@router.post("/settings")\ndef h2(x=Depends(get_settings)):\n    return {}\n\n` +
+      `@router.post("/pagination")\ndef h3(x=Depends(pagination_params)):\n    return {}\n\n` +
+      `@router.post("/bare")\ndef h4(x=Depends()):\n    return {}\n`,
+    groundTruth: [
+      { path: "/db", method: "POST", authed: false },
+      { path: "/settings", method: "POST", authed: false },
+      { path: "/pagination", method: "POST", authed: false },
+      { path: "/bare", method: "POST", authed: false },
+    ],
+  },
+  // ── Depends segment near-miss set (brief-mandated) ──
+  {
+    name: "depends-nearmiss",
+    source:
+      `@router.post("/x1")\ndef h1(a=Depends(get_author_stats)):\n    return {}\n\n` +
+      `@router.post("/x2")\ndef h2(a=Depends(get_authors)):\n    return {}\n\n` +
+      `@router.post("/x3")\ndef h3(a=Depends(get_jwt_settings)):\n    return {}\n\n` +
+      `@router.post("/x4")\ndef h4(a=Depends(get_api_key_usage_stats)):\n    return {}\n\n` +
+      `@router.post("/x5")\ndef h5(a=Depends(get_current_user_optional)):\n    return {}\n\n` +
+      `@router.post("/x6")\ndef h6(a=Depends(get_current_user_or_none)):\n    return {}\n`,
+    groundTruth: [
+      { path: "/x1", method: "POST", authed: false },
+      { path: "/x2", method: "POST", authed: false },
+      { path: "/x3", method: "POST", authed: false },
+      { path: "/x4", method: "POST", authed: false },
+      { path: "/x5", method: "POST", authed: false },
+      { path: "/x6", method: "POST", authed: false },
+    ],
+  },
+  // ── Depends: argument text never blesses (incl. Depends(Client(url=jwt_issuer_url))) ──
+  {
+    name: "depends-argtext",
+    source:
+      `@router.post("/x1")\ndef h1(a=Depends(make_client("oauth2_url"))):\n    return {}\n\n` +
+      `@router.post("/x2")\ndef h2(a=Depends(Client(url=jwt_issuer_url))):\n    return {}\n`,
+    groundTruth: [
+      { path: "/x1", method: "POST", authed: false },
+      { path: "/x2", method: "POST", authed: false },
+    ],
+  },
+  // ── dependencies= kwarg on the route decorator ──
+  {
+    name: "dep-kwarg",
+    source:
+      `@router.post("/dep-verify", dependencies=[Depends(verify_token)])\ndef h1():\n    return {}\n\n` +
+      `@router.post("/dep-db", dependencies=[Depends(get_db)])\ndef h2():\n    return {}\n\n` +
+      `@router.post("/dep-author", dependencies=[Depends(get_author_stats)])\ndef h3():\n    return {}\n\n` +
+      `@router.post("/dep-unrelated", dependencies=[Security(some_unrelated_name)])\ndef h4():\n    return {}\n`,
+    groundTruth: [
+      { path: "/dep-verify", method: "POST", authed: true },
+      { path: "/dep-db", method: "POST", authed: false },
+      { path: "/dep-author", method: "POST", authed: false },
+      { path: "/dep-unrelated", method: "POST", authed: false },
+    ],
+  },
+  // ── Module-level Annotated alias (Depends invisible at the param) ──
+  {
+    name: "annotated-alias",
+    source:
+      `CurrentUser = Annotated[User, Depends(get_current_user)]\n\n` +
+      `@router.post("/alias")\ndef h(user: CurrentUser):\n    return {}\n`,
+    groundTruth: [{ path: "/alias", method: "POST", authed: false }],
+  },
+  // ── Mixed-receiver middleware files (brief-mandated) ──
+  {
+    name: "mixed-bp",
+    source:
+      `@admin_bp.before_request\ndef require_login():\n    return None\n\n` +
+      `@admin_bp.route("/users", methods=["POST"])\ndef create_user():\n    return {}\n\n` +
+      `@public_bp.route("/webhook", methods=["POST"])\ndef webhook():\n    return {}\n`,
+    groundTruth: [
+      { path: "/users", method: "POST", authed: true },
+      { path: "/webhook", method: "POST", authed: false },
+    ],
+  },
+  {
+    name: "mixed-router",
+    source:
+      `admin_router = APIRouter(dependencies=[Depends(get_current_user)])\n` +
+      `public_router = APIRouter()\n\n` +
+      `@admin_router.post("/admin")\ndef admin_op():\n    return {}\n\n` +
+      `@public_router.post("/public")\ndef public_op():\n    return {}\n`,
+    groundTruth: [
+      { path: "/admin", method: "POST", authed: true },
+      { path: "/public", method: "POST", authed: false },
+    ],
+  },
+  // ── DRF permission_classes negatives ──
+  {
+    name: "perm-allowany",
+    source:
+      `@api_view(["POST"])\n@permission_classes([AllowAny])\ndef create_thing(request):\n    return Response({})\n`,
+    groundTruth: [{ path: "/create_thing", method: "POST", authed: false }],
+  },
+  {
+    name: "perm-readonly",
+    source:
+      `@api_view(["POST"])\n@permission_classes([IsAuthenticatedOrReadOnly])\ndef create_thing(request):\n    return Response({})\n`,
+    groundTruth: [{ path: "/create_thing", method: "POST", authed: false }],
+  },
+  {
+    name: "perm-above-apiview",
+    source:
+      `@permission_classes([IsAuthenticated])\n@api_view(["POST"])\ndef create_thing(request):\n    return Response({})\n`,
+    groundTruth: [{ path: "/create_thing", method: "POST", authed: false }],
+  },
+  {
+    name: "apiview-noperm",
+    source:
+      `@api_view(["POST"])\ndef create_thing(request):\n    return Response({})\n`,
+    groundTruth: [{ path: "/create_thing", method: "POST", authed: false }],
+  },
+  {
+    name: "perm-custom",
+    source:
+      `@api_view(["POST"])\n@permission_classes([IsAdminUser])\ndef a(request):\n    return Response({})\n\n` +
+      `@api_view(["POST"])\n@permission_classes([FooPermission])\ndef b(request):\n    return Response({})\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: false },
+      { path: "/b", method: "POST", authed: false },
+    ],
+  },
+  // ── Broken-parse fixtures (emit nothing; nothing can be blessed) ──
+  {
+    name: "merged-dd-missing-colon",
+    source:
+      `@app.post("/bad")\n@login_required\ndef bad()\n    return 1\n` +
+      `@app.post("/good")\ndef good():\n    return 2\n`,
+    groundTruth: [
+      { path: "/bad", method: "POST", authed: false },
+      { path: "/good", method: "POST", authed: false },
+    ],
+  },
+  {
+    name: "body-error-clean-sibling",
+    source:
+      `@app.post("/bad")\ndef bad():\n    x = = 1\n\n` +
+      `@app.post("/good")\ndef good():\n    return 2\n`,
+    groundTruth: [
+      { path: "/bad", method: "POST", authed: false },
+      { path: "/good", method: "POST", authed: false },
+    ],
+  },
+];
+
+describe("never-false-bless sweep", () => {
+  it("no route with ground truth authed:false is ever emitted hasAuth:true", async () => {
+    for (const entry of NEVER_FALSE_BLESS_SWEEP) {
+      const f = await py(`sweep/${entry.name}.py`, entry.source);
+      const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+      for (const gt of entry.groundTruth.filter((g) => !g.authed)) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        expect(emitted?.hasAuth ?? false, `${entry.name}: ${gt.method} ${gt.path}`).toBe(false);
+      }
+    }
+  });
+});

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
+import {
+  extractPythonRoutesAst,
+  extractPythonFileMiddlewareAst,
+} from "../../../src/drift/security-ast-python.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 
 const py = (path: string, src: string) => fileWithTree(path, src, "python");
@@ -884,5 +887,187 @@ describe("per-route validation and rate-limit lanes", () => {
     expect(routes[0].hasAuth).toBe(false);
     expect(routes[0].hasValidation).toBe(false);
     expect(routes[0].hasRateLimit).toBe(false);
+  });
+});
+
+describe("extractPythonFileMiddlewareAst", () => {
+  const NONE = { hasAuth: false, hasValidation: false, hasRateLimit: false };
+
+  it("blesses @app.before_request def require_login() (auth hook, tier 2)", async () => {
+    const f = await py("mw.py", `@app.before_request\ndef require_login():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual({
+      hasAuth: true, hasValidation: false, hasRateLimit: false,
+    });
+  });
+
+  it("blesses @bp.before_request def check_auth() (auth CORE segment, tier 1)", async () => {
+    const f = await py("mw.py", `@bp.before_request\ndef check_auth():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(true);
+  });
+
+  it("does NOT bless @app.before_request def log_request() (a real hook, not authn)", async () => {
+    const f = await py("mw.py", `@app.before_request\ndef log_request():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual(NONE);
+  });
+
+  it("does NOT bless ambiguous hooks that lack a CORE segment or an ENFORCE+SUBJECT pair", async () => {
+    // metrics hook (SUBJECT login, no ENFORCE), content negotiation (ENFORCE
+    // verify, no SUBJECT), cookie setter (SUBJECT token, no ENFORCE; CSRF is not
+    // authN).
+    const metrics = await py("m1.py", `@app.before_request\ndef track_login_metrics():\n    pass\n`);
+    const content = await py("m2.py", `@app.before_request\ndef verify_content_type():\n    pass\n`);
+    const csrf = await py("m3.py", `@app.before_request\ndef set_csrf_token():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(metrics.tree!).hasAuth).toBe(false);
+    expect(extractPythonFileMiddlewareAst(content.tree!).hasAuth).toBe(false);
+    expect(extractPythonFileMiddlewareAst(csrf.tree!).hasAuth).toBe(false);
+  });
+
+  it("blesses @app.before_request def verify_token() (ENFORCE verify + SUBJECT token)", async () => {
+    const f = await py("mw.py", `@app.before_request\ndef verify_token():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(true);
+  });
+
+  it("does NOT bless @job.before_request def check_auth() (receiver gate: job is not a router)", async () => {
+    const f = await py("mw.py", `@job.before_request\ndef check_auth():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual(NONE);
+  });
+
+  it("blesses add_middleware with an auth-segment class name (AuthMiddleware, AuthenticationMiddleware)", async () => {
+    const a = await py("mw.py", `app.add_middleware(AuthMiddleware)\n`);
+    const b = await py("mw.py", `app.add_middleware(AuthenticationMiddleware, backend=JWTBackend())\n`);
+    expect(extractPythonFileMiddlewareAst(a.tree!).hasAuth).toBe(true);
+    expect(extractPythonFileMiddlewareAst(b.tree!).hasAuth).toBe(true);
+  });
+
+  it("does NOT bless add_middleware with a non-auth class (CORSMiddleware, GZipMiddleware)", async () => {
+    const cors = await py("mw.py", `app.add_middleware(CORSMiddleware, allow_origins=["*"])\n`);
+    const gzip = await py("mw.py", `app.add_middleware(GZipMiddleware)\n`);
+    expect(extractPythonFileMiddlewareAst(cors.tree!).hasAuth).toBe(false);
+    expect(extractPythonFileMiddlewareAst(gzip.tree!).hasAuth).toBe(false);
+  });
+
+  it("does NOT bless add_middleware(AuthorTrackingMiddleware) / (AuthorNotesMiddleware): 'Author' is a segment, not 'Auth'", async () => {
+    const track = await py("mw.py", `app.add_middleware(AuthorTrackingMiddleware)\n`);
+    const notes = await py("mw.py", `app.add_middleware(AuthorNotesMiddleware)\n`);
+    expect(extractPythonFileMiddlewareAst(track.tree!).hasAuth).toBe(false);
+    expect(extractPythonFileMiddlewareAst(notes.tree!).hasAuth).toBe(false);
+  });
+
+  it("blesses a router/app constructor dependencies=[Depends(auth)] kwarg", async () => {
+    const router = await py("mw.py", `router = APIRouter(dependencies=[Depends(get_current_user)])\n`);
+    const app = await py("mw.py", `app = FastAPI(dependencies=[Depends(verify_token)])\n`);
+    expect(extractPythonFileMiddlewareAst(router.tree!).hasAuth).toBe(true);
+    expect(extractPythonFileMiddlewareAst(app.tree!).hasAuth).toBe(true);
+  });
+
+  it("does NOT bless a constructor with no auth dependency (prefix-only, get_db)", async () => {
+    const prefix = await py("mw.py", `router = APIRouter(prefix="/admin")\n`);
+    const db = await py("mw.py", `router = APIRouter(dependencies=[Depends(get_db)])\n`);
+    expect(extractPythonFileMiddlewareAst(prefix.tree!)).toEqual(NONE);
+    expect(extractPythonFileMiddlewareAst(db.tree!)).toEqual(NONE);
+  });
+
+  it("does NOT bless a bare unassigned APIRouter(dependencies=[Depends(auth)]) (no resolvable scope, never-false-bless)", async () => {
+    const f = await py("mw.py", `APIRouter(dependencies=[Depends(verify_token)])\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual(NONE);
+  });
+
+  it("lanes: SlowAPIMiddleware -> rateLimit, ValidationMiddleware -> validation, none -> all false", async () => {
+    const rate = await py("mw.py", `app.add_middleware(SlowAPIMiddleware)\n`);
+    const val = await py("mw.py", `app.add_middleware(ValidationMiddleware)\n`);
+    const none = await py("mw.py", `app.add_middleware(GZipMiddleware)\n`);
+    expect(extractPythonFileMiddlewareAst(rate.tree!)).toEqual({
+      hasAuth: false, hasValidation: false, hasRateLimit: true,
+    });
+    expect(extractPythonFileMiddlewareAst(val.tree!)).toEqual({
+      hasAuth: false, hasValidation: true, hasRateLimit: false,
+    });
+    expect(extractPythonFileMiddlewareAst(none.tree!)).toEqual(NONE);
+  });
+
+  it("a validation-only before_request hook sets validation, never auth (lanes independent)", async () => {
+    const f = await py("mw.py", `@app.before_request\ndef validate_payload():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual({
+      hasAuth: false, hasValidation: true, hasRateLimit: false,
+    });
+  });
+
+  it("empty and comments-only files are all false", async () => {
+    const empty = await py("mw.py", ``);
+    const comments = await py("mw.py", `# just a comment\n# another\n`);
+    expect(extractPythonFileMiddlewareAst(empty.tree!)).toEqual(NONE);
+    expect(extractPythonFileMiddlewareAst(comments.tree!)).toEqual(NONE);
+  });
+
+  it("CRITICAL: a per-route @login_required is NOT a file-level auth bless (the regex over-bless the AST kills)", async () => {
+    const f = await py("mw.py",
+      `@app.post("/x")\n` +
+      `@login_required\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual(NONE);
+  });
+});
+
+describe("receiver-scoped middleware inheritance (via extractPythonRoutesAst)", () => {
+  it("a before_request on admin_bp blesses the admin route but NOT a co-located public_bp route", async () => {
+    const f = await py("mixed.py",
+      `@admin_bp.before_request\n` +
+      `def require_login():\n` +
+      `    return None\n\n` +
+      `@admin_bp.route("/users", methods=["POST"])\n` +
+      `def create_user():\n` +
+      `    return {}\n\n` +
+      `@public_bp.route("/webhook", methods=["POST"])\n` +
+      `def webhook():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/users auth=true",
+      "/webhook auth=false",
+    ]);
+    // File-level OR is unchanged public shape: the file DOES have auth middleware.
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(true);
+  });
+
+  it("a FastAPI constructor dependency on admin_router blesses only its routes, not public_router's", async () => {
+    const f = await py("routers.py",
+      `admin_router = APIRouter(dependencies=[Depends(get_current_user)])\n` +
+      `public_router = APIRouter()\n\n` +
+      `@admin_router.post("/admin")\n` +
+      `def admin_op():\n` +
+      `    return {}\n\n` +
+      `@public_router.post("/public")\n` +
+      `def public_op():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/admin auth=true",
+      "/public auth=false",
+    ]);
+  });
+
+  it("an @app.before_request hook is file-wide: a blueprint route inherits it", async () => {
+    const f = await py("appwide.py",
+      `@app.before_request\n` +
+      `def require_login():\n` +
+      `    return None\n\n` +
+      `@orders_bp.route("/x", methods=["POST"])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+  });
+
+  it("a @bp.before_app_request hook is app-wide: an app route inherits it", async () => {
+    const f = await py("beforeapp.py",
+      `@bp.before_app_request\n` +
+      `def require_login():\n` +
+      `    return None\n\n` +
+      `@app.post("/x")\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -1548,6 +1548,54 @@ describe("hook-name lexicon boundary pins (Fix 4)", () => {
   });
 });
 
+// ─── KNOWN EXPOSURE pins: two-tier hook lexicon false-bless (owner decision
+// pending) ─────────────────────────────────────────────────────────────────
+//
+// These document CURRENT behavior; they do NOT endorse it. The ENFORCE+SUBJECT
+// two-tier match (see the KNOWN FALSE-BLESS EXPOSURE comment above
+// AUTH_ENFORCE_SEGMENTS in security-ast-python.ts) blesses attributive
+// non-auth hook names whose ENFORCE verb targets an object noun that also
+// happens to be a SUBJECT segment: verify_user_email only sends an
+// email-confirmation link, and protect_user_data only scrubs/anonymizes
+// stored data, but neither hook authenticates a request. Blessing means the
+// extractor marks the receiver's routes hasAuth:true, which is the
+// false-bless direction the module exists to prevent, not a safe over-flag.
+// Pinned here so a future lexicon resolution flips these deliberately instead
+// of silently.
+describe("KNOWN EXPOSURE pins: two-tier hook lexicon false-bless (pending owner decision)", () => {
+  it("KNOWN EXPOSURE pending owner decision: verify_user_email before_request hook blesses its receiver's routes via ENFORCE+SUBJECT", async () => {
+    const f = await py("exposure-verify-user-email.py",
+      `@app.before_request\n` +
+      `def verify_user_email():\n` +
+      `    return None\n\n` +
+      `@app.route("/x", methods=["POST"])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    // CURRENT behavior, documented as exposure: ENFORCE "verify" + SUBJECT
+    // "user" both match a hook that only confirms an email address. A future
+    // lexicon fix is expected to flip this to auth=false; update this
+    // assertion deliberately when it does, not as collateral of a refactor.
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+  });
+
+  it("KNOWN EXPOSURE pending owner decision: protect_user_data before_request hook blesses its receiver's routes via ENFORCE+SUBJECT", async () => {
+    const f = await py("exposure-protect-user-data.py",
+      `@app.before_request\n` +
+      `def protect_user_data():\n` +
+      `    return None\n\n` +
+      `@app.route("/y", methods=["POST"])\n` +
+      `def y():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    // CURRENT behavior, documented as exposure: ENFORCE "protect" + SUBJECT
+    // "user" both match a hook that only scrubs/anonymizes stored data. A
+    // future lexicon fix is expected to flip this to auth=false; update this
+    // assertion deliberately when it does, not as collateral of a refactor.
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/y auth=true"]);
+  });
+});
+
 // ─── Task 6: the systematic never-false-bless sweep ─────────────────────────
 //
 // A single registry of every ambiguity / "cannot determine" branch the Python

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -474,3 +474,415 @@ describe("extractPythonRoutesAst: method resolution", () => {
     expect(routes[0].method).toBe("POST");
   });
 });
+
+describe("auth recognition: decorators", () => {
+  it("blesses @login_required BELOW the route decorator (applied first, wraps the registered handler)", async () => {
+    const f = await py("below.py",
+      `@app.post("/orders")\n` +
+      `@login_required\n` +
+      `def create_order():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=true",
+    ]);
+  });
+
+  it("does NOT bless @login_required ABOVE the route decorator (registers the unwrapped handler)", async () => {
+    const f = await py("above.py",
+      `@login_required\n` +
+      `@app.post("/orders")\n` +
+      `def create_order():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=false",
+    ]);
+  });
+
+  it("mixed stacked-route order: /a wraps the auth decorator (true), /b registers unwrapped (false)", async () => {
+    const f = await py("mixed.py",
+      `@app.post("/a")\n` +
+      `@login_required\n` +
+      `@app.post("/b")\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /a auth=true",
+      "POST /b auth=false",
+    ]);
+  });
+
+  it("blesses @jwt_required() and @jwt_required(refresh=True)", async () => {
+    const f = await py("jwt.py",
+      `@app.post("/a")\n` +
+      `@jwt_required()\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/b")\n` +
+      `@jwt_required(refresh=True)\n` +
+      `def b():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=true",
+      "/b auth=true",
+    ]);
+  });
+
+  it("does not bless @jwt_required(optional=True): optional auth admits anonymous requests", async () => {
+    const f = await py("optionaltrue.py",
+      `@app.post("/x")\n` +
+      `@jwt_required(optional=True)\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("does not bless @jwt_required(optional=OPTIONAL_AUTH): statically unknowable value resolves false", async () => {
+    const f = await py("optionalflag.py",
+      `@app.post("/x")\n` +
+      `@jwt_required(optional=OPTIONAL_AUTH)\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("blesses @auth.login_required (flask-httpauth) and @flask_login.login_required", async () => {
+    const f = await py("attrdec.py",
+      `@app.post("/a")\n` +
+      `@auth.login_required\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/b")\n` +
+      `@flask_login.login_required\n` +
+      `def b():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=true",
+      "/b auth=true",
+    ]);
+  });
+
+  it("blesses lexicon names: requires_auth, admin_required, permission_required(...), token_required, bare requires(...)", async () => {
+    const f = await py("lexicon.py",
+      `@app.post("/a")\n` +
+      `@requires_auth\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/b")\n` +
+      `@admin_required\n` +
+      `def b():\n` +
+      `    return {}\n\n` +
+      `@app.post("/c")\n` +
+      `@permission_required("orders.write")\n` +
+      `def c():\n` +
+      `    return {}\n\n` +
+      `@app.post("/d")\n` +
+      `@token_required\n` +
+      `def d():\n` +
+      `    return {}\n\n` +
+      `@app.post("/e")\n` +
+      `@requires("admin")\n` +
+      `def e():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=true",
+      "/b auth=true",
+      "/c auth=true",
+      "/d auth=true",
+      "/e auth=true",
+    ]);
+  });
+
+  it("does not bless @feature.requires(...) or @pytest.mark.requires: bare requires only matches the bare-identifier call form", async () => {
+    const f = await py("bogusrequires.py",
+      `@app.post("/a")\n` +
+      `@feature.requires("new_ui")\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/b")\n` +
+      `@pytest.mark.requires\n` +
+      `def b():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=false",
+      "/b auth=false",
+    ]);
+  });
+
+  it("does not bless @author_stats: substring near-miss, exact-segment matching only", async () => {
+    const f = await py("authorstats.py",
+      `@app.post("/x")\n` +
+      `@author_stats\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("does not bless @track_metrics or an aliased @guard: name-based recognition is conservative", async () => {
+    const f = await py("aliases.py",
+      `@app.post("/a")\n` +
+      `@track_metrics\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/b")\n` +
+      `@guard\n` +
+      `def b():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=false",
+      "/b auth=false",
+    ]);
+  });
+
+  it("adjacent-function no-leak: a's auth decorator does not bless sibling b", async () => {
+    const f = await py("noleak.py",
+      `@app.post("/a")\n` +
+      `@login_required\n` +
+      `def a():\n` +
+      `    return {}\n\n` +
+      `@app.post("/b")\n` +
+      `def b():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/a auth=true",
+      "/b auth=false",
+    ]);
+  });
+});
+
+describe("auth recognition: FastAPI dependencies", () => {
+  it("blesses a typed default parameter: user: User = Depends(get_current_user)", async () => {
+    const f = await py("typeddefault.py",
+      `@router.post("/x")\n` +
+      `def h(user: User = Depends(get_current_user)):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => r.hasAuth)).toEqual([true]);
+  });
+
+  it("blesses an untyped default parameter: user=Depends(get_current_user)", async () => {
+    const f = await py("untypeddefault.py",
+      `@router.post("/x")\n` +
+      `def h(user=Depends(get_current_user)):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => r.hasAuth)).toEqual([true]);
+  });
+
+  it("blesses Annotated[User, Depends(get_current_user)] (typed_parameter, generic_type nesting)", async () => {
+    const f = await py("annotateddepends.py",
+      `@router.post("/x")\n` +
+      `def h(user: Annotated[User, Depends(get_current_user)]):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => r.hasAuth)).toEqual([true]);
+  });
+
+  it("blesses Annotated[str, Security(get_api_key)]", async () => {
+    const f = await py("annotatedsecurity.py",
+      `@router.post("/x")\n` +
+      `def h(key: Annotated[str, Security(get_api_key)]):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => r.hasAuth)).toEqual([true]);
+  });
+
+  it("does not bless db=Depends(get_db), Depends(get_settings), Depends(pagination_params), or bare Depends()", async () => {
+    const f = await py("nonauthdeps.py",
+      `@router.post("/db")\n` +
+      `def h1(db=Depends(get_db)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/settings")\n` +
+      `def h2(x=Depends(get_settings)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/pagination")\n` +
+      `def h3(x=Depends(pagination_params)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/bare")\n` +
+      `def h4(x=Depends()):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/db auth=false",
+      "/settings auth=false",
+      "/pagination auth=false",
+      "/bare auth=false",
+    ]);
+  });
+
+  it("blesses Depends(oauth2_scheme) and Depends(verify_token)", async () => {
+    const f = await py("oauthverify.py",
+      `@router.post("/oauth")\n` +
+      `def h1(x=Depends(oauth2_scheme)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/verify")\n` +
+      `def h2(x=Depends(verify_token)):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/oauth auth=true",
+      "/verify auth=true",
+    ]);
+  });
+
+  it("segment near-misses all resolve false: get_author_stats, get_authors, get_jwt_settings, get_api_key_usage_stats, get_current_user_optional, get_current_user_or_none", async () => {
+    const f = await py("nearmisses.py",
+      `@router.post("/x1")\n` +
+      `def h1(a=Depends(get_author_stats)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x2")\n` +
+      `def h2(a=Depends(get_authors)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x3")\n` +
+      `def h3(a=Depends(get_jwt_settings)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x4")\n` +
+      `def h4(a=Depends(get_api_key_usage_stats)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x5")\n` +
+      `def h5(a=Depends(get_current_user_optional)):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x6")\n` +
+      `def h6(a=Depends(get_current_user_or_none)):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/x1 auth=false",
+      "/x2 auth=false",
+      "/x3 auth=false",
+      "/x4 auth=false",
+      "/x5 auth=false",
+      "/x6 auth=false",
+    ]);
+  });
+
+  it("argument text never blesses: Depends(make_client(\"oauth2_url\")) and Depends(Client(url=jwt_issuer_url))", async () => {
+    const f = await py("argtextnoblesses.py",
+      `@router.post("/x1")\n` +
+      `def h1(a=Depends(make_client("oauth2_url"))):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x2")\n` +
+      `def h2(a=Depends(Client(url=jwt_issuer_url))):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/x1 auth=false",
+      "/x2 auth=false",
+    ]);
+  });
+
+  it("blesses class dependencies via CamelCase segments: Depends(JWTBearer()) and Depends(OAuth2PasswordBearer(tokenUrl=\"token\"))", async () => {
+    const f = await py("classdeps.py",
+      `@router.post("/x1")\n` +
+      `def h1(a=Depends(JWTBearer())):\n` +
+      `    return {}\n\n` +
+      `@router.post("/x2")\n` +
+      `def h2(token: str = Depends(OAuth2PasswordBearer(tokenUrl="token"))):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/x1 auth=true",
+      "/x2 auth=true",
+    ]);
+  });
+
+  it("blesses an auth dependency as the third of several params", async () => {
+    const f = await py("thirdparam.py",
+      `@router.post("/x")\n` +
+      `def h(a: int, b: str, user=Depends(get_current_user)):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => r.hasAuth)).toEqual([true]);
+  });
+
+  it("resolves the dependencies= kwarg on the route decorator: verify_token true, get_db/get_author_stats/unrelated Security false", async () => {
+    const f = await py("depkwarg.py",
+      `@router.post("/dep-verify", dependencies=[Depends(verify_token)])\n` +
+      `def h1():\n` +
+      `    return {}\n\n` +
+      `@router.post("/dep-db", dependencies=[Depends(get_db)])\n` +
+      `def h2():\n` +
+      `    return {}\n\n` +
+      `@router.post("/dep-author", dependencies=[Depends(get_author_stats)])\n` +
+      `def h3():\n` +
+      `    return {}\n\n` +
+      `@router.post("/dep-unrelated", dependencies=[Security(some_unrelated_name)])\n` +
+      `def h4():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/dep-verify auth=true",
+      "/dep-db auth=false",
+      "/dep-author auth=false",
+      "/dep-unrelated auth=false",
+    ]);
+  });
+
+  it("does not bless a module-level Annotated alias: the Depends signal is invisible at the param (documented recall gap)", async () => {
+    const f = await py("annotatedalias.py",
+      `CurrentUser = Annotated[User, Depends(get_current_user)]\n\n` +
+      `@router.post("/alias")\n` +
+      `def h(user: CurrentUser):\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/alias auth=false"]);
+  });
+});
+
+describe("per-route validation and rate-limit lanes", () => {
+  it("@limiter.limit(...) sets hasRateLimit true, leaves hasAuth false", async () => {
+    const f = await py("ratelimit.py",
+      `@app.post("/x")\n` +
+      `@limiter.limit("5/minute")\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasRateLimit).toBe(true);
+    expect(routes[0].hasAuth).toBe(false);
+  });
+
+  it("@validate_schema(OrderSchema) sets hasValidation true", async () => {
+    const f = await py("validate.py",
+      `@app.post("/y")\n` +
+      `@validate_schema(OrderSchema)\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasValidation).toBe(true);
+  });
+
+  it("a route PATH is not middleware: /validate and /ratelimit paths never bless their own lanes", async () => {
+    const f = await py("pathnoise.py",
+      `@app.post("/validate")\n` +
+      `def h1():\n` +
+      `    return {}\n\n` +
+      `@app.post("/ratelimit")\n` +
+      `def h2():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => r.hasValidation)).toEqual([false, false]);
+    expect(routes.map((r) => r.hasRateLimit)).toEqual([false, false]);
+  });
+
+  it("a bare route has all three lanes false", async () => {
+    const f = await py("bare.py", `@app.get("/bare")\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].hasValidation).toBe(false);
+    expect(routes[0].hasRateLimit).toBe(false);
+  });
+});

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -350,3 +350,127 @@ describe("extractPythonRoutesAst: path-string forms", () => {
       .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /café"]);
   });
 });
+
+describe("extractPythonRoutesAst: method resolution", () => {
+  it("defaults to GET when no methods kwarg is present", async () => {
+    const f = await py("nokw.py", `@app.route("/x")\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("resolves methods=[\"POST\"] to POST", async () => {
+    const f = await py("post.py", `@app.route("/x", methods=["POST"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves methods=[\"DELETE\"] to DELETE", async () => {
+    const f = await py("delete.py", `@app.route("/x", methods=["DELETE"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("DELETE");
+  });
+
+  it("resolves methods=[\"GET\", \"POST\"] to POST (mutating verb wins, regex parity)", async () => {
+    const f = await py("getpost.py",
+      `@app.route("/x", methods=["GET", "POST"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves methods=[\"DELETE\", \"POST\"] to DELETE (first mutating verb in list order)", async () => {
+    const f = await py("deletepost.py",
+      `@app.route("/x", methods=["DELETE", "POST"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("DELETE");
+  });
+
+  it("uppercases a lowercase methods=[\"post\"] entry (Werkzeug uppercases at runtime)", async () => {
+    const f = await py("lower.py", `@app.route("/x", methods=["post"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves a tuple methods=(\"POST\",) to POST", async () => {
+    const f = await py("tuple.py", `@app.route("/x", methods=("POST",))\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves a set methods={\"POST\"} to POST", async () => {
+    const f = await py("set.py", `@app.route("/x", methods={"POST"})\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves methods=ALLOWED (a variable) to ALL: statically unresolvable stays in the mutating vote", async () => {
+    const f = await py("var.py", `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("resolves methods=[*BASE, \"POST\"] to POST: the visible literal resolves it", async () => {
+    const f = await py("splatpost.py",
+      `@app.route("/x", methods=[*BASE, "POST"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves methods=[*BASE] to ALL: no visible literal, statically unresolvable", async () => {
+    const f = await py("splatonly.py", `@app.route("/x", methods=[*BASE])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("resolves @app.route(\"/x\", **opts) to ALL: methods may hide in opts", async () => {
+    const f = await py("kwsplat.py", `@app.route("/x", **opts)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("resolves a literal empty methods=[] to GET: fully visible and empty is the Flask default, not ambiguity", async () => {
+    const f = await py("empty.py", `@app.route("/x", methods=[])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("resolves methods=[\"GET\"] to GET: emitted, simply outside the mutating vote", async () => {
+    const f = await py("getonly.py", `@app.route("/x", methods=["GET"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("resolves @router.api_route(\"/x\", methods=[\"POST\"]) to POST", async () => {
+    const f = await py("apiroute.py",
+      `@router.api_route("/x", methods=["POST"])\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves a multiline decorator with a trailing-comma methods=[\"POST\",\"GET\"] to POST", async () => {
+    const f = await py("multiline.py",
+      `@app.route(\n` +
+      `    "/x",\n` +
+      `    methods=["POST", "GET"],\n` +
+      `)\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+});

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -761,3 +761,186 @@ describe("canonical mutating methods (Task B1)", () => {
     ).toBe(true);
   });
 });
+
+// ── Task 4: Python AST extractor wired into both seams ──────────────────────
+//
+// Seam 1 (extractRoutes) and seam 2 (buildFileMiddlewareIndex) dispatch to the
+// AST extractor for clean-parsed python files, with the regex path retained as a
+// byte-identical fallback for tree-less / broken-parse python and for every
+// non-python file.
+describe("Python AST wiring (Task 4)", () => {
+  const pyTree = (p: string, c: string) => fileWithTree(p, c, "python");
+  const authFinding = (findings: any[]) => findings.find((f) => f.subCategory === "Auth middleware");
+
+  // ── Seam 1: dispatch selects AST vs regex ──
+  it("dispatch: a route-shaped COMMENT yields a route via the regex path but NOT via the AST path", async () => {
+    // 4 authed POST routes (per-route @requires_auth, which does NOT trip the
+    // file-level pyAuth regex) plus a route-shaped COMMENT for /danger. The
+    // regex extractor matches the comment (a live over-capture); the AST
+    // extractor sees only a comment node, no route.
+    const src =
+      `@app.post("/a")\n@requires_auth\ndef a(): return {}\n\n` +
+      `@app.post("/b")\n@requires_auth\ndef b(): return {}\n\n` +
+      `@app.post("/c")\n@requires_auth\ndef c(): return {}\n\n` +
+      `@app.post("/d")\n@requires_auth\ndef d(): return {}\n\n` +
+      `# @app.post("/danger")\n`;
+
+    // Tree-less (regex): the comment extracts an unauthed POST /danger, so the
+    // 4/5 auth vote fires and cites it.
+    const regexCtx = mkCtx([file("src/routes/orders.py", src, "python")]);
+    const regexFinding = authFinding(securityConsistency.detect(regexCtx));
+    expect(regexFinding).toBeDefined();
+    expect(regexFinding!.deviatingFiles.some((d: any) => d.detectedPattern.includes("/danger"))).toBe(true);
+
+    // With a clean tree (AST): the comment is not a route, so all 4 real routes
+    // are authed and no auth finding fires.
+    const astCtx = mkCtx([await pyTree("src/routes/orders.py", src)]);
+    expect(authFinding(securityConsistency.detect(astCtx))).toBeUndefined();
+  });
+
+  it("tree-less parity: a plain @app.route(methods=['POST']) file still yields its route via the regex fallback", () => {
+    const src =
+      `@app.post("/a")\n@requires_auth\ndef a(): return {}\n` +
+      `@app.post("/b")\n@requires_auth\ndef b(): return {}\n` +
+      `@app.post("/c")\n@requires_auth\ndef c(): return {}\n` +
+      `@app.post("/d")\n@requires_auth\ndef d(): return {}\n` +
+      `@app.route("/x", methods=["POST"])\ndef x(): return {}\n`;
+    // No tree -> the regex extractor runs and extracts the /x POST route, which
+    // is the lone unauthed deviator against 4 authed peers.
+    const findings = securityConsistency.detect(mkCtx([file("src/routes/orders.py", src, "python")]));
+    const f = authFinding(findings);
+    expect(f).toBeDefined();
+    expect(f!.deviatingFiles.some((d: any) => d.detectedPattern.includes("/x"))).toBe(true);
+  });
+
+  // ── Seam 2: file-level middleware index no longer over-blesses ──
+  it("file-middleware seam: a per-route @login_required no longer blesses the whole file (bare route is flagged)", async () => {
+    const lines: string[] = [];
+    for (const p of ["a", "b", "c", "d"]) {
+      lines.push(`@app.post("/${p}")`, `@login_required`, `def ${p}():`, `    return {}`, ``);
+    }
+    const dangerLine = lines.length + 1; // next pushed line is the /danger decorator
+    lines.push(`@app.post("/danger")`, `def danger():`, `    return {}`);
+    const api = await pyTree("src/routes/api.py", lines.join("\n"));
+    // Tree-less auth machinery file in a different directory (repo-global signal).
+    const mw = file("src/middleware/auth.ts", `export function requireAuth(req, res, next) { verifyToken(req); next(); }`);
+    const ctx = { files: [api, mw], totalLines: api.lineCount + mw.lineCount, dominantLanguage: "typescript" };
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = findings.filter((f) => f.subCategory === "Auth middleware");
+    // Exactly one auth finding, and its sole deviator is the bare /danger route.
+    // Under the OLD regex file-index, @login_required marked the whole file
+    // authed and NO finding fired at all.
+    expect(auth).toHaveLength(1);
+    expect(auth[0].deviatingFiles).toHaveLength(1);
+    expect(auth[0].deviatingFiles[0].path).toBe("src/routes/api.py");
+    expect(auth[0].deviatingFiles[0].evidence[0].line).toBe(dangerLine);
+  });
+
+  // ── Inheritance precedence: receiver-scoped before_request ──
+  it("inheritance: a before_request auth hook blesses every route in its file (no auth finding among 4 hook-files)", async () => {
+    const hookFile = (p: string) =>
+      pyTree(`src/routes/${p}.py`,
+        `@app.before_request\ndef require_login():\n    return None\n\n` +
+        `@app.post("/${p}")\ndef ${p}():\n    return {}\n`);
+    const files = await Promise.all([hookFile("a"), hookFile("b"), hookFile("c"), hookFile("d")]);
+    const ctx = { files, totalLines: files.reduce((s, f) => s + f.lineCount, 0), dominantLanguage: "typescript" };
+    expect(authFinding(securityConsistency.detect(ctx as any))).toBeUndefined();
+  });
+
+  it("inheritance: a file with no hook stays unauthed and is flagged among hook-blessed peers", async () => {
+    const hookFile = (p: string) =>
+      pyTree(`src/routes/${p}.py`,
+        `@app.before_request\ndef require_login():\n    return None\n\n` +
+        `@app.post("/${p}")\ndef ${p}():\n    return {}\n`);
+    const authed = await Promise.all([hookFile("a"), hookFile("b"), hookFile("c"), hookFile("d")]);
+    const bare = await pyTree("src/routes/e.py", `@app.post("/e")\ndef e():\n    return {}\n`);
+    const files = [...authed, bare];
+    const ctx = { files, totalLines: files.reduce((s, f) => s + f.lineCount, 0), dominantLanguage: "typescript" };
+    const f = authFinding(securityConsistency.detect(ctx as any));
+    expect(f).toBeDefined();
+    // Only the no-hook e.py route deviates; the 4 hook-blessed peers do not.
+    expect(f!.deviatingFiles).toHaveLength(1);
+    expect(f!.deviatingFiles[0].path).toBe("src/routes/e.py");
+  });
+
+  // ── Mixed receivers end-to-end (the core never-false-bless case) ──
+  it("mixed receivers: an admin_bp before_request does not bless a co-located public_bp route end-to-end", async () => {
+    const mixed = await pyTree("src/routes/mixed.py",
+      `@admin_bp.before_request\n` +      // L1
+      `def require_login():\n` +          // L2
+      `    return None\n\n` +             // L3, L4
+      `@admin_bp.route("/users", methods=["POST"])\n` + // L5
+      `def create_user():\n` +           // L6
+      `    return {}\n\n` +               // L7, L8
+      `@public_bp.route("/webhook", methods=["POST"])\n` + // L9
+      `def webhook():\n` +                // L10
+      `    return {}\n`);                 // L11
+    const peer = (n: number) =>
+      pyTree(`src/routes/peer${n}.py`, `@app.post("/p${n}")\n@requires_auth\ndef p${n}():\n    return {}\n`);
+    const peers = await Promise.all([peer(1), peer(2), peer(3)]);
+    const files = [mixed, ...peers];
+    const ctx = { files, totalLines: files.reduce((s, f) => s + f.lineCount, 0), dominantLanguage: "typescript" };
+
+    const f = authFinding(securityConsistency.detect(ctx as any));
+    expect(f).toBeDefined();
+    // The public_bp webhook (L9) is the deviator; the admin_bp /users (L5) is
+    // NOT flagged. A file-granular OR would have blessed the webhook via the
+    // admin blueprint's hook and silenced both vote layers.
+    expect(f!.deviatingFiles.some((d: any) => d.path === "src/routes/mixed.py" && d.evidence[0].line === 9)).toBe(true);
+    expect(f!.deviatingFiles.some((d: any) => d.evidence[0].line === 5)).toBe(false);
+  });
+
+  // ── Cross-language regex noise can no longer bless a clean-parsed python file ──
+  it("cross-language noise: a docstring mentioning app.use(authMiddleware) never blesses a python route (seam 2)", async () => {
+    const orders = await pyTree("src/routes/orders.py",
+      `"""Mirrors the Node service: app.use(authMiddleware) runs first."""\n` + // L1
+      `@app.post("/orders")\n` +  // L2
+      `def create():\n` +          // L3
+      `    return {}\n`);          // L4
+    const peer = (p: string) =>
+      pyTree(`src/routes/${p}.py`, `@app.post("/${p}")\n@requires_auth\ndef ${p}():\n    return {}\n`);
+    const peers = await Promise.all([peer("a"), peer("b"), peer("c"), peer("d")]);
+    const files = [orders, ...peers];
+    const ctx = { files, totalLines: files.reduce((s, f) => s + f.lineCount, 0), dominantLanguage: "typescript" };
+
+    const f = authFinding(securityConsistency.detect(ctx as any));
+    expect(f).toBeDefined();
+    // The jsAuth regex matches "app.use(authMiddleware" in the docstring, but a
+    // python file with a clean tree forces the js/go arms false, so /orders
+    // stays unauthed and is the flagged deviator.
+    expect(f!.deviatingFiles.some((d: any) => d.path === "src/routes/orders.py" && d.evidence[0].line === 2)).toBe(true);
+  });
+
+  // ── healthPaths still excluded end-to-end ──
+  it("healthPaths: 7 authed POST routes + 1 unauthed POST /healthz produces zero auth findings", async () => {
+    const lines: string[] = [];
+    for (let i = 1; i <= 7; i++) {
+      lines.push(`@app.post("/r${i}")`, `@requires_auth`, `def r${i}():`, `    return {}`, ``);
+    }
+    lines.push(`@app.post("/healthz")`, `def health():`, `    return {}`);
+    const f = await pyTree("src/routes/api.py", lines.join("\n"));
+    const ctx = mkCtx([f]);
+    expect(authFinding(securityConsistency.detect(ctx))).toBeUndefined();
+  });
+
+  // ── Byte-identical guard: a python file cannot perturb JS-side findings ──
+  it("mixed-language: adding a python route file (different directory) does not change the JS-side findings", async () => {
+    const js = await fileWithTree("src/js/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+      `router.put("/items/:id", requireAuth, updateItem);\n` +
+      `router.patch("/items/:id", requireAuth, patchItem);\n` +
+      `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+      `router.post("/danger", wipeEverything);\n`);
+    const py = await fileWithTree("src/py/orders.py",
+      `@app.post("/o1")\n@requires_auth\ndef o1():\n    return {}\n\n` +
+      `@app.post("/o2")\n@requires_auth\ndef o2():\n    return {}\n`,
+      "python");
+
+    const withoutPy = securityConsistency.detect({ files: [js], totalLines: js.lineCount, dominantLanguage: "typescript" } as any);
+    const withPy = securityConsistency.detect({ files: [js, py], totalLines: js.lineCount + py.lineCount, dominantLanguage: "typescript" } as any);
+    // The python file is uniformly authed (no finding of its own) and lives in a
+    // different directory group, so the JS findings are byte-for-byte identical.
+    expect(withPy).toEqual(withoutPy);
+  });
+});

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -3,6 +3,7 @@ import { securityConsistency } from "../../../src/drift/security-consistency.js"
 import { runDriftDetection } from "../../../src/drift/index.js";
 import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
+import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
 import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
   SECURITY_SUPPRESSION_ANALYZER_ID,
@@ -942,5 +943,146 @@ describe("Python AST wiring (Task 4)", () => {
     // The python file is uniformly authed (no finding of its own) and lives in a
     // different directory group, so the JS findings are byte-for-byte identical.
     expect(withPy).toEqual(withoutPy);
+  });
+});
+
+// ── Task 6: detect-level fallback + suppression pins for the Python path ──────
+//
+// These exercise securityConsistency.detect end-to-end (not the extractor in
+// isolation), pinning two things: (1) a broken-parse python file still routes to
+// the regex extractor, preserving today's recall AND today's known regex over-
+// bless (the explicit scope boundary of the never-false-bless invariant); and
+// (2) the `# @vibedrift-public` annotation binds to a python route exactly as it
+// does for JS, using the `#` comment marker and the same own-line/preceding-line
+// rule.
+describe("Task 6: python detect-level fallback and suppression pins", () => {
+  const pyTree = (p: string, c: string) => fileWithTree(p, c, "python");
+  const auth = (findings: any[]) => findings.find((f) => f.subCategory === "Auth middleware");
+  const audit = (findings: any[]) => findings.find((f) => f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+  const ctxOf = (files: DriftFile[], extra: Record<string, unknown> = {}) => ({
+    files,
+    totalLines: files.reduce((s, f) => s + f.lineCount, 0),
+    dominantLanguage: "typescript",
+    ...extra,
+  });
+
+  it("an unclosed-paren file (rootNode.hasError) still yields its regex-visible route through detect", async () => {
+    // Unclosed decorator paren erases the file's decorator structure, so the AST
+    // extractor finds nothing on this tree — but detect's hasError gate routes the
+    // whole file to extractPythonRoutesRegex, which recovers the POST /danger
+    // route. Peers keep the auth vote alive so the recovered route is observable
+    // as the lone unauthed deviator.
+    const brokenSrc =
+      `@app.route("/broken"\n` +
+      `@app.post("/danger")\n` +
+      `def danger():\n` +
+      `    return {}\n`;
+    const broken = await pyTree("src/routes/broken.py", brokenSrc);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    // The AST path alone loses the route (proving the regex fallback is what
+    // preserves recall here, not the AST extractor).
+    expect(extractPythonRoutesAst(broken.tree!, broken.relativePath)).toEqual([]);
+
+    const peer = (n: number) =>
+      pyTree(`src/routes/p${n}.py`, `@app.post("/p${n}")\n@requires_auth\ndef p${n}():\n    return {}\n`);
+    const peers = await Promise.all([peer(1), peer(2), peer(3), peer(4)]);
+    const f = auth(securityConsistency.detect(ctxOf([broken, ...peers]) as any));
+    expect(f).toBeDefined();
+    expect(
+      f!.deviatingFiles.some(
+        (d: any) => d.path === "src/routes/broken.py" && d.detectedPattern.includes("/danger"),
+      ),
+    ).toBe(true);
+  });
+
+  it("pinned legacy: parse-error files keep the regex window over-bless", async () => {
+    // The recorded exception to never-false-bless: on a file with ANY parse error,
+    // detect falls back to the regex extractor, whose per-route auth check is a
+    // 30-line TEXT window. Here an unauthed POST /legacy route sits within that
+    // window of the bare word `token` in a comment, so the regex over-blesses it
+    // to hasAuth:true. This is the legacy behavior the AST path replaces on CLEAN
+    // files; on parse-error files it survives unchanged, by design. Pinned as a
+    // decision, not left silent.
+    const legacySrc =
+      `@app.route("/legacy", methods=["POST"])\n` + // L1: unauthed mutating route
+      `def legacy():\n` +                            // L2
+      `    # token validated upstream\n` +           // L3: bare word `token` in a comment, within the 30-line window
+      `    x = = 1\n` +                              // L4: parse error -> rootNode.hasError, routes file to regex
+      `    return {}\n`;                             // L5
+    const legacy = await pyTree("src/routes/legacy.py", legacySrc);
+    expect(legacy.tree!.rootNode.hasError).toBe(true);
+
+    // Group: the over-blessed /legacy + 3 authed peers + 1 genuine unauthed
+    // /danger. If the over-bless holds, /legacy counts as authed, the vote is
+    // 4 authed / 1 unauthed = 0.8 (fires), and /danger — NOT /legacy — is cited.
+    const peer = (n: number) =>
+      pyTree(`src/routes/lp${n}.py`, `@app.post("/lp${n}")\n@requires_auth\ndef lp${n}():\n    return {}\n`);
+    const peers = await Promise.all([peer(1), peer(2), peer(3)]);
+    const danger = await pyTree("src/routes/danger.py", `@app.post("/danger")\ndef danger():\n    return {}\n`);
+    const f = auth(securityConsistency.detect(ctxOf([legacy, ...peers, danger]) as any));
+
+    expect(f).toBeDefined();
+    // The genuine unauthed route is flagged...
+    expect(f!.deviatingFiles.some((d: any) => d.path === "src/routes/danger.py")).toBe(true);
+    // ...and /legacy is NOT flagged: the regex window over-blessed it via `token`,
+    // so it came out hasAuth:true (were it correctly unauthed, it would be cited
+    // here too — and the vote would have dropped to 3/5 = 0.6 and gone silent).
+    expect(f!.deviatingFiles.some((d: any) => d.path === "src/routes/legacy.py")).toBe(false);
+  });
+
+  it("suppresses a python route when # @vibedrift-public sits directly above its route decorator, and cites it", async () => {
+    // Four authed POST routes plus a fifth unauthed public route with a standalone
+    // `# @vibedrift-public` on the line immediately above its @app.post decorator.
+    const src = [
+      `@app.post("/a")`, `@requires_auth`, `def a():`, `    return {}`, ``,       // L1-5
+      `@app.post("/b")`, `@requires_auth`, `def b():`, `    return {}`, ``,       // L6-10
+      `@app.post("/c")`, `@requires_auth`, `def c():`, `    return {}`, ``,       // L11-15
+      `@app.post("/d")`, `@requires_auth`, `def d():`, `    return {}`, ``,       // L16-20
+      `# @vibedrift-public`,                                                       // L21
+      `@app.post("/public")`,                                                      // L22: route.line
+      `def public():`,                                                             // L23
+      `    return {}`,                                                             // L24
+    ].join("\n");
+    const f = await pyTree("src/routes/api.py", src);
+    const findings = securityConsistency.detect(ctxOf([f]) as any);
+
+    // /public is removed from the denominator, leaving 4/4 authed -> no auth drift.
+    expect(auth(findings)).toBeUndefined();
+    // The exclusion is cited on the route's own line (22), never silent.
+    const a = audit(findings);
+    expect(a).toBeDefined();
+    expect(a!.totalRelevantFiles).toBe(1);
+    expect(a!.deviatingFiles).toHaveLength(1);
+    expect(a!.deviatingFiles[0].path).toBe("src/routes/api.py");
+    expect(a!.deviatingFiles[0].evidence[0].line).toBe(22);
+  });
+
+  it("does NOT suppress when # @vibedrift-public sits above the FIRST decorator of a stack whose route decorator is lower", async () => {
+    // The annotation is 2 lines above route.line (a non-route decorator sits
+    // between them), so neither the own-line nor the preceding-line rule binds it.
+    // Under-matching is the documented safe direction: /public stays in the vote
+    // as the unauthed deviator, nothing is suppressed. This pins the python
+    // behavior as a decision, not an accident.
+    const src = [
+      `@app.post("/a")`, `@requires_auth`, `def a():`, `    return {}`, ``,       // L1-5
+      `@app.post("/b")`, `@requires_auth`, `def b():`, `    return {}`, ``,       // L6-10
+      `@app.post("/c")`, `@requires_auth`, `def c():`, `    return {}`, ``,       // L11-15
+      `@app.post("/d")`, `@requires_auth`, `def d():`, `    return {}`, ``,       // L16-20
+      `# @vibedrift-public`,                                                       // L21: annotation (2 lines above route.line)
+      `@log_calls`,                                                                // L22: first decorator of the stack
+      `@app.post("/public")`,                                                      // L23: route.line
+      `def public():`,                                                             // L24
+      `    return {}`,                                                             // L25
+    ].join("\n");
+    const f = await pyTree("src/routes/api.py", src);
+    const findings = securityConsistency.detect(ctxOf([f]) as any);
+
+    // Nothing suppressed -> no audit finding.
+    expect(audit(findings)).toBeUndefined();
+    // /public stays unauthed in the vote (4 authed + 1 unauthed = 0.8) and is
+    // cited on its own route-decorator line (23).
+    const a = auth(findings);
+    expect(a).toBeDefined();
+    expect(a!.deviatingFiles.some((d: any) => d.evidence[0].line === 23)).toBe(true);
   });
 });


### PR DESCRIPTION
## What this does

Upgrades the Security Consistency detector to read **Python** web apps through a parsed syntax tree (tree-sitter) instead of line-based regex, so it can tell which API routes require authentication and which are open. Covers Flask, FastAPI, and Django REST function views.

It extracts, per route: the HTTP method, the path, and whether the route is guarded, by reading route decorators, per-route dependencies (`Depends(...)`/`Security(...)`), auth decorators (`@login_required`, `@jwt_required`, ...), DRF `permission_classes`, and receiver-scoped middleware (blueprint/router `before_request`, `add_middleware`).

## Design principle

The extractor never marks an unauthed route as authed. When a route's auth mechanism is ambiguous or unrecognized, it resolves toward **not authenticated**: a false "unprotected" is a reviewable nuisance, a false "protected" hides a real gap. Method resolution follows the same rule (an unreadable `methods=` stays in the mutating-route vote rather than being silently dropped).

## Safety and compatibility

- **Regex fallback preserved**: files that do not parse cleanly fall back to the previous behavior.
- **JavaScript / TypeScript / Go paths are byte-identical**: the new branch only activates for Python files with a clean parse tree.
- Public types are unchanged.
- Covered by unit tests (including an adversarial never-false-bless sweep) and a precision/recall calibration gate, and spot-checked against real open-source Flask and FastAPI apps.

## Scope

This is the first language in a multi-language rollout (Python, then Go, then Rust). A follow-up refinement on this branch adds body-signature analysis for ambiguous auth hooks and "double check" finding copy before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
