### PR TITLE
Security Consistency: read Python auth hook bodies, with an explicit unsure state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ eval/reports/
 
 # Score-discrimination harness clone cache (cloned upstream repos)
 eval/discrimination/.cache/
+
+# Internal security sub-phase plans (local execution docs, not for the public repo)
+PLAN-security-conformance-phase*.md

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -122,31 +122,24 @@ const VAL_NAMES = /(?:pydantic|validate|validator|schema|serializer|marshmallow)
 const RATE_NAMES = /(?:rate_?limit|throttle|limiter|slowapi|slowdown)/i;
 
 // Two-tier segment lexicon for before_request / before_app_request HOOK HANDLER
-// names (see nameHasAuthToken). Deliberately stricter than the file-level regex,
-// which blesses ANY before_request. tier 1: a CORE segment alone (an unambiguous
+// names (see nameHasAuthToken). tier 1: a CORE segment alone (an unambiguous
 // authn word). tier 2: an ENFORCEMENT verb segment AND a SUBJECT segment anywhere
-// in the name. A lone SUBJECT (login / token / user) or a lone ENFORCE verb never
-// blesses: track_login_metrics, verify_content_type, and set_csrf_token are real
-// hooks that do not authenticate. Whole-segment matching makes substring blessing
-// structurally impossible.
+// in the name. A lone SUBJECT (login / token / user) or a lone ENFORCE verb is
+// never a token: track_login_metrics, verify_content_type, and set_csrf_token are
+// real hooks that do not authenticate. Whole-segment matching makes substring
+// blessing structurally impossible.
+//
+// BODY-FIRST (addendum): the hook path no longer blesses on NAME alone.
+// classifyHookAuth classifies by BODY behavior first; a name token only ever acts
+// as a SECOND tier, and only when the body is UNRESOLVABLE (opaque). A CORE token
+// (auth/authenticate, or an AUTH_DECORATORS name) with an opaque body blesses; an
+// ENFORCE+SUBJECT token (verify_user_email, protect_user_data, enforce_session)
+// with an opaque/absent body resolves UNSURE (a hedge, never a bless), and with a
+// VISIBLE non-enforcing body resolves flat not-auth. So the old ENFORCE+SUBJECT
+// attributive false-bless is closed: those names can hedge, never bless, and a
+// visible email/scrub body is plainly not-auth. (verify_token also appears in
+// AUTH_DECORATORS as a ROUTE decorator, unaffected here.)
 const AUTH_CORE_SEGMENTS = new Set(["auth", "authenticate", "authenticated"]);
-// KNOWN FALSE-BLESS EXPOSURE (owner decision required): the ENFORCE+SUBJECT
-// two-tier match blesses attributive non-auth hook names such as
-// verify_user_email (email-confirmation flow) and protect_user_data (data
-// scrubbing): ENFORCE verb + SUBJECT noun both match even though the hook
-// does not authenticate. This shape exists in the plan's pinned sets as well
-// (verify + user), so it is inherent to the two-tier design, not only to the
-// additions. Resolution options for the owner: narrow the ENFORCE x SUBJECT
-// cross-product, add attributive vetoes (subject followed by an object noun
-// like email/data/profile), or accept as documented risk. Blessing suppresses
-// findings, so this is the false-bless direction, never a safe over-flag.
-// Also note: verify_token in AUTH_DECORATORS matches flask-httpauth's
-// @auth.verify_token registration decorator, which is not a route wrapper;
-// if stacked on a route handler it would leak-bless (non-idiomatic, low
-// risk). The closest non-auth neighbors are pinned FALSE by boundary tests
-// (restricted_zone_redirect, track_user_metrics, role_labels, protect_branch)
-// to keep the surface explicit. The sets are left UNCHANGED here; any
-// narrowing waits on the owner's lexicon decision.
 const AUTH_ENFORCE_SEGMENTS = new Set([
   "require", "required", "requires", "verify", "verified", "ensure",
   "protect", "protected", "restrict", "restricted",
@@ -470,18 +463,34 @@ function nameHasAuthToken(name: string): boolean {
 // Classifies a before_request-style hook by what its BODY does, not what its
 // name suggests. `bodyAuthSignature` walks the body (plus ONE hop into a
 // same-file helper) and returns "reject" | "none" | "opaque"; `classifyHookAuth`
-// layers name precedence on top (an optionality-veto name always wins;
-// otherwise behavior beats a name; an opaque body hedges as "unsure" unless the
-// name is an unambiguous CORE auth token). Every walk keeps the module's
-// per-node `hasError` gate, so error-recovery nodes never contribute a bless.
+// layers name precedence on top and produces the THREE-WAY outcome
+// "auth" | "not-auth" | "unsure" (an optionality-veto name always wins; otherwise
+// behavior beats a name — a verified reject blesses even a boring name, a visible
+// non-enforcing body is not-auth whatever the name; an opaque body hedges as
+// "unsure" unless the name is an unambiguous CORE token). Wired into the hook path
+// (collectPyMiddleware) for both the decorator and call-registration forms.
+//
+// INVARIANT AMENDMENT: "unsure" is not-authed INTERNALLY — it never sets a hasAuth
+// lane, never reaches the FileMiddleware OR, and never blesses a route (hasAuth
+// stays false). It only records the hook's name (RouteInfo.authUnsureHook) so a
+// renderer can hedge the copy. NEVER-FALSE-BLESS holds: every ambiguous branch
+// resolves toward not-authed.
+//
+// TWO SAFE-DIRECTION TIGHTENINGS (this addendum): (1) the body scan prunes nested
+// def/lambda subtrees, so a reject that is not executed inline never counts; (2) a
+// 403 blesses only inside a reject driven by a credential-referencing guard
+// condition, never on body-wide co-occurrence with an unrelated credential read.
+// Both move strictly toward never-false-bless.
 //
 // MEASURED reject-catalog recall gaps (SAFE, over-flag direction — a later pass
 // may widen deliberately): reject via a Response/make_response object
 // (abort(make_response(..., 401)) / abort(Response(status=401)), arg0 a call not
 // an integer); Flask-Login `return login_manager.unauthorized()` (an attribute
-// call outside KNOWN_AUTH_PRIMITIVES); and custom auth exceptions outside the
-// lexicon (raise Http401, raise NotAuthenticated). All resolve opaque/unsure or
-// not-auth today, never a false-bless.
+// call outside KNOWN_AUTH_PRIMITIVES); custom auth exceptions outside the lexicon
+// (raise Http401, raise NotAuthenticated); and a credential-guarded 403 reached
+// only via an `elif` branch (the guard walk reads the `if` condition + its
+// consequence, not the alternative). All resolve opaque/unsure or not-auth today,
+// never a false-bless.
 
 // Calls whose reject/target semantics are read in the raise/return walks (or are
 // merely nested), so the generic call walk must not re-interpret them.
@@ -601,43 +610,158 @@ function isCredentialGetCall(call: SyntaxNode): boolean {
   return arg0 !== null && arg0.type === "string" && keyIsCredential(pyStringText(arg0));
 }
 
+/** Descendants of `node` of one of `types`, NOT descending into nested
+ *  `function_definition` / `lambda` subtrees. A reject signature inside a nested
+ *  def is not executed inline, so it must not count as the hook rejecting; the
+ *  hook's own try/if/for branches (and one-hop helper bodies, scanned
+ *  separately) still count. Pre-order; the root `node` itself is never yielded. */
+function prunedDescendants(node: SyntaxNode, types: Set<string>): SyntaxNode[] {
+  const out: SyntaxNode[] = [];
+  const visit = (n: SyntaxNode) => {
+    for (const child of n.namedChildren) {
+      if (!child) continue;
+      if (child.type === "function_definition" || child.type === "lambda") continue;
+      if (types.has(child.type)) out.push(child);
+      visit(child);
+    }
+  };
+  visit(node);
+  return out;
+}
+const CALL_T = new Set(["call"]);
+const COMPARISON_T = new Set(["comparison_operator"]);
+const SUBSCRIPT_T = new Set(["subscript"]);
+
+/** Like `prunedDescendants` but also yields `node` itself when it matches — an
+ *  `if` condition often IS the comparison/call/subscript, which a
+ *  descendants-only walk would miss. */
+function prunedSelfAndDescendants(node: SyntaxNode, types: Set<string>): SyntaxNode[] {
+  const out = prunedDescendants(node, types);
+  if (types.has(node.type)) out.unshift(node);
+  return out;
+}
+
+/** True when a node subtree reads a credential/session/auth surface, by the SAME
+ *  three shapes the body scan recognizes: a session/cookie/header `.get("<cred>")`
+ *  call; a `<cred> is None` comparison or a `"<cred>" in/not in <x>` comparison;
+ *  or a `session["<cred>"]` / `g["<cred>"]` subscript. Deliberately NOT a bare
+ *  credential-named identifier read (that would over-match user_agent, username,
+ *  ...): keeping this identical to the body-wide `credentialRead` detection
+ *  guarantees the guarded-403 blessing set is a strict SUBSET of the pre-tightening
+ *  body-wide set, so the tightening only ever REMOVES blesses, never adds one. */
+function nodeHasCredentialRead(node: SyntaxNode): boolean {
+  for (const call of prunedSelfAndDescendants(node, CALL_T)) {
+    if (!call.hasError && isCredentialGetCall(call)) return true;
+  }
+  for (const cmp of prunedSelfAndDescendants(node, COMPARISON_T)) {
+    if (cmp.hasError) continue;
+    const ops = cmp.children
+      .filter((c): c is SyntaxNode => c !== null && !c.isNamed)
+      .map((c) => c.type);
+    const named = cmp.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    if (ops.includes("is")) {
+      const hasNone = named.some((n) => n.type === "none");
+      const credOperand = named.some(
+        (n) =>
+          (n.type === "identifier" || n.type === "attribute") &&
+          nameSegments(n.text).some((s) => CREDENTIAL_KEY_SEGMENTS.has(s)),
+      );
+      if (hasNone && credOperand) return true;
+    }
+    if (ops.includes("in") || ops.includes("not in")) {
+      if (named.some((n) => n.type === "string" && keyIsCredential(pyStringText(n)))) return true;
+    }
+  }
+  for (const sub of prunedSelfAndDescendants(node, SUBSCRIPT_T)) {
+    if (sub.hasError) continue;
+    const value = sub.childForFieldName("value");
+    if (!value || value.type !== "identifier" || !(value.text === "session" || value.text === "g")) {
+      continue;
+    }
+    const idx = sub.childForFieldName("subscript");
+    if (idx && idx.type === "string" && keyIsCredential(pyStringText(idx))) return true;
+  }
+  return false;
+}
+
+/** True when a subtree contains a 403 reject: `abort(403)`, a raised
+ *  `HTTPException` with status 403, or a `(expr, 403)` return tuple. Nested def
+ *  subtrees are pruned (same inline-execution rule as the body scan). */
+function subtreeHas403Reject(node: SyntaxNode): boolean {
+  for (const call of prunedDescendants(node, CALL_T)) {
+    if (call.hasError) continue;
+    if (finalName(call.childForFieldName("function")) === "abort") {
+      if (rejectStatusKind(call.childForFieldName("arguments")?.namedChild(0) ?? null) === "403") return true;
+    }
+  }
+  for (const rs of prunedDescendants(node, new Set(["raise_statement"]))) {
+    if (rs.hasError) continue;
+    const raised = rs.namedChild(0);
+    if (
+      raised?.type === "call" &&
+      finalName(raised.childForFieldName("function")) === "HTTPException" &&
+      httpExceptionStatus(raised) === "403"
+    ) {
+      return true;
+    }
+  }
+  for (const ret of prunedDescendants(node, new Set(["return_statement"]))) {
+    if (ret.hasError) continue;
+    const val = ret.namedChild(0);
+    if (val?.type === "expression_list") {
+      const kids = val.namedChildren.filter((n): n is SyntaxNode => n !== null);
+      if (rejectStatusKind(kids[kids.length - 1] ?? null) === "403") return true;
+    }
+  }
+  return false;
+}
+
 interface BodySignals {
   reject401: boolean;
-  reject403: boolean;
+  /** A 403 reject that sits inside an `if` whose CONDITION reads a credential
+   *  surface. A bare 403 anywhere no longer contributes (a lone 403 is routinely
+   *  a CSRF / IP / maintenance gate, not an authentication denial). */
+  reject403Guarded: boolean;
   opaqueHint: boolean;
   credentialRead: boolean;
 }
 
 /** One body's direct signals; `hop` = whether a same-file helper body may be
- *  followed (depth exactly 1). reject401 blesses ALONE; reject403 blesses only
- *  WITH a credentialRead (403 is routinely non-auth). */
+ *  followed (depth exactly 1). reject401 blesses ALONE; a 403 blesses only via
+ *  reject403Guarded (inside an `if <credential-condition>:` branch), since a bare
+ *  403 is routinely non-auth. Nested def/lambda subtrees are pruned throughout. */
 function scanBody(
   body: SyntaxNode,
   defs: Map<string, SyntaxNode | null>,
   hop: boolean,
 ): BodySignals {
   const out: BodySignals = {
-    reject401: false, reject403: false, opaqueHint: false, credentialRead: false,
+    reject401: false, reject403Guarded: false, opaqueHint: false, credentialRead: false,
   };
   const merge = (s: BodySignals) => {
     out.reject401 = out.reject401 || s.reject401;
-    out.reject403 = out.reject403 || s.reject403;
+    out.reject403Guarded = out.reject403Guarded || s.reject403Guarded;
     out.opaqueHint = out.opaqueHint || s.opaqueHint;
     out.credentialRead = out.credentialRead || s.credentialRead;
   };
 
-  // Calls: aborts, auth primitives, one-hop helpers, opaque hints, credential .get.
-  for (const call of body.descendantsOfType("call")) {
-    if (!call || call.hasError) continue;
-    if (isCredentialGetCall(call)) out.credentialRead = true;
+  // Credential-surface reads (the three shapes: .get call, is-None / in-string
+  // comparison, session/g subscript). Body-wide here; scoped to an if-condition
+  // in the guarded-403 walk below via the same helper.
+  if (nodeHasCredentialRead(body)) out.credentialRead = true;
+
+  // Calls: aborts, auth primitives, one-hop helpers, opaque hints.
+  // Nested def/lambda subtrees are pruned (a reject there is not executed inline).
+  for (const call of prunedDescendants(body, CALL_T)) {
+    if (call.hasError) continue;
     const fn = call.childForFieldName("function");
     const args = call.childForFieldName("arguments");
     const name = finalName(fn);
     if (name === "abort") {
       const arg0 = args?.namedChild(0) ?? null;
-      const kind = rejectStatusKind(arg0);
-      if (kind === "401") out.reject401 = true;
-      else if (kind === "403") out.reject403 = true;
+      // 401 blesses alone; a bare abort(403) contributes NOTHING (only a
+      // credential-guarded 403 blesses, handled by the if-walk below).
+      if (rejectStatusKind(arg0) === "401") out.reject401 = true;
       else if (arg0 !== null && arg0.type !== "integer") out.opaqueHint = true; // abort(code_var)
       continue;
     }
@@ -660,9 +784,23 @@ function scanBody(
     if (name !== null && hintHit(name)) out.opaqueHint = true; // unresolvable flavored callee
   }
 
+  // Guarded 403: an `if <credential-condition>: ... <403 reject> ...`. A 403 is
+  // routinely a non-auth denial (CSRF, IP allowlist, maintenance), so it blesses
+  // ONLY when the reject is driven by a guard condition that reads a credential
+  // surface, never on body-wide co-occurrence with an unrelated credential read.
+  for (const ifs of prunedDescendants(body, new Set(["if_statement"]))) {
+    if (ifs.hasError) continue;
+    const cond = ifs.childForFieldName("condition");
+    const cons = ifs.childForFieldName("consequence");
+    if (cond && cons && nodeHasCredentialRead(cond) && subtreeHas403Reject(cons)) {
+      out.reject403Guarded = true;
+    }
+  }
+
   // raise <exception>: HTTPException status, else the auth-exception lexicon.
-  for (const rs of body.descendantsOfType("raise_statement")) {
-    if (!rs || rs.hasError) continue;
+  // A bare 403 HTTPException contributes nothing (same asymmetry as abort(403)).
+  for (const rs of prunedDescendants(body, new Set(["raise_statement"]))) {
+    if (rs.hasError) continue;
     const raised = rs.namedChild(0);
     if (!raised) continue;
     if (
@@ -671,7 +809,6 @@ function scanBody(
     ) {
       const st = httpExceptionStatus(raised);
       if (st === "401") out.reject401 = true;
-      else if (st === "403") out.reject403 = true;
       else if (st === "unreadable") out.opaqueHint = true;
       continue;
     }
@@ -679,9 +816,10 @@ function scanBody(
     if (rn !== null && isAuthExceptionName(rn)) out.reject401 = true;
   }
 
-  // return: a login-flavored redirect, or an (expr, 401|403) tuple.
-  for (const ret of body.descendantsOfType("return_statement")) {
-    if (!ret || ret.hasError) continue;
+  // return: a login-flavored redirect, or an (expr, 401) tuple. A trailing 403
+  // tuple contributes nothing here; a credential-guarded one is caught above.
+  for (const ret of prunedDescendants(body, new Set(["return_statement"]))) {
+    if (ret.hasError) continue;
     const val = ret.namedChild(0);
     if (!val) continue;
     if (val.type === "call") {
@@ -695,43 +833,8 @@ function scanBody(
     }
     if (val.type === "expression_list") {
       const kids = val.namedChildren.filter((n): n is SyntaxNode => n !== null);
-      const kind = rejectStatusKind(kids[kids.length - 1] ?? null);
-      if (kind === "401") out.reject401 = true;
-      else if (kind === "403") out.reject403 = true;
+      if (rejectStatusKind(kids[kids.length - 1] ?? null) === "401") out.reject401 = true;
     }
-  }
-
-  // Credential-surface reads (comparison + subscript shapes; the .get call shape
-  // is folded into the call walk above via isCredentialGetCall).
-  for (const cmp of body.descendantsOfType("comparison_operator")) {
-    if (!cmp || cmp.hasError) continue;
-    const ops = cmp.children
-      .filter((c): c is SyntaxNode => c !== null && !c.isNamed)
-      .map((c) => c.type);
-    const named = cmp.namedChildren.filter((n): n is SyntaxNode => n !== null);
-    if (ops.includes("is")) {
-      const hasNone = named.some((n) => n.type === "none");
-      const credOperand = named.some(
-        (n) =>
-          (n.type === "identifier" || n.type === "attribute") &&
-          nameSegments(n.text).some((s) => CREDENTIAL_KEY_SEGMENTS.has(s)),
-      );
-      if (hasNone && credOperand) out.credentialRead = true;
-    }
-    if (ops.includes("in") || ops.includes("not in")) {
-      if (named.some((n) => n.type === "string" && keyIsCredential(pyStringText(n)))) {
-        out.credentialRead = true;
-      }
-    }
-  }
-  for (const sub of body.descendantsOfType("subscript")) {
-    if (!sub || sub.hasError) continue;
-    const value = sub.childForFieldName("value");
-    if (!value || value.type !== "identifier" || !(value.text === "session" || value.text === "g")) {
-      continue;
-    }
-    const idx = sub.childForFieldName("subscript");
-    if (idx && idx.type === "string" && keyIsCredential(pyStringText(idx))) out.credentialRead = true;
   }
 
   return out;
@@ -751,14 +854,15 @@ export function collectFunctionDefs(root: SyntaxNode): Map<string, SyntaxNode | 
 }
 
 /** A hook body's three-way auth signal. 401-family blesses alone; a 403 blesses
- *  only when a credential surface is also read; an uncorroborated 403 is neither
- *  reject nor opaque (keeps the hedge meaningful). */
+ *  only inside a reject driven by a credential-referencing guard condition
+ *  (`if <credential>: abort(403)`); a bare/uncorroborated 403 is neither reject
+ *  nor opaque (keeps the hedge meaningful). */
 export function bodyAuthSignature(
   body: SyntaxNode,
   defs: Map<string, SyntaxNode | null>,
 ): BodySignal {
   const s = scanBody(body, defs, true);
-  if (s.reject401 || (s.reject403 && s.credentialRead)) return "reject";
+  if (s.reject401 || s.reject403Guarded) return "reject";
   if (s.opaqueHint || s.credentialRead) return "opaque";
   return "none";
 }
@@ -859,10 +963,14 @@ function isAuthDecorator(dec: SyntaxNode): boolean {
   return false;
 }
 
-/** Any Depends(...)/Security(...) call under `scope` whose RESOLVED dependency
- *  name matches the segment lexicon. Bare Depends(), an unresolvable target, or a
- *  vetoed name resolves false. */
-function callsWithAuthDependency(scope: SyntaxNode): boolean {
+/** Any Depends(...)/Security(...) call under `scope` whose RESOLVED dependency is
+ *  auth enforcement. Resolution order (never-false-bless): (1) an optional /
+ *  settings / stats-flavored VETO name never blesses, by name OR body; (2) a
+ *  name-segment lexicon hit blesses; (3) additive — a boring name whose
+ *  SAME-FILE def body raises a verified reject (Depends(load_actor) where
+ *  load_actor 401s) blesses. Bare Depends() or an unresolvable target resolves
+ *  false. */
+function callsWithAuthDependency(scope: SyntaxNode, defs: Map<string, SyntaxNode | null>): boolean {
   for (const call of scope.descendantsOfType("call")) {
     if (!call) continue;
     const fn = call.childForFieldName("function");
@@ -870,7 +978,16 @@ function callsWithAuthDependency(scope: SyntaxNode): boolean {
     if (fn.text !== "Depends" && fn.text !== "Security") continue;
     const target = call.childForFieldName("arguments")?.namedChild(0);
     const name = target ? dependencyTargetName(target) : null;
-    if (name !== null && dependsNameIsAuth(name)) return true;
+    if (name === null) continue;
+    // veto first: get_current_user_optional admits anonymous requests even if its
+    // body raises 401, so neither the name hit nor the body branch may bless it.
+    if (nameSegments(name).some((s) => DEPENDS_VETO_SEGMENTS.has(s))) continue;
+    if (dependsNameIsAuth(name)) return true; // name-segment hit
+    const def = defs.get(name); // same-file body reject (additive)
+    if (def) {
+      const body = def.childForFieldName("body");
+      if (body && bodyAuthSignature(body, defs) === "reject") return true;
+    }
   }
   return false;
 }
@@ -879,14 +996,14 @@ function callsWithAuthDependency(scope: SyntaxNode): boolean {
  *  node covers plain defaults (default_parameter), typed defaults
  *  (typed_default_parameter), and Annotated[T, Depends(...)] (typed_parameter,
  *  where the call nests under the TYPE field's generic_type). */
-function paramsHaveAuthDependency(definition: SyntaxNode): boolean {
+function paramsHaveAuthDependency(definition: SyntaxNode, defs: Map<string, SyntaxNode | null>): boolean {
   const params = definition.childForFieldName("parameters");
-  return params ? callsWithAuthDependency(params) : false;
+  return params ? callsWithAuthDependency(params, defs) : false;
 }
 
 /** Route-decorator-level dependencies kwarg:
  *  @router.post("/x", dependencies=[Depends(verify_token)]). */
-function routeCallHasAuthDependency(call: SyntaxNode): boolean {
+function routeCallHasAuthDependency(call: SyntaxNode, defs: Map<string, SyntaxNode | null>): boolean {
   const args = call.childForFieldName("arguments");
   if (!args) return false;
   const kw = args.namedChildren.find(
@@ -896,7 +1013,7 @@ function routeCallHasAuthDependency(call: SyntaxNode): boolean {
       n.childForFieldName("name")?.text === "dependencies",
   );
   const value = kw?.childForFieldName("value");
-  return value ? callsWithAuthDependency(value) : false;
+  return value ? callsWithAuthDependency(value, defs) : false;
 }
 
 /** Middleware scopes for one python file. Python file-level middleware attaches
@@ -910,14 +1027,23 @@ function routeCallHasAuthDependency(call: SyntaxNode): boolean {
 interface PyMiddlewareScopes {
   global: FileMiddleware;
   byReceiver: Map<string, FileMiddleware>;
+  /** First (document-order) unsure hook name at app scope, or null. An unsure
+   *  hook NEVER sets a hasAuth lane; it only records the name a route inherits so
+   *  a renderer can hedge. hasAuth stays false, so the FileMiddleware OR never
+   *  launders an unsure hook into a bless. */
+  globalUnsure: string | null;
+  /** First (document-order) unsure hook name per named receiver. */
+  unsureByReceiver: Map<string, string>;
 }
 
 const APP_SCOPED_RECEIVER = /^(?:app|application)$/;
 
-function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
+function collectPyMiddleware(tree: Tree, defs: Map<string, SyntaxNode | null>): PyMiddlewareScopes {
   const scopes: PyMiddlewareScopes = {
     global: { hasAuth: false, hasValidation: false, hasRateLimit: false },
     byReceiver: new Map(),
+    globalUnsure: null,
+    unsureByReceiver: new Map(),
   };
   const mark = (receiver: string, appWide: boolean, lane: keyof FileMiddleware) => {
     if (appWide || APP_SCOPED_RECEIVER.test(receiver)) {
@@ -929,6 +1055,31 @@ function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
       { hasAuth: false, hasValidation: false, hasRateLimit: false };
     entry[lane] = true;
     scopes.byReceiver.set(receiver, entry);
+  };
+  // First-wins: the earliest unsure hook on a scope is the one a route names.
+  const markUnsure = (receiver: string, appWide: boolean, hookName: string) => {
+    if (!hookName) return; // a lambda has no openable name; stay flat not-auth
+    if (appWide || APP_SCOPED_RECEIVER.test(receiver)) {
+      if (scopes.globalUnsure === null) scopes.globalUnsure = hookName;
+      return;
+    }
+    if (!scopes.unsureByReceiver.has(receiver)) scopes.unsureByReceiver.set(receiver, hookName);
+  };
+  // Three-way hook classification -> lane / hedge marks on the receiver scope.
+  const applyHookOutcome = (
+    receiver: string,
+    appWide: boolean,
+    hookName: string,
+    body: SyntaxNode | null,
+    nameIsSimpleIdentifier: boolean,
+  ) => {
+    const outcome = classifyHookAuth(hookName, body, defs, nameIsSimpleIdentifier);
+    if (outcome === "auth") mark(receiver, appWide, "hasAuth");
+    else if (outcome === "unsure") markUnsure(receiver, appWide, hookName);
+    // Validation / rate-limit lanes stay NAME-based and independent of the body:
+    // body analysis is the auth lane only.
+    if (RATE_NAMES.test(hookName)) mark(receiver, appWide, "hasRateLimit");
+    if (VAL_NAMES.test(hookName)) mark(receiver, appWide, "hasValidation");
   };
   const routerNames = collectRouterNames(tree.rootNode);
   const gated = (r: string | null): r is string =>
@@ -956,9 +1107,11 @@ function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
       const receiver = receiverName(attr.childForFieldName("object"));
       if (!gated(receiver)) continue;
       const appWide = hook === "before_app_request";
-      if (nameHasAuthToken(fnName)) mark(receiver, appWide, "hasAuth");
-      if (RATE_NAMES.test(fnName)) mark(receiver, appWide, "hasRateLimit");
-      if (VAL_NAMES.test(fnName)) mark(receiver, appWide, "hasValidation");
+      // Body-first: a verified reject body blesses even under a boring name; a
+      // visible non-enforcing body never blesses whatever the name (the
+      // verify_user_email fix); an opaque body hedges as unsure unless the name
+      // is an unambiguous CORE token. A decorated hook name is a simple identifier.
+      applyHookOutcome(receiver, appWide, fnName, definition.childForFieldName("body"), true);
     }
   }
 
@@ -966,6 +1119,32 @@ function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
     if (!call || call.hasError) continue;
     const fn = call.childForFieldName("function");
     if (!fn) continue;
+    // Call-form hook registration: app.before_request(fn) / (lambda) / (Cls.method).
+    // The decorator form @app.before_request() also parses to a call with an
+    // attribute callee, but its argument_list is empty (the function is decorated
+    // separately), so the arg0 gate below skips it (handled by the decorator loop).
+    if (
+      fn.type === "attribute" &&
+      (fn.childForFieldName("attribute")?.text === "before_request" ||
+        fn.childForFieldName("attribute")?.text === "before_app_request")
+    ) {
+      const receiver = receiverName(fn.childForFieldName("object"));
+      if (!gated(receiver)) continue;
+      const arg0 = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+      if (!arg0) continue; // decorator-form empty call, or before_request() with no target
+      const appWide = fn.childForFieldName("attribute")?.text === "before_app_request";
+      if (arg0.type === "identifier") {
+        // Same-file def -> classify its body; imported (not in defs) -> name-tier.
+        const def = defs.get(arg0.text) ?? null;
+        applyHookOutcome(receiver, appWide, arg0.text, def ? def.childForFieldName("body") : null, true);
+      } else if (arg0.type === "attribute") {
+        applyHookOutcome(receiver, appWide, arg0.text, null, false); // Cls.method: hedge only
+      } else if (arg0.type === "lambda") {
+        applyHookOutcome(receiver, appWide, "", arg0, false); // scan the lambda body
+      }
+      // Any other arg0 shape is unresolvable: blesses nothing (never-false-bless).
+      continue;
+    }
     if (fn.type === "attribute" && fn.childForFieldName("attribute")?.text === "add_middleware") {
       const receiver = receiverName(fn.childForFieldName("object"));
       if (!gated(receiver)) continue;
@@ -1005,7 +1184,7 @@ function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
     if (!fn || fn.type !== "identifier") continue;
     if (fn.text !== "APIRouter" && fn.text !== "FastAPI") continue;
     const value = kwargValue(right, "dependencies");
-    if (value && callsWithAuthDependency(value)) mark(left.text, false, "hasAuth");
+    if (value && callsWithAuthDependency(value, defs)) mark(left.text, false, "hasAuth");
   }
   return scopes;
 }
@@ -1015,7 +1194,7 @@ function collectPyMiddleware(tree: Tree): PyMiddlewareScopes {
  *  inheritance on the AST path does NOT read this OR; extractPythonRoutesAst
  *  consumes collectPyMiddleware directly (receiver-scoped). */
 export function extractPythonFileMiddlewareAst(tree: Tree): FileMiddleware {
-  const scopes = collectPyMiddleware(tree);
+  const scopes = collectPyMiddleware(tree, collectFunctionDefs(tree.rootNode));
   const all = [scopes.global, ...scopes.byReceiver.values()];
   return {
     hasAuth: all.some((s) => s.hasAuth),
@@ -1027,7 +1206,8 @@ export function extractPythonFileMiddlewareAst(tree: Tree): FileMiddleware {
 export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectRouterNames(tree.rootNode);
-  const scopes = collectPyMiddleware(tree);
+  const defs = collectFunctionDefs(tree.rootNode);
+  const scopes = collectPyMiddleware(tree, defs);
   for (const dd of tree.rootNode.descendantsOfType("decorated_definition")) {
     // Error recovery can merge adjacent handlers' decorators into one dd;
     // blessing (or even extracting) across that boundary is forbidden.
@@ -1056,7 +1236,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const permissionClassRows = decorators
       .filter(isAuthPermissionClasses)
       .map((d) => d.startPosition.row);
-    const paramAuth = paramsHaveAuthDependency(definition);
+    const paramAuth = paramsHaveAuthDependency(definition, defs);
     // Validation / rate-limit lanes match NON-ROUTE decorator CALLEE NAMES only
     // (@limiter.limit -> "limiter.limit", @validate_schema -> "validate_schema"),
     // never argument or path text: @app.post("/validate") is a path, not
@@ -1081,6 +1261,20 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
       const route = routeFromDecorator ?? apiViewRoute;
       if (!route) continue;
       const fromApiView = apiViewRoute !== null;
+      const hasAuth =
+        authDecoratorRows.some((row) => row > dec.startPosition.row) ||
+        (fromApiView &&
+          permissionClassRows.some((row) => row > dec.startPosition.row)) ||
+        paramAuth ||
+        routeCallHasAuthDependency(route.call, defs) ||
+        scopes.global.hasAuth ||
+        (scopes.byReceiver.get(route.receiver)?.hasAuth ?? false);
+      // A route is hedged "unsure" ONLY when it is not otherwise authed AND an
+      // unsure hook is in its scope (receiver-specific first, then app-wide). The
+      // field implies hasAuth === false; a blessed route never carries it.
+      const unsureHook = hasAuth
+        ? undefined
+        : (scopes.unsureByReceiver.get(route.receiver) ?? scopes.globalUnsure ?? undefined);
       routes.push({
         method: route.method,
         path: route.path,
@@ -1089,14 +1283,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
         // not the def line): regex parity, and the @vibedrift-public suppression
         // binding depends on it.
         line: dec.startPosition.row + 1,
-        hasAuth:
-          authDecoratorRows.some((row) => row > dec.startPosition.row) ||
-          (fromApiView &&
-            permissionClassRows.some((row) => row > dec.startPosition.row)) ||
-          paramAuth ||
-          routeCallHasAuthDependency(route.call) ||
-          scopes.global.hasAuth ||
-          (scopes.byReceiver.get(route.receiver)?.hasAuth ?? false),
+        hasAuth,
         hasValidation:
           perVal ||
           scopes.global.hasValidation ||
@@ -1106,6 +1293,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
           scopes.global.hasRateLimit ||
           (scopes.byReceiver.get(route.receiver)?.hasRateLimit ?? false),
         hasErrorHandler: false, // write-only field; JS AST extractor hard-codes false too
+        ...(unsureHook !== undefined ? { authUnsureHook: unsureHook } : {}),
       });
     }
   }

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -806,14 +806,28 @@ function prunedSelfAndDescendants(node: SyntaxNode, types: Set<string>): SyntaxN
   return out;
 }
 
-/** True when a node subtree reads a credential/session/auth surface, by the SAME
- *  three shapes the body scan recognizes: a session/cookie/header `.get("<cred>")`
- *  call; a `<cred> is None` comparison or a `"<cred>" in/not in <x>` comparison;
- *  or a `session["<cred>"]` / `g["<cred>"]` subscript. Deliberately NOT a bare
- *  credential-named identifier read (that would over-match user_agent, username,
- *  ...): keeping this identical to the body-wide `credentialRead` detection
- *  guarantees the guarded-403 blessing set is a strict SUBSET of the pre-tightening
- *  body-wide set, so the tightening only ever REMOVES blesses, never adds one. */
+/** True when `sub` is a `session["<cred>"]` / `g["<cred>"]` subscript reading a
+ *  credential key. Shared by the body-wide read and the strict guard gate. */
+function isCredentialSubscript(sub: SyntaxNode): boolean {
+  const value = sub.childForFieldName("value");
+  if (!value || value.type !== "identifier" || !(value.text === "session" || value.text === "g")) {
+    return false;
+  }
+  const idx = sub.childForFieldName("subscript");
+  return idx !== null && idx.type === "string" && keyIsCredential(pyStringText(idx));
+}
+
+/** True when a node subtree reads a credential/session/auth surface, by a LOOSE
+ *  reading of the recognized shapes: a session/cookie/header `.get("<cred>")`
+ *  call; a `<cred> is None` comparison or a `"<cred>" in/not in <x>` comparison
+ *  (against ANY container); or a `session["<cred>"]` / `g["<cred>"]` subscript.
+ *
+ *  Used ONLY for the body-wide `credentialRead` signal, which resolves at most to
+ *  `opaque` (a hedge, never a bless), so its deliberate over-match on a bare
+ *  credential-ish name merely widens the SAFE opaque bucket. The guarded-403 BLESS
+ *  gate does NOT use this helper — it uses the stricter
+ *  `guardConditionHasCredentialRead` below, so `request.user_agent is None` and
+ *  `"login" in request.path` never drive a bless. */
 function nodeHasCredentialRead(node: SyntaxNode): boolean {
   for (const call of prunedSelfAndDescendants(node, CALL_T)) {
     if (!call.hasError && isCredentialGetCall(call)) return true;
@@ -838,13 +852,94 @@ function nodeHasCredentialRead(node: SyntaxNode): boolean {
     }
   }
   for (const sub of prunedSelfAndDescendants(node, SUBSCRIPT_T)) {
-    if (sub.hasError) continue;
-    const value = sub.childForFieldName("value");
-    if (!value || value.type !== "identifier" || !(value.text === "session" || value.text === "g")) {
-      continue;
+    if (!sub.hasError && isCredentialSubscript(sub)) return true;
+  }
+  return false;
+}
+
+/** Local names in `body` bound to a STRUCTURAL credential source (a session/
+ *  request `.get(...)` call, or a `session`/`g` subscript), pruned of nested
+ *  defs. Lets `user = session.get("user_id"); if user is None: abort(403)` count
+ *  as a credential guard while a bare `request.user_agent` name never does. */
+function credentialBoundLocals(body: SyntaxNode): Set<string> {
+  const bound = new Set<string>();
+  for (const asn of prunedDescendants(body, new Set(["assignment"]))) {
+    if (asn.hasError) continue;
+    const left = asn.childForFieldName("left");
+    const right = asn.childForFieldName("right");
+    if (!left || left.type !== "identifier" || !right) continue;
+    const rhsIsCredential =
+      (right.type === "call" && isCredentialGetCall(right)) ||
+      (right.type === "subscript" && isCredentialSubscript(right));
+    if (rhsIsCredential) bound.add(left.text);
+  }
+  return bound;
+}
+
+/** Containers a credential membership test (`"<cred>" in/not in X`) may read
+ *  against: `session`/`g`, or `request.session`/`request.headers`/
+ *  `request.cookies`. `request.path` is deliberately NOT one, so
+ *  `"login" in request.path` is not a credential read. */
+function isCredentialContainer(node: SyntaxNode): boolean {
+  if (node.type === "identifier") return node.text === "session" || node.text === "g";
+  if (node.type === "attribute") {
+    return (
+      node.childForFieldName("object")?.text === "request" &&
+      ["session", "headers", "cookies"].includes(node.childForFieldName("attribute")?.text ?? "")
+    );
+  }
+  return false;
+}
+
+/** True when an is-None operand is a KNOWN credential surface: a `g.<cred>` /
+ *  `session.<cred>` attribute (never `request.<x>`, so `request.user_agent` is
+ *  out), or a bare identifier bound to a credential source earlier in the body. */
+function isCredentialNoneOperand(node: SyntaxNode, boundLocals: Set<string>): boolean {
+  if (node.type === "identifier") return boundLocals.has(node.text);
+  if (node.type === "attribute") {
+    const obj = node.childForFieldName("object");
+    const attr = node.childForFieldName("attribute")?.text ?? "";
+    return (
+      obj !== null &&
+      obj.type === "identifier" &&
+      (obj.text === "g" || obj.text === "session") &&
+      nameSegments(attr).some((s) => CREDENTIAL_KEY_SEGMENTS.has(s))
+    );
+  }
+  return false;
+}
+
+/** STRICTER credential read for the guarded-403 BLESS gate ONLY. A 403 guard
+ *  qualifies solely via a STRUCTURAL read: a session/request `.get(...)` call, a
+ *  `session`/`g` subscript, a credential membership against a credential
+ *  container (isCredentialContainer), or an is-None test on a known credential
+ *  surface (isCredentialNoneOperand). Never a bare credential-ish name against an
+ *  arbitrary container, so `"login" in request.path` and `request.user_agent is
+ *  None` never bless (they still resolve `opaque` -> unsure via the loose
+ *  body-wide read, a hedge, never a bless). */
+function guardConditionHasCredentialRead(cond: SyntaxNode, boundLocals: Set<string>): boolean {
+  for (const call of prunedSelfAndDescendants(cond, CALL_T)) {
+    if (!call.hasError && isCredentialGetCall(call)) return true;
+  }
+  for (const sub of prunedSelfAndDescendants(cond, SUBSCRIPT_T)) {
+    if (!sub.hasError && isCredentialSubscript(sub)) return true;
+  }
+  for (const cmp of prunedSelfAndDescendants(cond, COMPARISON_T)) {
+    if (cmp.hasError) continue;
+    const ops = cmp.children
+      .filter((c): c is SyntaxNode => c !== null && !c.isNamed)
+      .map((c) => c.type);
+    const named = cmp.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    if (ops.includes("in") || ops.includes("not in")) {
+      const credString = named.some((n) => n.type === "string" && keyIsCredential(pyStringText(n)));
+      const credContainer = named.some((n) => isCredentialContainer(n));
+      if (credString && credContainer) return true;
     }
-    const idx = sub.childForFieldName("subscript");
-    if (idx && idx.type === "string" && keyIsCredential(pyStringText(idx))) return true;
+    if (ops.includes("is")) {
+      const hasNone = named.some((n) => n.type === "none");
+      const credOperand = named.some((n) => isCredentialNoneOperand(n, boundLocals));
+      if (hasNone && credOperand) return true;
+    }
   }
   return false;
 }
@@ -883,9 +978,11 @@ function subtreeHas403Reject(node: SyntaxNode): boolean {
 
 interface BodySignals {
   reject401: boolean;
-  /** A 403 reject that sits inside an `if` whose CONDITION reads a credential
-   *  surface. A bare 403 anywhere no longer contributes (a lone 403 is routinely
-   *  a CSRF / IP / maintenance gate, not an authentication denial). */
+  /** A 403 reject that sits inside an `if` whose CONDITION STRUCTURALLY reads a
+   *  credential surface (guardConditionHasCredentialRead). A bare 403 anywhere no
+   *  longer contributes (a lone 403 is routinely a CSRF / IP / maintenance gate),
+   *  nor does a 403 guarded by a bare credential-ish name against an arbitrary
+   *  container (`"login" in request.path`, `request.user_agent is None`). */
   reject403Guarded: boolean;
   opaqueHint: boolean;
   credentialRead: boolean;
@@ -951,13 +1048,16 @@ function scanBody(
 
   // Guarded 403: an `if <credential-condition>: ... <403 reject> ...`. A 403 is
   // routinely a non-auth denial (CSRF, IP allowlist, maintenance), so it blesses
-  // ONLY when the reject is driven by a guard condition that reads a credential
-  // surface, never on body-wide co-occurrence with an unrelated credential read.
+  // ONLY when the reject is driven by a guard condition that STRUCTURALLY reads a
+  // credential surface (guardConditionHasCredentialRead — stricter than the loose
+  // body-wide read), never off a bare credential-ish name against an arbitrary
+  // container, and never on body-wide co-occurrence with an unrelated read.
+  const boundLocals = credentialBoundLocals(body);
   for (const ifs of prunedDescendants(body, new Set(["if_statement"]))) {
     if (ifs.hasError) continue;
     const cond = ifs.childForFieldName("condition");
     const cons = ifs.childForFieldName("consequence");
-    if (cond && cons && nodeHasCredentialRead(cond) && subtreeHas403Reject(cons)) {
+    if (cond && cons && guardConditionHasCredentialRead(cond, boundLocals) && subtreeHas403Reject(cons)) {
       out.reject403Guarded = true;
     }
   }

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -48,6 +48,15 @@
 import type { Tree, SyntaxNode } from "../core/types.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 
+/** Three-way verdict for a before_request-style hook. `unsure` never blesses
+ *  (hasAuth stays false); it only hedges the finding copy so the user is told
+ *  exactly which hook to double-check. */
+export type HookAuthOutcome = "auth" | "not-auth" | "unsure";
+/** Behavior a hook BODY exhibits: a verified auth rejection (`reject`), a fully
+ *  visible non-enforcing body (`none`), or auth-flavored behavior we cannot
+ *  statically verify (`opaque`). */
+export type BodySignal = "reject" | "none" | "opaque";
+
 // Route-registration attribute names on a router-like receiver.
 const ROUTE_METHODS = new Set(["route", "get", "post", "put", "patch", "delete", "api_route"]);
 // Verbs a methods=[...] kwarg may contribute (same set the regex extractor accepts).
@@ -171,11 +180,56 @@ const MIDDLEWARE_AUTH_SEGMENTS = new Set([
 // invariant, ambiguity and the unrecognized case both resolve to false.
 const PERMISSION_AUTH = new Set(["IsAuthenticated"]);
 
+// ─── Body-signature lexicons (addendum: hook body classification) ────────────
+// Rejection statuses that mean "request denied for identity reasons".
+// ASYMMETRIC by status (never-false-bless): 401 Unauthorized is specifically an
+// AUTHENTICATION denial and reject-blesses ALONE. 403 Forbidden is routinely
+// raised for NON-authentication reasons (CSRF token failure, IP allowlist,
+// maintenance/feature gate, generic authorization policy), so a bare
+// abort(403)/HTTPException(403) counts as a reject ONLY when a credential-surface
+// read (CREDENTIAL_KEY_SEGMENTS shapes) also occurs in the scanned bodies. An
+// uncorroborated lone 403 contributes NOTHING to the signal set (not reject, not
+// opaqueHint): the body resolves "none" -> flat not-auth for a boring name, so
+// csrf_protect / maintenance_gate neither bless (a false-bless the name-only path
+// never had) nor pollute the hedge with obvious non-auth hooks.
+const REJECT_STATUSES = new Set(["401", "403"]);
+const REJECT_STATUS_BLESSES_ALONE = new Set(["401"]); // 403 also needs a credential read
+// raise <X> auth-exception matching: an ALONE segment (unauthorized/forbidden),
+// or a TOPIC segment paired anywhere with a KIND segment (AuthenticationError,
+// PermissionDenied). raise ValueError / KeyError / NotFound never match.
+const AUTH_EXCEPTION_ALONE = new Set(["unauthorized", "forbidden"]);
+const AUTH_EXCEPTION_TOPIC = new Set(["auth", "authentication", "permission", "credentials"]);
+const AUTH_EXCEPTION_KIND = new Set(["error", "exception", "denied", "failed", "required"]);
+// Login-flavored redirect target segments; only these bless a redirect reject.
+const LOGIN_REDIRECT_SEGMENTS = new Set(["login", "signin", "signon", "auth"]);
+// Calls that enforce auth by raising internally; bless with no visible reject,
+// but ONLY with an EMPTY argument_list. A non-empty form
+// (verify_jwt_in_request(optional=True), which ADMITS anonymous requests) is
+// treated as an opaque-hint call, never a reject (mirrors the decorator twin
+// @jwt_required(optional=True)).
+const KNOWN_AUTH_PRIMITIVES = new Set(["verify_jwt_in_request"]);
+// Segments that make an UNRESOLVABLE callee auth-flavored enough that "we cannot
+// see what this call does" resolves UNSURE, not confident not-auth. CORE +
+// SUBJECT + ENFORCE, plus check/confirm/guard. Widening this set can only widen
+// UNSURE (hedged copy), never a bless.
+const OPAQUE_AUTH_HINT_SEGMENTS = new Set([
+  ...AUTH_CORE_SEGMENTS, ...AUTH_SUBJECT_SEGMENTS, ...AUTH_ENFORCE_SEGMENTS,
+  "check", "confirm", "guard",
+]);
+// Keys/attributes whose read marks a credential surface (gates the session/
+// cookie/header read shapes so session.get("locale") stays boring).
+const CREDENTIAL_KEY_SEGMENTS = new Set([
+  "user", "uid", "token", "jwt", "auth", "authorization", "login", "credentials",
+]);
+
 export const SECURITY_AST_PY = {
   ROUTE_METHODS, HTTP_VERBS, MUTATING_VERBS, ROUTER_RECEIVER, ROUTER_CONSTRUCTORS,
   AUTH_DECORATORS, DEPENDS_AUTH_SEGMENTS, DEPENDS_AUTH_PAIRS, DEPENDS_VETO_SEGMENTS,
   VAL_NAMES, RATE_NAMES, AUTH_CORE_SEGMENTS, AUTH_ENFORCE_SEGMENTS,
   AUTH_SUBJECT_SEGMENTS, OPTIONAL_AUTH_VETO, MIDDLEWARE_AUTH_SEGMENTS, PERMISSION_AUTH,
+  REJECT_STATUSES, REJECT_STATUS_BLESSES_ALONE, AUTH_EXCEPTION_ALONE, AUTH_EXCEPTION_TOPIC,
+  AUTH_EXCEPTION_KIND, LOGIN_REDIRECT_SEGMENTS, KNOWN_AUTH_PRIMITIVES,
+  OPAQUE_AUTH_HINT_SEGMENTS, CREDENTIAL_KEY_SEGMENTS,
 };
 
 /** Value of a Python string-ish path argument with quotes AND prefixes stripped.
@@ -409,6 +463,328 @@ function nameHasAuthToken(name: string): boolean {
     segs.some((s) => AUTH_ENFORCE_SEGMENTS.has(s)) &&
     segs.some((s) => AUTH_SUBJECT_SEGMENTS.has(s))
   );
+}
+
+// ─── Body-signature analyzer (addendum) ──────────────────────────────────────
+//
+// Classifies a before_request-style hook by what its BODY does, not what its
+// name suggests. `bodyAuthSignature` walks the body (plus ONE hop into a
+// same-file helper) and returns "reject" | "none" | "opaque"; `classifyHookAuth`
+// layers name precedence on top (an optionality-veto name always wins;
+// otherwise behavior beats a name; an opaque body hedges as "unsure" unless the
+// name is an unambiguous CORE auth token). Every walk keeps the module's
+// per-node `hasError` gate, so error-recovery nodes never contribute a bless.
+//
+// MEASURED reject-catalog recall gaps (SAFE, over-flag direction — a later pass
+// may widen deliberately): reject via a Response/make_response object
+// (abort(make_response(..., 401)) / abort(Response(status=401)), arg0 a call not
+// an integer); Flask-Login `return login_manager.unauthorized()` (an attribute
+// call outside KNOWN_AUTH_PRIMITIVES); and custom auth exceptions outside the
+// lexicon (raise Http401, raise NotAuthenticated). All resolve opaque/unsure or
+// not-auth today, never a false-bless.
+
+// Calls whose reject/target semantics are read in the raise/return walks (or are
+// merely nested), so the generic call walk must not re-interpret them.
+const CALL_HANDLED_ELSEWHERE = new Set([
+  "redirect", "RedirectResponse", "url_for", "jsonify", "HTTPException",
+]);
+
+/** Final callee/exception name of a node: an identifier's text, an attribute's
+ *  `attribute` field text, or (recursively) a call's function name. */
+function finalName(node: SyntaxNode | null): string | null {
+  if (!node) return null;
+  if (node.type === "identifier") return node.text;
+  if (node.type === "attribute") return node.childForFieldName("attribute")?.text ?? null;
+  if (node.type === "call") return finalName(node.childForFieldName("function"));
+  return null;
+}
+
+/** "401" | "403" only when `n` is exactly that integer literal; null otherwise. */
+function rejectStatusKind(n: SyntaxNode | null): "401" | "403" | null {
+  if (!n || n.type !== "integer") return null;
+  return REJECT_STATUSES.has(n.text) ? (n.text as "401" | "403") : null;
+}
+
+/** True when an argument_list has zero named children (a bare `f()`). */
+function isEmptyArgList(args: SyntaxNode | null): boolean {
+  return args !== null && args.namedChildren.filter((c) => c !== null).length === 0;
+}
+
+/** True when any whole segment of `name` is an OPAQUE_AUTH_HINT_SEGMENTS member. */
+function hintHit(name: string): boolean {
+  return nameSegments(name).some((s) => OPAQUE_AUTH_HINT_SEGMENTS.has(s));
+}
+
+/** Auth-exception name match (raise matching): an ALONE segment, or a TOPIC
+ *  segment paired anywhere in the name with a KIND segment. Whole-segment. */
+function isAuthExceptionName(name: string): boolean {
+  const segs = nameSegments(name);
+  if (segs.some((s) => AUTH_EXCEPTION_ALONE.has(s))) return true;
+  return (
+    segs.some((s) => AUTH_EXCEPTION_TOPIC.has(s)) &&
+    segs.some((s) => AUTH_EXCEPTION_KIND.has(s))
+  );
+}
+
+/** True when a stripped string key carries a credential segment. */
+function keyIsCredential(key: string | null): boolean {
+  return key !== null && nameSegments(key).some((s) => CREDENTIAL_KEY_SEGMENTS.has(s));
+}
+
+/** Status a raised HTTPException declares: "401"/"403"; "unreadable" (status_code
+ *  set to an opaque identifier such as CODE); or null (no 401/403 signal, e.g. a
+ *  404 or a detail-only raise). */
+function httpExceptionStatus(call: SyntaxNode): "401" | "403" | "unreadable" | null {
+  const args = call.childForFieldName("arguments");
+  if (!args) return null;
+  const named = args.namedChildren.filter((n): n is SyntaxNode => n !== null);
+  const kw = named.find(
+    (n) => n.type === "keyword_argument" && n.childForFieldName("name")?.text === "status_code",
+  );
+  if (kw) {
+    const val = kw.childForFieldName("value");
+    if (!val) return null;
+    if (val.type === "integer") {
+      return REJECT_STATUSES.has(val.text) ? (val.text as "401" | "403") : null;
+    }
+    if (val.type === "attribute") {
+      const m = (val.childForFieldName("attribute")?.text ?? "").match(/^HTTP_(401|403)_/);
+      return m ? (m[1] as "401" | "403") : null;
+    }
+    if (val.type === "identifier") {
+      const m = val.text.match(/^HTTP_(401|403)_/);
+      return m ? (m[1] as "401" | "403") : "unreadable"; // bare CODE identifier
+    }
+    return null;
+  }
+  const pos = named.find((n) => n.type !== "keyword_argument") ?? null;
+  return rejectStatusKind(pos);
+}
+
+/** Resolved redirect target string, or null when statically unreadable. */
+function redirectTargetString(call: SyntaxNode): string | null {
+  const arg0 = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+  if (!arg0) return null;
+  if (arg0.type === "string") return pyStringText(arg0);
+  if (arg0.type === "call" && finalName(arg0.childForFieldName("function")) === "url_for") {
+    const inner = arg0.childForFieldName("arguments")?.namedChild(0) ?? null;
+    return inner && inner.type === "string" ? pyStringText(inner) : null;
+  }
+  return null;
+}
+
+/** True when a resolved redirect target has a login-flavored segment. */
+function redirectTargetIsLogin(target: string): boolean {
+  return target
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((s) => s.length > 0)
+    .some((s) => LOGIN_REDIRECT_SEGMENTS.has(s));
+}
+
+/** True when a `.get(...)`-style call reads a credential key off a session /
+ *  cookie / header surface (session.get, g.get, request.headers.get, ...). */
+function isCredentialGetCall(call: SyntaxNode): boolean {
+  const fn = call.childForFieldName("function");
+  if (!fn || fn.type !== "attribute" || fn.childForFieldName("attribute")?.text !== "get") {
+    return false;
+  }
+  const obj = fn.childForFieldName("object");
+  if (!obj) return false;
+  const receiverOk =
+    (obj.type === "identifier" && (obj.text === "session" || obj.text === "g")) ||
+    (obj.type === "attribute" &&
+      obj.childForFieldName("object")?.text === "request" &&
+      ["headers", "cookies", "session"].includes(obj.childForFieldName("attribute")?.text ?? ""));
+  if (!receiverOk) return false;
+  const arg0 = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+  return arg0 !== null && arg0.type === "string" && keyIsCredential(pyStringText(arg0));
+}
+
+interface BodySignals {
+  reject401: boolean;
+  reject403: boolean;
+  opaqueHint: boolean;
+  credentialRead: boolean;
+}
+
+/** One body's direct signals; `hop` = whether a same-file helper body may be
+ *  followed (depth exactly 1). reject401 blesses ALONE; reject403 blesses only
+ *  WITH a credentialRead (403 is routinely non-auth). */
+function scanBody(
+  body: SyntaxNode,
+  defs: Map<string, SyntaxNode | null>,
+  hop: boolean,
+): BodySignals {
+  const out: BodySignals = {
+    reject401: false, reject403: false, opaqueHint: false, credentialRead: false,
+  };
+  const merge = (s: BodySignals) => {
+    out.reject401 = out.reject401 || s.reject401;
+    out.reject403 = out.reject403 || s.reject403;
+    out.opaqueHint = out.opaqueHint || s.opaqueHint;
+    out.credentialRead = out.credentialRead || s.credentialRead;
+  };
+
+  // Calls: aborts, auth primitives, one-hop helpers, opaque hints, credential .get.
+  for (const call of body.descendantsOfType("call")) {
+    if (!call || call.hasError) continue;
+    if (isCredentialGetCall(call)) out.credentialRead = true;
+    const fn = call.childForFieldName("function");
+    const args = call.childForFieldName("arguments");
+    const name = finalName(fn);
+    if (name === "abort") {
+      const arg0 = args?.namedChild(0) ?? null;
+      const kind = rejectStatusKind(arg0);
+      if (kind === "401") out.reject401 = true;
+      else if (kind === "403") out.reject403 = true;
+      else if (arg0 !== null && arg0.type !== "integer") out.opaqueHint = true; // abort(code_var)
+      continue;
+    }
+    if (name !== null && KNOWN_AUTH_PRIMITIVES.has(name) && isEmptyArgList(args)) {
+      out.reject401 = true; // verify_jwt_in_request() raises internally
+      continue;
+    }
+    if (name !== null && CALL_HANDLED_ELSEWHERE.has(name)) continue;
+    if (fn?.type === "identifier" && name !== null && defs.has(name)) {
+      const def = defs.get(name) ?? null;
+      if (def && hop) {
+        const hopBody = def.childForFieldName("body");
+        if (hopBody) merge(scanBody(hopBody, defs, false));
+      } else if (!def && hintHit(name)) {
+        out.opaqueHint = true; // duplicate same-name def: unresolvable + flavored
+      }
+      // A resolvable def at hop=false is the cycle guard: contribute nothing.
+      continue;
+    }
+    if (name !== null && hintHit(name)) out.opaqueHint = true; // unresolvable flavored callee
+  }
+
+  // raise <exception>: HTTPException status, else the auth-exception lexicon.
+  for (const rs of body.descendantsOfType("raise_statement")) {
+    if (!rs || rs.hasError) continue;
+    const raised = rs.namedChild(0);
+    if (!raised) continue;
+    if (
+      raised.type === "call" &&
+      finalName(raised.childForFieldName("function")) === "HTTPException"
+    ) {
+      const st = httpExceptionStatus(raised);
+      if (st === "401") out.reject401 = true;
+      else if (st === "403") out.reject403 = true;
+      else if (st === "unreadable") out.opaqueHint = true;
+      continue;
+    }
+    const rn = finalName(raised);
+    if (rn !== null && isAuthExceptionName(rn)) out.reject401 = true;
+  }
+
+  // return: a login-flavored redirect, or an (expr, 401|403) tuple.
+  for (const ret of body.descendantsOfType("return_statement")) {
+    if (!ret || ret.hasError) continue;
+    const val = ret.namedChild(0);
+    if (!val) continue;
+    if (val.type === "call") {
+      const cn = finalName(val.childForFieldName("function"));
+      if (cn === "redirect" || cn === "RedirectResponse") {
+        const target = redirectTargetString(val);
+        if (target === null) out.opaqueHint = true; // redirect(page_var): unreadable target
+        else if (redirectTargetIsLogin(target)) out.reject401 = true;
+      }
+      continue;
+    }
+    if (val.type === "expression_list") {
+      const kids = val.namedChildren.filter((n): n is SyntaxNode => n !== null);
+      const kind = rejectStatusKind(kids[kids.length - 1] ?? null);
+      if (kind === "401") out.reject401 = true;
+      else if (kind === "403") out.reject403 = true;
+    }
+  }
+
+  // Credential-surface reads (comparison + subscript shapes; the .get call shape
+  // is folded into the call walk above via isCredentialGetCall).
+  for (const cmp of body.descendantsOfType("comparison_operator")) {
+    if (!cmp || cmp.hasError) continue;
+    const ops = cmp.children
+      .filter((c): c is SyntaxNode => c !== null && !c.isNamed)
+      .map((c) => c.type);
+    const named = cmp.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    if (ops.includes("is")) {
+      const hasNone = named.some((n) => n.type === "none");
+      const credOperand = named.some(
+        (n) =>
+          (n.type === "identifier" || n.type === "attribute") &&
+          nameSegments(n.text).some((s) => CREDENTIAL_KEY_SEGMENTS.has(s)),
+      );
+      if (hasNone && credOperand) out.credentialRead = true;
+    }
+    if (ops.includes("in") || ops.includes("not in")) {
+      if (named.some((n) => n.type === "string" && keyIsCredential(pyStringText(n)))) {
+        out.credentialRead = true;
+      }
+    }
+  }
+  for (const sub of body.descendantsOfType("subscript")) {
+    if (!sub || sub.hasError) continue;
+    const value = sub.childForFieldName("value");
+    if (!value || value.type !== "identifier" || !(value.text === "session" || value.text === "g")) {
+      continue;
+    }
+    const idx = sub.childForFieldName("subscript");
+    if (idx && idx.type === "string" && keyIsCredential(pyStringText(idx))) out.credentialRead = true;
+  }
+
+  return out;
+}
+
+/** File-wide map of top-level and nested function definitions by name. A name
+ *  seen more than once maps to null (duplicate: follow NEITHER definition). */
+export function collectFunctionDefs(root: SyntaxNode): Map<string, SyntaxNode | null> {
+  const defs = new Map<string, SyntaxNode | null>();
+  for (const def of root.descendantsOfType("function_definition")) {
+    if (!def || def.hasError) continue;
+    const name = def.childForFieldName("name")?.text;
+    if (!name) continue;
+    defs.set(name, defs.has(name) ? null : def);
+  }
+  return defs;
+}
+
+/** A hook body's three-way auth signal. 401-family blesses alone; a 403 blesses
+ *  only when a credential surface is also read; an uncorroborated 403 is neither
+ *  reject nor opaque (keeps the hedge meaningful). */
+export function bodyAuthSignature(
+  body: SyntaxNode,
+  defs: Map<string, SyntaxNode | null>,
+): BodySignal {
+  const s = scanBody(body, defs, true);
+  if (s.reject401 || (s.reject403 && s.credentialRead)) return "reject";
+  if (s.opaqueHint || s.credentialRead) return "opaque";
+  return "none";
+}
+
+/** Precedence layer over `bodyAuthSignature`. `nameIsSimpleIdentifier` is false
+ *  for attribute targets (AuthGate.check), which can hedge but never bless. */
+export function classifyHookAuth(
+  hookName: string,
+  body: SyntaxNode | null,
+  defs: Map<string, SyntaxNode | null>,
+  nameIsSimpleIdentifier: boolean,
+): HookAuthOutcome {
+  const segs = nameSegments(hookName);
+  if (segs.some((s) => OPTIONAL_AUTH_VETO.has(s))) return "not-auth"; // rule 1
+  const isCore =
+    nameIsSimpleIdentifier &&
+    (segs.some((s) => AUTH_CORE_SEGMENTS.has(s)) || AUTH_DECORATORS.has(hookName));
+  if (body) {
+    const sig = bodyAuthSignature(body, defs);
+    if (sig === "reject") return "auth"; // rule 2: behavior beats name
+    if (sig === "none") return "not-auth"; // rule 3: a visible non-enforcing body, name never rescues
+    return isCore ? "auth" : "unsure"; // rule 4: opaque -> CORE carve-out, else hedge
+  }
+  if (isCore) return "auth"; // rule 5: resolved simple CORE name
+  const flavored = segs.some((s) => AUTH_CORE_SEGMENTS.has(s)) || nameHasAuthToken(hookName);
+  return flavored ? "unsure" : "not-auth";
 }
 
 /** Segment-matched auth verdict for a resolved dependency name (see the constants

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -208,14 +208,15 @@ const PERMISSION_AUTH = new Set(["IsAuthenticated", "IsAdminUser"]);
 // AUTHENTICATION denial and reject-blesses ALONE. 403 Forbidden is routinely
 // raised for NON-authentication reasons (CSRF token failure, IP allowlist,
 // maintenance/feature gate, generic authorization policy), so a bare
-// abort(403)/HTTPException(403) counts as a reject ONLY when a credential-surface
-// read (CREDENTIAL_KEY_SEGMENTS shapes) also occurs in the scanned bodies. An
-// uncorroborated lone 403 contributes NOTHING to the signal set (not reject, not
-// opaqueHint): the body resolves "none" -> flat not-auth for a boring name, so
-// csrf_protect / maintenance_gate neither bless (a false-bless the name-only path
-// never had) nor pollute the hedge with obvious non-auth hooks.
+// abort(403)/HTTPException(403) blesses ONLY inside a reject whose GUARD CONDITION
+// structurally reads a credential surface (`if "user_id" not in session:
+// abort(403)`), via guardConditionHasCredentialRead. A lone or otherwise-guarded
+// 403 contributes NOTHING to the signal set (not reject, not opaqueHint): the body
+// resolves "none" -> flat not-auth for a boring name, so csrf_protect /
+// maintenance_gate neither bless (a false-bless the name-only path never had) nor
+// pollute the hedge with obvious non-auth hooks. The 401/403 asymmetry is enforced
+// directly in scanBody (abort/HTTPException/return branches), not via a lookup set.
 const REJECT_STATUSES = new Set(["401", "403"]);
-const REJECT_STATUS_BLESSES_ALONE = new Set(["401"]); // 403 also needs a credential read
 // raise <X> auth-exception matching: an ALONE segment (unauthorized/forbidden),
 // or a TOPIC segment paired anywhere with a KIND segment (AuthenticationError,
 // PermissionDenied). raise ValueError / KeyError / NotFound never match.
@@ -249,7 +250,7 @@ export const SECURITY_AST_PY = {
   AUTH_DECORATORS, DEPENDS_AUTH_SEGMENTS, DEPENDS_AUTH_PAIRS, DEPENDS_VETO_SEGMENTS,
   VAL_NAMES, RATE_NAMES, AUTH_CORE_SEGMENTS, AUTH_ENFORCE_SEGMENTS,
   AUTH_SUBJECT_SEGMENTS, OPTIONAL_AUTH_VETO, MIDDLEWARE_AUTH_SEGMENTS, PERMISSION_AUTH,
-  REJECT_STATUSES, REJECT_STATUS_BLESSES_ALONE, AUTH_EXCEPTION_ALONE, AUTH_EXCEPTION_TOPIC,
+  REJECT_STATUSES, AUTH_EXCEPTION_ALONE, AUTH_EXCEPTION_TOPIC,
   AUTH_EXCEPTION_KIND, LOGIN_REDIRECT_SEGMENTS, KNOWN_AUTH_PRIMITIVES,
   OPAQUE_AUTH_HINT_SEGMENTS, CREDENTIAL_KEY_SEGMENTS,
 };
@@ -1565,8 +1566,11 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
         scopes.global.hasAuth ||
         (scopes.byReceiver.get(route.receiver)?.hasAuth ?? false);
       // A route is hedged "unsure" ONLY when it is not otherwise authed AND an
-      // unsure hook is in its scope (receiver-specific first, then app-wide). The
-      // field implies hasAuth === false; a blessed route never carries it.
+      // unsure hook is in its scope. RECEIVER-FIRST is the shipped convention: a
+      // route on a named blueprint/router attributes its OWN receiver's unsure
+      // hook before falling back to an app-scoped one, because the receiver hook
+      // is the more actionable one for that route to double-check. The field
+      // implies hasAuth === false; a blessed route never carries it.
       const unsureHook = hasAuth
         ? undefined
         : (scopes.unsureByReceiver.get(route.receiver) ?? scopes.globalUnsure ?? undefined);

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -366,6 +366,21 @@ function isTopLevelAssignment(asn: SyntaxNode, root: SyntaxNode): boolean {
   return stmt !== null && stmt.parent !== null && stmt.parent.id === root.id;
 }
 
+/** True when `node` sits inside a `function_definition` / `lambda` body anywhere
+ *  up to `root`. A variable local to a function is a DIFFERENT binding from the
+ *  module-level name, so a def-local write must not count toward the module
+ *  name's write census (preserving def-local precision). A write merely nested in
+ *  a module-scope `if`/`try`/`with`/`for` is NOT excluded — it rebinds the same
+ *  module name and so DOES count. */
+function isInsideFunctionBody(node: SyntaxNode, root: SyntaxNode): boolean {
+  let p = node.parent;
+  while (p !== null && p.id !== root.id) {
+    if (p.type === "function_definition" || p.type === "lambda") return true;
+    p = p.parent;
+  }
+  return false;
+}
+
 /** Names written through a form the census cannot safely read a single value
  *  through, ANYWHERE in the file (no scope analysis, mirroring
  *  collectRouterNames's flat census): an augmented assignment (`X += ...`), a
@@ -430,15 +445,19 @@ function collectPoisonedMethodsNames(root: SyntaxNode): Set<string> {
 /** Identifiers assigned, at MODULE TOP LEVEL, to a single unambiguous
  *  `list`/`tuple`/`set` literal of string verbs — the value a Flask
  *  `methods=` kwarg may safely resolve through (Upgrade 2). Mirrors
- *  collectRouterNames's flat, no-scope census: MULTIPLE top-level assignments
- *  to the same name (any RHS shape, not only a literal — a literal followed
- *  by a computed reassignment is exactly as ambiguous as two literals) make
- *  its value ambiguous, and any poisoned write form (collectPoisonedMethodsNames)
- *  disqualifies it regardless of how many literal assignments exist. A name
- *  that is imported, computed, an identifier alias (`B = A`: the census
- *  refuses to chase an identifier RHS), written more than once, written only
- *  conditionally/def-locally, or poisoned is simply ABSENT from the returned
- *  map — `resolveMethod` then falls through to "ALL", never a silent GET. */
+ *  collectRouterNames's flat census: MULTIPLE module-scope writes to the same
+ *  name make its value ambiguous, where a write is counted at ANY module-scope
+ *  DEPTH (a top-level assignment AND a nested `if F: ALLOWED = [...]` / try-block
+ *  rebind both count — any RHS shape, not only a literal), so a nested reassign
+ *  poisons rather than silently vanishing. Only a def-local write (a different
+ *  binding) is excluded from the count. Any poisoned write form
+ *  (collectPoisonedMethodsNames) disqualifies the name regardless of how many
+ *  literal assignments exist; the single RECORDED literal must still be
+ *  top-level. A name that is imported, computed, an identifier alias (`B = A`:
+ *  the census refuses to chase an identifier RHS), written more than once at
+ *  module scope, written only conditionally/def-locally, or poisoned is simply
+ *  ABSENT from the returned map — `resolveMethod` then falls through to "ALL",
+ *  never a silent GET. */
 function collectMethodsVars(root: SyntaxNode): Map<string, SyntaxNode> {
   const writeCounts = new Map<string, number>();
   const literalByName = new Map<string, SyntaxNode>();
@@ -446,11 +465,21 @@ function collectMethodsVars(root: SyntaxNode): Map<string, SyntaxNode> {
     if (!asn) continue;
     const left = asn.childForFieldName("left");
     if (!left || left.type !== "identifier") continue; // subscript/pattern_list: no plain-name write
-    if (!isTopLevelAssignment(asn, root)) continue; // conditional / def-local: not unconditional
+    if (isInsideFunctionBody(asn, root)) continue; // def-local: a different binding
     const name = left.text;
+    // Count identifier-left writes at ANY module-scope depth: a nested reassign
+    // (`if F: ALLOWED = [...]`, a try-block rebind) is a SECOND write that
+    // POISONS the name (writeCounts > 1 -> unresolvable -> ALL), never an
+    // invisible one that silently GET-drops the route. A nested write MUST NOT be
+    // skipped before it is counted (the original bug).
     writeCounts.set(name, (writeCounts.get(name) ?? 0) + 1);
     const right = asn.childForFieldName("right");
-    if (right && ["list", "tuple", "set"].includes(right.type)) literalByName.set(name, right);
+    // Only a TOP-LEVEL literal is a safe single value to read through; a nested
+    // literal only sometimes runs, so it is never the RECORDED value even though
+    // the write above still counts toward poisoning.
+    if (isTopLevelAssignment(asn, root) && right && ["list", "tuple", "set"].includes(right.type)) {
+      literalByName.set(name, right);
+    }
   }
   const poisoned = collectPoisonedMethodsNames(root);
   const resolved = new Map<string, SyntaxNode>();

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -25,17 +25,43 @@
  *
  * OPEN QUESTION FOR SIGN-OFF: `resolveMethod`'s handling of a Flask `methods=`
  * kwarg that is not a statically readable list/tuple/set of string literals
- * (a variable, `**kwargs`, or a `*splat` with no visible literal verb)
  * deliberately diverges from the regex extractor. The regex silently defaults
  * such a route to GET, which excludes it from the mutating vote. This AST
  * path instead resolves it to "ALL", which keeps the route IN the mutating
  * vote (matching how an Express `.all()` route is treated). This is a real,
  * user-visible behavior change from today's regex path, not a bug fix; it is
  * called out here for explicit sign-off rather than shipped silently.
- * `asApiViewDecorator` follows the SAME ALL-on-unresolvable convention: an
- * `@api_view([METHOD])` / `@api_view([*BASE])` list whose only verbs are hidden
- * behind a variable resolves to "ALL", not GET. Same open question, same
- * pending sign-off.
+ *
+ * UPGRADE 2 (Task 3) partially resolves this divergence: `methods=VAR` now
+ * reads through VAR's value when, and ONLY when, VAR is written EXACTLY ONCE,
+ * at module top level, to a literal list/tuple/set of string verbs
+ * (`collectMethodsVars`, mirroring `collectRouterNames`'s same flat, no-scope
+ * census). That resolved literal is reduced by the SAME `methodFromLiteral`
+ * helper the inline `methods=[...]` path already used, so a same-file
+ * `ALLOWED = ["GET", "POST"]` behaves identically to an inline
+ * `methods=["GET", "POST"]`. Every other shape of `methods=VAR` still resolves
+ * "ALL", never a silent GET: an identifier with no same-file assignment
+ * (imported, or an alias chain `B = A` — the census refuses to chase an
+ * identifier RHS), a computed value (`BASE + EXTRA`, a `binary_operator`, or a
+ * call), a `**kwargs` splat, a `*splat` with no visible literal verb, a
+ * variable written more than once at top level, a variable written inside a
+ * conditional or a function body (not an UNCONDITIONAL same-file literal), or
+ * a variable written through any poisoned form the census cannot safely read
+ * through: an augmented assignment (`X += ...`), a mutating attribute call
+ * (`X.append(...)`), a `global X` statement, a walrus write, a for-loop
+ * target, a subscript/slice-target assignment (`X[:] = ...`, `X[0] = ...`),
+ * or a `with ... as X:` binding. When in doubt, the census leaves the name
+ * out of its map and `resolveMethod` falls through to "ALL" — the
+ * false-negative direction (never GET-dropping a route out of the mutating
+ * vote) always wins over precision.
+ *
+ * `asApiViewDecorator` follows the SAME ALL-on-unresolvable convention for its
+ * own unresolvable forms, but is DELIBERATELY NOT extended by Upgrade 2: an
+ * `@api_view([METHOD])` / `@api_view([*BASE])` / `@api_view(METHODS)` list
+ * whose only verbs are hidden behind a variable resolves to "ALL", not GET,
+ * even when that variable has a same-file literal assignment. Upgrade 2 names
+ * the Flask `methods=` kwarg only; widening it to api_view's positional list
+ * argument is a separate, unapproved change.
  *
  * DJANGO REST SCOPE (best-effort, function views only): `@api_view(["POST"])`
  * routes are recognized; the URL lives in `urls.py` and cross-file resolution
@@ -165,13 +191,16 @@ const MIDDLEWARE_AUTH_SEGMENTS = new Set([
   "auth", "authentication", "authenticate", "authenticated", "jwt", "oauth", "oauth2", "bearer",
 ]);
 // DRF @permission_classes([...]) EXACT class names that unconditionally require
-// an authenticated request. Deliberately narrow: AllowAny never requires auth;
+// an authenticated request: IsAuthenticated, and IsAdminUser (requires
+// request.user.is_staff, which implies an authenticated user — admin is a
+// strict subset of authed, so recognizing it carries zero false-bless risk).
+// Deliberately narrow otherwise: AllowAny never requires auth;
 // IsAuthenticatedOrReadOnly and DjangoModelPermissionsOrAnonReadOnly only require
 // auth for unsafe (write) methods, which is a per-method condition this
 // route-level check cannot statically resolve, so they are NOT here; any other
 // built-in or custom permission class is unrecognized. Per the never-false-bless
 // invariant, ambiguity and the unrecognized case both resolve to false.
-const PERMISSION_AUTH = new Set(["IsAuthenticated"]);
+const PERMISSION_AUTH = new Set(["IsAuthenticated", "IsAdminUser"]);
 
 // ─── Body-signature lexicons (addendum: hook body classification) ────────────
 // Rejection statuses that mean "request denied for identity reasons".
@@ -297,7 +326,145 @@ function collectRouterNames(root: SyntaxNode): Set<string> {
   return names;
 }
 
-function asRouteDecorator(dec: SyntaxNode, routerNames: Set<string>): PyRoute | null {
+/** Reduces a `list`/`tuple`/`set` literal node to its resolved method: the
+ *  mutating verb when one is present, else the first recognized verb, else
+ *  GET for a fully visible literal (including an empty one — Flask's own
+ *  default), or "ALL" when a non-string element (`*splat`, a bare variable
+ *  entry) hides a possible verb. Shared by `resolveMethod`'s `methods=` kwarg
+ *  (inline literal AND same-file-resolved variable) and
+ *  `asApiViewDecorator`'s `@api_view([...])` list: same literal shape, same
+ *  reduction rules, one implementation. */
+function methodFromLiteral(value: SyntaxNode): string {
+  const children = value.namedChildren.filter((n): n is SyntaxNode => n !== null);
+  const verbs = children
+    .filter((n) => n.type === "string")
+    .map((s) => (pyStringText(s) ?? "").toUpperCase())
+    .filter((v) => HTTP_VERBS.has(v));
+  const hidden = children.some((n) => n.type !== "string");
+  if (verbs.length === 0) return hidden ? "ALL" : "GET"; // [*BASE] vs literal []
+  return verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0];
+}
+
+/** `node` itself when it IS an `identifier`, else every `identifier`
+ *  descendant — covers pattern-unpack targets (`x, ALLOWED = pair`,
+ *  `for a, ALLOWED in pairs:`) without needing to special-case
+ *  `pattern_list`/`tuple_pattern` shapes individually. */
+function identifiersIn(node: SyntaxNode): SyntaxNode[] {
+  if (node.type === "identifier") return [node];
+  return node.descendantsOfType("identifier").filter((n): n is SyntaxNode => n !== null);
+}
+
+/** True when `asn` (an `assignment` node) is a direct module-level statement:
+ *  its parent (`expression_statement`) is itself a direct child of `root`. A
+ *  write nested inside an `if`/`for`/`while`/`try`/`with`/function/class body
+ *  is NOT an unconditional same-file literal — resolving it could pick a
+ *  value that only sometimes runs (the conditional case) or a value scoped to
+ *  a function that never reaches the module binding at all (the def-local
+ *  case) — so it must never become a resolvable methods= candidate. */
+function isTopLevelAssignment(asn: SyntaxNode, root: SyntaxNode): boolean {
+  const stmt = asn.parent;
+  return stmt !== null && stmt.parent !== null && stmt.parent.id === root.id;
+}
+
+/** Names written through a form the census cannot safely read a single value
+ *  through, ANYWHERE in the file (no scope analysis, mirroring
+ *  collectRouterNames's flat census): an augmented assignment (`X += ...`), a
+ *  subscript/slice-target assignment (`X[:] = ...`, `X[0] = ...`), a
+ *  tuple/pattern-unpack assignment target (`x, X = pair`), a `global X`
+ *  statement, a walrus write (`X := ...`), a for-loop target (`for X in
+ *  ...:`), a `with ... as X:` binding, or a mutating attribute call on the
+ *  identifier (`X.append(...)`, `X.<anything>(...)`). A name in this set can
+ *  never resolve through collectMethodsVars, however many literal assignments
+ *  it also has — a write ANYWHERE in the file only ever ADDS poisoning, never
+ *  removes it, so this can only over-poison (stay "ALL"), never under-poison
+ *  into a false GET-drop. */
+function collectPoisonedMethodsNames(root: SyntaxNode): Set<string> {
+  const poisoned = new Set<string>();
+  const add = (n: SyntaxNode | null) => {
+    if (n && n.type === "identifier") poisoned.add(n.text);
+  };
+  for (const asn of root.descendantsOfType("augmented_assignment")) {
+    if (!asn) continue;
+    const left = asn.childForFieldName("left");
+    if (left) identifiersIn(left).forEach(add);
+  }
+  for (const asn of root.descendantsOfType("assignment")) {
+    if (!asn) continue;
+    const left = asn.childForFieldName("left");
+    if (!left) continue;
+    if (left.type === "subscript") {
+      add(left.childForFieldName("value")); // ALLOWED[:] = ... / ALLOWED[0] = ...
+    } else if (left.type !== "identifier") {
+      identifiersIn(left).forEach(add); // pattern_list unpack: x, ALLOWED = pair
+    }
+  }
+  for (const gs of root.descendantsOfType("global_statement")) {
+    if (!gs) continue;
+    gs.namedChildren.forEach(add);
+  }
+  for (const ne of root.descendantsOfType("named_expression")) {
+    if (!ne) continue;
+    add(ne.childForFieldName("name")); // walrus: (ALLOWED := ...)
+  }
+  for (const fs of root.descendantsOfType("for_statement")) {
+    if (!fs) continue;
+    const left = fs.childForFieldName("left");
+    if (left) identifiersIn(left).forEach(add);
+  }
+  for (const wi of root.descendantsOfType("with_item")) {
+    if (!wi) continue;
+    const value = wi.childForFieldName("value");
+    if (value && value.type === "as_pattern") {
+      const alias = value.childForFieldName("alias"); // with ... as ALLOWED:
+      if (alias) identifiersIn(alias).forEach(add);
+    }
+  }
+  for (const call of root.descendantsOfType("call")) {
+    if (!call) continue;
+    const fn = call.childForFieldName("function");
+    if (fn && fn.type === "attribute") add(fn.childForFieldName("object")); // ALLOWED.append(...)
+  }
+  return poisoned;
+}
+
+/** Identifiers assigned, at MODULE TOP LEVEL, to a single unambiguous
+ *  `list`/`tuple`/`set` literal of string verbs — the value a Flask
+ *  `methods=` kwarg may safely resolve through (Upgrade 2). Mirrors
+ *  collectRouterNames's flat, no-scope census: MULTIPLE top-level assignments
+ *  to the same name (any RHS shape, not only a literal — a literal followed
+ *  by a computed reassignment is exactly as ambiguous as two literals) make
+ *  its value ambiguous, and any poisoned write form (collectPoisonedMethodsNames)
+ *  disqualifies it regardless of how many literal assignments exist. A name
+ *  that is imported, computed, an identifier alias (`B = A`: the census
+ *  refuses to chase an identifier RHS), written more than once, written only
+ *  conditionally/def-locally, or poisoned is simply ABSENT from the returned
+ *  map — `resolveMethod` then falls through to "ALL", never a silent GET. */
+function collectMethodsVars(root: SyntaxNode): Map<string, SyntaxNode> {
+  const writeCounts = new Map<string, number>();
+  const literalByName = new Map<string, SyntaxNode>();
+  for (const asn of root.descendantsOfType("assignment")) {
+    if (!asn) continue;
+    const left = asn.childForFieldName("left");
+    if (!left || left.type !== "identifier") continue; // subscript/pattern_list: no plain-name write
+    if (!isTopLevelAssignment(asn, root)) continue; // conditional / def-local: not unconditional
+    const name = left.text;
+    writeCounts.set(name, (writeCounts.get(name) ?? 0) + 1);
+    const right = asn.childForFieldName("right");
+    if (right && ["list", "tuple", "set"].includes(right.type)) literalByName.set(name, right);
+  }
+  const poisoned = collectPoisonedMethodsNames(root);
+  const resolved = new Map<string, SyntaxNode>();
+  for (const [name, node] of literalByName) {
+    if (writeCounts.get(name) === 1 && !poisoned.has(name)) resolved.set(name, node);
+  }
+  return resolved;
+}
+
+function asRouteDecorator(
+  dec: SyntaxNode,
+  routerNames: Set<string>,
+  methodsVars: Map<string, SyntaxNode>,
+): PyRoute | null {
   const expr = dec.namedChild(0);
   if (!expr || expr.type !== "call") return null;
   const fn = expr.childForFieldName("function");
@@ -311,7 +478,7 @@ function asRouteDecorator(dec: SyntaxNode, routerNames: Set<string>): PyRoute | 
   if (!receiver || !(routerNames.has(receiver) || ROUTER_RECEIVER.test(receiver))) return null;
   const path = routePath(args);
   if (path === null || !path.startsWith("/")) return null; // leading-slash gate, same as JS
-  return { method: resolveMethod(attr, args), path, call: expr, receiver };
+  return { method: resolveMethod(attr, args, methodsVars), path, call: expr, receiver };
 }
 
 /** Resolves the HTTP method(s) a route decorator registers.
@@ -324,15 +491,17 @@ function asRouteDecorator(dec: SyntaxNode, routerNames: Set<string>): PyRoute | 
  *  to GET whenever `methods=` isn't a literal list it can pattern-match (a
  *  variable, a set, a splat), which quietly excludes that route from the
  *  mutating vote. This AST path instead emits "ALL" for every statically
- *  unresolvable form (variable value, **kwargs splat, a *splat with no visible
- *  literal verb), so the route STAYS in the mutating vote ("ALL" is a member of
- *  both MUTATION_METHODS and BODY_METHODS), the same way Express's `.all()` is
- *  treated. This is a real behavior change from the regex path and is flagged
- *  as an open question for sign-off, not a silent fix.
+ *  unresolvable form (**kwargs splat, a *splat with no visible literal verb,
+ *  or a methods= variable that Upgrade 2's same-file census cannot safely
+ *  resolve — see `collectMethodsVars`), so the route STAYS in the mutating
+ *  vote ("ALL" is a member of both MUTATION_METHODS and BODY_METHODS), the
+ *  same way Express's `.all()` is treated. This is a real behavior change
+ *  from the regex path and is flagged as an open question for sign-off, not a
+ *  silent fix.
  *
  *  A fully visible, empty `methods=[]` is NOT ambiguous: Flask's own default is
  *  GET, so an empty literal resolves to GET rather than ALL. */
-function resolveMethod(attr: string, args: SyntaxNode): string {
+function resolveMethod(attr: string, args: SyntaxNode, methodsVars: Map<string, SyntaxNode>): string {
   if (attr !== "route" && attr !== "api_route") return attr.toUpperCase();
   const named = args.namedChildren.filter((n): n is SyntaxNode => n !== null);
   const kw = named.find(
@@ -348,15 +517,18 @@ function resolveMethod(attr: string, args: SyntaxNode): string {
     return hasSplat ? "ALL" : "GET";
   }
   const value = kw.childForFieldName("value");
-  if (!value || !["list", "tuple", "set"].includes(value.type)) return "ALL"; // methods=VARIABLE
-  const children = value.namedChildren.filter((n): n is SyntaxNode => n !== null);
-  const verbs = children
-    .filter((n) => n.type === "string")
-    .map((s) => (pyStringText(s) ?? "").toUpperCase())
-    .filter((v) => HTTP_VERBS.has(v));
-  const hidden = children.some((n) => n.type !== "string");
-  if (verbs.length === 0) return hidden ? "ALL" : "GET"; // [*BASE] vs literal []
-  return verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0];
+  if (!value || !["list", "tuple", "set"].includes(value.type)) {
+    // methods=VARIABLE: resolve through a same-file single-literal assignment
+    // (Upgrade 2) when one exists; every other shape (computed, imported,
+    // reassigned, mutated, an identifier alias chain — refuse to chase) stays
+    // "ALL", never a silent GET.
+    if (value?.type === "identifier") {
+      const literal = methodsVars.get(value.text);
+      if (literal) return methodFromLiteral(literal);
+    }
+    return "ALL"; // methods=VARIABLE, computed, imported, reassigned, or mutated
+  }
+  return methodFromLiteral(value);
 }
 
 /** Django REST function views: @api_view(["POST"]). Identifier callee, NOT an
@@ -372,26 +544,19 @@ function asApiViewDecorator(dec: SyntaxNode, definition: SyntaxNode): PyRoute | 
   const list = expr.childForFieldName("arguments")?.namedChild(0);
   let method = "GET"; // DRF default when @api_view() has no args
   if (list && ["list", "tuple", "set"].includes(list.type)) {
-    const children = list.namedChildren.filter((n): n is SyntaxNode => n !== null);
-    const verbs = children
-      .filter((n) => n.type === "string")
-      .map((s) => (pyStringText(s) ?? "").toUpperCase())
-      .filter((v) => HTTP_VERBS.has(v));
-    // A non-string element (a variable verb: @api_view([METHOD]) or
-    // @api_view([*BASE])) is statically unresolvable. Following the module's
-    // ALL-on-unresolvable convention (resolveMethod, pending the owner sign-off
-    // in the header OPEN QUESTION), an unresolvable list with no visible literal
-    // verb resolves ALL so the route STAYS in the mutating vote rather than
-    // silently defaulting GET; a visible literal still resolves it normally.
-    const hidden = children.some((n) => n.type !== "string");
-    method =
-      verbs.length === 0
-        ? hidden
-          ? "ALL"
-          : "GET"
-        : (verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0]);
+    // Reduced by the SAME methodFromLiteral helper resolveMethod's methods=
+    // kwarg uses: a non-string element (a variable verb: @api_view([METHOD])
+    // or @api_view([*BASE])) is statically unresolvable and resolves ALL so
+    // the route STAYS in the mutating vote rather than silently defaulting
+    // GET; a visible literal still resolves it normally.
+    method = methodFromLiteral(list);
   } else if (list) {
-    method = "ALL"; // verbs behind a variable: keep the route in the mutating vote
+    // verbs behind a bare variable (@api_view(METHODS)): stays ALL. Unlike
+    // resolveMethod's methods= kwarg, this is NOT extended by Upgrade 2 even
+    // when METHODS has a same-file literal assignment — a deliberate boundary
+    // (see the header OPEN QUESTION): the approved upgrade names methods=
+    // only, not api_view's positional list argument.
+    method = "ALL";
   }
   // No receiver: DRF function views register via urls.py, not on a router
   // variable. The empty string matches no byReceiver scope, so only global
@@ -1206,6 +1371,7 @@ export function extractPythonFileMiddlewareAst(tree: Tree): FileMiddleware {
 export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectRouterNames(tree.rootNode);
+  const methodsVars = collectMethodsVars(tree.rootNode);
   const defs = collectFunctionDefs(tree.rootNode);
   const scopes = collectPyMiddleware(tree, defs);
   for (const dd of tree.rootNode.descendantsOfType("decorated_definition")) {
@@ -1242,7 +1408,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     // never argument or path text: @app.post("/validate") is a path, not
     // validation middleware, and must not bless its lane.
     const laneNames = decorators
-      .filter((d) => asRouteDecorator(d, routerNames) === null)
+      .filter((d) => asRouteDecorator(d, routerNames, methodsVars) === null)
       .map((d) => {
         const expr = d.namedChild(0);
         if (!expr) return "";
@@ -1253,7 +1419,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const perVal = laneNames.some((t) => VAL_NAMES.test(t));
     const perRate = laneNames.some((t) => RATE_NAMES.test(t));
     for (const dec of decorators) {
-      const routeFromDecorator = asRouteDecorator(dec, routerNames);
+      const routeFromDecorator = asRouteDecorator(dec, routerNames, methodsVars);
       // asApiViewDecorator is only consulted when the decorator is not already a
       // router/app route, so the api_view-only permission_classes bless below can
       // key off apiViewRoute !== null.

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -118,6 +118,15 @@ export interface RouteInfo {
   hasValidation: boolean;
   hasRateLimit: boolean;
   hasErrorHandler: boolean;
+  /** Python AST path only: the name of a before_request-style hook whose BODY is
+   *  auth-flavored but statically unverifiable (an opaque helper, an imported or
+   *  attribute target, a duplicate def). Present ONLY when `hasAuth === false`;
+   *  `hasAuth === true` always omits it. An "unsure" route still counts as
+   *  not-authed in every vote (never blesses) — this field only lets a renderer
+   *  hedge the finding copy to name the exact hook the user should double-check.
+   *  Never set on JS/TS/Go or the regex fallback, so those routes serialize
+   *  byte-identically. */
+  authUnsureHook?: string;
 }
 
 // ─── Phase 1: file-level middleware index ────────────────────────────

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -46,6 +46,33 @@ const MUTATION_METHODS = [...SECURITY_AST.MUTATING].map((m) => m.toUpperCase());
 // Body-bearing methods for the validation vote (DELETE usually has no body).
 const BODY_METHODS = ["POST", "PUT", "PATCH", "ALL"];
 
+// ─── Hedged copy for auth routes whose hook could not be verified ────────────
+//
+// A route only carries `authUnsureHook` on the Python AST path, and only when
+// `hasAuth === false` (a blessed route never sets it). Task 4 turns the flat
+// "no auth" copy into a HEDGE that names the exact before_request-style hook the
+// user should verify. The route stays not-authed in every vote — this is copy
+// only. JS/TS/Go/regex routes never set the field, so they always take the flat
+// arm and render byte-identically. No em-dash / double hyphen in the hedged
+// strings (comma/colon/period only).
+
+/** Per-deviator hedged pattern naming the unresolved hook, e.g.
+ *  `POST /x: auth not confirmed, double check hook 'verify_session'`. */
+function hedgedDeviatorPattern(r: RouteInfo): string {
+  return `${r.method} ${r.path}: auth not confirmed, double check hook '${r.authUnsureHook}'`;
+}
+
+/** Sentence appended to an auth finding's recommendation when some deviators are
+ *  unsure (their hook body could not be verified). Empty string when none are
+ *  hedged, so a confident finding's recommendation is byte-identical. `names` is
+ *  the sorted distinct set of hook names. */
+function hedgeRecommendationSuffix(deviators: RouteInfo[]): string {
+  const hedged = deviators.filter((r) => r.authUnsureHook);
+  if (hedged.length === 0) return "";
+  const names = [...new Set(hedged.map((r) => r.authUnsureHook!))].sort().join(", ");
+  return ` ${hedged.length} of these could not be confirmed: a before_request hook (${names}) may authenticate them but its body could not be verified. Double check those hooks before treating the routes as unauthenticated.`;
+}
+
 // Does the codebase use auth machinery anywhere? If it does, a mutating route
 // with no auth is drift ("you know how to auth — this route forgot"), not an
 // intentionally-public API. Specific symbols only, to keep false positives low.
@@ -93,13 +120,15 @@ function analyzeUniformAuthGap(
     consistencyScore: mutating.length ? Math.round((have / mutating.length) * 100) : 0,
     deviatingFiles: unauthed.map((r) => ({
       path: r.file,
-      detectedPattern: `${r.method} ${r.path} — no auth`,
+      detectedPattern: r.authUnsureHook ? hedgedDeviatorPattern(r) : `${r.method} ${r.path} — no auth`,
       evidence: [{ line: r.line, code: `${r.method} ${r.path}` }],
     })),
     dominantFiles: [],
-    recommendation: declared
-      ? `${opts.hint!.source}:${opts.hint!.line} declares auth is required. Add auth middleware to these ${unauthed.length} mutating route(s), or mark them explicitly public.`
-      : `These ${unauthed.length} mutating route(s) have no auth while the codebase authenticates elsewhere. Add auth middleware, or confirm they are intentionally public.`,
+    recommendation:
+      (declared
+        ? `${opts.hint!.source}:${opts.hint!.line} declares auth is required. Add auth middleware to these ${unauthed.length} mutating route(s), or mark them explicitly public.`
+        : `These ${unauthed.length} mutating route(s) have no auth while the codebase authenticates elsewhere. Add auth middleware, or confirm they are intentionally public.`) +
+      hedgeRecommendationSuffix(unauthed),
   };
 }
 
@@ -449,11 +478,19 @@ function analyzeSecurityProperty(
     consistencyScore: Math.round(ratio * 100),
     deviatingFiles: withoutProperty.map((r) => ({
       path: r.file,
-      detectedPattern: `${r.method} ${r.path} — no ${propertyName}`,
+      // Hedge only the AUTH subcategory: authUnsureHook is an auth-only marker,
+      // and gating on propertyName keeps the validation / rate-limit findings'
+      // deviator copy free of the hook name for a route that also misses those.
+      detectedPattern:
+        propertyName === SECURITY_SUBCATEGORIES.auth && r.authUnsureHook
+          ? hedgedDeviatorPattern(r)
+          : `${r.method} ${r.path} — no ${propertyName}`,
       evidence: [{ line: r.line, code: `${r.method} ${r.path}` }],
     })),
     dominantFiles: [...new Set(withProperty.map((r) => r.file))].sort().slice(0, 3),
-    recommendation: `${withProperty.length} of ${applicableRoutes.length} routes have ${propertyName}. Review ${withoutProperty.length} unprotected routes — apply per-route middleware or move them under a router that does.`,
+    recommendation:
+      `${withProperty.length} of ${applicableRoutes.length} routes have ${propertyName}. Review ${withoutProperty.length} unprotected routes — apply per-route middleware or move them under a router that does.` +
+      (propertyName === SECURITY_SUBCATEGORIES.auth ? hedgeRecommendationSuffix(withoutProperty) : ""),
   };
 }
 

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -138,6 +138,37 @@ function scoreColorFn(score: number, max: number): typeof chalk {
 }
 
 /**
+ * True when this is an auth-consistency finding the Python body-signature
+ * analyzer could not confirm: its recommendation carries the appended "Double
+ * check" hedge naming a before_request hook. For such a finding the flat
+ * confident "unprotected routes" consequence is a FALSE claim, so the terminal
+ * must hedge instead. Confident security findings never carry this marker, so
+ * their output is byte-identical.
+ */
+function isHedgedAuthFinding(f: Finding): boolean {
+  const isSecurity = (f.tags ?? []).includes("security_posture") || f.analyzerId.startsWith("drift-security");
+  const rec = f.metadata?.recommendation;
+  return isSecurity && !!rec && /Double check/.test(rec);
+}
+
+/** The before_request hook name(s) the appended hedge sentence named, read back
+ *  out of the recommendation so the terminal can point at the exact hook. */
+function hedgedHookNames(f: Finding): string | null {
+  const m = f.metadata?.recommendation?.match(/before_request hook \(([^)]+)\)/);
+  return m ? m[1] : null;
+}
+
+/** Hedged replacement for the confident security consequence. Names the hook(s)
+ *  to verify and says "double check" instead of asserting the routes are
+ *  unprotected. No em-dash / double hyphen (commas/periods only). */
+function hedgedSecurityConsequence(f: Finding): string {
+  const names = hedgedHookNames(f);
+  return names
+    ? `A before_request hook (${names}) may already authenticate some of these routes, double check it before treating them as unprotected`
+    : `A before_request hook may already authenticate some of these routes, double check before treating them as unprotected`;
+}
+
+/**
  * One-line "why this matters" for each finding category. Turns
  * abstract consistency points into a concrete consequence the user
  * can feel — the shift from "interesting" to "I should fix this."
@@ -156,6 +187,8 @@ function findingConsequence(f: Finding): string | null {
     return "New code in this directory will copy the wrong pattern";
   }
   if (tags.includes("security_posture") || id.startsWith("drift-security")) {
+    // An unverifiable auth hook must not read as a confident "exposed" verdict.
+    if (isHedgedAuthFinding(f)) return hedgedSecurityConsequence(f);
     return "Unprotected routes may be exposed in production";
   }
   if (tags.includes("semantic_duplication") || id.startsWith("drift-semantic")) {
@@ -392,6 +425,13 @@ function renderFindingsForCategory(
           lines.push(chalk.dim(`    ${loc.file}${lineStr}`));
         }
         lines.push(chalk.dim(`    ... and ${finding.locations.length - 3} more`));
+      }
+      // Hedge line: when an auth finding could not be verified, name the hook and
+      // say "double check" rather than letting the flat message read as a
+      // confident "unprotected" verdict. Gated on the hedge marker, so every
+      // other finding (and every confident security finding) is byte-identical.
+      if (isHedgedAuthFinding(finding)) {
+        lines.push(chalk.yellow(`    ${hedgedSecurityConsequence(finding)}`));
       }
     }
   }

--- a/test/calibration/README.md
+++ b/test/calibration/README.md
@@ -111,7 +111,7 @@ not minimal stubs, split into three independent roots:
   (that check is repo-global over whatever files are in `ctx.files`, not
   scoped to a route group).
 
-Five scenarios, each computing precision/recall explicitly against planted
+Nine scenarios, each computing precision/recall explicitly against planted
 ground truth:
 
 - **S0** recognition self-check — every route file in the Flask/FastAPI
@@ -130,6 +130,34 @@ ground truth:
   routes were actually seen.
 - **S5** the uniformly-authed control: zero findings on every axis (auth,
   validation, rate-limit).
+
+The addendum adds four body-signature / methods-variable scenarios, each in
+its own directory root and each RED-FIRST against the pre-addendum commit
+(`353a939`): the assertion fails there and passes on this branch, so the pin
+measures a real behavior change, not a tautology.
+
+- **S6** name-auth-but-body-isnt collision (`hookcol/`): four
+  `@login_required` routes plus one whose only gate is a `verify_user_email`
+  before_request hook that merely emails. Body-first classification resolves
+  it flat not-auth, so the finding must NOT be suppressed (dominantCount 4,
+  consistencyScore 80, precision/recall 1.0). Red-first: the pre-addendum
+  name-only path blessed the hook and the scenario produced ZERO findings.
+- **S7** body-is-real-auth positive (`bodysrv/`): five routes whose ONLY auth
+  is a boring-named `gate()` hook (session read + `abort(401)`); a
+  machinery-style self-check asserts no auth-lexicon identifier appears. All
+  five bless on the body signature alone (scenario A: zero findings);
+  stripping one hook flags exactly it (scenario B). Red-first: scenario A
+  fails non-vacuity pre-addendum (no body-bless, so nothing is authed).
+- **S8** unresolvable-body UNSURE (`unsuresrv/`): four `@login_required`
+  routes plus one gated only by an imported `before_request` hook, which
+  resolves UNSURE — still flagged, with HEDGED copy naming the hook
+  (`double check hook 'verify_session'`), counts identical to S6, and the S1
+  deviator asserted flat in the same run (no hedge leakage). Red-first: the
+  pre-addendum name path blessed the imported hook.
+- **S9** methods=variable resolution (`varsrv/`): five routes registered via
+  `methods=ALLOWED` where `ALLOWED = ("POST",)` is a same-file literal; every
+  route resolves method exactly POST and enters the mutating auth vote.
+  Red-first: pre-addendum a `methods=` variable resolved ALL, not POST.
 
 ## Adding a new injection type
 

--- a/test/calibration/python-security-fixture.ts
+++ b/test/calibration/python-security-fixture.ts
@@ -16,6 +16,16 @@
  *   fastsrv/deps.py            the shared get_current_user dependency
  *   hooks/routes/*_hook.py     5 uniformly PUBLIC webhook receivers (negative control)
  *
+ * Addendum (S6-S9) adds four more independent roots exercising the body-signature
+ * hook classifier and the methods= variable resolver:
+ *   hookcol/routes/*_routes.py    S6: 4 @login_required + 1 name-auth-but-body-isnt
+ *                                 collision (verify_user_email that only emails)
+ *   bodysrv/routes/*_routes.py    S7: 5 routes whose ONLY auth is a boring gate()
+ *                                 before_request hook (session read + abort(401))
+ *   unsuresrv/routes/*_routes.py  S8: 4 @login_required + 1 imported-hook UNSURE
+ *   varsrv/routes/*_routes.py     S9: 5 routes with methods=ALLOWED resolved from a
+ *                                 same-file ("POST",) tuple literal
+ *
  * Receiver names in the Flask group deliberately mix two recognition paths so
  * the fixture measures recall across BOTH: four convention-gated names
  * (users_bp, orders_bp, payments_router, api — recognized by ROUTER_RECEIVER)
@@ -271,5 +281,202 @@ export function stripFastapiAuth(files: BaselineFile[], count: number): Baseline
       .join("\n")
       .replace(", user=Depends(get_current_user)", "");
     return { path: f.path, content };
+  });
+}
+
+// ─── S6-S9: body-signature + methods-var calibration groups (addendum) ───────
+//
+// Each group roots its own directory so the route-directory vote grouping and
+// `repoHasAuthMachinery` evidence never bleed between scenarios. Each helper
+// keeps "one route per file" so the non-vacuity guards stay exact.
+
+/** A Flask route file authed by an @login_required decorator applied BELOW the
+ *  route decorator (positional binding: it must sit below to be enforced). */
+function loginRequiredRouteFile(root: string, receiver: string, blueprintName: string, name: string): BaselineFile {
+  return {
+    path: `${root}/${name}_routes.py`,
+    content:
+`"""POST /${name}: create a ${name} record."""
+from flask import Blueprint, jsonify, request
+from ..auth import login_required
+
+${receiver} = Blueprint("${blueprintName}", __name__)
+
+@${receiver}.route("/${name}", methods=["POST"])
+@login_required
+def create_${name}():
+    payload = request.get_json()
+    return jsonify(payload), 201
+`,
+  };
+}
+
+// ── S6: name-auth-but-body-isnt collision (negative) ─────────────────────────
+const S6_ROOT = "hookcol/routes";
+/** The one deviator in S6: its only gate is a `verify_user_email` before_request
+ *  hook whose visible body merely sends a confirmation email. Body-first
+ *  classification resolves it flat not-auth (name looks like auth, body is not),
+ *  so the finding must NOT be suppressed. */
+export const hookCollisionDeviatorPath = `${S6_ROOT}/notify_routes.py`;
+export function hookCollisionGroup(): BaselineFile[] {
+  const authed = [
+    loginRequiredRouteFile(S6_ROOT, "users_bp", "users", "users"),
+    loginRequiredRouteFile(S6_ROOT, "orders_bp", "orders", "orders"),
+    loginRequiredRouteFile(S6_ROOT, "payments_router", "payments", "payments"),
+    loginRequiredRouteFile(S6_ROOT, "carts", "carts", "carts"),
+  ];
+  const collision: BaselineFile = {
+    path: hookCollisionDeviatorPath,
+    content:
+`"""POST /notify: send a notification. The only before_request gate is
+verify_user_email, whose visible body merely emails a confirmation link, so the
+NAME looks like auth while the BODY does not authenticate (body-first: flat
+not-auth, no bless)."""
+from flask import Blueprint, jsonify, request, g
+
+notify_bp = Blueprint("notify", __name__)
+
+
+@notify_bp.before_request
+def verify_user_email():
+    send_confirmation_email(g.user.email)
+    return None
+
+
+@notify_bp.route("/notify", methods=["POST"])
+def create_notify():
+    payload = request.get_json()
+    return jsonify(payload), 201
+`,
+  };
+  return [...authed, collision];
+}
+
+// ── S7: body-is-real-auth positive (boring gate() hook) ──────────────────────
+const S7_ROOT = "bodysrv/routes";
+/** The exact before_request block S7 files carry and stripBodyHook removes; a
+ *  boring name (`gate`) whose BODY reads the session and abort(401)s, so ONLY
+ *  the body signature blesses (no auth-lexicon identifier anywhere in S7). */
+function bodyGateBlock(receiver: string): string {
+  return (
+`@${receiver}.before_request
+def gate():
+    if not session.get("user_id"):
+        abort(401)
+
+
+`
+  );
+}
+function bodyGateFile(name: string): BaselineFile {
+  const receiver = `${name}_bp`;
+  return {
+    path: `${S7_ROOT}/${name}_routes.py`,
+    content:
+`"""POST /${name}: create a ${name}. The ONLY auth is a boring-named gate()
+before_request hook (session read + abort(401)); no auth-lexicon identifier
+appears in this corpus, so a name-based check would see nothing."""
+from flask import Blueprint, session, abort, request, jsonify
+
+${receiver} = Blueprint("${name}", __name__)
+
+
+${bodyGateBlock(receiver)}@${receiver}.route("/${name}", methods=["POST"])
+def create_${name}():
+    return jsonify(request.get_json()), 201
+`,
+  };
+}
+export function bodyAuthedGroup(): BaselineFile[] {
+  return ["items", "accounts", "subscriptions", "tickets", "shipments"].map(bodyGateFile);
+}
+export function sortedBodyRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${S7_ROOT}/`) && p.endsWith("_routes.py"));
+}
+/** Removes the gate() before_request block from the first `count` S7 files,
+ *  sorted by path, leaving a bare (now unauthed) still-mutating route. */
+export function stripBodyHook(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedBodyRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const name = f.path.slice(`${S7_ROOT}/`.length, -"_routes.py".length);
+    return { path: f.path, content: f.content.replace(bodyGateBlock(`${name}_bp`), "") };
+  });
+}
+
+// ── S8: unresolvable-body UNSURE (imported before_request hook) ───────────────
+const S8_ROOT = "unsuresrv/routes";
+/** The one deviator in S8: an IMPORTED before_request hook whose body is not
+ *  visible in-file, so it resolves UNSURE (hasAuth false, authUnsureHook set,
+ *  hedged copy), never a bless. */
+export const unsureHookDeviatorPath = `${S8_ROOT}/reports_routes.py`;
+export function unsureHookGroup(): BaselineFile[] {
+  const authed = [
+    loginRequiredRouteFile(S8_ROOT, "alpha_bp", "alpha", "alpha"),
+    loginRequiredRouteFile(S8_ROOT, "beta_bp", "beta", "beta"),
+    loginRequiredRouteFile(S8_ROOT, "gamma_bp", "gamma", "gamma"),
+    loginRequiredRouteFile(S8_ROOT, "delta_bp", "delta", "delta"),
+  ];
+  const unsure: BaselineFile = {
+    path: unsureHookDeviatorPath,
+    content:
+`"""POST /reports: create a report. The only gate is an IMPORTED before_request
+hook whose body is not visible in this file, so it resolves UNSURE (hedged copy
+naming the hook), never a bless."""
+from flask import Blueprint, jsonify, request
+from .auth_helpers import verify_session
+
+reports_bp = Blueprint("reports", __name__)
+reports_bp.before_request(verify_session)
+
+
+@reports_bp.route("/reports", methods=["POST"])
+def create_reports():
+    return jsonify(request.get_json()), 201
+`,
+  };
+  return [...authed, unsure];
+}
+
+// ── S9: methods= variable resolved from a same-file literal ───────────────────
+const S9_ROOT = "varsrv/routes";
+function methodsVarFile(name: string, authed: boolean): BaselineFile {
+  const receiver = `${name}_bp`;
+  return {
+    path: `${S9_ROOT}/${name}_routes.py`,
+    content:
+`"""POST /${name}: methods resolved from a same-file ALLOWED tuple literal."""
+from flask import Blueprint, jsonify, request
+from ..auth import login_required
+
+${receiver} = Blueprint("${name}", __name__)
+ALLOWED = ("POST",)
+
+@${receiver}.route("/${name}", methods=ALLOWED)${authed ? "\n@login_required" : ""}
+def create_${name}():
+    return jsonify(request.get_json()), 201
+`,
+  };
+}
+export function methodsVarGroup(): BaselineFile[] {
+  return ["invoices", "refunds", "coupons", "receipts", "credits"].map((n) => methodsVarFile(n, true));
+}
+export function sortedMethodsVarRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${S9_ROOT}/`) && p.endsWith("_routes.py"));
+}
+/** Strips @login_required (decorator + import) from the first `count` S9 files,
+ *  sorted by path. The route decorator and its methods=ALLOWED kwarg are
+ *  untouched, so the stripped file stays a POST-resolved, unauthed route. */
+export function stripMethodsVarAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedMethodsVarRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const lines = f.content
+      .split("\n")
+      .filter(
+        (line) =>
+          line.trim() !== "@login_required" && line.trim() !== "from ..auth import login_required",
+      );
+    return { path: f.path, content: lines.join("\n") };
   });
 }

--- a/test/calibration/security-python.test.ts
+++ b/test/calibration/security-python.test.ts
@@ -3,7 +3,7 @@
  * security extractor (vitest discovers test/**\/*.test.ts, so this runs as
  * part of `npm test`, not just `npm run calibrate`).
  *
- * Five scenarios against test/calibration/python-security-fixture.ts's
+ * Nine scenarios against test/calibration/python-security-fixture.ts's
  * realistic Flask/FastAPI corpus, each computing precision/recall explicitly
  * against planted ground truth (not just checking the finding fired):
  *   S0  recognition self-check — the route-loss guard. Regresses with a
@@ -16,6 +16,16 @@
  *       NEVER-FALSE-BLESS: silence only proves something once we know the
  *       routes were actually seen.
  *   S5  uniformly-authed control — zero findings on every axis.
+ *   S6  name-auth-but-body-isnt collision (verify_user_email that only emails):
+ *       must NOT suppress the finding. RED-FIRST: pre-addendum the hook name
+ *       blessed and the scenario produced ZERO findings.
+ *   S7  body-is-real-auth positive (a boring gate() hook: session read +
+ *       abort(401)): the body signature alone blesses; no auth-lexicon name
+ *       anywhere. RED-FIRST: pre-addendum scenario A fails non-vacuity.
+ *   S8  unresolvable-body UNSURE (imported before_request hook): stays flagged
+ *       with HEDGED copy naming the hook; counts match S6; S1 stays flat.
+ *   S9  methods=variable resolved from a same-file ("POST",) literal: every
+ *       route resolves POST. RED-FIRST: pre-addendum they resolved ALL.
  */
 import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../src/drift/security-consistency.js";
@@ -35,6 +45,16 @@ import {
   sortedFastapiRoutePaths,
   stripFlaskAuth,
   stripFastapiAuth,
+  hookCollisionGroup,
+  hookCollisionDeviatorPath,
+  bodyAuthedGroup,
+  sortedBodyRoutePaths,
+  stripBodyHook,
+  unsureHookGroup,
+  unsureHookDeviatorPath,
+  methodsVarGroup,
+  sortedMethodsVarRoutePaths,
+  stripMethodsVarAuth,
 } from "./python-security-fixture.js";
 
 async function toDriftFiles(files: BaselineFile[]): Promise<DriftFile[]> {
@@ -218,5 +238,171 @@ describe("Python calibration: S5 uniformly-authed control", () => {
     expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
     expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.validation)).toEqual([]);
     expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.rateLimit)).toEqual([]);
+  });
+});
+
+// ─── S6-S9: body-signature + methods-var scenarios (addendum) ────────────────
+// Each red-first-verified against pre-addendum behavior (checkout 353a939): S6
+// blessed on the hook NAME and produced zero findings; S7 scenario A failed
+// non-vacuity (no body-bless); S8 blessed the imported hook by name; S9 routes
+// resolved ALL, not POST. S0-S5 above stay byte-identical.
+
+describe("Python calibration: S6 name-auth-but-body-isnt collision (negative)", () => {
+  it("non-vacuity FIRST: 5 routes; the verify_user_email collision route hasAuth false, the unsure key ABSENT", async () => {
+    let total = 0;
+    for (const f of hookCollisionGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      if (f.path === hookCollisionDeviatorPath) {
+        expect(routes[0].hasAuth).toBe(false);
+        expect("authUnsureHook" in routes[0]).toBe(false); // visible non-auth body: flat, not hedged
+      } else {
+        expect(routes[0].hasAuth, f.path).toBe(true);
+      }
+      total += 1;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("flags exactly the collision file (dominantCount 4, score 80), precision 1 recall 1, no-auth copy that is NOT hedged", async () => {
+    const ctx = await ctxFor(hookCollisionGroup());
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([hookCollisionDeviatorPath]);
+
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp.toLowerCase()).toContain("no auth");
+    expect(dp.toLowerCase()).not.toContain("double check");
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([hookCollisionDeviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Python calibration: S7 body-is-real-auth positive (boring gate() hook)", () => {
+  const MACHINERY =
+    /\b(requireAuth|isAuthenticated|verifyToken|authMiddleware|ensureAuth|withAuth|jwt_required|login_required|AuthMiddleware|passport)\b/;
+
+  it("self-check: the S7 corpus contains no auth-lexicon identifier (only the BODY blesses)", () => {
+    for (const f of bodyAuthedGroup()) {
+      expect(MACHINERY.test(f.content), f.path).toBe(false);
+    }
+  });
+
+  it("scenario A (uniform): all 5 routes hasAuth true via the body signature, THEN zero security_posture findings", async () => {
+    let total = 0;
+    for (const f of bodyAuthedGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(true);
+      total += 1;
+    }
+    expect(total).toBe(5);
+
+    const ctx = await ctxFor(bodyAuthedGroup());
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+
+  it("scenario B: stripping the gate hook from the first sorted file flags exactly it, precision 1 recall 1", async () => {
+    const strippedPath = sortedBodyRoutePaths(bodyAuthedGroup())[0];
+    const ctx = await ctxFor(stripBodyHook(bodyAuthedGroup(), 1));
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    expect(auth[0].deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Python calibration: S8 unresolvable-body UNSURE (imported before_request hook)", () => {
+  it("non-vacuity FIRST: the unsure route is POST/hasAuth false with authUnsureHook 'verify_session'; the 4 peers omit the key", async () => {
+    for (const f of unsureHookGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      if (f.path === unsureHookDeviatorPath) {
+        expect(routes[0].method).toBe("POST");
+        expect(routes[0].hasAuth).toBe(false);
+        expect(routes[0].authUnsureHook).toBe("verify_session");
+      } else {
+        expect(routes[0].hasAuth, f.path).toBe(true);
+        expect("authUnsureHook" in routes[0], f.path).toBe(false);
+      }
+    }
+  });
+
+  it("flags the unsure file with HEDGED copy; counts match the S6 control; the S1 deviator stays FLAT in the same run", async () => {
+    const auth = authFindings(securityConsistency.detect((await ctxFor(unsureHookGroup())) as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([unsureHookDeviatorPath]);
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp).toContain("verify_session");
+    expect(dp.toLowerCase()).toContain("double check");
+    expect(dp).not.toMatch(/—|--/); // hedged deviator copy carries no em-dash / double hyphen
+
+    // Vote-arithmetic invariance: S8's counts equal the S6 control (5 files, 1 deviator).
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([unsureHookDeviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+
+    // No hedge leakage: a plain stripped-auth deviator (S1 shape) stays flat.
+    const s1Path = sortedFlaskRoutePaths(flaskAuthedGroup())[0];
+    const s1Files = [...stripFlaskAuth(flaskAuthedGroup(), 1), pyAuthFile, pyAppFile];
+    const s1Auth = authFindings(securityConsistency.detect((await ctxFor(s1Files)) as any));
+    expect(s1Auth).toHaveLength(1);
+    expect(s1Auth[0].deviatingFiles.map((d) => d.path)).toEqual([s1Path]);
+    expect(s1Auth[0].deviatingFiles[0].detectedPattern.toLowerCase()).not.toContain("double check");
+  });
+});
+
+describe("Python calibration: S9 methods=variable resolved from a same-file literal", () => {
+  it("non-vacuity FIRST: every one of the 5 routes resolves method exactly POST (never ALL, never GET)", async () => {
+    let total = 0;
+    for (const f of methodsVarGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].method, f.path).toBe("POST"); // red-first: pre-addendum resolved ALL
+      total += 1;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("flags exactly the stripped file among the methods-var-resolved routes, precision 1 recall 1", async () => {
+    const strippedPath = sortedMethodsVarRoutePaths(methodsVarGroup())[0];
+    const auth = authFindings(
+      securityConsistency.detect((await ctxFor(stripMethodsVarAuth(methodsVarGroup(), 1))) as any),
+    );
+    expect(auth).toHaveLength(1);
+    expect(auth[0].deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -898,15 +898,30 @@ describe("per-route validation and rate-limit lanes", () => {
 describe("extractPythonFileMiddlewareAst", () => {
   const NONE = { hasAuth: false, hasValidation: false, hasRateLimit: false };
 
-  it("blesses @app.before_request def require_login() (auth hook, tier 2)", async () => {
+  // MIGRATION (body-first): a visible pass-stub body never blesses, whatever the
+  // name. require_login/check_auth/verify_token used to bless on NAME alone; now
+  // the fully-visible `pass` body resolves not-auth (the name never rescues a
+  // visible non-enforcing body). Each keeps its named pass-body negative and gains
+  // a body-positive twin proving a real reject body under the same name blesses.
+  it("does NOT bless @app.before_request def require_login() with a pass stub (visible body, body-first)", async () => {
     const f = await py("mw.py", `@app.before_request\ndef require_login():\n    pass\n`);
     expect(extractPythonFileMiddlewareAst(f.tree!)).toEqual({
-      hasAuth: true, hasValidation: false, hasRateLimit: false,
+      hasAuth: false, hasValidation: false, hasRateLimit: false,
     });
   });
 
-  it("blesses @bp.before_request def check_auth() (auth CORE segment, tier 1)", async () => {
+  it("blesses @app.before_request def require_login() with an abort(401) body (body-positive twin)", async () => {
+    const f = await py("mw.py", `@app.before_request\ndef require_login():\n    abort(401)\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(true);
+  });
+
+  it("does NOT bless @bp.before_request def check_auth() with a pass stub (CORE name, still not rescued)", async () => {
     const f = await py("mw.py", `@bp.before_request\ndef check_auth():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("blesses @bp.before_request def check_auth() with an abort(401) body (body-positive twin)", async () => {
+    const f = await py("mw.py", `@bp.before_request\ndef check_auth():\n    abort(401)\n`);
     expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(true);
   });
 
@@ -927,9 +942,24 @@ describe("extractPythonFileMiddlewareAst", () => {
     expect(extractPythonFileMiddlewareAst(csrf.tree!).hasAuth).toBe(false);
   });
 
-  it("blesses @app.before_request def verify_token() (ENFORCE verify + SUBJECT token)", async () => {
+  it("does NOT bless @app.before_request def verify_token() with a pass stub (visible body, body-first)", async () => {
     const f = await py("mw.py", `@app.before_request\ndef verify_token():\n    pass\n`);
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("blesses @app.before_request def verify_token() with an abort(401) body (body-positive twin)", async () => {
+    const f = await py("mw.py", `@app.before_request\ndef verify_token():\n    abort(401)\n`);
     expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(true);
+  });
+
+  it("still blesses @verify_token as a ROUTE decorator below @app.post (AUTH_DECORATORS untouched)", async () => {
+    const f = await py("routedec.py",
+      `@app.post("/x")\n` +
+      `@verify_token\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
   });
 
   it("does NOT bless @job.before_request def check_auth() (receiver gate: job is not a router)", async () => {
@@ -1019,7 +1049,7 @@ describe("receiver-scoped middleware inheritance (via extractPythonRoutesAst)", 
     const f = await py("mixed.py",
       `@admin_bp.before_request\n` +
       `def require_login():\n` +
-      `    return None\n\n` +
+      `    abort(401)\n\n` +
       `@admin_bp.route("/users", methods=["POST"])\n` +
       `def create_user():\n` +
       `    return {}\n\n` +
@@ -1056,7 +1086,7 @@ describe("receiver-scoped middleware inheritance (via extractPythonRoutesAst)", 
     const f = await py("appwide.py",
       `@app.before_request\n` +
       `def require_login():\n` +
-      `    return None\n\n` +
+      `    abort(401)\n\n` +
       `@orders_bp.route("/x", methods=["POST"])\n` +
       `def x():\n` +
       `    return {}\n`);
@@ -1068,7 +1098,7 @@ describe("receiver-scoped middleware inheritance (via extractPythonRoutesAst)", 
     const f = await py("beforeapp.py",
       `@bp.before_app_request\n` +
       `def require_login():\n` +
-      `    return None\n\n` +
+      `    abort(401)\n\n` +
       `@app.post("/x")\n` +
       `def x():\n` +
       `    return {}\n`);
@@ -1553,51 +1583,41 @@ describe("hook-name lexicon boundary pins (Fix 4)", () => {
   });
 });
 
-// ─── KNOWN EXPOSURE pins: two-tier hook lexicon false-bless (owner decision
-// pending) ─────────────────────────────────────────────────────────────────
+// ─── EXPOSURE FIXED (was: two-tier hook lexicon false-bless) ─────────────────
 //
-// These document CURRENT behavior; they do NOT endorse it. The ENFORCE+SUBJECT
-// two-tier match (see the KNOWN FALSE-BLESS EXPOSURE comment above
-// AUTH_ENFORCE_SEGMENTS in security-ast-python.ts) blesses attributive
-// non-auth hook names whose ENFORCE verb targets an object noun that also
-// happens to be a SUBJECT segment: verify_user_email only sends an
-// email-confirmation link, and protect_user_data only scrubs/anonymizes
-// stored data, but neither hook authenticates a request. Blessing means the
-// extractor marks the receiver's routes hasAuth:true, which is the
-// false-bless direction the module exists to prevent, not a safe over-flag.
-// Pinned here so a future lexicon resolution flips these deliberately instead
-// of silently.
-describe("KNOWN EXPOSURE pins: two-tier hook lexicon false-bless (pending owner decision)", () => {
-  it("KNOWN EXPOSURE pending owner decision: verify_user_email before_request hook blesses its receiver's routes via ENFORCE+SUBJECT", async () => {
+// These fixtures used to bless on NAME alone (ENFORCE+SUBJECT: verify+user,
+// protect+user). Body-first classification fixes the exposure: a fully-visible
+// hook body that does not enforce auth resolves not-auth, so an email-confirming
+// verify_user_email and a data-scrubbing protect_user_data no longer bless their
+// receiver's routes — flat not-auth, no hedge (the body is visible, so it is not
+// even "unsure"). The name never rescues a visible non-enforcing body.
+describe("EXPOSURE FIXED: attributive non-auth hooks resolve flat not-auth (body-first)", () => {
+  it("verify_user_email that only sends a confirmation email does NOT bless (auth=false, no unsure hedge)", async () => {
     const f = await py("exposure-verify-user-email.py",
       `@app.before_request\n` +
       `def verify_user_email():\n` +
+      `    send_confirmation_email(g.user.email)\n` +
       `    return None\n\n` +
       `@app.route("/x", methods=["POST"])\n` +
       `def x():\n` +
       `    return {}\n`);
     const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
-    // CURRENT behavior, documented as exposure: ENFORCE "verify" + SUBJECT
-    // "user" both match a hook that only confirms an email address. A future
-    // lexicon fix is expected to flip this to auth=false; update this
-    // assertion deliberately when it does, not as collateral of a refactor.
-    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
   });
 
-  it("KNOWN EXPOSURE pending owner decision: protect_user_data before_request hook blesses its receiver's routes via ENFORCE+SUBJECT", async () => {
+  it("protect_user_data that only scrubs stored data does NOT bless (auth=false, no unsure hedge)", async () => {
     const f = await py("exposure-protect-user-data.py",
       `@app.before_request\n` +
       `def protect_user_data():\n` +
+      `    scrub_pii(record)\n` +
       `    return None\n\n` +
       `@app.route("/y", methods=["POST"])\n` +
       `def y():\n` +
       `    return {}\n`);
     const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
-    // CURRENT behavior, documented as exposure: ENFORCE "protect" + SUBJECT
-    // "user" both match a hook that only scrubs/anonymizes stored data. A
-    // future lexicon fix is expected to flip this to auth=false; update this
-    // assertion deliberately when it does, not as collateral of a refactor.
-    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/y auth=true"]);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/y auth=false"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
   });
 });
 
@@ -1771,7 +1791,7 @@ const NEVER_FALSE_BLESS_SWEEP: Array<{
   {
     name: "mixed-bp",
     source:
-      `@admin_bp.before_request\ndef require_login():\n    return None\n\n` +
+      `@admin_bp.before_request\ndef require_login():\n    abort(401)\n\n` +
       `@admin_bp.route("/users", methods=["POST"])\ndef create_user():\n    return {}\n\n` +
       `@public_bp.route("/webhook", methods=["POST"])\ndef webhook():\n    return {}\n`,
     groundTruth: [
@@ -2246,5 +2266,342 @@ describe("SECURITY_AST_PY export bag: body-signature lexicons", () => {
     ]) {
       expect(keys).toContain(name);
     }
+  });
+});
+
+// ─── ADDENDUM Task 2: safe-direction tightening 1 — prune nested def subtrees ──
+//
+// A reject signature inside a nested `function_definition` in the hook body is
+// NOT executed inline, so it must not count as the hook rejecting. The body scan
+// prunes nested def/lambda subtrees (the hook's own try/if/for branches still
+// count). Moves strictly toward NEVER-FALSE-BLESS.
+describe("tightening 1: nested def subtrees are pruned from the body scan", () => {
+  it("bodyAuthSignature: an abort(401) inside a nested def + a logging body -> none (not reject)", async () => {
+    const src = `def hook():\n    def _never():\n        abort(401)\n    logger.info("hi")\n`;
+    expect(await sig(src)).toBe("none");
+  });
+
+  it("classifyHookAuth: add_request_id whose only 401 sits in a nested def -> not-auth", async () => {
+    const { body, defs } = await hookBody(
+      `def hook():\n    def _never():\n        abort(401)\n    logger.info("hi")\n`,
+    );
+    expect(classifyHookAuth("add_request_id", body, defs, true)).toBe("not-auth");
+  });
+
+  it("extractor: an add_request_id hook whose 401 is only in a nested def does NOT bless its routes", async () => {
+    const f = await py("nesteddef.py",
+      `@app.before_request\n` +
+      `def add_request_id():\n` +
+      `    def _never():\n` +
+      `        abort(401)\n` +
+      `    logger.info("hi")\n\n` +
+      `@app.route("/x", methods=["POST"])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+    expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth).toBe(false);
+  });
+
+  it("the hook's OWN try/if/for branches still count (a real inline 401 blesses)", async () => {
+    const src = `def hook():\n    for x in items:\n        if bad:\n            abort(401)\n`;
+    expect(await sig(src)).toBe("reject");
+  });
+});
+
+// ─── ADDENDUM Task 2: safe-direction tightening 2 — guard-condition-then-403 ───
+//
+// A lone 403 anywhere + a credential read anywhere used to bless (a body-wide
+// co-occurrence). That false-blessed a CSRF gate that merely reads the session.
+// Now a 403 blesses ONLY when it sits in a reject driven by an `if` whose
+// CONDITION references a credential/session/auth value. 401 blessing alone is
+// unchanged. Moves strictly toward NEVER-FALSE-BLESS.
+describe("tightening 2: a 403 blesses only inside a credential-guarded reject", () => {
+  it("bodyAuthSignature: session read + a CSRF-guarded abort(403) -> NOT reject (opaque)", async () => {
+    const src = `def hook():\n    user = session.get("user")\n    if not csrf_valid(request):\n        abort(403)\n`;
+    const s = await sig(src);
+    expect(s).not.toBe("reject");
+    expect(s).toBe("opaque");
+  });
+
+  it("bodyAuthSignature: a credential-guarded abort(403) stays reject", async () => {
+    const src = `def hook():\n    if "user_id" not in session:\n        abort(403)\n`;
+    expect(await sig(src)).toBe("reject");
+  });
+
+  it("bodyAuthSignature: a bare truthiness guard on a user_agent-style attribute + abort(403) does NOT bless (no new false-bless from a substring 'user')", async () => {
+    // The guard reads no credential SHAPE (no .get / is-None / in-string /
+    // session-subscript), only a bare attribute whose name happens to contain the
+    // 'user' segment. It must resolve away from reject, exactly as before the
+    // tightening — the guarded-403 set is a strict subset of the old set.
+    const src = `def hook():\n    if request.user_agent:\n        abort(403)\n`;
+    expect(await sig(src)).not.toBe("reject");
+    expect(await sig(src)).toBe("none");
+  });
+
+  it("extractor: a CSRF gate that reads the session but 403s on csrf failure does NOT bless", async () => {
+    const f = await py("csrfgate.py",
+      `@app.before_request\n` +
+      `def csrf_gate():\n` +
+      `    user = session.get("user")\n` +
+      `    if not csrf_valid(request):\n` +
+      `        abort(403)\n\n` +
+      `@app.route("/x", methods=["POST"])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes[0].hasAuth).toBe(false);
+  });
+
+  it("extractor: a credential-guarded 403 hook under a boring name blesses its routes", async () => {
+    const f = await py("credgate.py",
+      `@app.before_request\n` +
+      `def gate():\n` +
+      `    if "user_id" not in session:\n` +
+      `        abort(403)\n\n` +
+      `@app.route("/x", methods=["POST"])\n` +
+      `def x():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+  });
+});
+
+// ─── ADDENDUM Task 2: hook body signatures wired into the extractor ───────────
+//
+// The decorator/call-form hook path now classifies by BODY behavior. A verified
+// reject body blesses the receiver's routes even under a boring name; a fully
+// visible non-enforcing body never blesses, whatever the name (the
+// verify_user_email fix, exercised end-to-end above).
+describe("hook body signatures (extractor level)", () => {
+  const hookRoute = (hook: string, body: string[]) =>
+    [`@app.before_request`, `def ${hook}():`, ...body, ``,
+     `@app.route("/x", methods=["POST"])`, `def x():`, `    return {}`, ``].join("\n");
+  const firstRoute = async (src: string) => {
+    const f = await py("hookext.py", src);
+    return { routes: extractPythonRoutesAst(f.tree!, f.relativePath), tree: f.tree! };
+  };
+
+  const BODY_BLESS: Array<[string, string[]]> = [
+    ["abort(401), boring name", ["    if not g.user:", "        abort(401)"]],
+    ["flask.abort(401) attribute callee", ["    if not g.user:", "        flask.abort(401)"]],
+    ["credential-guarded abort(403)", ['    if "user_id" not in session:', "        abort(403)"]],
+    ["raise HTTPException(status_code=401)", ["    raise HTTPException(status_code=401)"]],
+    ["redirect to login", ['    if not session.get("user_id"):', '        return redirect(url_for("auth.login"))']],
+    ["header read then 401 tuple", ['    token = request.headers.get("Authorization")', "    if not token:", '        return jsonify({"error": "no"}), 401']],
+    ["current_user guard then abort(401)", ["    if not current_user.is_authenticated:", "        abort(401)"]],
+    ["verify_jwt_in_request()", ["    verify_jwt_in_request()"]],
+  ];
+  it.each(BODY_BLESS)('body reject "%s" blesses /x under the boring name gate', async (_n, body) => {
+    const { routes, tree } = await firstRoute(hookRoute("gate", body));
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+    expect(extractPythonFileMiddlewareAst(tree).hasAuth).toBe(true);
+  });
+
+  it("one-hop same-file helper that aborts 401 blesses under a boring hook name", async () => {
+    const { routes } = await firstRoute(
+      `def _reject_anon():\n    if not g.user:\n        abort(401)\n\n\n` +
+      `@app.before_request\ndef gate():\n    _reject_anon()\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  const BODY_NONE_NEG: Array<[string, string, string[]]> = [
+    ["verify_user_email emailing", "verify_user_email", ["    send_confirmation_email(g.user.email)", "    return None"]],
+    ["protect_user_data scrubbing", "protect_user_data", ["    scrub_pii(record)", "    return None"]],
+    ["log-only require_login", "require_login", ['    logger.info("hit %s", request.path)']],
+    ["header-set-only verify_token", "verify_token", ['    response.headers["X-Frame-Options"] = "DENY"']],
+    ["pass under require_login", "require_login", ["    pass"]],
+    ["docstring under check_auth", "check_auth", ['    """docs"""']],
+    ["abort(400)", "gate", ["    abort(400)"]],
+    ["abort(404)", "gate", ["    abort(404)"]],
+    ["raise ValueError", "gate", ['    raise ValueError("bad")']],
+    ["non-login redirect", "gate", ['    return redirect("/checkout")']],
+    ["lone abort(403) under csrf_protect", "csrf_protect", ["    abort(403)"]],
+    ["lone abort(403) under maintenance_gate", "maintenance_gate", ["    abort(403)"]],
+  ];
+  it.each(BODY_NONE_NEG)('visible non-enforcing body "%s" -> flat not-auth (key absent)', async (_n, hook, body) => {
+    const { routes, tree } = await firstRoute(hookRoute(hook, body));
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+    expect(extractPythonFileMiddlewareAst(tree).hasAuth).toBe(false);
+  });
+
+  it("require_admin whose only reject is a LONE abort(403) -> not-auth, key absent (forced by the visible-none rule that also fixes verify_user_email)", async () => {
+    // NOTE: the brief's parenthetical expected `unsure` here, but a lone abort(403)
+    // resolves the body to `none` (Task 1's frozen catalog), and a visible `none`
+    // body is flat not-auth regardless of name — the exact rule the
+    // verify_user_email fix depends on. Both outcomes are hasAuth:false; not-auth
+    // is the more conservative, design-consistent one.
+    const { routes } = await firstRoute(hookRoute("require_admin", ["    abort(403)"]));
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("a boring `before` hook calling only verify_jwt_in_request(optional=True) -> unsure, never a bless", async () => {
+    const { routes } = await firstRoute(hookRoute("before", ["    verify_jwt_in_request(optional=True)"]));
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("before");
+  });
+
+  it("lanes untouched: a validate_payload/pass hook sets validation, never auth (route level)", async () => {
+    const { routes } = await firstRoute(hookRoute("validate_payload", ["    pass"]));
+    expect(routes[0].hasValidation).toBe(true);
+    expect(routes[0].hasAuth).toBe(false);
+  });
+
+  it("receiver scoping preserved: a body-blessed admin_bp hook blesses only admin_bp routes", async () => {
+    const f = await py("scoped.py",
+      `@admin_bp.before_request\ndef gate():\n    abort(401)\n\n` +
+      `@admin_bp.route("/users", methods=["POST"])\ndef create_user():\n    return {}\n\n` +
+      `@public_bp.route("/webhook", methods=["POST"])\ndef webhook():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/users auth=true",
+      "/webhook auth=false",
+    ]);
+  });
+});
+
+// ─── ADDENDUM Task 2: unsure hooks surface the exact hook name ────────────────
+//
+// An auth-flavored but statically unverifiable hook resolves `unsure`: hasAuth
+// stays false (never blesses) and route.authUnsureHook carries the REGISTERED
+// hook's name so a renderer can hedge the copy. Covers decorator + call-form
+// registration.
+describe("unsure hooks (extractor level)", () => {
+  const routesOf = async (src: string) => {
+    const f = await py("unsure.py", src);
+    return { routes: extractPythonRoutesAst(f.tree!, f.relativePath), tree: f.tree! };
+  };
+  const ROUTE = `\n@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`;
+
+  it("opaque auth-flavored helper: @app.before_request require_login -> check_session() -> authUnsureHook 'require_login'", async () => {
+    const { routes, tree } = await routesOf(
+      `@app.before_request\ndef require_login():\n    check_session()\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("require_login");
+    expect(extractPythonFileMiddlewareAst(tree).hasAuth).toBe(false);
+  });
+
+  it("call-form imported hook: app.before_request(verify_session) -> authUnsureHook 'verify_session'", async () => {
+    const { routes } = await routesOf(
+      `from .auth import verify_session\napp.before_request(verify_session)\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("verify_session");
+  });
+
+  it("call-form CORE name blesses: app.before_request(authenticate) -> auth=true, key absent", async () => {
+    const { routes } = await routesOf(`app.before_request(authenticate)\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(true);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("call-form lambda: app.before_request(lambda: abort(401)) -> auth=true", async () => {
+    const { routes } = await routesOf(`app.before_request(lambda: abort(401))\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(true);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("call-form attribute target: app.before_request(AuthGate.check) -> unsure, hook name 'AuthGate.check'", async () => {
+    const { routes } = await routesOf(`app.before_request(AuthGate.check)\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("AuthGate.check");
+  });
+
+  it("attributive-collision unresolvable: verify_user_email -> confirm(user) -> unsure, never blessed on name", async () => {
+    const { routes } = await routesOf(
+      `@app.before_request\ndef verify_user_email():\n    confirm(user)\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("verify_user_email");
+  });
+
+  it("@bp.before_app_request unsure hook marks authUnsureHook app-wide", async () => {
+    const { routes } = await routesOf(
+      `@bp.before_app_request\ndef require_login():\n    check_session()\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("require_login");
+  });
+
+  it("per-route auth clears unsure: unsure hook + @login_required below the route -> auth=true, key absent", async () => {
+    const { routes } = await routesOf(
+      `@app.before_request\ndef require_login():\n    check_session()\n\n` +
+      `@app.route("/x", methods=["POST"])\n@login_required\ndef x():\n    return {}\n`);
+    expect(routes[0].hasAuth).toBe(true);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("global real auth clears receiver unsure: app-scoped abort(401) hook + an unsure receiver hook -> auth=true, key absent", async () => {
+    const { routes } = await routesOf(
+      `@app.before_request\ndef gate():\n    abort(401)\n\n` +
+      `@orders_bp.before_request\ndef require_login():\n    check_session()\n\n` +
+      `@orders_bp.route("/x", methods=["POST"])\ndef x():\n    return {}\n`);
+    expect(routes[0].hasAuth).toBe(true);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("deterministic attribution: two unsure hooks on one receiver -> the FIRST in document order", async () => {
+    const { routes } = await routesOf(
+      `@app.before_request\ndef require_login():\n    check_session()\n\n` +
+      `@app.before_request\ndef verify_user_email():\n    confirm(user)\n` + ROUTE);
+    expect(routes[0].authUnsureHook).toBe("require_login");
+  });
+
+  it("errored hook dd is invisible: no throw, no bless, no unsure on any emitted route", async () => {
+    const f = await py("errdd.py",
+      `@app.before_request\ndef gate():\n    x = = 1\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`);
+    expect(() => extractPythonRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    for (const r of extractPythonRoutesAst(f.tree!, f.relativePath)) {
+      expect(r.hasAuth).toBe(false);
+      expect(r.authUnsureHook).toBeUndefined();
+    }
+  });
+
+  it("cycle-safe hook a()->b()->a() -> not blessed, not unsure (boring name resolves none)", async () => {
+    const { routes } = await routesOf(
+      `def b():\n    a()\n\n\n@app.before_request\ndef a():\n    b()\n` + ROUTE);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+});
+
+// ─── ADDENDUM Task 2: Depends additive-only same-file body bless ──────────────
+//
+// A boring-named FastAPI dependency whose VISIBLE same-file body raises a
+// verified 401 IS auth enforcement. Order is veto first, name-segment hit
+// second, same-file body reject third. Imported-target verdicts are unchanged
+// (no same-file def to resolve).
+describe("Depends additive-only body bless", () => {
+  it("Depends(load_actor) whose same-file body raises HTTPException(401) blesses", async () => {
+    const f = await py("depbody.py",
+      `@router.post("/x")\ndef h(actor=Depends(load_actor)):\n    return {}\n\n\n` +
+      `def load_actor(request):\n    token = request.headers.get("Authorization")\n` +
+      `    if not token:\n        raise HTTPException(status_code=401)\n    return token\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+  });
+
+  it("Depends(get_current_user_optional) whose body raises 401 -> auth=false (veto beats body)", async () => {
+    const f = await py("depveto.py",
+      `@router.post("/x")\ndef h(user=Depends(get_current_user_optional)):\n    return {}\n\n\n` +
+      `def get_current_user_optional(request):\n    token = request.headers.get("Authorization")\n` +
+      `    if not token:\n        raise HTTPException(status_code=401)\n    return token\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+  });
+
+  it("imported Depends verdicts unchanged: oauth2_scheme blesses, get_author_stats does not", async () => {
+    const f = await py("depimported.py",
+      `@router.post("/x1")\ndef h1(x=Depends(oauth2_scheme)):\n    return {}\n\n` +
+      `@router.post("/x2")\ndef h2(x=Depends(get_author_stats)):\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
+      "/x1 auth=true",
+      "/x2 auth=false",
+    ]);
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   extractPythonRoutesAst,
   extractPythonFileMiddlewareAst,
+  bodyAuthSignature,
+  classifyHookAuth,
+  collectFunctionDefs,
+  SECURITY_AST_PY,
 } from "../../../src/drift/security-ast-python.js";
+import type { SyntaxNode } from "../../../src/core/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 
 const py = (path: string, src: string) => fileWithTree(path, src, "python");
@@ -1870,6 +1875,376 @@ describe("never-false-bless sweep", () => {
         const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
         expect(emitted?.hasAuth ?? false, `${entry.name}: ${gt.method} ${gt.path}`).toBe(false);
       }
+    }
+  });
+});
+
+// ─── ADDENDUM Task 1: body-signature analyzer (pure helpers) ────────────────
+//
+// These test the pure, exported helpers directly: a hook body node in ->
+// "reject" | "none" | "opaque" (bodyAuthSignature), and the precedence layer
+// classifyHookAuth -> "auth" | "not-auth" | "unsure". The governing invariant
+// (NEVER-FALSE-BLESS) means "auth"/"reject" only ever fires on a verified
+// rejection signature; every ambiguity resolves away from a bless.
+
+// Select the body + defs of a named function ("hook" by default). Selecting by
+// name (not descendantsOfType[0]) keeps one-hop fixtures — where a same-file
+// helper is defined before the hook — unambiguous.
+async function hookBody(src: string, fnName = "hook") {
+  const f = await py("body.py", src);
+  const root = f.tree!.rootNode;
+  const defs = collectFunctionDefs(root);
+  const named = root
+    .descendantsOfType("function_definition")
+    .filter((d): d is SyntaxNode => d !== null);
+  const def = named.find((d) => d.childForFieldName("name")?.text === fnName) ?? named[0]!;
+  return { body: def.childForFieldName("body")!, defs };
+}
+const sig = async (src: string, fnName = "hook") => {
+  const { body, defs } = await hookBody(src, fnName);
+  return bodyAuthSignature(body, defs);
+};
+
+describe("body-signature grammar prerequisites", () => {
+  const rootOf = async (src: string) => (await py("g.py", src)).tree!.rootNode;
+  const noError = (n: SyntaxNode) => expect(n.hasError).toBe(false);
+
+  it("abort(401): call > identifier + argument_list > integer", async () => {
+    const root = await rootOf(`def f():\n    abort(401)\n`);
+    noError(root);
+    const call = root.descendantsOfType("call")[0]!;
+    expect(call.childForFieldName("function")!.type).toBe("identifier");
+    expect(call.childForFieldName("function")!.text).toBe("abort");
+    const args = call.childForFieldName("arguments")!;
+    expect(args.type).toBe("argument_list");
+    expect(args.namedChild(0)!.type).toBe("integer");
+    expect(args.namedChild(0)!.text).toBe("401");
+  });
+
+  it("raise HTTPException(...): raise_statement > namedChild(0) call with keyword_argument", async () => {
+    const root = await rootOf(`def f():\n    raise HTTPException(status_code=401)\n`);
+    noError(root);
+    const rs = root.descendantsOfType("raise_statement")[0]!;
+    const call = rs.namedChild(0)!;
+    expect(call.type).toBe("call");
+    expect(call.childForFieldName("function")!.text).toBe("HTTPException");
+    const kw = call.childForFieldName("arguments")!.namedChild(0)!;
+    expect(kw.type).toBe("keyword_argument");
+    expect(kw.childForFieldName("name")!.text).toBe("status_code");
+  });
+
+  it("bare raise PermissionDenied: raise_statement > identifier, NOT a call", async () => {
+    const root = await rootOf(`def f():\n    raise PermissionDenied\n`);
+    noError(root);
+    const raised = root.descendantsOfType("raise_statement")[0]!.namedChild(0)!;
+    expect(raised.type).toBe("identifier");
+    expect(raised.text).toBe("PermissionDenied");
+  });
+
+  it("return redirect(url_for('auth.login')): return_statement > call > call", async () => {
+    const root = await rootOf(`def f():\n    return redirect(url_for('auth.login'))\n`);
+    noError(root);
+    const val = root.descendantsOfType("return_statement")[0]!.namedChild(0)!;
+    expect(val.type).toBe("call");
+    expect(val.childForFieldName("function")!.text).toBe("redirect");
+    const inner = val.childForFieldName("arguments")!.namedChild(0)!;
+    expect(inner.type).toBe("call");
+    expect(inner.childForFieldName("function")!.text).toBe("url_for");
+  });
+
+  it("return jsonify({}), 401: return_statement > expression_list ending in integer", async () => {
+    const root = await rootOf(`def f():\n    return jsonify({}), 401\n`);
+    noError(root);
+    const val = root.descendantsOfType("return_statement")[0]!.namedChild(0)!;
+    expect(val.type).toBe("expression_list");
+    const kids = val.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    const last = kids[kids.length - 1]!;
+    expect(last.type).toBe("integer");
+    expect(last.text).toBe("401");
+  });
+
+  it("'user_id' not in session: comparison_operator with an unnamed 'not in' child", async () => {
+    const root = await rootOf(`def f():\n    if 'user_id' not in session:\n        pass\n`);
+    noError(root);
+    const cmp = root.descendantsOfType("comparison_operator")[0]!;
+    const ops = cmp.children
+      .filter((c): c is SyntaxNode => c !== null && !c.isNamed)
+      .map((c) => c.type);
+    expect(ops).toContain("not in");
+  });
+
+  it("session.get('user'): call on an attribute callee", async () => {
+    const root = await rootOf(`def f():\n    session.get('user')\n`);
+    noError(root);
+    const fn = root.descendantsOfType("call")[0]!.childForFieldName("function")!;
+    expect(fn.type).toBe("attribute");
+    expect(fn.childForFieldName("attribute")!.text).toBe("get");
+    expect(fn.childForFieldName("object")!.text).toBe("session");
+  });
+
+  it("pass body is a block > pass_statement", async () => {
+    const root = await rootOf(`def f():\n    pass\n`);
+    noError(root);
+    const body = root.descendantsOfType("function_definition")[0]!.childForFieldName("body")!;
+    expect(body.type).toBe("block");
+    expect(body.namedChild(0)!.type).toBe("pass_statement");
+  });
+
+  it("async def is a function_definition with intact name/body fields", async () => {
+    const root = await rootOf(`async def f():\n    abort(401)\n`);
+    noError(root);
+    const def = root.descendantsOfType("function_definition")[0]!;
+    expect(def.type).toBe("function_definition");
+    expect(def.childForFieldName("name")!.text).toBe("f");
+    expect(def.childForFieldName("body")!.type).toBe("block");
+  });
+
+  it("a @lru_cache-decorated def still surfaces in descendantsOfType('function_definition')", async () => {
+    const root = await rootOf(`@functools.lru_cache\ndef helper():\n    abort(401)\n`);
+    noError(root);
+    const defs = root
+      .descendantsOfType("function_definition")
+      .filter((d): d is SyntaxNode => d !== null);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].childForFieldName("name")!.text).toBe("helper");
+  });
+});
+
+describe("bodyAuthSignature: reject signatures", () => {
+  const REJECTS: Array<[string, string]> = [
+    ["abort(401) alone", `def hook():\n    abort(401)\n`],
+    ["flask.abort(401) attribute callee", `def hook():\n    flask.abort(401)\n`],
+    ["return abort(401)", `def hook():\n    return abort(401)\n`],
+    [
+      "abort(401) nested in try/if/for",
+      `def hook():\n    for x in items:\n        try:\n            if bad:\n                abort(401)\n        except Exception:\n            pass\n`,
+    ],
+    [
+      "raise HTTPException(status_code=401, detail='no')",
+      `def hook():\n    raise HTTPException(status_code=401, detail="no")\n`,
+    ],
+    ["raise HTTPException(401) positional", `def hook():\n    raise HTTPException(401)\n`],
+    [
+      "raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)",
+      `def hook():\n    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)\n`,
+    ],
+    [
+      "corroborated 403: session read + abort(403)",
+      `def hook():\n    user = session.get("user_id")\n    if user is None:\n        abort(403)\n`,
+    ],
+    ["raise AuthenticationError('nope')", `def hook():\n    raise AuthenticationError("nope")\n`],
+    ["raise Unauthorized()", `def hook():\n    raise Unauthorized()\n`],
+    [
+      "raise werkzeug.exceptions.Unauthorized()",
+      `def hook():\n    raise werkzeug.exceptions.Unauthorized()\n`,
+    ],
+    ["bare raise PermissionDenied", `def hook():\n    raise PermissionDenied\n`],
+    [
+      "return redirect(url_for('auth.login'))",
+      `def hook():\n    return redirect(url_for("auth.login"))\n`,
+    ],
+    ["return redirect('/login')", `def hook():\n    return redirect("/login")\n`],
+    ["return RedirectResponse('/login')", `def hook():\n    return RedirectResponse("/login")\n`],
+    [
+      "session guard then redirect to login",
+      `def hook():\n    if not session.get("user_id"):\n        return redirect(url_for("auth.login"))\n`,
+    ],
+    [
+      "pyAuthFile wrapper: header read + jsonify tuple 401",
+      `def hook():\n    token = request.headers.get("Authorization")\n    if not token:\n        return jsonify({"error": "unauthorized"}), 401\n`,
+    ],
+    [
+      "current_user guard then abort(401)",
+      `def hook():\n    if not current_user.is_authenticated:\n        abort(401)\n`,
+    ],
+    ["verify_jwt_in_request() alone", `def hook():\n    verify_jwt_in_request()\n`],
+    [
+      "one-hop helper: _reject_anon() aborts 401",
+      `def _reject_anon():\n    if not g.user:\n        abort(401)\n\n\ndef hook():\n    _reject_anon()\n`,
+    ],
+    [
+      "one-hop helper decorated with @functools.lru_cache",
+      `@functools.lru_cache\ndef _reject_anon():\n    if not g.user:\n        abort(401)\n\n\ndef hook():\n    _reject_anon()\n`,
+    ],
+    [
+      "one-hop async helper",
+      `async def _reject_anon():\n    if not g.user:\n        abort(401)\n\n\ndef hook():\n    _reject_anon()\n`,
+    ],
+  ];
+  it.each(REJECTS)('"%s" -> reject', async (_name, src) => {
+    expect(await sig(src)).toBe("reject");
+  });
+});
+
+describe("bodyAuthSignature: none (visible body, no rejection)", () => {
+  const NONES: Array<[string, string]> = [
+    [
+      "verify_user_email body: email + return None",
+      `def hook():\n    send_confirmation_email(g.user.email)\n    return None\n`,
+    ],
+    ["scrub_pii(record)", `def hook():\n    scrub_pii(record)\n`],
+    ["anonymize(record)", `def hook():\n    anonymize(record)\n`],
+    ["logger.info(...)", `def hook():\n    logger.info("hit %s", request.path)\n`],
+    ["g.request_id = uuid4().hex", `def hook():\n    g.request_id = uuid4().hex\n`],
+    [
+      "header setter (subscript assignment)",
+      `def hook():\n    response.headers["X-Frame-Options"] = "DENY"\n`,
+    ],
+    ["pass", `def hook():\n    pass\n`],
+    ["docstring only", `def hook():\n    """just docs"""\n`],
+    ["abort(400)", `def hook():\n    abort(400)\n`],
+    ["abort(404)", `def hook():\n    abort(404)\n`],
+    ["abort(500)", `def hook():\n    abort(500)\n`],
+    ["raise HTTPException(status_code=404)", `def hook():\n    raise HTTPException(status_code=404)\n`],
+    ["lone uncorroborated abort(403)", `def hook():\n    abort(403)\n`],
+    [
+      "lone uncorroborated raise HTTPException(status_code=403)",
+      `def hook():\n    raise HTTPException(status_code=403)\n`,
+    ],
+    [
+      "lone uncorroborated raise HTTPException(status_code=HTTP_403_FORBIDDEN)",
+      `def hook():\n    raise HTTPException(status_code=HTTP_403_FORBIDDEN)\n`,
+    ],
+    ["raise ValueError('bad')", `def hook():\n    raise ValueError("bad")\n`],
+    ["raise KeyError", `def hook():\n    raise KeyError\n`],
+    ["raise NotFound", `def hook():\n    raise NotFound\n`],
+    [
+      "return redirect(url_for('maintenance.notice'))",
+      `def hook():\n    return redirect(url_for("maintenance.notice"))\n`,
+    ],
+    ["return redirect('/checkout')", `def hook():\n    return redirect("/checkout")\n`],
+    ["session.get('locale') (not a credential key)", `def hook():\n    session.get("locale")\n`],
+  ];
+  it.each(NONES)('"%s" -> none', async (_name, src) => {
+    expect(await sig(src)).toBe("none");
+  });
+});
+
+describe("bodyAuthSignature: opaque (auth-flavored but unverifiable)", () => {
+  const OPAQUES: Array<[string, string]> = [
+    ["check_session() undefined helper", `def hook():\n    check_session()\n`],
+    ["confirm(user) undefined helper", `def hook():\n    confirm(user)\n`],
+    ["_do_auth() undefined helper", `def hook():\n    _do_auth()\n`],
+    ["abort(code_var) unreadable status", `def hook():\n    abort(code_var)\n`],
+    [
+      "raise HTTPException(status_code=CODE) unreadable status",
+      `def hook():\n    raise HTTPException(status_code=CODE)\n`,
+    ],
+    [
+      "verify_jwt_in_request(optional=True) non-empty args",
+      `def hook():\n    verify_jwt_in_request(optional=True)\n`,
+    ],
+    ["redirect(page_var) unreadable target", `def hook():\n    return redirect(page_var)\n`],
+    [
+      "credential read + opaque validate_or_die",
+      `def hook():\n    token = request.headers.get("Authorization")\n    validate_or_die(token)\n`,
+    ],
+    [
+      "duplicate same-file def: check_session unresolvable + hint",
+      `def check_session():\n    pass\n\n\ndef check_session():\n    pass\n\n\ndef hook():\n    check_session()\n`,
+    ],
+    ["get_jwt_identity() analytics: jwt hint, never reject", `def hook():\n    get_jwt_identity()\n`],
+  ];
+  it.each(OPAQUES)('"%s" -> opaque', async (_name, src) => {
+    expect(await sig(src)).toBe("opaque");
+  });
+
+  it("cycle a()->b()->a() terminates and returns none (no reject, no hint)", async () => {
+    const src = `def a():\n    b()\n\n\ndef b():\n    a()\n`;
+    expect(await sig(src, "a")).toBe("none");
+  });
+});
+
+describe("classifyHookAuth: precedence", () => {
+  const cls = async (name: string, src: string, simple: boolean, fnName = "hook") => {
+    const { body, defs } = await hookBody(src, fnName);
+    return classifyHookAuth(name, body, defs, simple);
+  };
+
+  it("veto beats a body-positive: optional_authenticate + abort(401) body -> not-auth", async () => {
+    const body =
+      `def hook():\n    token = request.headers.get("Authorization")\n    if token is None:\n        abort(401)\n`;
+    expect(await cls("optional_authenticate", body, true)).toBe("not-auth");
+  });
+
+  it("body beats name (bless): boring gate() with session+abort(401) -> auth", async () => {
+    const body = `def hook():\n    if not session.get("user_id"):\n        abort(401)\n`;
+    expect(await cls("gate", body, true)).toBe("auth");
+  });
+
+  it("body beats name (deny): verify_user_email emailing body -> not-auth", async () => {
+    const body = `def hook():\n    send_confirmation_email(g.user.email)\n    return None\n`;
+    expect(await cls("verify_user_email", body, true)).toBe("not-auth");
+  });
+
+  it("visible pass stub never rescued: require_login/pass -> not-auth", async () => {
+    expect(await cls("require_login", `def hook():\n    pass\n`, true)).toBe("not-auth");
+  });
+
+  it("tier-1 CORE does not rescue a visible stub: check_auth/pass -> not-auth", async () => {
+    expect(await cls("check_auth", `def hook():\n    pass\n`, true)).toBe("not-auth");
+  });
+
+  it("wrong reject code: require_login/abort(404) -> not-auth", async () => {
+    expect(await cls("require_login", `def hook():\n    abort(404)\n`, true)).toBe("not-auth");
+  });
+
+  it("opaque + CORE carve-out: authenticate_request delegating to _do_auth() -> auth", async () => {
+    expect(await cls("authenticate_request", `def hook():\n    _do_auth()\n`, true)).toBe("auth");
+  });
+
+  it("opaque + tier-2 name: require_login -> check_session() -> unsure", async () => {
+    expect(await cls("require_login", `def hook():\n    check_session()\n`, true)).toBe("unsure");
+  });
+
+  it("opaque + attributive name: verify_user_email -> confirm(user) -> unsure", async () => {
+    expect(await cls("verify_user_email", `def hook():\n    confirm(user)\n`, true)).toBe("unsure");
+  });
+
+  it("opaque under a boring name: setup -> check_session() -> unsure (flavored delegation is evidence)", async () => {
+    expect(await cls("setup", `def hook():\n    check_session()\n`, true)).toBe("unsure");
+  });
+
+  it("body null + CORE simple: authenticate -> auth", () => {
+    expect(classifyHookAuth("authenticate", null, new Map(), true)).toBe("auth");
+  });
+
+  it("body null + tier-2 simple: verify_session -> unsure", () => {
+    expect(classifyHookAuth("verify_session", null, new Map(), true)).toBe("unsure");
+  });
+
+  it("body null + attributive simple: verify_user_email -> unsure", () => {
+    expect(classifyHookAuth("verify_user_email", null, new Map(), true)).toBe("unsure");
+  });
+
+  it("body null + auth segment on a non-simple target: AuthGate.check -> unsure (never blesses)", () => {
+    expect(classifyHookAuth("AuthGate.check", null, new Map(), false)).toBe("unsure");
+  });
+
+  it("body null + zero flavor: add_request_id -> not-auth (no hedge)", () => {
+    expect(classifyHookAuth("add_request_id", null, new Map(), true)).toBe("not-auth");
+  });
+
+  it("body null + optional veto: optional_auth_hook -> not-auth", () => {
+    expect(classifyHookAuth("optional_auth_hook", null, new Map(), true)).toBe("not-auth");
+  });
+});
+
+describe("SECURITY_AST_PY export bag: body-signature lexicons", () => {
+  it("includes each new body-signature lexicon name", () => {
+    const keys = Object.keys(SECURITY_AST_PY);
+    for (const name of [
+      "REJECT_STATUSES",
+      "REJECT_STATUS_BLESSES_ALONE",
+      "AUTH_EXCEPTION_ALONE",
+      "AUTH_EXCEPTION_TOPIC",
+      "AUTH_EXCEPTION_KIND",
+      "LOGIN_REDIRECT_SEGMENTS",
+      "KNOWN_AUTH_PRIMITIVES",
+      "OPAQUE_AUTH_HINT_SEGMENTS",
+      "CREDENTIAL_KEY_SEGMENTS",
+    ]) {
+      expect(keys).toContain(name);
     }
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -418,7 +418,7 @@ describe("extractPythonRoutesAst: method resolution", () => {
     expect(routes[0].method).toBe("POST");
   });
 
-  it("resolves methods=ALLOWED (a variable) to ALL: statically unresolvable stays in the mutating vote", async () => {
+  it("resolves methods=ALLOWED (a variable with NO same-file assignment) to ALL: the unresolved case; see the resolved-var suite below for the assigned case", async () => {
     const f = await py("var.py", `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
     const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
     expect(routes).toHaveLength(1);
@@ -475,6 +475,254 @@ describe("extractPythonRoutesAst: method resolution", () => {
       `    "/x",\n` +
       `    methods=["POST", "GET"],\n` +
       `)\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+});
+
+// ─── Upgrade 2: methods= same-file variable resolution ──────────────────────
+//
+// A `methods=VAR` kwarg now resolves through VAR's value WHEN VAR is written
+// EXACTLY ONCE at module top level to a literal list/tuple/set of string
+// verbs (reusing the same methodFromLiteral reduction the inline literal path
+// uses). Every other shape — imported, computed, an identifier alias chain,
+// reassigned more than once, or written through any of the poisoned forms
+// below (augmented assignment, a mutating method call, `global`, walrus, a
+// for-loop target, a subscript/slice-target assignment, a `with ... as`
+// binding, or a conditional/def-local assignment) — stays unresolvable and
+// resolves "ALL", never a silent GET: the invariant is never dropping a
+// mutating route out of the vote because its methods= variable was
+// unreadable.
+describe("methods= same-file variable resolution", () => {
+  it("resolves methods=ALLOWED to POST when ALLOWED = [\"GET\", \"POST\"] is the sole same-file assignment (mutating verb wins, same reduction as the inline literal path)", async () => {
+    const f = await py("resolved-list.py",
+      `ALLOWED = ["GET", "POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves methods=VERBS to PUT when VERBS = (\"PUT\",) is a same-file tuple literal", async () => {
+    const f = await py("resolved-tuple.py",
+      `VERBS = ("PUT",)\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("PUT");
+  });
+
+  it("resolves methods=VERBS to DELETE when VERBS = {\"delete\"} is a same-file set literal (uppercased)", async () => {
+    const f = await py("resolved-set.py",
+      `VERBS = {"delete"}\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("DELETE");
+  });
+
+  it("resolves methods=VERBS to GET when VERBS = [\"GET\"]: a fully visible literal legitimately exits the mutating vote; the route IS emitted", async () => {
+    const f = await py("resolved-get.py",
+      `VERBS = ["GET"]\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("resolves methods=VERBS to GET when VERBS = []: fully visible and empty, mirrors the inline empty-literal pin (visibility, not ambiguity)", async () => {
+    const f = await py("resolved-empty.py",
+      `VERBS = []\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("resolves methods=VERBS to GET when VERBS = [\"MKCOL\"]: fully visible with no recognized verb, mirrors the inline MKCOL pin", async () => {
+    const f = await py("resolved-mkcol.py",
+      `VERBS = ["MKCOL"]\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+  });
+
+  it("resolves methods=ALLOWED to POST when ALLOWED = [*BASE, \"POST\"]: the visible literal wins, the same shared helper as the inline kwarg", async () => {
+    const f = await py("resolved-splat-verb.py",
+      `ALLOWED = [*BASE, "POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves methods=ALLOWED to ALL when ALLOWED = [*BASE]: no visible literal verb even though the assignment itself is unambiguous", async () => {
+    const f = await py("resolved-splat-only.py",
+      `ALLOWED = [*BASE]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("resolves methods=ALLOWED to POST when ALLOWED: list[str] = [\"POST\"] is an annotated assignment (still an `assignment` node)", async () => {
+    const f = await py("resolved-annotated.py",
+      `ALLOWED: list[str] = ["POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("stays ALL for ALL_VERBS = BASE + EXTRA: a computed (binary_operator) same-file value, not a literal", async () => {
+    const f = await py("computed.py",
+      `ALL_VERBS = BASE + EXTRA\n\n@app.route("/x", methods=ALL_VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for an imported `from config import ALLOWED`: no same-file assignment to chase", async () => {
+    const f = await py("imported.py",
+      `from config import ALLOWED\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for ALLOWED = get_methods(): a computed call, not a literal", async () => {
+    const f = await py("computed-call.py",
+      `ALLOWED = get_methods()\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for an alias chain (A = [\"POST\"]; B = A; methods=B): an identifier RHS is refused, never chased", async () => {
+    const f = await py("alias-chain.py",
+      `A = ["POST"]\nB = A\n\n@app.route("/x", methods=B)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for a twice-reassigned variable: two same-file literal assignments make the value ambiguous", async () => {
+    const f = await py("twice-reassigned.py",
+      `ALLOWED = ["GET"]\nALLOWED = ["POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("AUGMENTED-ASSIGNMENT TRAP: ALLOWED = [\"GET\"] then ALLOWED += [\"POST\"] stays ALL, never GET (a naive single-assignment scan would resolve GET and silently drop the POST route from the mutating vote)", async () => {
+    const f = await py("augmented-trap.py",
+      `ALLOWED = ["GET"]\nALLOWED += ["POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL when `global ALLOWED` is declared and written inside a def", async () => {
+    const f = await py("global-write.py",
+      `ALLOWED = ["GET"]\n\ndef configure():\n    global ALLOWED\n    ALLOWED = ["POST"]\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for a walrus write to the variable", async () => {
+    const f = await py("walrus-write.py",
+      `ALLOWED = ["GET"]\nif (ALLOWED := recompute()):\n    pass\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for a for-loop target write to the variable", async () => {
+    const f = await py("for-target-write.py",
+      `ALLOWED = ["GET"]\nfor ALLOWED in candidate_lists():\n    pass\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("MUTATION TRAP: ALLOWED.append(\"DELETE\") stays ALL, never GET", async () => {
+    const f = await py("append-trap.py",
+      `ALLOWED = ["GET"]\nALLOWED.append("DELETE")\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for a tuple-unpack write `x, ALLOWED = pair`", async () => {
+    const f = await py("tuple-unpack-write.py",
+      `ALLOWED = ["GET"]\nx, ALLOWED = pair\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("SLICE-REPLACEMENT TRAP: ALLOWED = [\"GET\"] then ALLOWED[:] = load_methods() stays ALL, never GET (a subscript-left assignment a naive identifier-left census would miss)", async () => {
+    const f = await py("slice-replacement-trap.py",
+      `ALLOWED = ["GET"]\nALLOWED[:] = load_methods()\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("ELEMENT-ASSIGNMENT TRAP: ALLOWED = [\"GET\"] then ALLOWED[0] = \"POST\" stays ALL, never GET (another subscript-left assignment)", async () => {
+    const f = await py("element-trap.py",
+      `ALLOWED = ["GET"]\nALLOWED[0] = "POST"\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("WITH-AS TRAP: `with open(\"m\") as ALLOWED:` rebinds the name, stays ALL", async () => {
+    const f = await py("with-as-trap.py",
+      `ALLOWED = ["GET"]\nwith open("m") as ALLOWED:\n    pass\n\n` +
+      `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for a lone assignment inside an `if:` block: conditional, not an unconditional same-file literal", async () => {
+    const f = await py("conditional-assignment.py",
+      `if COND:\n    VERBS = ["GET"]\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("stays ALL for a def-local sole assignment: not a module top-level write", async () => {
+    const f = await py("def-local-assignment.py",
+      `def configure():\n    VERBS = ["GET"]\n\n@app.route("/x", methods=VERBS)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("resolves a multiline decorator with methods=ALLOWED identically to the inline-literal multiline pin (POST)", async () => {
+    const f = await py("multiline-var.py",
+      `ALLOWED = ["POST", "GET"]\n\n` +
+      `@app.route(\n` +
+      `    "/x",\n` +
+      `    methods=ALLOWED,\n` +
+      `)\n` +
+      `def h():\n` +
+      `    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("POST");
+  });
+
+  it("resolves a trailing-kwarg flood with methods=ALLOWED identically to the inline-literal flood pin (POST)", async () => {
+    const f = await py("flood-var.py",
+      `ALLOWED = ["POST"]\n\n` +
+      `@app.route("/x", methods=ALLOWED, strict_slashes=False, endpoint="e", defaults={"a": 1})\n` +
       `def h():\n` +
       `    return {}\n`);
     const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
@@ -1434,11 +1682,12 @@ describe("documented trade-offs (task-review pins)", () => {
     expect(routes[0].method).toBe("GET");
   });
 
-  it("does not bless custom or non-IsAuthenticated permission classes: permission_classes([IsAdminUser]) and ([FooPermission])", async () => {
-    // Only IsAuthenticated is in PERMISSION_AUTH. IsAdminUser is a real DRF class
-    // that requires staff, but it is not in the narrow whitelist, and FooPermission
-    // is an unknown custom class; both resolve hasAuth:false per never-false-bless
-    // (an unrecognized permission class is ambiguity, which never blesses).
+  it("does not bless a custom, unrecognized permission class: permission_classes([FooPermission])", async () => {
+    // FooPermission is not in PERMISSION_AUTH (an unknown custom class is
+    // ambiguity, which never blesses per never-false-bless). IsAdminUser WAS
+    // grouped here too until Upgrade 2 (Task 3): it is now recognized (see the
+    // "IsAdminUser in PERMISSION_AUTH" describe below), so it is asserted
+    // separately as a positive alongside this negative.
     const f = await py("custcompermclass.py",
       `@api_view(["POST"])\n` +
       `@permission_classes([IsAdminUser])\n` +
@@ -1450,9 +1699,49 @@ describe("documented trade-offs (task-review pins)", () => {
       `    return Response({})\n`);
     expect(extractPythonRoutesAst(f.tree!, f.relativePath)
       .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual([
-      "/a auth=false",
+      "/a auth=true",
       "/b auth=false",
     ]);
+  });
+
+  it("@api_view(METHODS) with a same-file METHODS = [\"POST\"] stays ALL: Upgrade 2 names methods= only, not api_view's positional list argument (deliberate boundary)", async () => {
+    const f = await py("apiview-methodsvar.py",
+      `METHODS = ["POST"]\n\n` +
+      `@api_view(METHODS)\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+});
+
+// ─── Upgrade 2 (Task 3): IsAdminUser recognized in PERMISSION_AUTH ──────────
+//
+// IsAdminUser is unconditional auth (Django's IsAdminUser requires
+// request.user.is_staff, which implies an authenticated user; there is no
+// per-method carve-out the way IsAuthenticatedOrReadOnly has), so recognizing
+// it carries zero false-bless risk. Its neighbors (AllowAny,
+// IsAuthenticatedOrReadOnly, an unrecognized custom class) are unaffected.
+describe("IsAdminUser in PERMISSION_AUTH", () => {
+  it("blesses @permission_classes([IsAdminUser]) BELOW @api_view", async () => {
+    const f = await py("isadminuser.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([IsAdminUser])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=true"]);
+  });
+
+  it("blesses the attribute form @permission_classes([permissions.IsAdminUser])", async () => {
+    const f = await py("isadminuser-attr.py",
+      `@api_view(["POST"])\n` +
+      `@permission_classes([permissions.IsAdminUser])\n` +
+      `def create_thing(request):\n` +
+      `    return Response({})\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=true"]);
   });
 });
 
@@ -1841,8 +2130,12 @@ const NEVER_FALSE_BLESS_SWEEP: Array<{
     source:
       `@api_view(["POST"])\n@permission_classes([IsAdminUser])\ndef a(request):\n    return Response({})\n\n` +
       `@api_view(["POST"])\n@permission_classes([FooPermission])\ndef b(request):\n    return Response({})\n`,
+    // /a is a documented POSITIVE since Upgrade 2 (Task 3): IsAdminUser is now
+    // in PERMISSION_AUTH. Sweep positives are documentation-only (the sweep
+    // assertion filters to `!authed`); /b (FooPermission, unrecognized) is the
+    // negative this entry still exercises.
     groundTruth: [
-      { path: "/a", method: "POST", authed: false },
+      { path: "/a", method: "POST", authed: true },
       { path: "/b", method: "POST", authed: false },
     ],
   },

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -7,6 +7,9 @@ import {
   collectFunctionDefs,
   SECURITY_AST_PY,
 } from "../../../src/drift/security-ast-python.js";
+import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
+import { securityConsistency } from "../../../src/drift/security-consistency.js";
+import { SECURITY_SUBCATEGORIES } from "../../../src/drift/types.js";
 import type { SyntaxNode } from "../../../src/core/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 
@@ -1426,6 +1429,23 @@ describe("extractPythonRoutesAst: Django REST function views", () => {
     expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/create_thing auth=false"]);
   });
 
+  // The highest-risk permission-class negative: IsAuthenticatedOrReadOnly is a
+  // string PREFIX of the blessed IsAuthenticated. Recognition is EXACT Set
+  // membership (PERMISSION_AUTH.has), never a prefix/substring test, so the
+  // prefix must NOT bless even though the blessed class blesses in the same
+  // shape. Pins that the two verdicts diverge (a prefix relaxation would fail
+  // here loudly rather than silently over-bless a write-exposing route).
+  it("IsAuthenticatedOrReadOnly (a prefix of the blessed IsAuthenticated) does NOT bless: recognition is exact Set membership, not a prefix match", async () => {
+    const blessed = await py("blessed.py",
+      `@api_view(["POST"])\n@permission_classes([IsAuthenticated])\ndef a(request):\n    return Response({})\n`);
+    const prefixed = await py("prefixed.py",
+      `@api_view(["POST"])\n@permission_classes([IsAuthenticatedOrReadOnly])\ndef b(request):\n    return Response({})\n`);
+    expect(extractPythonRoutesAst(blessed.tree!, blessed.relativePath)[0].hasAuth).toBe(true);
+    const b = extractPythonRoutesAst(prefixed.tree!, prefixed.relativePath)[0];
+    expect(b.hasAuth).toBe(false);
+    expect("authUnsureHook" in b).toBe(false);
+  });
+
   it("does not bless @api_view([\"POST\"]) with no permission_classes at all", async () => {
     const f = await py("views.py",
       `@api_view(["POST"])\n` +
@@ -2177,6 +2197,168 @@ const NEVER_FALSE_BLESS_SWEEP: Array<{
       { path: "/good", method: "POST", authed: false },
     ],
   },
+  // ── ADDENDUM Task 5: body-signature ambiguity fixtures ──
+  // Every new body-analysis branch, restated as a co-located mutating route with
+  // ground-truth authed:false. Visible non-enforcing bodies (email/scrub/log/
+  // header/pass/wrong-code/non-login-redirect) resolve flat not-auth; opaque and
+  // optionality bodies resolve unsure (hasAuth still false); the two Task 1
+  // tightenings (lone-403 does NOT bless, optional-veto beats a reject body) stay
+  // pinned. The single assertion below only checks the negatives never bless.
+  {
+    name: "verify-user-email-emails-only",
+    source:
+      `@app.before_request\ndef verify_user_email():\n    send_confirmation_email(g.user.email)\n    return None\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "protect-user-data-scrubs-only",
+    source:
+      `@app.before_request\ndef protect_user_data():\n    scrub_pii(record)\n    return None\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "log-only-auth-named-hook",
+    source:
+      `@app.before_request\ndef require_login():\n    logger.info("hit %s", request.path)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "header-set-only-hook",
+    source:
+      `@app.before_request\ndef verify_token():\n    response.headers["X-Frame-Options"] = "DENY"\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "pass-body-auth-named-hook",
+    source:
+      `@app.before_request\ndef require_login():\n    pass\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "abort-404-hook",
+    source:
+      `@app.before_request\ndef gate():\n    abort(404)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "abort-400-hook",
+    source:
+      `@app.before_request\ndef gate():\n    abort(400)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "abort-variable-hook", // opaque -> unsure, hasAuth still false
+    source:
+      `@app.before_request\ndef require_login():\n    abort(code_var)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "raise-valueerror-hook",
+    source:
+      `@app.before_request\ndef gate():\n    raise ValueError("bad")\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "redirect-non-login-hook",
+    source:
+      `@app.before_request\ndef gate():\n    return redirect("/checkout")\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "optional-veto-with-reject-body", // veto beats a real reject body
+    source:
+      `@app.before_request\ndef optional_authenticate():\n    token = request.headers.get("Authorization")\n    if token is None:\n        abort(401)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "opaque-auth-flavored-helper", // opaque -> unsure
+    source:
+      `@app.before_request\ndef require_login():\n    check_session()\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "call-form-imported-hook", // imported target -> unsure
+    source:
+      `from .auth import verify_session\napp.before_request(verify_session)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "attribute-target-hook", // Cls.method target -> unsure
+    source:
+      `app.before_request(AuthGate.check)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "attributive-collision-unresolvable", // verify_user_email + opaque call -> unsure
+    source:
+      `@app.before_request\ndef verify_user_email():\n    confirm(user)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "hook-helper-cycle", // a()->b()->a() terminates as none
+    source:
+      `def b():\n    a()\n\n\n@app.before_request\ndef a():\n    b()\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "errored-hook-dd", // the hook's decorated_definition errors -> invisible
+    source:
+      `@app.before_request\ndef gate():\n    x = = 1\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "csrf-protect-lone-403-hook", // lone abort(403), no credential read: never blesses
+    source:
+      `@app.before_request\ndef csrf_protect():\n    abort(403)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "maintenance-gate-lone-403-hook", // same 403-corroboration rule, feature gate shape
+    source:
+      `@app.before_request\ndef maintenance_gate():\n    abort(403)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "verify-jwt-optional-true-hook", // non-empty arg admits anonymous -> opaque/unsure
+    source:
+      `@app.before_request\ndef before():\n    verify_jwt_in_request(optional=True)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  // ACCEPTED OVER-BLESS (documented, NOT asserted authed:false): a boring `gate`
+  // hook that early-returns for public paths then abort(401)s reads as a verified
+  // reject and blesses its receiver's routes at RECEIVER granularity — including
+  // the path it actually exempts. The per-path exemption is invisible to a
+  // receiver-scoped analyzer; this is a known, accepted over-bless (route marked
+  // authed:true so the never-false-bless assertion below does NOT flag it), the
+  // one deliberate over-bless the body path carries. Recorded here so it is an
+  // explicit verdict, not a silent pass.
+  {
+    name: "partial-guard-public-exempt",
+    source:
+      `@app.before_request\ndef gate():\n    if request.path in PUBLIC:\n        return\n    abort(401)\n\n` +
+      `@app.route("/public", methods=["POST"])\ndef public():\n    return {}\n`,
+    groundTruth: [{ path: "/public", method: "POST", authed: true }],
+  },
 ];
 
 describe("never-false-bless sweep", () => {
@@ -2188,6 +2370,194 @@ describe("never-false-bless sweep", () => {
         const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
         expect(emitted?.hasAuth ?? false, `${entry.name}: ${gt.method} ${gt.path}`).toBe(false);
       }
+    }
+  });
+});
+
+// ─── ADDENDUM Task 5: the unsure-state sweep + structural invariants ─────────
+//
+// The machine statement of the THIRD output state. Every fixture whose ground
+// truth is "auth-flavored but statically unverifiable" must emit its route with
+// hasAuth false AND authUnsureHook === the exact hook name (deterministic
+// attribution: a fixture that stops being unsure fails loudly here instead of
+// silently degrading to flat copy). The cross-registry law then pins the whole
+// third state: unsure never blesses, blessed never hedges.
+interface UnsureEntry {
+  name: string;
+  source: string;
+  hook: string; // exact expected authUnsureHook
+  path: string;
+  method: string;
+}
+const UNSURE_ROUTE = `\n@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`;
+const UNSURE_SWEEP: UnsureEntry[] = [
+  {
+    name: "opaque-auth-flavored-helper",
+    source: `@app.before_request\ndef require_login():\n    check_session()\n` + UNSURE_ROUTE,
+    hook: "require_login", path: "/x", method: "POST",
+  },
+  {
+    name: "call-form-imported-hook",
+    source: `from .auth import verify_session\napp.before_request(verify_session)\n` + UNSURE_ROUTE,
+    hook: "verify_session", path: "/x", method: "POST",
+  },
+  {
+    name: "attribute-target-hook",
+    source: `app.before_request(AuthGate.check)\n` + UNSURE_ROUTE,
+    hook: "AuthGate.check", path: "/x", method: "POST",
+  },
+  {
+    name: "attributive-collision-unresolvable",
+    source: `@app.before_request\ndef verify_user_email():\n    confirm(user)\n` + UNSURE_ROUTE,
+    hook: "verify_user_email", path: "/x", method: "POST",
+  },
+  {
+    name: "verify-jwt-optional-true-hook",
+    source: `@app.before_request\ndef before():\n    verify_jwt_in_request(optional=True)\n` + UNSURE_ROUTE,
+    hook: "before", path: "/x", method: "POST",
+  },
+  {
+    name: "before-app-request-unsure",
+    source: `@bp.before_app_request\ndef require_login():\n    check_session()\n` + UNSURE_ROUTE,
+    hook: "require_login", path: "/x", method: "POST",
+  },
+  {
+    name: "abort-variable-hook",
+    source: `@app.before_request\ndef require_login():\n    abort(code_var)\n` + UNSURE_ROUTE,
+    hook: "require_login", path: "/x", method: "POST",
+  },
+];
+
+describe("unsure-state sweep + structural invariants (addendum Task 5)", () => {
+  it("every unsure fixture emits its route hasAuth false AND authUnsureHook equal to the expected hook", async () => {
+    for (const e of UNSURE_SWEEP) {
+      const f = await py(`unsuresweep/${e.name}.py`, e.source);
+      const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+      const r = routes.find((x) => x.path === e.path && x.method === e.method);
+      expect(r, e.name).toBeDefined();
+      expect(r!.hasAuth, e.name).toBe(false);
+      expect(r!.authUnsureHook, e.name).toBe(e.hook);
+    }
+  });
+
+  it("FileMiddleware honesty: no unsure fixture ever sets FileMiddleware.hasAuth", async () => {
+    for (const e of UNSURE_SWEEP) {
+      const f = await py(`unsuresweep/${e.name}.py`, e.source);
+      expect(extractPythonFileMiddlewareAst(f.tree!).hasAuth, e.name).toBe(false);
+    }
+  });
+
+  it("third-state law over BOTH registries: authUnsureHook implies hasAuth false, hasAuth true implies the key is absent", async () => {
+    const sources = [
+      ...NEVER_FALSE_BLESS_SWEEP.map((e) => ({ name: e.name, source: e.source })),
+      ...UNSURE_SWEEP.map((e) => ({ name: e.name, source: e.source })),
+    ];
+    for (const s of sources) {
+      const f = await py(`law/${s.name}.py`, s.source);
+      for (const r of extractPythonRoutesAst(f.tree!, f.relativePath)) {
+        if (r.authUnsureHook !== undefined) {
+          expect(r.hasAuth, `${s.name} ${r.method} ${r.path}`).toBe(false);
+        }
+        if (r.hasAuth === true) {
+          expect("authUnsureHook" in r, `${s.name} ${r.method} ${r.path}`).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("ambiguous-body generator sweep: every opaque/ambiguous body under an auth-named hook resolves not-auth or unsure, never a bless", async () => {
+    const bodies = [
+      "    abort(code_var)",
+      "    abort(404)",
+      "    abort(500)",
+      "    raise HTTPException(status_code=CODE)",
+      "    return redirect(url_for(page_var))",
+      "    raise SomeException()",
+      "    opaque_boring_call()",
+    ];
+    for (const body of bodies) {
+      const src =
+        `@app.before_request\ndef require_login():\n${body}\n\n` +
+        `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`;
+      const f = await py("ambig.py", src);
+      const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+      expect(routes[0]?.hasAuth ?? false, body).toBe(false);
+    }
+  });
+
+  it("methods=variable never GET-defaults: every statically unresolvable form resolves ALL, specifically never GET", async () => {
+    const FORMS: Array<[string, string]> = [
+      ["computed binary", `@app.route("/x", methods=BASE + EXTRA)\ndef h():\n    return {}\n`],
+      ["imported (no same-file assignment)", `@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["call rhs", `ALLOWED = get_methods()\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["identifier alias chain", `ALLOWED = OTHER\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["twice reassigned", `ALLOWED = ["GET"]\nALLOWED = ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["augmented", `ALLOWED = ["GET"]\nALLOWED += ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["conditional (not top-level)", `if PROD:\n    ALLOWED = ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["subscript element write", `ALLOWED = ["GET"]\nALLOWED[0] = "POST"\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["slice replacement", `ALLOWED = ["GET"]\nALLOWED[:] = ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["with-as binding", `ALLOWED = ["GET"]\nwith open("m") as ALLOWED:\n    pass\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["inline splat [*BASE]", `@app.route("/x", methods=[*BASE])\ndef h():\n    return {}\n`],
+      ["non-string element", `@app.route("/x", methods=[SOME_VERB])\ndef h():\n    return {}\n`],
+    ];
+    for (const [label, src] of FORMS) {
+      const f = await py("mvar.py", src);
+      const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+      expect(routes[0], label).toBeDefined();
+      expect(routes[0].method, label).toBe("ALL");
+      expect(routes[0].method, label).not.toBe("GET");
+    }
+  });
+
+  it("hasError gate: broken-parse and errored-hook fixtures emit nothing bless-able and nothing hedged", async () => {
+    const broken = [
+      `@app.post("/bad")\n@login_required\ndef bad()\n    return 1\n@app.post("/good")\ndef good():\n    return 2\n`,
+      `@app.post("/bad")\ndef bad():\n    x = = 1\n\n@app.post("/good")\ndef good():\n    return 2\n`,
+      `@app.before_request\ndef gate():\n    x = = 1\n\n@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    ];
+    for (const src of broken) {
+      const f = await py("broken.py", src);
+      for (const r of extractPythonRoutesAst(f.tree!, f.relativePath)) {
+        expect(r.hasAuth).toBe(false);
+        expect(r.authUnsureHook).toBeUndefined();
+      }
+    }
+  });
+
+  it("byte-identity: JS AST routes and Go regex routes never carry the Python-only authUnsureHook", async () => {
+    const jf = await fileWithTree(
+      "src/routes/x.ts",
+      `const router = express.Router();\nrouter.post("/x", requireAuth, (req, res) => res.json({}));\n`,
+      "typescript",
+    );
+    const jsRoute = extractJsRoutesAst(jf.tree!, jf.relativePath, undefined)[0];
+    expect("authUnsureHook" in jsRoute).toBe(false);
+    // Serialized shape unchanged (no stray hedge key leaks into the JS RouteInfo).
+    expect(JSON.stringify(jsRoute)).toBe(
+      `{"method":"POST","path":"/x","file":"src/routes/x.ts","line":2,"hasAuth":true,"hasValidation":false,"hasRateLimit":false,"hasErrorHandler":false}`,
+    );
+    // Go regex path (no tree): a fired auth finding renders the flat deviator
+    // copy, never the hedge — proving Go RouteInfos carry no authUnsureHook.
+    const goFile = (n: string, auth: boolean) => ({
+      relativePath: `gosrv/routes/${n}.go`,
+      language: "go" as const,
+      content:
+        `package routes\n${auth ? "// authMiddleware\n" : ""}func R${n}(e *echo.Echo) {\n${auth ? "\te.Use(authMiddleware)\n" : ""}\te.POST("/${n}", c${n})\n}\n`,
+      lineCount: 6,
+      tree: undefined,
+    });
+    const goCtx = {
+      files: [goFile("a", true), goFile("b", true), goFile("c", true), goFile("d", true), goFile("e", false)],
+      totalLines: 30,
+      dominantLanguage: "go",
+    };
+    const goAuth = securityConsistency
+      .detect(goCtx as any)
+      .filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.auth);
+    expect(goAuth.length).toBeGreaterThan(0);
+    for (const a of goAuth) {
+      const rendered = (a.recommendation + JSON.stringify(a.deviatingFiles)).toLowerCase();
+      expect(rendered).not.toContain("double check");
     }
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -2460,6 +2460,18 @@ const UNSURE_SWEEP: UnsureEntry[] = [
     source: `@app.before_request\ndef require_login():\n    abort(code_var)\n` + UNSURE_ROUTE,
     hook: "require_login", path: "/x", method: "POST",
   },
+  {
+    // ITEM 5: mixed scope. Both an app-scoped unsure hook AND a receiver-scoped
+    // unsure hook are present; the route on the named receiver must attribute the
+    // RECEIVER hook (verify_local), NOT the app-scoped one (verify_global). Pins
+    // the shipped receiver-first precedence.
+    name: "mixed-scope-receiver-first",
+    source:
+      `@app.before_request\ndef verify_global():\n    check_session()\n\n` +
+      `@orders_bp.before_request\ndef verify_local():\n    check_session()\n\n` +
+      `@orders_bp.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    hook: "verify_local", path: "/x", method: "POST",
+  },
 ];
 
 describe("unsure-state sweep + structural invariants (addendum Task 5)", () => {
@@ -2954,7 +2966,6 @@ describe("SECURITY_AST_PY export bag: body-signature lexicons", () => {
     const keys = Object.keys(SECURITY_AST_PY);
     for (const name of [
       "REJECT_STATUSES",
-      "REJECT_STATUS_BLESSES_ALONE",
       "AUTH_EXCEPTION_ALONE",
       "AUTH_EXCEPTION_TOPIC",
       "AUTH_EXCEPTION_KIND",

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -612,6 +612,22 @@ describe("methods= same-file variable resolution", () => {
     expect(routes[0].method).toBe("ALL");
   });
 
+  it("CONDITIONAL-REASSIGN TRAP: ALLOWED = [\"GET\"] then `if F: ALLOWED = [\"GET\", \"POST\"]` stays ALL, never GET (a nested module-scope reassign is a SECOND write that poisons the name, not an invisible one)", async () => {
+    const f = await py("conditional-reassign.py",
+      `ALLOWED = ["GET"]\nif FEATURE_WRITES:\n    ALLOWED = ["GET", "POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
+  it("TRY-REASSIGN TRAP: ALLOWED = [\"GET\"] then `try: ALLOWED = load()` stays ALL, never GET (a try-block rebind is a second write)", async () => {
+    const f = await py("try-reassign.py",
+      `ALLOWED = ["GET"]\ntry:\n    ALLOWED = load()\nexcept Exception:\n    pass\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
+    const routes = extractPythonRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("ALL");
+  });
+
   it("AUGMENTED-ASSIGNMENT TRAP: ALLOWED = [\"GET\"] then ALLOWED += [\"POST\"] stays ALL, never GET (a naive single-assignment scan would resolve GET and silently drop the POST route from the mutating vote)", async () => {
     const f = await py("augmented-trap.py",
       `ALLOWED = ["GET"]\nALLOWED += ["POST"]\n\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`);
@@ -2510,6 +2526,8 @@ describe("unsure-state sweep + structural invariants (addendum Task 5)", () => {
       ["call rhs", `ALLOWED = get_methods()\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
       ["identifier alias chain", `ALLOWED = OTHER\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
       ["twice reassigned", `ALLOWED = ["GET"]\nALLOWED = ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["conditional reassign (nested second write)", `ALLOWED = ["GET"]\nif F:\n    ALLOWED = ["GET", "POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
+      ["try-block reassign (nested second write)", `ALLOWED = ["GET"]\ntry:\n    ALLOWED = load()\nexcept Exception:\n    pass\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
       ["augmented", `ALLOWED = ["GET"]\nALLOWED += ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
       ["conditional (not top-level)", `if PROD:\n    ALLOWED = ["POST"]\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],
       ["subscript element write", `ALLOWED = ["GET"]\nALLOWED[0] = "POST"\n@app.route("/x", methods=ALLOWED)\ndef h():\n    return {}\n`],

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -2344,6 +2344,24 @@ const NEVER_FALSE_BLESS_SWEEP: Array<{
       `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
     groundTruth: [{ path: "/x", method: "POST", authed: false }],
   },
+  // CRITICAL 1: guarded-403 over-match. A 403 gated by a bare credential-ish name
+  // against a non-credential container (`"login" in request.path`) or an
+  // is-None on an attribute that merely contains the "user" segment
+  // (`request.user_agent`) is NOT a credential guard and must never bless.
+  {
+    name: "path-filter-403", // "login" in request.path is a path filter, not an auth guard
+    source:
+      `@app.before_request\ndef path_filter():\n    if "login" in request.path:\n        abort(403)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "user-agent-403", // request.user_agent is None reads no credential surface
+    source:
+      `@app.before_request\ndef user_agent_gate():\n    if request.user_agent is None:\n        abort(403)\n\n` +
+      `@app.route("/x", methods=["POST"])\ndef x():\n    return {}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
   // ACCEPTED OVER-BLESS (documented, NOT asserted authed:false): a boring `gate`
   // hook that early-returns for public paths then abort(401)s reads as a verified
   // reject and blesses its receiver's routes at RECEIVER granularity — including
@@ -3001,6 +3019,34 @@ describe("tightening 2: a 403 blesses only inside a credential-guarded reject", 
     const src = `def hook():\n    if request.user_agent:\n        abort(403)\n`;
     expect(await sig(src)).not.toBe("reject");
     expect(await sig(src)).toBe("none");
+  });
+
+  // CRITICAL 1 (false-bless): the guarded-403 bless gate must read a STRUCTURAL
+  // credential surface (a session/request .get call, a session/g subscript, a
+  // credential membership against session/request.session/request.headers, or an
+  // is-None test on a known credential surface), never a bare credential-ish name
+  // against ANY container. A path filter that 403s and a user-agent null-check
+  // that 403s must NOT drive a bless.
+  it("bodyAuthSignature: `if \"login\" in request.path: abort(403)` does NOT bless (string-in-ANY-container over-match closed)", async () => {
+    const src = `def hook():\n    if "login" in request.path:\n        abort(403)\n`;
+    expect(await sig(src)).not.toBe("reject");
+    expect(await sig(src)).toBe("opaque");
+  });
+
+  it("bodyAuthSignature: `if request.user_agent is None: abort(403)` does NOT bless (bare credential-segment name over-match closed)", async () => {
+    const src = `def hook():\n    if request.user_agent is None:\n        abort(403)\n`;
+    expect(await sig(src)).not.toBe("reject");
+    expect(await sig(src)).toBe("opaque");
+  });
+
+  it("bodyAuthSignature: `if not session.get(\"user\"): abort(403)` stays reject (structural .get guard on session)", async () => {
+    const src = `def hook():\n    if not session.get("user"):\n        abort(403)\n`;
+    expect(await sig(src)).toBe("reject");
+  });
+
+  it("bodyAuthSignature: `if request.headers.get(\"Authorization\") is None: abort(403)` stays reject (structural header .get guard)", async () => {
+    const src = `def hook():\n    if request.headers.get("Authorization") is None:\n        abort(403)\n`;
+    expect(await sig(src)).toBe("reject");
   });
 
   it("extractor: a CSRF gate that reads the session but 403s on csrf failure does NOT bless", async () => {

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -842,7 +842,7 @@ describe("Python AST wiring (Task 4)", () => {
   it("inheritance: a before_request auth hook blesses every route in its file (no auth finding among 4 hook-files)", async () => {
     const hookFile = (p: string) =>
       pyTree(`src/routes/${p}.py`,
-        `@app.before_request\ndef require_login():\n    return None\n\n` +
+        `@app.before_request\ndef require_login():\n    abort(401)\n\n` +
         `@app.post("/${p}")\ndef ${p}():\n    return {}\n`);
     const files = await Promise.all([hookFile("a"), hookFile("b"), hookFile("c"), hookFile("d")]);
     const ctx = { files, totalLines: files.reduce((s, f) => s + f.lineCount, 0), dominantLanguage: "typescript" };
@@ -852,7 +852,7 @@ describe("Python AST wiring (Task 4)", () => {
   it("inheritance: a file with no hook stays unauthed and is flagged among hook-blessed peers", async () => {
     const hookFile = (p: string) =>
       pyTree(`src/routes/${p}.py`,
-        `@app.before_request\ndef require_login():\n    return None\n\n` +
+        `@app.before_request\ndef require_login():\n    abort(401)\n\n` +
         `@app.post("/${p}")\ndef ${p}():\n    return {}\n`);
     const authed = await Promise.all([hookFile("a"), hookFile("b"), hookFile("c"), hookFile("d")]);
     const bare = await pyTree("src/routes/e.py", `@app.post("/e")\ndef e():\n    return {}\n`);
@@ -870,7 +870,7 @@ describe("Python AST wiring (Task 4)", () => {
     const mixed = await pyTree("src/routes/mixed.py",
       `@admin_bp.before_request\n` +      // L1
       `def require_login():\n` +          // L2
-      `    return None\n\n` +             // L3, L4
+      `    abort(401)\n\n` +              // L3, L4
       `@admin_bp.route("/users", methods=["POST"])\n` + // L5
       `def create_user():\n` +           // L6
       `    return {}\n\n` +               // L7, L8

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -4,6 +4,7 @@ import { runDriftDetection } from "../../../src/drift/index.js";
 import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
+import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
 import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
   SECURITY_SUPPRESSION_ANALYZER_ID,
@@ -1084,5 +1085,179 @@ describe("Task 6: python detect-level fallback and suppression pins", () => {
     const a = auth(findings);
     expect(a).toBeDefined();
     expect(a!.deviatingFiles.some((d: any) => d.evidence[0].line === 23)).toBe(true);
+  });
+});
+
+// ── Task 4: hedged "unsure, double check" finding copy ───────────────────────
+//
+// A route whose only auth gate is a before_request hook the body-signature
+// analyzer could not verify carries RouteInfo.authUnsureHook (Python AST only).
+// Such a route STAYS not-authed in every vote (hasAuth === false); Task 4 only
+// makes the FINDING COPY hedged so the user is told the exact hook to verify.
+// The hedge is auth-subcategory-only and never touches JS/TS/Go findings.
+describe("Task 4: hedged unsure-auth finding copy", () => {
+  const pyTree = (p: string, c: string) => fileWithTree(p, c, "python");
+  const auth = (findings: any[]) => findings.find((f) => f.subCategory === "Auth middleware");
+  const ctxOf = (files: any[]) => ({
+    files,
+    totalLines: files.reduce((s: number, f: any) => s + f.lineCount, 0),
+    dominantLanguage: "typescript",
+  });
+
+  // A confidently-authed peer route (per-route @requires_auth decorator).
+  const peerAuth = (n: number) =>
+    pyTree(`src/routes/p${n}.py`, `@app.post("/p${n}")\n@requires_auth\ndef p${n}():\n    return {}\n`);
+  // Call-form registration of an imported hook whose body cannot be resolved ->
+  // classifyHookAuth returns "unsure" -> authUnsureHook = "verify_session",
+  // hasAuth stays false. Route path is /x so the deviator reads "POST /x".
+  const unsureRoute = () =>
+    pyTree(
+      "src/routes/x.py",
+      `from auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`,
+    );
+
+  it("dominance vote: the unsure deviator is hedged and names the hook; the recommendation appends the double-check sentence", async () => {
+    const peers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
+    const unsure = await unsureRoute();
+    const findings = securityConsistency.detect(ctxOf([...peers, unsure]) as any);
+
+    // exactly one auth finding
+    expect(findings.filter((f: any) => f.subCategory === "Auth middleware")).toHaveLength(1);
+    const a = auth(findings)!;
+    // exactly one deviator (the unsure route), hedged with the EXACT string
+    expect(a.deviatingFiles).toHaveLength(1);
+    expect(a.deviatingFiles[0].detectedPattern).toBe(
+      "POST /x: auth not confirmed, double check hook 'verify_session'",
+    );
+    // recommendation ends with the appended hedge sentence naming the hook
+    expect(a.recommendation).toMatch(/\d+ of these could not be confirmed/);
+    expect(a.recommendation.toLowerCase()).toContain("double check");
+    expect(a.recommendation).toContain("verify_session");
+  });
+
+  it("confident sibling: a plainly-unauthed route (no unsure hook) keeps today's exact flat deviator byte-for-byte", async () => {
+    const peers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
+    const bare = await pyTree("src/routes/x.py", `@app.post("/x")\ndef x():\n    return {}\n`);
+    const a = auth(securityConsistency.detect(ctxOf([...peers, bare]) as any))!;
+    expect(a.deviatingFiles[0].detectedPattern).toBe("POST /x — no Auth middleware");
+    expect(a.recommendation).not.toMatch(/double check/i);
+    expect(a.recommendation).not.toContain("verify_session");
+  });
+
+  it("uniform-auth-gap: the unsure route is hedged; plainly-unauthed peers keep `— no auth`; counts/severity/confidence unchanged", async () => {
+    const flat = (n: number) => pyTree(`src/routes/f${n}.py`, `@app.post("/f${n}")\ndef f${n}():\n    return {}\n`);
+    const flats = await Promise.all([flat(1), flat(2), flat(3)]);
+    const unsure = await unsureRoute();
+    const machinery = await pyTree("src/lib/auth.py", `def login_required():\n    pass\n`);
+    const a = auth(securityConsistency.detect(ctxOf([...flats, unsure, machinery]) as any))!;
+
+    // headline / counts include the unsure route (still counted as not-authed)
+    expect(a.finding).toBe("4 mutating route(s) lack auth while the codebase uses auth elsewhere");
+    expect(a.confidence).toBe(0.6);
+    expect(a.severity).toBe("error");
+    const byPath = new Map(a.deviatingFiles.map((d: any) => [d.path, d.detectedPattern]));
+    expect(byPath.get("src/routes/x.py")).toBe(
+      "POST /x: auth not confirmed, double check hook 'verify_session'",
+    );
+    expect(byPath.get("src/routes/f1.py")).toBe("POST /f1 — no auth");
+    expect(byPath.get("src/routes/f2.py")).toBe("POST /f2 — no auth");
+    expect(a.recommendation.toLowerCase()).toContain("double check");
+    expect(a.recommendation).toContain("verify_session");
+  });
+
+  it("no cross-property leakage: validation and rate-limit findings never carry the hedge for an unsure-auth route", async () => {
+    const peer = (n: number) =>
+      pyTree(
+        `src/routes/p${n}.py`,
+        `@app.post("/p${n}")\n@requires_auth\n@validate_schema\n@limiter.limit("5/min")\ndef p${n}():\n    return {}\n`,
+      );
+    const peers = await Promise.all([peer(1), peer(2), peer(3), peer(4)]);
+    const unsure = await unsureRoute();
+    const findings = securityConsistency.detect(ctxOf([...peers, unsure]) as any);
+
+    const val = findings.find((f: any) => f.subCategory === "Input validation");
+    const rate = findings.find((f: any) => f.subCategory === "Rate limiting");
+    expect(val).toBeDefined();
+    expect(rate).toBeDefined();
+    for (const f of [val!, rate!]) {
+      for (const d of f.deviatingFiles) {
+        expect(d.detectedPattern).not.toMatch(/double check/i);
+        expect(d.detectedPattern).not.toContain("verify_session");
+      }
+      expect(f.recommendation).not.toMatch(/double check/i);
+      expect(f.recommendation).not.toContain("verify_session");
+    }
+    // sanity: the auth finding IS hedged in the same run
+    expect(auth(findings)!.deviatingFiles[0].detectedPattern).toContain("double check hook 'verify_session'");
+  });
+
+  it("field-absence contract: authUnsureHook key is ABSENT on confident py, unsure-but-authed py, and JS routes", async () => {
+    const conf = await pyTree("src/api/c.py", `@app.post("/c")\ndef c():\n    return {}\n`);
+    const confR = extractPythonRoutesAst(conf.tree!, "src/api/c.py");
+    expect("authUnsureHook" in confR[0]).toBe(false);
+
+    // A route that is authed per-route AND has an unsure hook in scope: hasAuth
+    // wins, so the field is omitted entirely (a blessed route never hedges).
+    const unsureAuthed = await pyTree(
+      "src/api/u.py",
+      `from auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/u")\n@requires_auth\ndef u():\n    return {}\n`,
+    );
+    const uR = extractPythonRoutesAst(unsureAuthed.tree!, "src/api/u.py");
+    expect(uR[0].hasAuth).toBe(true);
+    expect("authUnsureHook" in uR[0]).toBe(false);
+
+    // JS extractor never sets the field; the route serializes byte-identically
+    // to the pre-addendum shape.
+    const jsf = await fileWithTree("src/api/x.ts", `router.post("/danger", wipeEverything);\n`, "typescript");
+    const jsRoutes = extractJsRoutesAst(jsf.tree!, "src/api/x.ts", undefined);
+    expect("authUnsureHook" in jsRoutes[0]).toBe(false);
+    expect(JSON.stringify(jsRoutes[0])).toBe(
+      JSON.stringify({
+        method: "POST",
+        path: "/danger",
+        file: "src/api/x.ts",
+        line: 1,
+        hasAuth: false,
+        hasValidation: false,
+        hasRateLimit: false,
+        hasErrorHandler: false,
+      }),
+    );
+  });
+
+  it("copy hygiene: every NEW hedged string says `double check` and contains no em-dash or double hyphen", async () => {
+    const peers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
+    const unsure = await unsureRoute();
+    const a = auth(securityConsistency.detect(ctxOf([...peers, unsure]) as any))!;
+
+    // The hedged deviator is a NEW string.
+    const dev = a.deviatingFiles[0].detectedPattern;
+    expect(dev).toMatch(/double check/i);
+    expect(dev).not.toMatch(/—|--/);
+
+    // The appended hedge sentence is a NEW string (the shipped base
+    // recommendation before it is exempt and keeps its em-dash).
+    const m = a.recommendation.match(/\d+ of these could not be confirmed:.*$/);
+    expect(m).not.toBeNull();
+    expect(m![0]).toMatch(/double check/i);
+    expect(m![0]).not.toMatch(/—|--/);
+  });
+
+  it("vote-arithmetic invariance: hedging changes COPY only, never dominantCount/total/consistency/severity/confidence", async () => {
+    const hedgedPeers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
+    const unsure = await unsureRoute();
+    const hedged = auth(securityConsistency.detect(ctxOf([...hedgedPeers, unsure]) as any))!;
+
+    // Control: the SAME corpus with the hook-registration line deleted, so /x is
+    // a plainly-unauthed (confident) route instead of unsure.
+    const ctrlPeers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
+    const ctrl = await pyTree("src/routes/x.py", `@app.post("/x")\ndef x():\n    return {}\n`);
+    const flat = auth(securityConsistency.detect(ctxOf([...ctrlPeers, ctrl]) as any))!;
+
+    for (const k of ["dominantCount", "totalRelevantFiles", "consistencyScore", "severity", "confidence"] as const) {
+      expect((hedged as any)[k]).toBe((flat as any)[k]);
+    }
+    // The ONLY difference is the deviator copy (and the appended recommendation).
+    expect(hedged.deviatingFiles[0].detectedPattern).not.toBe(flat.deviatingFiles[0].detectedPattern);
   });
 });

--- a/test/unit/output/security-hedge-surfaces.test.ts
+++ b/test/unit/output/security-hedge-surfaces.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { inflateRawSync } from "zlib";
+import { securityConsistency } from "../../../src/drift/security-consistency.js";
+import { driftFindingToFinding } from "../../../src/drift/index.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+import type { ScanResult, Finding } from "../../../src/core/types.js";
+import type { DriftFinding } from "../../../src/drift/types.js";
+import { renderHtmlReport } from "../../../src/output/html.js";
+import { renderCsvReport } from "../../../src/output/csv.js";
+import { renderDocxReport } from "../../../src/output/docx.js";
+import { buildContextMarkdown } from "../../../src/output/context-md.js";
+import { renderJsonOutput } from "../../../src/output/terminal.js";
+import { buildFixPromptMarkdown } from "../../../src/output/fix-prompt.js";
+
+/**
+ * Cross-surface hedge plumbing (Task 4).
+ *
+ * The hedged deviator copy and the appended "Double check" recommendation live
+ * on the DriftFinding, which the HTML / CSV / DOCX / JSON renderers consume
+ * directly, so the hedge reaches them natively (no code change) — these tests
+ * pin that it does, and that a confident finding keeps the flat copy.
+ * context-md renders only the neutral aggregate headline (never the deviator
+ * copy or the recommendation), so it makes no confident per-route claim; its
+ * output is byte-identical whether or not the route is hedged — justified below.
+ */
+
+const pyTree = (p: string, c: string) => fileWithTree(p, c, "python");
+const ctxOf = (files: any[]) => ({
+  files,
+  totalLines: files.reduce((s: number, f: any) => s + f.lineCount, 0),
+  dominantLanguage: "typescript",
+});
+const peerAuth = (n: number) =>
+  pyTree(`src/routes/p${n}.py`, `@app.post("/p${n}")\n@requires_auth\ndef p${n}():\n    return {}\n`);
+
+async function driftFindingsFor(kind: "hedged" | "confident"): Promise<DriftFinding[]> {
+  const peers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
+  const x =
+    kind === "hedged"
+      ? await pyTree(
+          "src/routes/x.py",
+          `from auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`,
+        )
+      : await pyTree("src/routes/x.py", `@app.post("/x")\ndef x():\n    return {}\n`);
+  return securityConsistency.detect(ctxOf([...peers, x]) as any) as DriftFinding[];
+}
+
+function mkResult(driftFindings: DriftFinding[]): ScanResult {
+  const findings: Finding[] = driftFindings.map((d) => ({
+    ...driftFindingToFinding(d),
+    consistencyImpact: 5,
+  }));
+  const cat = { score: 15, maxScore: 20, locked: false, findingCount: 1, applicable: true };
+  const na = { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: false };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "python",
+      languageBreakdown: new Map(),
+      totalLines: 500,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 80,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "python",
+    scores: {
+      architecturalConsistency: { ...na },
+      redundancy: { ...na },
+      dependencyHealth: { ...na },
+      securityPosture: { ...cat },
+      intentClarity: { ...na },
+    },
+    hygieneScore: 0,
+    maxHygieneScore: 0,
+    hygieneScores: {},
+    findings,
+    driftFindings,
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+  } as unknown as ScanResult;
+}
+
+/** Inflate a DOCX (OOXML zip) and return word/document.xml as searchable text. */
+function docxDocumentXml(zip: Buffer): string {
+  let off = 0;
+  while (off + 4 <= zip.length && zip.readUInt32LE(off) === 0x04034b50) {
+    const compSize = zip.readUInt32LE(off + 18);
+    const nameLen = zip.readUInt16LE(off + 26);
+    const extraLen = zip.readUInt16LE(off + 28);
+    const name = zip.slice(off + 30, off + 30 + nameLen).toString("utf-8");
+    const dataStart = off + 30 + nameLen + extraLen;
+    const data = zip.slice(dataStart, dataStart + compSize);
+    if (name === "word/document.xml") return inflateRawSync(data).toString("utf-8");
+    off = dataStart + compSize;
+  }
+  throw new Error("word/document.xml not found in DOCX");
+}
+
+describe("security hedge reaches every render surface", () => {
+  it("HTML: hedged recommendation surfaces the hook + double check; confident stays flat", async () => {
+    const hedged = renderHtmlReport(mkResult(await driftFindingsFor("hedged")), "detailed");
+    expect(hedged).toContain("verify_session");
+    expect(hedged.toLowerCase()).toContain("double check");
+
+    const confident = renderHtmlReport(mkResult(await driftFindingsFor("confident")), "detailed");
+    expect(confident).not.toContain("verify_session");
+    expect(confident.toLowerCase()).not.toContain("double check");
+  });
+
+  it("CSV: hedged recommendation column carries the hedge; confident does not", async () => {
+    const hedged = renderCsvReport(mkResult(await driftFindingsFor("hedged")));
+    expect(hedged).toContain("verify_session");
+    expect(hedged.toLowerCase()).toContain("double check");
+
+    const confident = renderCsvReport(mkResult(await driftFindingsFor("confident")));
+    expect(confident).not.toContain("verify_session");
+    expect(confident.toLowerCase()).not.toContain("double check");
+  });
+
+  it("DOCX: hedged deviator pattern + recommendation carry the hedge; confident does not", async () => {
+    const hedged = docxDocumentXml(renderDocxReport(mkResult(await driftFindingsFor("hedged"))));
+    expect(hedged).toContain("verify_session");
+    expect(hedged.toLowerCase()).toContain("double check");
+
+    const confident = docxDocumentXml(renderDocxReport(mkResult(await driftFindingsFor("confident"))));
+    expect(confident).not.toContain("verify_session");
+    expect(confident.toLowerCase()).not.toContain("double check");
+  });
+
+  it("JSON: hedged deviator + recommendation are serialized; confident is flat", async () => {
+    const hedged = renderJsonOutput(mkResult(await driftFindingsFor("hedged")));
+    // The Finding metadata.recommendation carries the appended hedge sentence,
+    // and locations snippet falls back to the hedged detectedPattern.
+    expect(hedged).toContain("verify_session");
+    expect(hedged.toLowerCase()).toContain("double check");
+
+    const confident = renderJsonOutput(mkResult(await driftFindingsFor("confident")));
+    expect(confident).not.toContain("verify_session");
+    expect(confident.toLowerCase()).not.toContain("double check");
+  });
+
+  it("fix-prompt (Copy AI prompt): the recommendation carries the hedge into the AI prompt; confident does not", async () => {
+    const hedgedFinding: Finding = {
+      ...driftFindingToFinding((await driftFindingsFor("hedged"))[0]),
+      consistencyImpact: 5,
+    };
+    const hedged = buildFixPromptMarkdown(hedgedFinding);
+    expect(hedged).toContain("verify_session");
+    expect(hedged.toLowerCase()).toContain("double check");
+
+    const confidentFinding: Finding = {
+      ...driftFindingToFinding((await driftFindingsFor("confident"))[0]),
+      consistencyImpact: 5,
+    };
+    const confident = buildFixPromptMarkdown(confidentFinding);
+    expect(confident).not.toContain("verify_session");
+    expect(confident.toLowerCase()).not.toContain("double check");
+  });
+
+  it("context-md: renders only the accurate aggregate headline, so it makes no confident per-route claim (hedge-neutral, needs no change)", async () => {
+    const hedged = buildContextMarkdown(mkResult(await driftFindingsFor("hedged")), "proj");
+    const confident = buildContextMarkdown(mkResult(await driftFindingsFor("confident")), "proj");
+    // Accurate, neutral headline in both (the unsure route legitimately counts as
+    // not-authed). context-md renders neither the deviator copy nor the
+    // recommendation, so it carries NO hedge tokens and NO flat confident
+    // consequence — there is no false per-route claim to correct.
+    for (const md of [hedged, confident]) {
+      expect(md).toContain("Auth middleware missing on 1 of 5 routes");
+      expect(md).not.toContain("Unprotected routes may be exposed in production");
+      expect(md).not.toContain("verify_session");
+      expect(md.toLowerCase()).not.toContain("double check");
+    }
+  });
+});

--- a/test/unit/output/security-hedge-surfaces.test.ts
+++ b/test/unit/output/security-hedge-surfaces.test.ts
@@ -11,6 +11,7 @@ import { renderDocxReport } from "../../../src/output/docx.js";
 import { buildContextMarkdown } from "../../../src/output/context-md.js";
 import { renderJsonOutput } from "../../../src/output/terminal.js";
 import { buildFixPromptMarkdown } from "../../../src/output/fix-prompt.js";
+import { toCategoryVote } from "../../../src/core/baseline.js";
 
 /**
  * Cross-surface hedge plumbing (Task 4).
@@ -160,6 +161,21 @@ describe("security hedge reaches every render surface", () => {
     const confident = buildFixPromptMarkdown(confidentFinding);
     expect(confident).not.toContain("verify_session");
     expect(confident.toLowerCase()).not.toContain("double check");
+  });
+
+  it("MCP baseline: the persisted CategoryVote deviator carries the hedged detectedPattern for an unsure route; a confident one stays flat", async () => {
+    // toCategoryVote copies deviatingFiles[].detectedPattern verbatim into the
+    // persisted baseline deviators the MCP server reads, so the hedge reaches MCP
+    // tool output natively. This pins that surface (closes the sweep gap).
+    const hedgedVote = toCategoryVote((await driftFindingsFor("hedged"))[0]);
+    const hedgedPatterns = hedgedVote.deviators.map((d) => d.detectedPattern).join(" ");
+    expect(hedgedPatterns).toContain("verify_session");
+    expect(hedgedPatterns.toLowerCase()).toContain("double check");
+
+    const confidentVote = toCategoryVote((await driftFindingsFor("confident"))[0]);
+    const confidentPatterns = confidentVote.deviators.map((d) => d.detectedPattern).join(" ");
+    expect(confidentPatterns).not.toContain("verify_session");
+    expect(confidentPatterns.toLowerCase()).not.toContain("double check");
   });
 
   it("context-md: renders only the accurate aggregate headline, so it makes no confident per-route claim (hedge-neutral, needs no change)", async () => {

--- a/test/unit/output/terminal-hedge.test.ts
+++ b/test/unit/output/terminal-hedge.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { renderTerminalOutput } from "../../../src/output/terminal.js";
+import type { ScanResult, Finding } from "../../../src/core/types.js";
+
+/**
+ * Terminal hedge visibility (Task 4, gate item 5).
+ *
+ * The terminal renders neither `detectedPattern` nor `recommendation` for drift
+ * findings directly: `findingConsequence` returns the hardcoded confident
+ * "Unprotected routes may be exposed in production" for every security finding.
+ * For a route whose auth could not be verified (the Python body-signature
+ * analyzer marked it "unsure"), that flat confident consequence is a FALSE
+ * claim. These tests pin that the terminal surfaces the hedge (the hook name and
+ * "double check") for a hedged finding and keeps the confident output unchanged.
+ */
+
+const emptyCat = { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+
+function mkResult(findings: Finding[]): ScanResult {
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "python",
+      languageBreakdown: new Map(),
+      totalLines: 500,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 82,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "python",
+    scores: {
+      architecturalConsistency: { ...emptyCat, applicable: false },
+      redundancy: { ...emptyCat, applicable: false },
+      dependencyHealth: { ...emptyCat, applicable: false },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat, applicable: false },
+    },
+    hygieneScore: 0,
+    maxHygieneScore: 0,
+    hygieneScores: {},
+    findings,
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+  } as unknown as ScanResult;
+}
+
+function securityFinding(recommendation: string): Finding {
+  return {
+    analyzerId: "drift-security_posture",
+    severity: "warning",
+    message: "DRIFT: Auth middleware missing on 1 of 5 routes (after router-scope middleware inheritance)",
+    locations: [{ file: "src/routes/x.py", line: 4 }],
+    consistencyImpact: 5,
+    tags: ["drift", "security_posture", "cross-file"],
+    metadata: {
+      dominantPattern: "Auth middleware applied",
+      dominantFiles: ["src/routes/p1.py"],
+      recommendation,
+    },
+  } as unknown as Finding;
+}
+
+const HEDGED_REC =
+  "4 of 5 routes have Auth middleware. Review 1 unprotected routes — apply per-route middleware or move them under a router that does. " +
+  "1 of these could not be confirmed: a before_request hook (verify_session) may authenticate them but its body could not be verified. " +
+  "Double check those hooks before treating the routes as unauthenticated.";
+
+const CONFIDENT_REC =
+  "4 of 5 routes have Auth middleware. Review 1 unprotected routes — apply per-route middleware or move them under a router that does.";
+
+describe("terminal hedge visibility", () => {
+  it("hedged security finding: no flat confident consequence; surfaces the hook name and 'double check'", () => {
+    const out = renderTerminalOutput(mkResult([securityFinding(HEDGED_REC)]));
+    // The hardcoded confident consequence must NOT be the takeaway for an unsure route.
+    expect(out).not.toContain("Unprotected routes may be exposed in production");
+    // The hedge MUST reach the user: the exact hook and "double check".
+    expect(out).toContain("verify_session");
+    expect(out.toLowerCase()).toContain("double check");
+  });
+
+  it("confident security finding (sibling): keeps the flat consequence and shows no hedge", () => {
+    const out = renderTerminalOutput(mkResult([securityFinding(CONFIDENT_REC)]));
+    expect(out).toContain("Unprotected routes may be exposed in production");
+    expect(out.toLowerCase()).not.toContain("double check");
+    expect(out).not.toContain("verify_session");
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,47 @@
 # CLI backlog
 
+- **Python hook body: `Depends`-target body DEMOTION.** The additive Depends
+  same-file body path (`callsWithAuthDependency`, `security-ast-python.ts`) only
+  ever ADDS a bless when a boring-named dependency's visible body raises a
+  verified reject; it never DEMOTES a name-hit dependency whose visible body is
+  plainly non-enforcing (the mirror of the `verify_user_email` fix on the hook
+  path). Symmetry with the before_request path would close a residual name-only
+  bless for Depends. Left additive-only for now (demotion could hide a real
+  reject reached via a shape the scanner does not model).
+
+- **`add_middleware` class-body analysis.** `app.add_middleware(X)` blesses on
+  the CLASS NAME segments only (`MIDDLEWARE_AUTH_SEGMENTS`); it does not read the
+  middleware class body (its `__call__`/`dispatch`) to confirm or deny auth. A
+  body-first pass (as done for before_request hooks) would let a boring-named
+  middleware whose dispatch 401s bless, and stop an auth-named one whose body is
+  visibly non-enforcing. Out of scope for this addendum.
+
+- **`@api_view(SOME_VAR)` same-file methods resolution.** Upgrade 2 resolves a
+  Flask `methods=VAR` kwarg through a same-file literal (`collectMethodsVars` +
+  `methodFromLiteral`), but `asApiViewDecorator` deliberately does NOT: an
+  `@api_view(METHODS)` list behind a variable stays ALL even when METHODS has a
+  same-file literal assignment. Flipping it is a two-line owner-gated change
+  (reuse `methodFromLiteral` against the same census); scoped out because the
+  approved Upgrade 2 names the `methods=` kwarg only.
+
+- **Poison-census residual: `match`/`case` capture rebinding a `methods=` var.**
+  `collectPoisonedMethodsNames` covers augmented/subscript/slice/pattern-unpack/
+  `global`/walrus/for-target/`with-as`/mutating-call writes, but a `case`
+  capture pattern that rebinds a module-level name used as `methods=VAR`
+  (`match x:\n    case [*ALLOWED]:`) is not in the census. Astronomically rare
+  (a match capture reusing a route's methods variable name) and only ever
+  under-poisons toward a false GET-drop in that one shape; out of scope, safe to
+  defer.
+
+- **`context-md.ts` does not surface the auth hedge.** `buildContextMarkdown`
+  renders only the neutral aggregate headline (`Auth middleware missing on N of
+  M routes`), never the per-route deviator copy or the recommendation, so an
+  UNSURE (hedged) route is not named in the committed `.vibedrift/context.md`.
+  Safe today because context-md makes no confident per-route claim (see
+  `test/unit/output/security-hedge-surfaces.test.ts`); a follow-up could add a
+  short "N routes could not be confirmed (hooks: ...)" line so the AI-agent
+  context file carries the same hedge the report surfaces do.
+
 - **Landing-page release notes for SCORING_VERSION v10 (cross-repo).** The
   security release bumps `SCORING_VERSION` v9 -> v10 (Express `.all()` + Flask
   `@app.route(methods=[...])` mutating routes now enter the security auth vote,

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,12 @@
 # CLI backlog
 
+- **Terminal hedge detection is a prose-regex.** The terminal decides a security
+  finding is hedged by testing its recommendation text with `/Double check/`
+  (`src/output/terminal.ts`), which is brittle copy coupling: a wording change to
+  the hedge sentence silently drops the hedge from the terminal. A dedicated
+  finding-metadata flag (a boolean the renderers read instead of the prose) would
+  be more robust. Parked.
+
 - **Python hook body: `Depends`-target body DEMOTION.** The additive Depends
   same-file body path (`callsWithAuthDependency`, `security-ast-python.ts`) only
   ever ADDS a bless when a boring-named dependency's visible body raises a


### PR DESCRIPTION
## What this does

Makes the Python auth extractor read hook **behavior**, not just names. Before, a route was judged protected or open by pattern-matching function names (`login_required`, `verify_user`, ...), which both missed real auth and, worse, blessed hooks that only look auth-ish. This change reads the hook's body and decides from what it actually does, and introduces an explicit third state for the cases we cannot resolve.

Builds on the Python AST extractor from #42.

## The three outcomes

- **Protected**: the hook body performs a real auth rejection, an `abort(401/403)` guarded by a credential/session read, `raise HTTPException(status_code=401)`, a redirect to a login route, or a recognized auth primitive.
- **Open**: the body is fully visible and does none of those. This closes the main false-bless, a hook named `verify_user_email` that only sends a confirmation email no longer marks routes protected.
- **Unsure**: the body cannot be resolved (an opaque helper, an imported hook, no visible body). The route is treated as not protected and still flagged, but with hedged copy that names the hook and tells the reader exactly what to double check, rather than a flat "no auth" claim that might be wrong.

## Also included

- Flask `methods=VAR` is resolved when the variable is a single same-file literal list/tuple/set; any reassigned, mutated, computed, or imported variable stays fully in the mutating-route check rather than being dropped.
- `IsAdminUser` is recognized as authentication (admin implies authenticated).
- The hedged "double check" copy is plumbed through every output surface (terminal, HTML, CSV, DOCX, JSON, fix prompts).

## Design principle

The extractor never marks an unauthed route as authed. Every ambiguous or unrecognized case resolves toward not protected, an unsure hook produces a hedged finding, and an unreadable method set keeps the route in the security check. A false "open" is a reviewable nuisance, a false "protected" hides a real gap.

## Safety and compatibility

- The unsure marker is an additive, Python-only field. JavaScript, TypeScript, and Go findings render exactly as before (pinned by byte-identity tests).
- The route auth vote and score are unchanged; unsure routes count as not protected exactly as they did.
- No em-dashes or double hyphens in user-facing strings.
- Covered by unit tests, an adversarial never-false-bless sweep, and precision/recall calibration scenarios, and spot-checked against real Flask and FastAPI apps with no false "protected" verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
