### PR TITLE
Security Consistency: Go AST route and body-first auth extraction

### DIFF
--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -1,0 +1,372 @@
+/**
+ * AST-based route extraction for Go (Gin, Echo, chi), used by
+ * security-consistency.ts in place of the regex line-window extractor
+ * whenever a parsed tree is available and clean. Mirrors the shipped JS/TS
+ * design in src/drift/security-ast.ts and the Python port in
+ * src/drift/security-ast-python.ts.
+ *
+ * A find-replace port from either sibling module fails silently on five Go
+ * grammar traps:
+ *   1. Both sides of `:=` and `=` are `expression_list` WRAPPERS, even for a
+ *      single name/value pair (`api := r.Group("/api")` has a one-element
+ *      `expression_list` on each side, not a bare `identifier`/`call_expression`
+ *      the way Python's `assignment` does). `var name = value` is different
+ *      again: `var_spec` exposes `name` and `value` directly, and `value` is
+ *      itself an `expression_list` needing `namedChild(0)`.
+ *   2. chi closure params shadow: `r.Route("/admin", func(r chi.Router) {
+ *      r.Post("/users", h) })` rebinds `r` to a NEW router value inside the
+ *      closure with the SAME NAME as the outer receiver. A scope-blind walk
+ *      that resolves receivers purely by name (as this module does) gets the
+ *      right answer here by coincidence of naming, but the closure-parameter
+ *      case has to be handled on its own terms for the (more common) case
+ *      where the inner parameter has a DIFFERENT name than the outer router.
+ *   3. `With(...)` and `Subrouter()` are themselves `call_expression`
+ *      OPERANDS, not identifiers: `r.With(auth).Post(...)` has a
+ *      `call_expression` (`r.With(auth)`) sitting where a plain receiver
+ *      identifier normally would; `r.PathPrefix("/x").Subrouter()` nests a
+ *      second `call_expression` one level deeper still. Both need their own
+ *      unwrapping, not a generic "receiver is always identifier/selector"
+ *      assumption.
+ *   4. Chained calls double-visit under a naive walk: `r.With(auth).Post(...)`
+ *      is ONE `call_expression` for `.Post(...)` whose `function` operand is
+ *      ANOTHER `call_expression` for `.With(auth)`. `descendantsOfType`
+ *      surfaces BOTH nodes. This is harmless here because `With` is never in
+ *      `VERB_FIELDS`, but a Gorilla-style builder chain
+ *      (`r.Methods("POST").Path("/x").HandlerFunc(h)`, out of scope for this
+ *      task) has THREE nested `call_expression`s under one statement; whoever
+ *      wires that chain up in a later task must resolve it from the
+ *      OUTERMOST call only, or the same registration double-counts.
+ *   5. Go 1.22's `net/http` added verb-prefixed pattern strings
+ *      (`http.HandleFunc("POST /orders", h)`, `mux.HandleFunc("GET /x", h)`):
+ *      the method lives INSIDE the path string, not in the call's field name.
+ *      None of this module's forms parse a leading verb out of a path string;
+ *      that is entirely separate machinery, deliberately not built here.
+ *
+ * INVARIANT SCOPE: the never-false-bless guarantee (never mark an unauthed
+ * route as authed) holds on THIS AST path only. A file with a parse error
+ * anywhere (`tree.rootNode.hasError`) is routed whole to the existing regex
+ * extractor, which keeps its own legacy behavior unchanged. Even on a clean
+ * tree, this module never emits `hasAuth: true` in this task: auth
+ * recognition is Task 3, so every route below carries `hasAuth: false`
+ * unconditionally, which can only under-report auth, never over-report it.
+ *
+ * KNOWN FALSE-BLESS EXPOSURE (carried forward from the Integration contract,
+ * not yet reachable from this module since `hasAuth` is hard-coded false
+ * here): once Task 3 lands per-route auth recognition, a handful of
+ * recognized-but-non-enforcing names are expected to remain a residual
+ * exposure by design (matching the Python module's own documented
+ * exposures): a custom type or middleware literally named `AuthContext`
+ * that carries identity without enforcing it, an `apiKeyRotator` helper
+ * that manages keys without gating a request, and single-argument DI
+ * constructors whose one parameter happens to read as auth-flavored
+ * without the constructor itself checking anything. None of these can
+ * fire in Task 1: they are named here so the eventual auth pass documents
+ * the same exposure the Python module already accepted, rather than
+ * silently reintroducing it.
+ *
+ * PINNED RECALL GAPS (measured, never a false-bless; each is a route this
+ * module will not find rather than one it misclassifies):
+ *   - Gorilla mux route-builder chains (`r.Methods("POST").Path("/x").
+ *     HandlerFunc(h)`): no verb-selector field, out of scope until a later
+ *     task builds the chain-resolution machinery noted in grammar trap 4.
+ *   - Embedded-engine method receivers: `type Server struct { *gin.Engine }`
+ *     then `func (s *Server) routes() { s.POST("/orders", h) }`. The
+ *     receiver `s` is a bare identifier that fails both the constructor gate
+ *     (no `s := ctor()` assignment exists) and the naming convention, and
+ *     this module does not read struct field lists to learn that `s`
+ *     transitively embeds a known router type. The line-window regex
+ *     extractor DOES see this route (it is a plain `X.POST(` match), so it
+ *     shows up as a classified drop in the AST-vs-regex diff, not a silent
+ *     one.
+ *   - Conditional route registration guarded by a runtime flag (`if
+ *     featureFlag { r.POST(...) }`): the route is extracted unconditionally,
+ *     which is a recall-direction (never a bless-direction) simplification,
+ *     consistent with how the JS/TS and Python siblings treat conditional
+ *     registration.
+ *
+ * OPEN QUESTIONS FOR SIGN-OFF (deliberate divergences the eventual full
+ * module will carry; most are not reachable from Task 1's code, since this
+ * task only recognizes routes and never resolves methods, auth, or
+ * middleware scope; named here as a preview so each lands as an explicit,
+ * reviewed decision rather than an implicit one when its owning task ships):
+ *   - ALL-on-unresolvable methods (Task 2): a Go 1.22 pattern string or a
+ *     `Handle`/`HandleFunc` call whose method cannot be read statically
+ *     resolves to "ALL" rather than defaulting to GET, mirroring the
+ *     Python module's `methods=` divergence, so the route stays in the
+ *     mutating vote instead of silently dropping out of it.
+ *   - HEAD/OPTIONS exclusion (this task, and carried through chain,
+ *     verb-first, and Go 1.22 forms in later tasks): neither verb is ever
+ *     mutating, so omitting them from `VERB_FIELDS` is bless-safe by
+ *     construction, mirroring Phase A's exclusion of `@router.websocket`.
+ *   - Dropped in-body validation scanning, position-aware `Use` resolution,
+ *     conditional-`Use` skip, config-not-vetoed, and an extended veto set
+ *     (Task 4 middleware scope): none of this module's Task-1 code reads
+ *     middleware at all yet.
+ *   - Arity-1 wrap recursion and pure-selector name resolution for auth
+ *     helpers (Task 3): out of scope; `hasAuth` is unconditionally false.
+ *   - Segment-matched validation/rate-limit lanes (Task 4): out of scope;
+ *     `hasValidation`/`hasRateLimit` are unconditionally false.
+ *
+ * Route-registration scope for THIS task: Gin/Echo/chi verb-selector calls
+ * (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`Any`) on a structurally- or
+ * conventionally-resolved receiver, plus chi's `With(...)` chain receiver
+ * (auth recognition on the `With` argument is Task 3) and `Route(...)`
+ * closure-parameter routers. `Handle`/`HandleFunc`, Gorilla `Methods()`
+ * chains, and Go 1.22 verb-in-string patterns are Task 2.
+ */
+
+import type { Tree, SyntaxNode } from "../core/types.js";
+import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
+
+// Verbs a Gin/Echo/chi verb-selector call may register, keyed by the exact
+// field-name spelling each framework uses: Gin and Echo use ALL-CAPS
+// (`r.GET`, `e.POST`), chi and fiber use Capitalized-only (`r.Get`,
+// `r.Post`). Both casings map to the same canonical uppercase verb. A fully
+// lowercase field (`api.post(...)`) matches NEITHER key and is a different,
+// unrecognized selector, not the same call spelled differently (mirrors
+// HEAD/OPTIONS staying out of scope below rather than being silently
+// normalized in).
+const VERB_FIELDS = new Map([
+  ["GET", "GET"], ["Get", "GET"],
+  ["POST", "POST"], ["Post", "POST"],
+  ["PUT", "PUT"], ["Put", "PUT"],
+  ["PATCH", "PATCH"], ["Patch", "PATCH"],
+  ["DELETE", "DELETE"], ["Delete", "DELETE"],
+]);
+// `Any` (Gin/Echo: register the path for every method) resolves to the same
+// "ALL" sentinel Express's `.all()` uses, so it participates in the mutating
+// vote alongside a real mutating verb.
+const ANY_FIELDS = new Set(["Any"]);
+// Verbs a resolved route may carry (VERB_FIELDS' values, plus the ALL
+// sentinel ANY_FIELDS resolves to). HEAD and OPTIONS are deliberately absent:
+// neither is ever mutating, so their exclusion can only under-report, never
+// bless (see the OPEN QUESTIONS block above).
+const HTTP_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "ALL"]);
+const MUTATING_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE", "ALL"]);
+
+// Receivers that plausibly register routes, by naming convention alone
+// (structural resolution via GO_ROUTER_CONSTRUCTORS below is checked first;
+// this is the fallback for the dominant real-world layout where the router
+// is built in a different file, e.g. main.go, and only passed into this one
+// as a function parameter with no in-file constructor call to key off of).
+// ASCII only, whole-name match: a unicode or unconventional receiver name is
+// a recognition miss, never a bless.
+const GO_ROUTER_RECEIVER =
+  /^(?:r|router|e|g|grp|group|app|application|server|srv|engine|api|mux|v\d+|[a-zA-Z][a-zA-Z0-9]*(?:Router|Group|Mux|Engine))$/;
+// Structural receiver resolution: an identifier assigned in-file from one of
+// these constructors is a route receiver regardless of spelling (`zzz :=
+// gin.New()` makes `zzz.POST` extractable even though "zzz" fails
+// GO_ROUTER_RECEIVER by convention), matching the shipped Python module's
+// Blueprint()/APIRouter() structural resolution. Keyed as "pkg.Ctor" against
+// the literal package-qualifier text used at the call site: an import
+// aliased away from the framework's usual package name (`gorillamux
+// "github.com/gorilla/mux"` instead of the default `mux` alias) will not
+// match here, a measured recall gap (see PINNED RECALL GAPS above; that gap
+// is moot for Gorilla specifically since mux.NewRouter is not itself in this
+// set, Gorilla method-chain semantics being out of scope until a later
+// task).
+const GO_ROUTER_CONSTRUCTORS = new Set(["gin.Default", "gin.New", "echo.New", "chi.NewRouter"]);
+// Field name for a scoped-group derivation (`api := r.Group("/api")`): the
+// receiver on the left becomes a router in its own right.
+const GROUP_FIELD = "Group";
+// Field name for a Gorilla-style subrouter derivation
+// (`s := r.PathPrefix("/api").Subrouter()`): same idea as GROUP_FIELD, one
+// call_expression deeper (PathPrefix(...) sits where GROUP_FIELD's operand
+// normally would).
+const SUBROUTER_FIELD = "Subrouter";
+// Field names whose LAST positional func_literal argument introduces a new
+// router-scoped identifier via its own parameter (chi's `r.Route("/admin",
+// func(sub chi.Router) { ... })`): "sub" is a router inside that closure's
+// body, gate-only (name-level) in this task; middleware-scope use of the
+// closure BODY node itself is Task 4.
+const CLOSURE_ROUTE_FIELDS = new Set(["Route"]);
+
+export const SECURITY_AST_GO = {
+  VERB_FIELDS, ANY_FIELDS, HTTP_VERBS, MUTATING_VERBS,
+  GO_ROUTER_RECEIVER, GO_ROUTER_CONSTRUCTORS,
+  GROUP_FIELD, SUBROUTER_FIELD, CLOSURE_ROUTE_FIELDS,
+};
+
+/** Path/verb text of a Go string literal. BOTH literal kinds include their
+ *  single-character delimiters in .text and this grammar generation has NO
+ *  *_content named children, so slice(1, -1) is correct for both. Escapes stay
+ *  raw (never unescaped): the path is only used for equality/exclusion.
+ *  Anything else (identifier, binary_expression, call) returns null:
+ *  statically unresolvable, the route is skipped (a miss is safe, a guessed
+ *  path is not). */
+function goStringText(node: SyntaxNode): string | null {
+  if (node.type !== "interpreted_string_literal" && node.type !== "raw_string_literal") return null;
+  return node.text.slice(1, -1);
+}
+
+/** Receiver name of X.METHOD(...): identifier text for a plain receiver, the
+ *  chain's LAST field name for struct-field receivers (s.router.POST gates on
+ *  "router"), and the With-chain's own receiver for chi
+ *  r.With(auth).Post(...) (call_expression operand). Anything else is null:
+ *  no gate pass, no route (never a bless). */
+function goReceiverName(operand: SyntaxNode | null): string | null {
+  if (!operand) return null;
+  if (operand.type === "identifier") return operand.text;
+  if (operand.type === "selector_expression") {
+    return operand.childForFieldName("field")?.text ?? null;
+  }
+  if (operand.type === "call_expression") {
+    const fn = operand.childForFieldName("function");
+    if (fn?.type === "selector_expression" && fn.childForFieldName("field")?.text === "With") {
+      return goReceiverName(fn.childForFieldName("operand"));
+    }
+  }
+  return null;
+}
+
+/** True when node or any ancestor BELOW source_file carries a parse error.
+ *  Probe-verified hazard: error recovery swallows a later, syntactically valid
+ *  registration into a broken call's argument_list as a clean-looking nested
+ *  call_expression; extracting from that garbage context could attribute the
+ *  route to the wrong receiver/scope. The walk stops below source_file so a
+ *  file-level error in a SIBLING function does not suppress clean functions
+ *  (per-construct surgical skip; the whole-file dispatch gate is separate). */
+function inErroredContext(node: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = node;
+  while (cur && cur.type !== "source_file") {
+    if (cur.hasError) return true;
+    cur = cur.parent;
+  }
+  return false;
+}
+
+/** Identifiers assigned in-file from a router constructor (gin.Default(),
+ *  chi.NewRouter(), ...) or derived via X.Group(...) / X.PathPrefix().Subrouter()
+ *  on an already-resolved base, across ALL THREE declaration forms. TRAP: both
+ *  sides of := and = are expression_list WRAPPERS (unlike Python assignment);
+ *  var_spec exposes name/value directly. Derived names resolve to a bounded
+ *  fixpoint so r -> api -> v1 chains work and pathological chains terminate. */
+function collectGoRouterNames(root: SyntaxNode): Set<string> {
+  const names = new Set<string>();
+  const bindings: Array<{ name: string; rhs: SyntaxNode }> = [];
+
+  const record = (nameNode: SyntaxNode | null, valueNode: SyntaxNode | null) => {
+    if (!nameNode || nameNode.type !== "identifier" || !valueNode) return;
+    if (valueNode.type !== "call_expression") return;
+    bindings.push({ name: nameNode.text, rhs: valueNode });
+  };
+  for (const decl of root.descendantsOfType(["short_var_declaration", "assignment_statement"])) {
+    if (!decl) continue;
+    const left = decl.childForFieldName("left");
+    const right = decl.childForFieldName("right");
+    if (left?.type !== "expression_list" || right?.type !== "expression_list") continue;
+    const lc = left.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    const rc = right.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    // Positional pairing covers a, b := x, y; r, err := f() records nothing useful.
+    for (let i = 0; i < lc.length && i < rc.length; i++) record(lc[i], rc[i]);
+  }
+  for (const spec of root.descendantsOfType("var_spec")) {
+    if (!spec) continue;
+    const value = spec.childForFieldName("value"); // expression_list
+    record(spec.childForFieldName("name"), value?.namedChild(0) ?? null);
+  }
+
+  /** "pkg.Ctor" for a constructor call, or null. */
+  const ctorKey = (call: SyntaxNode): string | null => {
+    const fn = call.childForFieldName("function");
+    if (fn?.type !== "selector_expression") return null;
+    const pkg = fn.childForFieldName("operand");
+    const field = fn.childForFieldName("field");
+    if (pkg?.type !== "identifier" || !field) return null;
+    return `${pkg.text}.${field.text}`;
+  };
+  /** Base receiver of X.Group(...) or X.PathPrefix(...).Subrouter(), or null. */
+  const derivedBase = (call: SyntaxNode): string | null => {
+    const fn = call.childForFieldName("function");
+    if (fn?.type !== "selector_expression") return null;
+    const field = fn.childForFieldName("field")?.text;
+    if (field === GROUP_FIELD) return goReceiverName(fn.childForFieldName("operand"));
+    if (field === SUBROUTER_FIELD) {
+      const inner = fn.childForFieldName("operand"); // the PathPrefix(...) call
+      if (inner?.type !== "call_expression") return null;
+      const innerFn = inner.childForFieldName("function");
+      if (innerFn?.type !== "selector_expression") return null;
+      return goReceiverName(innerFn.childForFieldName("operand"));
+    }
+    return null;
+  };
+
+  for (const b of bindings) {
+    const key = ctorKey(b.rhs);
+    if (key && GO_ROUTER_CONSTRUCTORS.has(key)) names.add(b.name);
+  }
+  // Derivations resolve against constructor-assigned AND convention-gated bases,
+  // to a bounded fixpoint (chained groups; cap terminates pathological input).
+  for (let pass = 0; pass < 8; pass++) {
+    let grew = false;
+    for (const b of bindings) {
+      if (names.has(b.name)) continue;
+      const base = derivedBase(b.rhs);
+      if (base !== null && (names.has(base) || GO_ROUTER_RECEIVER.test(base))) {
+        names.add(b.name);
+        grew = true;
+      }
+    }
+    if (!grew) break;
+  }
+  // chi closure params: r.Route("/x", func(sub chi.Router) { ... }) makes sub a
+  // router inside the closure. Name-level add is gate-only over-approximation;
+  // middleware scoping (Task 4) keys on the closure body node, not the name.
+  for (const call of root.descendantsOfType("call_expression")) {
+    if (!call) continue;
+    const fn = call.childForFieldName("function");
+    if (fn?.type !== "selector_expression") continue;
+    if (!CLOSURE_ROUTE_FIELDS.has(fn.childForFieldName("field")?.text ?? "")) continue;
+    const base = goReceiverName(fn.childForFieldName("operand"));
+    if (base === null || !(names.has(base) || GO_ROUTER_RECEIVER.test(base))) continue;
+    const lit = call.childForFieldName("arguments")?.namedChildren
+      .find((n) => n?.type === "func_literal");
+    const param = lit?.childForFieldName("parameters")?.descendantsOfType("parameter_declaration")[0];
+    const pname = param?.childForFieldName("name");
+    if (pname?.type === "identifier") names.add(pname.text);
+  }
+  return names;
+}
+
+interface GoRoute {
+  method: string;
+  path: string;
+  call: SyntaxNode;    // the route-ANCHOR call (line + arg scanning)
+  receiver: string;
+}
+
+export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
+  const routes: RouteInfo[] = [];
+  const routerNames = collectGoRouterNames(tree.rootNode);
+  const gated = (r: string | null): r is string =>
+    r !== null && (routerNames.has(r) || GO_ROUTER_RECEIVER.test(r));
+
+  for (const call of tree.rootNode.descendantsOfType("call_expression")) {
+    if (!call || inErroredContext(call)) continue;
+    const fn = call.childForFieldName("function");
+    if (!fn || fn.type !== "selector_expression") continue;
+    const field = fn.childForFieldName("field")?.text ?? "";
+    const verb = VERB_FIELDS.get(field) ?? (ANY_FIELDS.has(field) ? "ALL" : null);
+    if (verb === null) continue;
+    const receiver = goReceiverName(fn.childForFieldName("operand"));
+    if (!gated(receiver)) continue;
+    const args = call.childForFieldName("arguments");
+    if (!args) continue;
+    const named = args.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    const path = named.length > 0 ? goStringText(named[0]) : null;
+    if (path === null || !path.startsWith("/")) continue; // leading-slash gate
+    routes.push({
+      method: verb,
+      path,
+      file: filePath,
+      // 1-based, the registration call's OWN first row (= the chain start for
+      // fluent forms): the @vibedrift-public suppression binding depends on it.
+      line: call.startPosition.row + 1,
+      hasAuth: false,        // Task 3 (per-route) + Task 4 (scope inheritance)
+      hasValidation: false,
+      hasRateLimit: false,
+      hasErrorHandler: false, // write-only field; JS and Python AST hard-code false
+    });
+  }
+  return routes;
+}

--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -1,9 +1,9 @@
 /**
- * AST-based route extraction for Go (Gin, Echo, chi), used by
- * security-consistency.ts in place of the regex line-window extractor
- * whenever a parsed tree is available and clean. Mirrors the shipped JS/TS
- * design in src/drift/security-ast.ts and the Python port in
- * src/drift/security-ast-python.ts.
+ * AST-based route extraction for Go (Gin, Echo, chi, Gorilla mux, and
+ * stdlib net/http), used by security-consistency.ts in place of the regex
+ * line-window extractor whenever a parsed tree is available and clean.
+ * Mirrors the shipped JS/TS design in src/drift/security-ast.ts and the
+ * Python port in src/drift/security-ast-python.ts.
  *
  * A find-replace port from either sibling module fails silently on five Go
  * grammar traps:
@@ -30,17 +30,28 @@
  *   4. Chained calls double-visit under a naive walk: `r.With(auth).Post(...)`
  *      is ONE `call_expression` for `.Post(...)` whose `function` operand is
  *      ANOTHER `call_expression` for `.With(auth)`. `descendantsOfType`
- *      surfaces BOTH nodes. This is harmless here because `With` is never in
- *      `VERB_FIELDS`, but a Gorilla-style builder chain
- *      (`r.Methods("POST").Path("/x").HandlerFunc(h)`, out of scope for this
- *      task) has THREE nested `call_expression`s under one statement; whoever
- *      wires that chain up in a later task must resolve it from the
- *      OUTERMOST call only, or the same registration double-counts.
+ *      surfaces BOTH nodes. This is harmless for `With` (never in
+ *      `VERB_FIELDS`) and for Gorilla's `.HandleFunc(x).Methods("POST")`
+ *      two-link chain (probe-verified: `descendantsOfType` visits the OUTER
+ *      `.Methods(...)` call FIRST, but "Methods" is not itself a recognized
+ *      route-registration field, so it is simply skipped when the walk
+ *      reaches it; the INNER `HandleFunc` call is the anchor and resolves the
+ *      chain by walking back UP via `chainedMethodVerbs`, never double
+ *      counting). A Gorilla-style ROUTE-BUILDER chain
+ *      (`r.Methods("POST").Path("/x").HandlerFunc(h)`) is a THIRD, different
+ *      shape: three nested `call_expression`s where the registering field
+ *      (`HandlerFunc`/`Handler`) sits OUTERMOST and the path/method live in
+ *      chain links, not in that call's own arguments. This module does not
+ *      unwind that chain (see PINNED RECALL GAPS below); every one of its
+ *      three links is individually unrecognized, so it emits zero routes
+ *      rather than guessing.
  *   5. Go 1.22's `net/http` added verb-prefixed pattern strings
  *      (`http.HandleFunc("POST /orders", h)`, `mux.HandleFunc("GET /x", h)`):
  *      the method lives INSIDE the path string, not in the call's field name.
- *      None of this module's forms parse a leading verb out of a path string;
- *      that is entirely separate machinery, deliberately not built here.
+ *      `splitServeMuxPattern` parses a leading `UPPERCASE-VERB ` prefix off a
+ *      path that does NOT start with `/`; a host pattern
+ *      (`"example.com/route"`) or a lowercase verb (`"post /x"`) is left
+ *      alone and the whole registration is skipped, never guessed.
  *
  * INVARIANT SCOPE: the never-false-bless guarantee (never mark an unauthed
  * route as authed) holds on THIS AST path only. A file with a parse error
@@ -66,9 +77,15 @@
  *
  * PINNED RECALL GAPS (measured, never a false-bless; each is a route this
  * module will not find rather than one it misclassifies):
- *   - Gorilla mux route-builder chains (`r.Methods("POST").Path("/x").
- *     HandlerFunc(h)`): no verb-selector field, out of scope until a later
- *     task builds the chain-resolution machinery noted in grammar trap 4.
+ *   - Gorilla mux ROUTE-BUILDER chains (`r.Methods("POST").Path("/x").
+ *     HandlerFunc(h)`, `r.Path("/x").Handler(h)`, `r.PathPrefix("/api").
+ *     HandlerFunc(h)`): deliberately NOT unwound (see grammar trap 4). The
+ *     registering call's field is `HandlerFunc`/`Handler`, never an anchor
+ *     this module recognizes, and the path/method live in earlier chain
+ *     links, not that call's own arguments. Extending recognition (walking
+ *     the chain back to its base identifier, harvesting `Path`/`PathPrefix` +
+ *     `Methods` links) is future work, deliberately not built. A skipped
+ *     route is a miss, never a bless.
  *   - Embedded-engine method receivers: `type Server struct { *gin.Engine }`
  *     then `func (s *Server) routes() { s.POST("/orders", h) }`. The
  *     receiver `s` is a bare identifier that fails both the constructor gate
@@ -84,35 +101,43 @@
  *     consistent with how the JS/TS and Python siblings treat conditional
  *     registration.
  *
+ * METHOD CONVENTION (Task 2, batched Sub-Phase A decision, LOCKED): an
+ * unresolvable or absent method resolves to "ALL", mirroring the Python
+ * module's own `methods=` divergence exactly — NEVER a silent GET-drop (an
+ * unresolvable route must stay in the mutating vote) and NEVER "ANY" (not a
+ * member of the shared mutating vocabulary; see
+ * `SECURITY_AST.MUTATING`/`MUTATION_METHODS` in security-ast.ts /
+ * security-consistency.ts). A fully-literal but UNRECOGNIZED verb
+ * (`.Methods("MKCOL")`) resolves GET instead: fully visible is not ambiguity,
+ * the same rule DRF's bare `@api_view()` gets in the Python module. HEAD and
+ * OPTIONS are excluded on EVERY resolution path (chained `.Methods(...)`,
+ * verb-first, and Go 1.22 verb-in-pattern) the same way `VERB_FIELDS` already
+ * excludes them: neither verb is ever mutating, so omission can only
+ * under-report, never bless.
+ *
  * OPEN QUESTIONS FOR SIGN-OFF (deliberate divergences the eventual full
- * module will carry; most are not reachable from Task 1's code, since this
- * task only recognizes routes and never resolves methods, auth, or
- * middleware scope; named here as a preview so each lands as an explicit,
- * reviewed decision rather than an implicit one when its owning task ships):
- *   - ALL-on-unresolvable methods (Task 2): a Go 1.22 pattern string or a
- *     `Handle`/`HandleFunc` call whose method cannot be read statically
- *     resolves to "ALL" rather than defaulting to GET, mirroring the
- *     Python module's `methods=` divergence, so the route stays in the
- *     mutating vote instead of silently dropping out of it.
- *   - HEAD/OPTIONS exclusion (this task, and carried through chain,
- *     verb-first, and Go 1.22 forms in later tasks): neither verb is ever
- *     mutating, so omitting them from `VERB_FIELDS` is bless-safe by
- *     construction, mirroring Phase A's exclusion of `@router.websocket`.
+ * module will carry; not reachable from this module's code yet, since Tasks
+ * 1-2 only recognize routes and resolve methods, never auth or middleware
+ * scope; named here as a preview so each lands as an explicit, reviewed
+ * decision rather than an implicit one when its owning task ships):
  *   - Dropped in-body validation scanning, position-aware `Use` resolution,
  *     conditional-`Use` skip, config-not-vetoed, and an extended veto set
- *     (Task 4 middleware scope): none of this module's Task-1 code reads
- *     middleware at all yet.
+ *     (Task 4 middleware scope): none of this module's code reads middleware
+ *     at all yet.
  *   - Arity-1 wrap recursion and pure-selector name resolution for auth
  *     helpers (Task 3): out of scope; `hasAuth` is unconditionally false.
  *   - Segment-matched validation/rate-limit lanes (Task 4): out of scope;
  *     `hasValidation`/`hasRateLimit` are unconditionally false.
  *
- * Route-registration scope for THIS task: Gin/Echo/chi verb-selector calls
+ * Route-registration scope covered so far: Gin/Echo/chi verb-selector calls
  * (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`Any`) on a structurally- or
  * conventionally-resolved receiver, plus chi's `With(...)` chain receiver
  * (auth recognition on the `With` argument is Task 3) and `Route(...)`
- * closure-parameter routers. `Handle`/`HandleFunc`, Gorilla `Methods()`
- * chains, and Go 1.22 verb-in-string patterns are Task 2.
+ * closure-parameter routers (Task 1); Gorilla mux `HandleFunc`/`Handle` with
+ * a chained `.Methods(...)`, Gin's verb-first `Handle(method, path, h)`, chi's
+ * verb-first `Method`/`MethodFunc`, Echo's verb-first `Add`, and Go 1.22
+ * verb-in-pattern strings on both `Handle` and `HandleFunc` (Task 2). The
+ * Gorilla route-builder chain form stays pinned out (see PINNED RECALL GAPS).
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
@@ -137,11 +162,40 @@ const VERB_FIELDS = new Map([
 // "ALL" sentinel Express's `.all()` uses, so it participates in the mutating
 // vote alongside a real mutating verb.
 const ANY_FIELDS = new Set(["Any"]);
-// Verbs a resolved route may carry (VERB_FIELDS' values, plus the ALL
-// sentinel ANY_FIELDS resolves to). HEAD and OPTIONS are deliberately absent:
-// neither is ever mutating, so their exclusion can only under-report, never
-// bless (see the OPEN QUESTIONS block above).
-const HTTP_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "ALL"]);
+// Verb-first registration fields: the FIRST positional argument IS the verb
+// literal (chi's `r.Method(method, path, h)` / `r.MethodFunc(...)`, Echo's
+// `e.Add(method, path, h)`). "Handle" is deliberately absent from this set:
+// Gin's verb-first `r.Handle(method, path, h)` and Gorilla/chi/stdlib's
+// path-first `r.Handle(path, h)` share the SAME field name, so "Handle" is
+// disambiguated per call site by inspecting arg0 (see the walk below), never
+// by static field-set membership.
+const VERB_FIRST_FIELDS = new Set(["Method", "MethodFunc", "Add"]);
+// Path-first Handle/HandleFunc: Gorilla (`router.Handle`/`HandleFunc(path,
+// h)`), chi's any-method form, and stdlib net/http (both the package-level
+// `http.Handle`/`HandleFunc` and a constructed `*ServeMux`). The method is
+// resolved separately per call — an embedded Go 1.22 verb in the path
+// string, a chained `.Methods(...)`, or absent -> "ALL" — never from the
+// field name itself.
+const HANDLE_FIELDS = new Set(["Handle", "HandleFunc"]);
+// Real HTTP verb tokens this module can read out of source TEXT: a
+// `.Methods("...")` string argument, a verb-first call's leading argument
+// (`r.Method("PATCH", ...)`, `r.Handle("POST", ...)`), or the embedded verb
+// in a Go 1.22 ServeMux pattern (`"POST /orders"`). Mirrors the Python
+// module's own `HTTP_VERBS` exactly (GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS).
+// HEAD and OPTIONS ARE members here (recognized TEXT) even though neither is
+// ever emitted as a route's method: every resolution path below filters them
+// back out before a route is pushed. Recognized-but-excluded is what lets a
+// real HEAD/OPTIONS registration (must SKIP) be told apart from a fully
+// unrecognized verb like "MKCOL" (resolves GET; see mkcol parity below).
+// "ALL" is never a member here: it is purely a resolved OUTPUT sentinel,
+// never literal source text.
+const HTTP_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
+// Verbs a RESOLVED route.method may carry once emitted: VERB_FIELDS' values,
+// plus the ALL sentinel every unresolvable/wildcard/Any form resolves to.
+// Used to pick the first MUTATING verb out of a resolved, HEAD/OPTION-free
+// verb list, in argument order. HEAD and OPTIONS are deliberately absent:
+// neither is ever mutating, and (per the HTTP_VERBS comment above) neither
+// ever reaches this set anyway, having already been filtered to a skip.
 const MUTATING_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE", "ALL"]);
 
 // Receivers that plausibly register routes, by naming convention alone
@@ -182,7 +236,7 @@ const SUBROUTER_FIELD = "Subrouter";
 const CLOSURE_ROUTE_FIELDS = new Set(["Route"]);
 
 export const SECURITY_AST_GO = {
-  VERB_FIELDS, ANY_FIELDS, HTTP_VERBS, MUTATING_VERBS,
+  VERB_FIELDS, ANY_FIELDS, VERB_FIRST_FIELDS, HANDLE_FIELDS, HTTP_VERBS, MUTATING_VERBS,
   GO_ROUTER_RECEIVER, GO_ROUTER_CONSTRUCTORS,
   GROUP_FIELD, SUBROUTER_FIELD, CLOSURE_ROUTE_FIELDS,
 };
@@ -335,38 +389,185 @@ interface GoRoute {
   receiver: string;
 }
 
+/** Chained `.Methods(...)` recovery, walking UP from the route-ANCHOR call
+ *  (probe-verified against the pinned tree-sitter-go grammar: the OUTER node
+ *  of `router.HandleFunc(x).Methods("POST")` is the `Methods` call, and
+ *  `descendantsOfType`'s pre-order visits it FIRST; the anchor is the INNER
+ *  `HandleFunc` call, so route recognition never double-processes a chain —
+ *  "Methods" is not itself a recognized route-registration field, so the
+ *  outer call is simply skipped when the walk reaches it on its own). Walks
+ *  THROUGH intermediate links (`.Name()`, `.Host()`, `.Schemes()`, in either
+ *  order relative to `.Methods()`); hop-capped so a pathological chain
+ *  terminates rather than looping. Returns null when there is no attached
+ *  `.Methods(...)` at all (a bare anchor, or a chain carried through a
+ *  variable across two statements — `route := r.HandleFunc(...)` breaks the
+ *  parent-is-selector-expression link immediately). */
+function chainedMethodVerbs(anchor: SyntaxNode): { verbs: string[]; unresolvable: boolean } | null {
+  let current: SyntaxNode = anchor;
+  for (let hops = 0; hops < 8; hops++) {
+    const parent = current.parent;
+    if (!parent || parent.type !== "selector_expression") return null;
+    if (!(parent.childForFieldName("operand")?.equals(current) ?? false)) return null;
+    const grand = parent.parent;
+    if (!grand || grand.type !== "call_expression") return null;
+    if (!(grand.childForFieldName("function")?.equals(parent) ?? false)) return null;
+    if (parent.childForFieldName("field")?.text === "Methods") {
+      const named = grand.childForFieldName("arguments")?.namedChildren
+        .filter((n): n is SyntaxNode => n !== null) ?? [];
+      const raw = named.map((n) => goStringText(n));
+      if (raw.length === 0 || raw.some((v) => v === null)) {
+        // .Methods() empty, or a non-literal arg (an identifier, a `verbs...`
+        // spread): statically unresolvable, the route must STAY in the
+        // mutating vote ("ALL"), never default toward GET.
+        return { verbs: [], unresolvable: true };
+      }
+      return {
+        verbs: raw.map((v) => (v as string).toUpperCase()).filter((v) => HTTP_VERBS.has(v)),
+        unresolvable: false,
+      };
+    }
+    current = grand; // not Methods: keep climbing through this chain link
+  }
+  return null;
+}
+
+/** Method for a Handle/HandleFunc anchor with no embedded Go 1.22 verb, or
+ *  null to SKIP the route. Absent chain resolves "ALL" (MUTATING_VERBS
+ *  membership keeps it voted; never a silent GET-drop, mirroring Python's own
+ *  `methods=` divergence). HEAD/OPTIONS are filtered BEFORE the
+ *  first-mutating pick; a chain whose recognized verbs are ONLY HEAD/OPTIONS
+ *  skips the route entirely (parity with VERB_FIELDS never emitting either
+ *  verb). Fully-literal-but-unrecognized verbs (`.Methods("MKCOL")`, zero
+ *  recognized of ANY kind) resolve GET: fully visible is not ambiguity (mkcol
+ *  parity, the same rule Python's `methodFromLiteral` applies). */
+function resolveAnyFieldMethod(anchor: SyntaxNode): string | null {
+  const chain = chainedMethodVerbs(anchor);
+  if (chain === null || chain.unresolvable) return "ALL";
+  const verbs = chain.verbs.filter((v) => v !== "HEAD" && v !== "OPTIONS");
+  if (verbs.length === 0) {
+    // Recognized verbs were exclusively HEAD/OPTIONS: skip. None recognized
+    // at all (MKCOL): GET.
+    return chain.verbs.length > 0 ? null : "GET";
+  }
+  return verbs.find((v) => MUTATING_VERBS.has(v)) ?? verbs[0];
+}
+
+/** Method for a verb-first call (chi's Method/MethodFunc, Echo's Add, Gin's
+ *  verb-first Handle): arg0 IS the verb. A non-literal arg0 (a bare variable)
+ *  is statically unresolvable and stays "ALL", never a silent GET. A literal
+ *  HEAD or OPTIONS SKIPS the route (null) on this path too, the same
+ *  exclusion the chain and Go 1.22 paths apply. A literal but unrecognized
+ *  verb resolves GET, the same fully-visible-is-not-ambiguity rule
+ *  `resolveAnyFieldMethod` applies to `.Methods("MKCOL")`. */
+function resolveVerbFirstMethod(arg0: SyntaxNode): string | null {
+  const raw = goStringText(arg0);
+  if (raw === null) return "ALL"; // variable/expression verb: unresolvable, stays mutating
+  const upper = raw.toUpperCase();
+  if (upper === "HEAD" || upper === "OPTIONS") return null;
+  return HTTP_VERBS.has(upper) ? upper : "GET";
+}
+
+/** Go 1.22 `net/http` ServeMux patterns embed the verb in the path string
+ *  (`"POST /items"`), not in the call's field name. Accept only an exact
+ *  uppercase HTTP verb, whitespace, then a leading-slash remainder; a host
+ *  pattern (`"example.com/route"`) and a lowercase verb (`"post /x"`) skip
+ *  entirely (a miss is safe, a guessed method is not). HEAD/OPTIONS patterns
+ *  skip too, so a route never reaches the walk carrying either verb. A plain
+ *  path with no embedded verb returns `method: null` so the caller resolves
+ *  it through its own chain/Any logic instead. */
+function splitServeMuxPattern(raw: string): { method: string | null; path: string } | null {
+  if (raw.startsWith("/")) return { method: null, path: raw };
+  const m = raw.match(/^([A-Z]+)\s+(\/.*)$/);
+  if (!m || !HTTP_VERBS.has(m[1])) return null;
+  if (m[1] === "HEAD" || m[1] === "OPTIONS") return null;
+  return { method: m[1], path: m[2] };
+}
+
 export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectGoRouterNames(tree.rootNode);
   const gated = (r: string | null): r is string =>
     r !== null && (routerNames.has(r) || GO_ROUTER_RECEIVER.test(r));
 
-  for (const call of tree.rootNode.descendantsOfType("call_expression")) {
-    if (!call || inErroredContext(call)) continue;
-    const fn = call.childForFieldName("function");
-    if (!fn || fn.type !== "selector_expression") continue;
-    const field = fn.childForFieldName("field")?.text ?? "";
-    const verb = VERB_FIELDS.get(field) ?? (ANY_FIELDS.has(field) ? "ALL" : null);
-    if (verb === null) continue;
-    const receiver = goReceiverName(fn.childForFieldName("operand"));
-    if (!gated(receiver)) continue;
-    const args = call.childForFieldName("arguments");
-    if (!args) continue;
-    const named = args.namedChildren.filter((n): n is SyntaxNode => n !== null);
-    const path = named.length > 0 ? goStringText(named[0]) : null;
-    if (path === null || !path.startsWith("/")) continue; // leading-slash gate
+  const emit = (method: string, path: string, call: SyntaxNode) => {
     routes.push({
-      method: verb,
+      method,
       path,
       file: filePath,
       // 1-based, the registration call's OWN first row (= the chain start for
-      // fluent forms): the @vibedrift-public suppression binding depends on it.
+      // fluent forms, i.e. the anchor, never a chained .Methods() call's own
+      // row): the @vibedrift-public suppression binding depends on it.
       line: call.startPosition.row + 1,
       hasAuth: false,        // Task 3 (per-route) + Task 4 (scope inheritance)
       hasValidation: false,
       hasRateLimit: false,
       hasErrorHandler: false, // write-only field; JS and Python AST hard-code false
     });
+  };
+
+  for (const call of tree.rootNode.descendantsOfType("call_expression")) {
+    if (!call || inErroredContext(call)) continue;
+    const fn = call.childForFieldName("function");
+    if (!fn || fn.type !== "selector_expression") continue;
+    const field = fn.childForFieldName("field")?.text ?? "";
+    const receiver = goReceiverName(fn.childForFieldName("operand"));
+    const args = call.childForFieldName("arguments");
+    const named = args?.namedChildren.filter((n): n is SyntaxNode => n !== null) ?? [];
+    const arg0Raw = named.length > 0 ? goStringText(named[0]) : null;
+
+    // Gin/Echo/chi verb-selector calls (Task 1, unchanged): the field name
+    // itself IS the verb.
+    const directVerb = VERB_FIELDS.get(field);
+    if (directVerb !== undefined) {
+      if (!gated(receiver)) continue;
+      if (arg0Raw === null || !arg0Raw.startsWith("/")) continue; // leading-slash gate
+      emit(directVerb, arg0Raw, call);
+      continue;
+    }
+
+    // Gin/Echo Any(...): always the ALL sentinel, arg0 is the path directly
+    // (no Go 1.22 pattern parsing: Any never carries an embedded verb).
+    if (ANY_FIELDS.has(field)) {
+      if (!gated(receiver)) continue;
+      if (arg0Raw === null || !arg0Raw.startsWith("/")) continue;
+      emit("ALL", arg0Raw, call);
+      continue;
+    }
+
+    // "http" is a valid receiver ONLY for the two stdlib registration fields
+    // (net/http's package-level Handle/HandleFunc); every other field here
+    // (verb-first below, HANDLE_FIELDS below) requires a real router receiver.
+    const httpBypass = receiver === "http" && (field === "Handle" || field === "HandleFunc");
+
+    // Verb-first: chi's Method/MethodFunc, Echo's Add, or Gin's verb-first
+    // Handle(method, path, h) — disambiguated from Gorilla/chi/stdlib's
+    // path-first Handle(path, h) by inspecting arg0: a recognized uppercase
+    // HTTP-verb literal means verb-first; anything else falls through to the
+    // HANDLE_FIELDS branch below.
+    const isVerbFirstHandle = field === "Handle" && arg0Raw !== null && HTTP_VERBS.has(arg0Raw.toUpperCase());
+    if (VERB_FIRST_FIELDS.has(field) || isVerbFirstHandle) {
+      if (!(gated(receiver) || httpBypass)) continue;
+      if (named.length < 2) continue;
+      const method = resolveVerbFirstMethod(named[0]);
+      if (method === null) continue; // literal HEAD/OPTIONS
+      const path = goStringText(named[1]);
+      if (path === null || !path.startsWith("/")) continue;
+      emit(method, path, call);
+      continue;
+    }
+
+    // Path-first Handle/HandleFunc: Gorilla, chi's any-method form, and
+    // stdlib net/http, Go 1.22 verb-in-pattern aware.
+    if (HANDLE_FIELDS.has(field)) {
+      if (!(gated(receiver) || httpBypass)) continue;
+      if (arg0Raw === null) continue;
+      const split = splitServeMuxPattern(arg0Raw);
+      if (split === null) continue; // host pattern / lowercase verb / verb-alone / HEAD|OPTIONS embedded
+      const method = split.method ?? resolveAnyFieldMethod(call); // embedded verb wins over the chain
+      if (method === null) continue; // chain narrowed to HEAD/OPTIONS only
+      emit(method, split.path, call);
+      continue;
+    }
   }
   return routes;
 }

--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -1076,17 +1076,299 @@ function goRouteMiddleware(
   };
 }
 
+// ─── Use()/group-scoped middleware collector (Task 4) ────────────────────────
+//
+// Middleware scope model for one Go file. NO app-global lane (Go has no
+// before_app_request analog): r.Use blesses only r-registered routes and
+// r-derived groups. Marks are keyed (receiver name, enclosing function body)
+// with their row; inheritance requires same name + same scope node + mark row
+// strictly below the route row (position-aware: correct for Gin/chi, over-flags
+// late-Use Echo/Gorilla, never false-blesses). A Use call under a
+// conditional/loop ancestor within its function never marks (statically
+// ambiguous registration resolves false). Derivations are in-file provable edges
+// only; a name rebound 2+ times in ONE scope is poisoned for that (name, scope)
+// pair (blessing removed, never added). Every Use/group arg classifies through
+// classifyGoMiddlewareArg (body-first): an imported / opaque / no-in-file-def
+// hook NEVER blesses (LOCKED owner decision) — it resolves UNSURE (auth-flavored
+// name) or NOT-AUTH. The auth lane on a mark is set ONLY by an in-file verifiably
+// rejecting body; the unsureHook rides additively and only fills a route's
+// authUnsureHook when no confirmed auth mark/edge wins first.
+interface GoScopeMark { receiver: string; scope: SyntaxNode; row: number; lanes: FileMiddleware; unsureHook?: string }
+interface GoDerivation {
+  child: string; childScope: SyntaxNode;
+  parent: string; parentScope: SyntaxNode;
+  row: number; inlineLanes: FileMiddleware; inlineUnsureHook?: string;
+}
+interface GoMiddlewareScopes {
+  marks: GoScopeMark[];
+  derivations: GoDerivation[];
+  // (name, scope) pairs with 2+ assignment-form bindings in that ONE scope.
+  // Deliberately NOT per-name file-wide: marks/derivations are already
+  // (name, scope)-keyed, so cross-function same-name bindings cannot cross-bless,
+  // and per-name poisoning would kill the legitimate own-function bless in the
+  // canonical one-group-per-RegisterX layout.
+  poisoned: Array<{ name: string; scope: SyntaxNode }>;
+  routerNames: Set<string>;
+}
+
+// Conditional/loop registration ancestors: a Use CALL nested under any of these
+// (strictly between it and its function body) is statically-ambiguous
+// registration and never marks (env-gated auth is a real Go pattern; a
+// conditional Use is a conservative over-flag, never a bless). Orthogonal to
+// body classification: a reject inside an if/switch branch of a Use hook's BODY
+// still counts (that gates what the hook does, not whether the Use fires).
+const GO_CONDITIONAL_ANCESTORS = new Set([
+  "if_statement", "for_statement", "expression_switch_statement",
+  "type_switch_statement", "select_statement",
+]);
+const GO_NO_LANES: FileMiddleware = { hasAuth: false, hasValidation: false, hasRateLimit: false };
+
+/** Nearest enclosing function body (function_declaration, method_declaration,
+ *  or func_literal), else the source root: the structural scope key that defuses
+ *  chi closure shadowing (an inner r.Use is keyed to the func_literal body, never
+ *  the outer receiver's scope). */
+function enclosingScope(node: SyntaxNode, root: SyntaxNode): SyntaxNode {
+  let cur: SyntaxNode | null = node.parent;
+  while (cur) {
+    if (cur.type === "function_declaration" || cur.type === "method_declaration" || cur.type === "func_literal") {
+      return cur.childForFieldName("body") ?? cur;
+    }
+    cur = cur.parent;
+  }
+  return root;
+}
+
+/** True when a conditional/loop node sits strictly between `node` and its
+ *  enclosing function scope body (statically-ambiguous registration). */
+function hasConditionalRegistrationAncestor(node: SyntaxNode, scope: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = node.parent;
+  while (cur && !cur.equals(scope)) {
+    if (GO_CONDITIONAL_ANCESTORS.has(cur.type)) return true;
+    cur = cur.parent;
+  }
+  return false;
+}
+
+/** BODY-FIRST lanes for a set of Use/group middleware ARG NODES. The auth lane is
+ *  classifyGoMiddlewareArg (body-first); val/rate stay NAME-based on the resolved
+ *  name. Returns the confirmed lanes PLUS the FIRST unsure hook name (only when
+ *  the auth lane did not confirm). The unsure name is a SEPARATE output; it never
+ *  sets hasAuth. */
+function lanesFromArgs(
+  args: SyntaxNode[], defs: Map<string, SyntaxNode | null>,
+): { lanes: FileMiddleware; unsureHook?: string } {
+  let hasAuth = false;
+  let unsureHook: string | undefined;
+  for (const a of args) {
+    const { outcome, name } = classifyGoMiddlewareArg(a, defs);
+    if (outcome === "auth") hasAuth = true;
+    else if (outcome === "unsure" && unsureHook === undefined && name) unsureHook = name;
+  }
+  const names = args.map(goMiddlewareName);
+  const lanes: FileMiddleware = {
+    hasAuth,
+    hasValidation: names.some((n) => n !== null && goNameIsVal(n)),
+    hasRateLimit: names.some((n) => n !== null && goNameIsRate(n)),
+  };
+  // A mark that confirmed auth never hedges (auth wins over its own unsure arg).
+  return hasAuth ? { lanes } : { lanes, unsureHook };
+}
+
+/** Collect the file's Use marks, group/closure derivations, and (name, scope)
+ *  poisoning in one pass set. Receiver-scoped; NO global bucket. */
+function collectGoMiddleware(tree: Tree): GoMiddlewareScopes {
+  const root = tree.rootNode;
+  const defs = collectGoFunctionDefs(root);
+  const routerNames = collectGoRouterNames(root);
+  const marks: GoScopeMark[] = [];
+  const derivations: GoDerivation[] = [];
+  const bindings: Array<{ name: string; scope: SyntaxNode }> = [];
+  const gated = (r: string | null): r is string =>
+    r !== null && (routerNames.has(r) || GO_ROUTER_RECEIVER.test(r));
+
+  // Pass A — Use marks + chi closure-param derivations (call_expression walk).
+  for (const call of root.descendantsOfType("call_expression")) {
+    if (!call || inErroredContext(call)) continue;
+    const fn = call.childForFieldName("function");
+    if (fn?.type !== "selector_expression") continue;
+    const field = fn.childForFieldName("field")?.text ?? "";
+    const receiver = goReceiverName(fn.childForFieldName("operand"));
+
+    if (field === "Use") {
+      if (!gated(receiver)) continue;
+      const scope = enclosingScope(call, root);
+      if (hasConditionalRegistrationAncestor(call, scope)) continue;
+      const named = goNamed(call.childForFieldName("arguments"));
+      const { lanes, unsureHook } = lanesFromArgs(named, defs);
+      marks.push({ receiver, scope, row: call.startPosition.row, lanes, unsureHook });
+      continue;
+    }
+
+    // chi closure-param derivation: r.Route("/x", func(sub chi.Router){...}) makes
+    // `sub` a child router whose scope is the CLOSURE BODY, inheriting the parent
+    // stack as of the Route call's row (chi copy-at-Route-time). Closure params
+    // are a single structural binding and never poison.
+    if (CLOSURE_ROUTE_FIELDS.has(field)) {
+      if (!gated(receiver)) continue;
+      const lit = goNamed(call.childForFieldName("arguments")).find((n) => n.type === "func_literal");
+      if (!lit) continue;
+      const param = lit.childForFieldName("parameters")?.descendantsOfType("parameter_declaration")[0];
+      const pname = param?.childForFieldName("name");
+      const closureBody = lit.childForFieldName("body");
+      if (pname?.type !== "identifier" || !closureBody) continue;
+      derivations.push({
+        child: pname.text, childScope: closureBody,
+        parent: receiver, parentScope: enclosingScope(call, root),
+        row: call.startPosition.row, inlineLanes: { ...GO_NO_LANES },
+      });
+    }
+  }
+
+  // Pass B — Group / Subrouter derivations + assignment-form binding counts.
+  const recordDecl = (nameNode: SyntaxNode | null, valueNode: SyntaxNode | null) => {
+    if (!nameNode || nameNode.type !== "identifier") return;
+    const scope = enclosingScope(nameNode, root);
+    bindings.push({ name: nameNode.text, scope });
+    if (!valueNode || valueNode.type !== "call_expression" || inErroredContext(valueNode)) return;
+    const fn = valueNode.childForFieldName("function");
+    if (fn?.type !== "selector_expression") return;
+    const field = fn.childForFieldName("field")?.text;
+    const row = valueNode.startPosition.row;
+    if (field === GROUP_FIELD) {
+      const parent = goReceiverName(fn.childForFieldName("operand"));
+      if (parent === null) return;
+      // On a Group creation call every arg AFTER the path is a middleware
+      // candidate INCLUDING the last (no handler position).
+      const inlineArgs = goNamed(valueNode.childForFieldName("arguments")).slice(1);
+      const { lanes, unsureHook } = lanesFromArgs(inlineArgs, defs);
+      derivations.push({
+        child: nameNode.text, childScope: scope,
+        parent, parentScope: scope, row, inlineLanes: lanes, inlineUnsureHook: unsureHook,
+      });
+    } else if (field === SUBROUTER_FIELD) {
+      const inner = fn.childForFieldName("operand"); // the PathPrefix(...) call
+      if (inner?.type !== "call_expression") return;
+      const innerFn = inner.childForFieldName("function");
+      if (innerFn?.type !== "selector_expression") return;
+      const parent = goReceiverName(innerFn.childForFieldName("operand"));
+      if (parent === null) return;
+      derivations.push({
+        child: nameNode.text, childScope: scope,
+        parent, parentScope: scope, row, inlineLanes: { ...GO_NO_LANES },
+      });
+    }
+  };
+  for (const decl of root.descendantsOfType(["short_var_declaration", "assignment_statement"])) {
+    if (!decl || inErroredContext(decl)) continue;
+    const left = decl.childForFieldName("left");
+    const right = decl.childForFieldName("right");
+    if (left?.type !== "expression_list" || right?.type !== "expression_list") continue;
+    const lc = goNamed(left);
+    const rc = goNamed(right);
+    for (let i = 0; i < lc.length && i < rc.length; i++) recordDecl(lc[i], rc[i]);
+  }
+  for (const spec of root.descendantsOfType("var_spec")) {
+    if (!spec || inErroredContext(spec)) continue;
+    const value = spec.childForFieldName("value"); // expression_list
+    recordDecl(spec.childForFieldName("name"), value?.namedChild(0) ?? null);
+  }
+
+  // A (name, scope) pair bound 2+ times in ONE scope is poisoned for that pair
+  // (blessing removed, never added). (name, scope)-keyed so another function's
+  // same-name binding cannot suppress this one.
+  const poisoned: Array<{ name: string; scope: SyntaxNode }> = [];
+  for (const b of bindings) {
+    const count = bindings.filter((o) => o.name === b.name && o.scope.equals(b.scope)).length;
+    if (count >= 2 && !poisoned.some((p) => p.name === b.name && p.scope.equals(b.scope))) {
+      poisoned.push({ name: b.name, scope: b.scope });
+    }
+  }
+
+  return { marks, derivations, poisoned, routerNames };
+}
+
+/** True when (receiver, scope) inherits `lane` from a same-scope mark row-below
+ *  `beforeRow`, or transitively from a derivation's inline lane / parent scope. */
+function scopeLane(
+  s: GoMiddlewareScopes, receiver: string, scope: SyntaxNode,
+  beforeRow: number, lane: keyof FileMiddleware, depth = 0,
+): boolean {
+  if (depth > 8) return false; // pathological chains terminate
+  if (s.poisoned.some((p) => p.name === receiver && p.scope.equals(scope))) return false;
+  if (s.marks.some((m) =>
+    m.receiver === receiver && m.scope.equals(scope) && m.row < beforeRow && m.lanes[lane],
+  )) return true;
+  for (const d of s.derivations) {
+    if (d.child !== receiver || !d.childScope.equals(scope)) continue;
+    if (d.inlineLanes[lane]) return true; // creation-time group middleware
+    if (scopeLane(s, d.parent, d.parentScope, d.row, lane, depth + 1)) return true;
+  }
+  return false;
+}
+
+/** First inheritable UNSURE hook for (receiver, scope, row). Receiver-scoped
+ *  only (no global tier). NEVER consulted unless the AUTH lane is already false
+ *  for this route (auth beats unsure): the caller passes it only into the
+ *  `hasAuth ? undefined : ...` branch. First-wins in (row, then document) order
+ *  so attribution is deterministic. */
+function scopeUnsureHook(
+  s: GoMiddlewareScopes, receiver: string, scope: SyntaxNode, beforeRow: number, depth = 0,
+): string | undefined {
+  if (depth > 8) return undefined;
+  if (s.poisoned.some((p) => p.name === receiver && p.scope.equals(scope))) return undefined;
+  const own = s.marks
+    .filter((m) => m.receiver === receiver && m.scope.equals(scope) && m.row < beforeRow && m.unsureHook)
+    .sort((a, b) => a.row - b.row)[0];
+  if (own?.unsureHook) return own.unsureHook;
+  for (const d of s.derivations) {
+    if (d.child !== receiver || !d.childScope.equals(scope)) continue;
+    if (d.inlineUnsureHook) return d.inlineUnsureHook;
+    const up = scopeUnsureHook(s, d.parent, d.parentScope, d.row, depth + 1);
+    if (up) return up;
+  }
+  return undefined;
+}
+
+/** File-level OR of every scope: the seam-2 index entry (public FileMiddleware
+ *  shape, unchanged) and the regex fallback's inheritance input. Route-level
+ *  inheritance on the AST path does NOT read this OR; extractGoRoutesAst consumes
+ *  the scopes directly (receiver + scope + row). UNSURE hooks are NEVER OR-ed in
+ *  (honesty invariant, mirror extractPythonFileMiddlewareAst). */
+export function extractGoFileMiddlewareAst(tree: Tree): FileMiddleware {
+  const s = collectGoMiddleware(tree);
+  const all = [...s.marks.map((m) => m.lanes), ...s.derivations.map((d) => d.inlineLanes)];
+  return {
+    hasAuth: all.some((x) => x.hasAuth),
+    hasValidation: all.some((x) => x.hasValidation),
+    hasRateLimit: all.some((x) => x.hasRateLimit),
+  };
+}
+
 export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
-  const routerNames = collectGoRouterNames(tree.rootNode);
-  const defs = collectGoFunctionDefs(tree.rootNode);
+  const root = tree.rootNode;
+  const routerNames = collectGoRouterNames(root);
+  const defs = collectGoFunctionDefs(root);
+  const scopes = collectGoMiddleware(tree);
   const gated = (r: string | null): r is string =>
     r !== null && (routerNames.has(r) || GO_ROUTER_RECEIVER.test(r));
 
   const emit = (
-    method: string, path: string, call: SyntaxNode,
+    method: string, path: string, call: SyntaxNode, receiver: string,
     mw: { hasAuth: boolean; hasValidation: boolean; hasRateLimit: boolean; unsureHook: string | undefined },
   ) => {
+    // Finalize per-route lanes + unsure by folding in receiver-scoped inheritance
+    // (per-route/wrap already resolved in `mw`). The route's structural scope and
+    // row key the lookup; auth beats unsure, so the scope-unsure fallback is read
+    // ONLY when hasAuth is false.
+    const routeScope = enclosingScope(call, root);
+    const routeRow = call.startPosition.row;
+    const hasAuth = mw.hasAuth || scopeLane(scopes, receiver, routeScope, routeRow, "hasAuth");
+    const hasValidation = mw.hasValidation || scopeLane(scopes, receiver, routeScope, routeRow, "hasValidation");
+    const hasRateLimit = mw.hasRateLimit || scopeLane(scopes, receiver, routeScope, routeRow, "hasRateLimit");
+    const authUnsureHook = hasAuth
+      ? undefined
+      : (mw.unsureHook ?? scopeUnsureHook(scopes, receiver, routeScope, routeRow));
     routes.push({
       method,
       path,
@@ -1095,14 +1377,14 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       // fluent forms, i.e. the anchor, never a chained .Methods() call's own
       // row): the @vibedrift-public suppression binding depends on it.
       line: call.startPosition.row + 1,
-      // Per-route body-first auth (Task 3); scope inheritance is Task 4.
-      hasAuth: mw.hasAuth,
-      hasValidation: mw.hasValidation,
-      hasRateLimit: mw.hasRateLimit,
+      // Per-route body-first auth (Task 3) OR receiver-scoped inheritance (Task 4).
+      hasAuth,
+      hasValidation,
+      hasRateLimit,
       hasErrorHandler: false, // write-only field; JS and Python AST hard-code false
       // authUnsureHook only on a NON-blessed, auth-flavored-opaque route; the key
       // is ABSENT otherwise so every other Go route serializes byte-identically.
-      ...(mw.unsureHook !== undefined ? { authUnsureHook: mw.unsureHook } : {}),
+      ...(authUnsureHook !== undefined ? { authUnsureHook } : {}),
     });
   };
 
@@ -1125,7 +1407,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       if (arg0Raw === null || !arg0Raw.startsWith("/")) continue; // leading-slash gate
       // Middleware are the args strictly between the path (arg0) and the handler
       // (last); the last arg is the handler and is NEVER classified.
-      emit(directVerb, arg0Raw, call, goRouteMiddleware(named, 0, null, fnOperand, defs));
+      emit(directVerb, arg0Raw, call, receiver ?? "", goRouteMiddleware(named, 0, null, fnOperand, defs));
       continue;
     }
 
@@ -1134,7 +1416,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
     if (ANY_FIELDS.has(field)) {
       if (!gated(receiver)) continue;
       if (arg0Raw === null || !arg0Raw.startsWith("/")) continue;
-      emit("ALL", arg0Raw, call, goRouteMiddleware(named, 0, null, fnOperand, defs));
+      emit("ALL", arg0Raw, call, receiver ?? "", goRouteMiddleware(named, 0, null, fnOperand, defs));
       continue;
     }
 
@@ -1158,7 +1440,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       if (path === null || !path.startsWith("/")) continue;
       // Verb-first: verb=arg0, path=arg1, so the middleware window starts after
       // arg1; the handler (last arg) is never classified.
-      emit(method, path, call, goRouteMiddleware(named, 1, null, fnOperand, defs));
+      emit(method, path, call, receiver ?? "", goRouteMiddleware(named, 1, null, fnOperand, defs));
       continue;
     }
 
@@ -1174,7 +1456,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       // The handler is the arg right after the path (arg1); for these forms it
       // may be a WRAP callee (auth(handler)) — the only body-first position here.
       const wrapCallee = named.length > 1 ? named[1] : null;
-      emit(method, split.path, call, goRouteMiddleware(named, 0, wrapCallee, fnOperand, defs));
+      emit(method, split.path, call, receiver ?? "", goRouteMiddleware(named, 0, wrapCallee, fnOperand, defs));
       continue;
     }
   }

--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -56,24 +56,22 @@
  * INVARIANT SCOPE: the never-false-bless guarantee (never mark an unauthed
  * route as authed) holds on THIS AST path only. A file with a parse error
  * anywhere (`tree.rootNode.hasError`) is routed whole to the existing regex
- * extractor, which keeps its own legacy behavior unchanged. Even on a clean
- * tree, this module never emits `hasAuth: true` in this task: auth
- * recognition is Task 3, so every route below carries `hasAuth: false`
- * unconditionally, which can only under-report auth, never over-report it.
+ * extractor, which keeps its own legacy behavior unchanged. Per-route auth
+ * recognition (Task 3) now emits `hasAuth: true` ONLY when a middleware-position
+ * argument resolves to an in-file body that VERIFIABLY rejects (401-family, or a
+ * credential-guarded 403); every opaque, imported, unreadable, or veto case
+ * resolves `hasAuth: false` (plus `authUnsureHook` when auth-flavored-opaque), so
+ * a wrong answer can only under-report auth, never over-report it. Scope
+ * inheritance from Use/group middleware is Task 4 (still unwired).
  *
- * KNOWN FALSE-BLESS EXPOSURE (carried forward from the Integration contract,
- * not yet reachable from this module since `hasAuth` is hard-coded false
- * here): once Task 3 lands per-route auth recognition, a handful of
- * recognized-but-non-enforcing names are expected to remain a residual
- * exposure by design (matching the Python module's own documented
- * exposures): a custom type or middleware literally named `AuthContext`
- * that carries identity without enforcing it, an `apiKeyRotator` helper
- * that manages keys without gating a request, and single-argument DI
- * constructors whose one parameter happens to read as auth-flavored
- * without the constructor itself checking anything. None of these can
- * fire in Task 1: they are named here so the eventual auth pass documents
- * the same exposure the Python module already accepted, rather than
- * silently reintroducing it.
+ * RESIDUAL EXPOSURE (matching the Python module's own accepted exposures): a
+ * recognized-but-non-enforcing name whose in-file body actually rejects will
+ * bless — e.g. a middleware named to imply auth that reads a credential and 401s
+ * for an unrelated reason. The pre-LOCKED name-only plan additionally carried a
+ * chi `jwtauth.Verifier`, config-object-through-wrap, and arity-1-DI false-bless;
+ * those are CLOSED here by requiring a readable rejecting body to bless and by
+ * restricting wrap recursion to transparent/unnamed outers (see the Task 3
+ * section below).
  *
  * PINNED RECALL GAPS (measured, never a false-bless; each is a route this
  * module will not find rather than one it misclassifies):
@@ -115,19 +113,19 @@
  * excludes them: neither verb is ever mutating, so omission can only
  * under-report, never bless.
  *
- * OPEN QUESTIONS FOR SIGN-OFF (deliberate divergences the eventual full
- * module will carry; not reachable from this module's code yet, since Tasks
- * 1-2 only recognize routes and resolve methods, never auth or middleware
- * scope; named here as a preview so each lands as an explicit, reviewed
- * decision rather than an implicit one when its owning task ships):
- *   - Dropped in-body validation scanning, position-aware `Use` resolution,
- *     conditional-`Use` skip, config-not-vetoed, and an extended veto set
- *     (Task 4 middleware scope): none of this module's code reads middleware
- *     at all yet.
- *   - Arity-1 wrap recursion and pure-selector name resolution for auth
- *     helpers (Task 3): out of scope; `hasAuth` is unconditionally false.
- *   - Segment-matched validation/rate-limit lanes (Task 4): out of scope;
- *     `hasValidation`/`hasRateLimit` are unconditionally false.
+ * OPEN QUESTIONS FOR SIGN-OFF (deliberate divergences named so each lands as an
+ * explicit, reviewed decision):
+ *   - Position-aware `Use` / group-scope resolution, conditional-`Use` skip, and
+ *     scope inheritance onto routes (Task 4 middleware scope): this module reads
+ *     only PER-ROUTE middleware positions today, never file/group scope.
+ *   - Arity-1 wrap recursion and pure-selector name resolution for auth helpers
+ *     (Task 3): IMPLEMENTED below. Recursion descends single-argument calls only,
+ *     through a transparent/unnamed outer, and a bare handler position is never
+ *     read (body-first is middleware-position-only).
+ *   - Validation/rate-limit lanes (Task 3) are per-route, whole-segment,
+ *     NAME-based (body analysis is auth-lane only); file/group-scoped lanes are
+ *     Task 4. A handler body calling `c.ShouldBindJSON` does NOT set
+ *     `hasValidation` (the regex path's text window is dropped on the AST path).
  *
  * Route-registration scope covered so far: Gin/Echo/chi verb-selector calls
  * (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`Any`) on a structurally- or
@@ -142,6 +140,17 @@
 
 import type { Tree, SyntaxNode } from "../core/types.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
+
+/** A middleware body's three-way behavioral signal. 401-family blesses alone; a
+ *  403 blesses only inside a credential-guarded reject; a bare/uncorroborated 403,
+ *  a 404/500, or a 200 write is neither reject nor opaque (keeps the hedge
+ *  meaningful). Mirrors the Python `BodySignal`. */
+export type GoBodySignal = "reject" | "none" | "opaque";
+/** Precedence outcome over `GoBodySignal`. `unsure` is not-authed INTERNALLY (it
+ *  never sets hasAuth) — it only records the middleware name so a renderer can
+ *  hedge. NEVER-FALSE-BLESS: every ambiguous/opaque/unreadable branch resolves to
+ *  `not-auth` or `unsure`, never `auth`. */
+export type GoAuthOutcome = "auth" | "not-auth" | "unsure";
 
 // Verbs a Gin/Echo/chi verb-selector call may register, keyed by the exact
 // field-name spelling each framework uses: Gin and Echo use ALL-CAPS
@@ -483,13 +492,601 @@ function splitServeMuxPattern(raw: string): { method: string | null; path: strin
   return { method: m[1], path: m[2] };
 }
 
+// ─── Body-first auth classification (Task 3) ─────────────────────────────────
+//
+// Classifies a MIDDLEWARE/wrapper argument by what its BODY does, not what its
+// name suggests. `bodyAuthSignatureGo` walks the effective body (plus ONE hop
+// into a same-file helper) and returns "reject" | "none" | "opaque";
+// `classifyGoMiddlewareAuth` layers the LOCKED five-rule precedence on top and
+// produces the THREE-WAY "auth" | "not-auth" | "unsure".
+//
+// LOCKED OWNER DECISION: blessing REQUIRES a verifiable reject in a READABLE
+// in-file body (rule 2). There is NO name-only bless — an opaque body (rule 4)
+// and an unreadable/imported body (rule 5) resolve `goNameIsFlavored ? "unsure"
+// : "not-auth"`, NEVER "auth". A veto segment (rule 1) beats even a real body
+// reject. So a package-qualified selector (middleware.AuthMiddleware) is used
+// ONLY to RESOLVE an in-file def's body; unresolved -> opaque/name-tier.
+//
+// NEVER-FALSE-BLESS: every ambiguous/opaque/unreadable case resolves to
+// not-auth or unsure. Scope of body-first: it upgrades MIDDLEWARE positions
+// (per-route middle args, With links, wrap callees) — never a route's own
+// handler target. Wrap recursion is single-argument only (arity >= 2 is Go DI,
+// never classified), depth-capped, and descends ONLY through a
+// recursion-transparent observability outer (logRequests / metricsWrap) or an
+// UNNAMED outer; a SUBSUMING-veto outer (optionalAuth / SkipAuth /
+// DisableAuthInDev / parseJWT) HALTS recursion so it cannot bless an inner CORE
+// name. This restriction closes the chi jwtauth.Verifier / config-object /
+// arity-1-DI false-bless exposures the pre-LOCKED name-only plan carried.
+
+const GO_STATUS_CONSTS = new Map<string, "401" | "403" | "404" | "500">([
+  ["StatusUnauthorized", "401"], ["StatusForbidden", "403"],
+  ["StatusNotFound", "404"], ["StatusInternalServerError", "500"],
+]);
+// Auth-DISABLING / non-enforcing name segments that CANCEL a flavor and, at
+// rule 1, resolve not-auth even over a real body reject (blessing a disabler
+// inverts reality). Whole-segment matched. "logged" is NOT "log" (EnsureLoggedIn
+// stays flavored). "login" vetoes the login-endpoint handler idiom (authLogin).
+const GO_AUTH_VETO_SEGMENTS = new Set([
+  "skip", "bypass", "mock", "disable", "disabled", "optional", "noop", "fake",
+  "stub", "dummy", "test", "dev", "insecure", "parse", "handler", "login",
+  "log", "logger", "logging", "metrics", "stats",
+]);
+// The subset of vetoes that INVERT the auth they wrap: they HALT wrap recursion
+// (optionalAuth(requireAuth) must not bless on the inner name).
+const GO_SUBSUMING_VETO_SEGMENTS = new Set([
+  "skip", "bypass", "mock", "disable", "disabled", "optional", "noop", "fake",
+  "stub", "dummy", "insecure", "parse",
+]);
+// Observability wrappers we recurse THROUGH to find a real inner auth wrap
+// (logRequests(requireAuth(h)) — observability does not subsume auth).
+const GO_TRANSPARENT_WRAP_SEGMENTS = new Set([
+  "log", "logger", "logging", "metrics", "stats", "audit", "trace", "timing", "recover",
+]);
+// Flavored segments: drive UNSURE-vs-NOT-AUTH for opaque/unreadable bodies (never
+// a bless). "auth2" catches OAuth2 (which segments to [o, auth2, ...]).
+const GO_AUTH_SEGMENTS = new Set([
+  "auth", "auth2", "authenticate", "authenticated", "authentication",
+  "authorize", "authorization", "jwt", "oauth", "oauth2", "bearer",
+  "session", "token", "user", "users", "credential", "credentials",
+  "principal", "identity",
+]);
+// Adjacent-segment flavored pairs (enforce verb + subject), for names whose
+// individual segments are boring but whose pair reads as auth.
+const GO_AUTH_PAIRS = new Set([
+  "logged in", "require auth", "require login", "require user", "require role",
+  "require session", "ensure user", "ensure auth", "ensure session",
+  "verify token", "verify user", "verify session", "token required",
+  "check auth", "check session", "is authenticated", "validate token",
+]);
+// Segments that make an UNRESOLVABLE callee opaque-hint (auth-flavored enough
+// that "we cannot see what it does" resolves opaque, never a bless).
+const GO_OPAQUE_HINT_SEGMENTS = new Set([
+  ...GO_AUTH_SEGMENTS, "check", "confirm", "guard", "verify", "require",
+  "ensure", "protect", "restrict",
+]);
+// Credential-surface read shapes. GetHeader/Cookie match on ANY receiver; a bare
+// `Get` only when its operand is one of these receivers (excludes Query().Get,
+// cache.Get, store.Get). The string key must hit GO_CREDENTIAL_KEY_SEGMENTS and
+// NOT GO_CREDENTIAL_KEY_VETO (csrf/xsrf/agent — X-CSRF-Token contains "token").
+const GO_CRED_READ_FIELDS = new Set(["GetHeader", "Cookie"]);
+const GO_CRED_GET_RECEIVERS = new Set(["session", "ctx", "c", "g"]);
+const GO_CREDENTIAL_KEY_SEGMENTS = new Set([
+  "user", "uid", "token", "jwt", "auth", "authorization", "login",
+  "credentials", "session", "bearer", "cookie", "sid",
+]);
+const GO_CREDENTIAL_KEY_VETO = new Set(["csrf", "xsrf", "agent"]);
+// Gin write methods whose arg0 is a status code (bless only WITH corroboration).
+const GO_WRITE_STATUS_FIELDS = new Set([
+  "JSON", "String", "XML", "Data", "IndentedJSON", "HTML", "YAML", "ProtoBuf",
+  "SecureJSON", "AsciiJSON", "PureJSON",
+]);
+// Validation / rate-limit lane segments (whole-segment; no veto set — the
+// discipline exists to stop substring smuggling, not optionality).
+const GO_VAL_SEGMENTS = new Set(["validate", "validator", "validation", "sanitize", "schema"]);
+const GO_RATE_SEGMENTS = new Set(["ratelimit", "ratelimiter", "limiter", "throttle", "throttler"]);
+const GO_RATE_PAIRS = new Set(["rate limit", "rate limiter", "rate limiting"]);
+
+const CALL_EXPR_T = new Set(["call_expression"]);
+const RETURN_T = new Set(["return_statement"]);
+const IF_T = new Set(["if_statement"]);
+
+/** Non-null named children of a node. */
+function goNamed(n: SyntaxNode | null | undefined): SyntaxNode[] {
+  return n ? n.namedChildren.filter((c): c is SyntaxNode => c !== null) : [];
+}
+
+/** Lowercase segments of an identifier, split on non-alphanumeric AND CamelCase
+ *  boundaries. Copied VERBATIM from security-ast-python.ts:628 (whole-segment
+ *  matching makes substring blessing structurally impossible). */
+function nameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((s) => s.length > 0);
+}
+
+/** "401"|"403"|"404"|"500"|"other"|null. An int_literal OR the http.StatusXxx
+ *  selector; NEVER guesses a bare local const (returns null so the caller treats
+ *  it as unreadable/opaque). */
+function goRejectStatus(n: SyntaxNode | null): "401" | "403" | "404" | "500" | "other" | null {
+  if (!n) return null;
+  if (n.type === "int_literal") {
+    const t = n.text;
+    return t === "401" || t === "403" || t === "404" || t === "500" ? t : "other";
+  }
+  if (n.type === "selector_expression") {
+    const op = n.childForFieldName("operand");
+    const field = n.childForFieldName("field")?.text;
+    if (op?.type === "identifier" && op.text === "http" && field) {
+      return GO_STATUS_CONSTS.get(field) ?? "other";
+    }
+  }
+  return null;
+}
+
+/** Descendants of `node` of one of `types`, NOT descending into nested
+ *  `func_literal` subtrees (a reject in a goroutine/defer/callback closure is not
+ *  executed inline). Pre-order; the root is never yielded. Mirror of
+ *  security-ast-python.ts:813 prunedDescendants. */
+function goPrunedDescendants(node: SyntaxNode, types: Set<string>): SyntaxNode[] {
+  const out: SyntaxNode[] = [];
+  const visit = (n: SyntaxNode) => {
+    for (const child of n.namedChildren) {
+      if (!child || child.type === "func_literal") continue;
+      if (types.has(child.type)) out.push(child);
+      visit(child);
+    }
+  };
+  visit(node);
+  return out;
+}
+
+/** True when a string key reads as a credential (segment hit, veto cancels). */
+function goCredKeyIsCredential(key: string): boolean {
+  const segs = nameSegments(key);
+  if (segs.some((s) => GO_CREDENTIAL_KEY_VETO.has(s))) return false;
+  return segs.some((s) => GO_CREDENTIAL_KEY_SEGMENTS.has(s));
+}
+
+/** True when a call structurally reads a credential surface: a GetHeader/Cookie
+ *  call (any receiver) or a bare `Get` on a session/ctx/c/g receiver, whose arg0
+ *  string key is credential-flavored and NOT csrf/xsrf/agent. */
+function goIsCredentialReadCall(call: SyntaxNode): boolean {
+  const fn = call.childForFieldName("function");
+  if (!fn || fn.type !== "selector_expression") return false;
+  const field = fn.childForFieldName("field")?.text ?? "";
+  const arg0 = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+  const key = arg0 ? goStringText(arg0) : null;
+  if (key === null) return false;
+  if (GO_CRED_READ_FIELDS.has(field)) return goCredKeyIsCredential(key);
+  if (field === "Get") {
+    const op = fn.childForFieldName("operand");
+    if (op?.type === "identifier" && GO_CRED_GET_RECEIVERS.has(op.text)) {
+      return goCredKeyIsCredential(key);
+    }
+  }
+  return false;
+}
+
+/** True when an unresolvable callee name is auth-flavored enough to be opaque. */
+function goNameHasHint(name: string): boolean {
+  return nameSegments(name).some((s) => GO_OPAQUE_HINT_SEGMENTS.has(s));
+}
+
+/** True when a write-status call (c.JSON(401,...), http.Error(...,401),
+ *  w.WriteHeader(401)) is corroborated by a following return / Abort sibling in
+ *  the same block — a non-self-aborting 401 write that keeps calling next is NOT
+ *  a reject (never-false-bless). */
+function goCallCorroborated(call: SyntaxNode): boolean {
+  let stmt: SyntaxNode = call;
+  while (stmt.parent && stmt.parent.type !== "block") stmt = stmt.parent;
+  const block = stmt.parent;
+  if (!block) return false;
+  const sibs = goNamed(block);
+  const idx = sibs.findIndex((s) => s.equals(stmt));
+  if (idx < 0) return false;
+  for (let i = idx + 1; i < sibs.length; i++) {
+    const s = sibs[i];
+    if (s.type === "return_statement") return true;
+    if (s.type === "expression_statement") {
+      const inner = s.namedChild(0);
+      const f = inner?.type === "call_expression" ? inner.childForFieldName("function") : null;
+      if (f?.type === "selector_expression" && (f.childForFieldName("field")?.text ?? "").startsWith("Abort")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** True when a composite_literal is an echo.HTTPError{Code: 401}. */
+function goCompositeIs401Error(composite: SyntaxNode): boolean {
+  let typeText = "";
+  let lv: SyntaxNode | null = null;
+  for (const c of composite.namedChildren) {
+    if (!c) continue;
+    if (c.type === "literal_value") lv = c;
+    else typeText = c.text;
+  }
+  if (!/HTTPError$/.test(typeText) || !lv) return false;
+  for (const ke of goNamed(lv)) {
+    if (ke.type !== "keyed_element") continue;
+    const key = ke.namedChild(0);
+    const valEl = ke.namedChild(1);
+    if ((key?.text ?? "") === "Code" && goRejectStatus(valEl?.namedChild(0) ?? valEl ?? null) === "401") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** True when a subtree contains a 403 self-aborting reject. */
+function goSubtreeHas403Reject(node: SyntaxNode): boolean {
+  for (const call of goPrunedDescendants(node, CALL_EXPR_T)) {
+    if (call.hasError) continue;
+    const fn = call.childForFieldName("function");
+    if (fn?.type !== "selector_expression") continue;
+    const field = fn.childForFieldName("field")?.text ?? "";
+    if (field === "AbortWithStatus" || field === "AbortWithStatusJSON") {
+      if (goRejectStatus(call.childForFieldName("arguments")?.namedChild(0) ?? null) === "403") return true;
+    }
+  }
+  return false;
+}
+
+/** Local names bound to a structural credential read (`tok := c.GetHeader(...)`),
+ *  pruned of nested closures. Lets `tok == ""` count as a credential guard. */
+function goCredentialBoundLocals(body: SyntaxNode): Set<string> {
+  const bound = new Set<string>();
+  for (const decl of goPrunedDescendants(body, new Set(["short_var_declaration", "assignment_statement"]))) {
+    if (decl.hasError) continue;
+    const left = decl.childForFieldName("left");
+    const right = decl.childForFieldName("right");
+    if (left?.type !== "expression_list" || right?.type !== "expression_list") continue;
+    const lc = goNamed(left);
+    const rc = goNamed(right);
+    for (let i = 0; i < lc.length && i < rc.length; i++) {
+      if (lc[i].type === "identifier" && rc[i].type === "call_expression" && goIsCredentialReadCall(rc[i])) {
+        bound.add(lc[i].text);
+      }
+    }
+  }
+  return bound;
+}
+
+/** STRICT credential read for the guarded-403 BLESS gate: the if-INITIALIZER (Go
+ *  `if _, err := v(c.GetHeader(...)); ...` idiom) or CONDITION must structurally
+ *  read a credential surface, or reference a credential-bound local. A vetoed key
+ *  (X-CSRF-Token) never qualifies. */
+function goGuardHasCredentialRead(
+  init: SyntaxNode | null, cond: SyntaxNode | null, boundLocals: Set<string>,
+): boolean {
+  for (const root of [init, cond]) {
+    if (!root) continue;
+    const calls = goPrunedDescendants(root, CALL_EXPR_T);
+    if (root.type === "call_expression") calls.unshift(root);
+    if (calls.some((c) => !c.hasError && goIsCredentialReadCall(c))) return true;
+    if (boundLocals.size > 0) {
+      const ids = goPrunedDescendants(root, new Set(["identifier"]));
+      if (root.type === "identifier") ids.unshift(root);
+      if (ids.some((id) => boundLocals.has(id.text))) return true;
+    }
+  }
+  return false;
+}
+
+interface GoBodySignals {
+  reject401: boolean;
+  reject403Guarded: boolean;
+  opaqueHint: boolean;
+  credentialRead: boolean;
+}
+
+/** One EFFECTIVE body's direct signals; `hop` = whether a same-file bare-callee
+ *  helper may be followed once. reject401 blesses ALONE; reject403Guarded blesses
+ *  only WITH a credential-guarded 403. Nested func_literals are pruned throughout
+ *  (a reject in a non-returned closure never blesses). */
+function scanGoBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>, hop: boolean): GoBodySignals {
+  const out: GoBodySignals = { reject401: false, reject403Guarded: false, opaqueHint: false, credentialRead: false };
+  const merge = (s: GoBodySignals) => {
+    out.reject401 ||= s.reject401;
+    out.reject403Guarded ||= s.reject403Guarded;
+    out.opaqueHint ||= s.opaqueHint;
+    out.credentialRead ||= s.credentialRead;
+  };
+
+  for (const call of goPrunedDescendants(body, CALL_EXPR_T)) {
+    if (call.hasError) continue;
+    const fn = call.childForFieldName("function");
+    const args = call.childForFieldName("arguments");
+    if (!out.credentialRead && goIsCredentialReadCall(call)) out.credentialRead = true;
+    if (fn?.type === "selector_expression") {
+      const field = fn.childForFieldName("field")?.text ?? "";
+      if (field === "AbortWithStatus" || field === "AbortWithStatusJSON") {
+        const st = goRejectStatus(args?.namedChild(0) ?? null);
+        if (st === "401") out.reject401 = true;
+        else if (st === null || st === "other") out.opaqueHint = true; // variable / unknown status
+        continue; // 403 via the guarded-if walk; 404/500 contribute nothing
+      }
+      if (GO_WRITE_STATUS_FIELDS.has(field)) {
+        if (goRejectStatus(args?.namedChild(0) ?? null) === "401" && goCallCorroborated(call)) out.reject401 = true;
+        continue;
+      }
+      if (field === "Error" && fn.childForFieldName("operand")?.text === "http") {
+        const named = goNamed(args);
+        if (goRejectStatus(named[named.length - 1] ?? null) === "401" && goCallCorroborated(call)) out.reject401 = true;
+        continue;
+      }
+      if (field === "WriteHeader") {
+        if (goRejectStatus(args?.namedChild(0) ?? null) === "401" && goCallCorroborated(call)) out.reject401 = true;
+        continue;
+      }
+      continue; // GetHeader/Cookie handled above; Next/ServeHTTP = pass path
+    }
+    if (fn?.type === "identifier") {
+      const name = fn.text;
+      if (defs.has(name)) {
+        const def = defs.get(name) ?? null;
+        if (def && hop) {
+          const hopBody = resolveEffectiveBody(def, defs);
+          if (hopBody) merge(scanGoBody(hopBody, defs, false));
+        } else if (!def && goNameHasHint(name)) {
+          out.opaqueHint = true; // duplicate same-name def: unresolvable + flavored
+        }
+        continue; // resolvable at hop=false = cycle guard, contribute nothing
+      }
+      if (goNameHasHint(name)) out.opaqueHint = true; // unresolvable flavored callee
+    }
+  }
+
+  // Returned rejects: return echo.NewHTTPError(401) / c.NoContent(401) /
+  // &echo.HTTPError{Code:401} / echo.HTTPError{Code:401}.
+  for (const ret of goPrunedDescendants(body, RETURN_T)) {
+    if (ret.hasError) continue;
+    const exprList = ret.namedChild(0);
+    if (exprList?.type !== "expression_list") continue;
+    const val = exprList.namedChild(0);
+    if (!val) continue;
+    if (val.type === "call_expression") {
+      if (goRejectStatus(val.childForFieldName("arguments")?.namedChild(0) ?? null) === "401") out.reject401 = true;
+      continue;
+    }
+    const composite = val.type === "unary_expression" ? val.namedChild(0) : val;
+    if (composite?.type === "composite_literal" && goCompositeIs401Error(composite)) out.reject401 = true;
+  }
+
+  // Guarded 403: an `if <credential-condition>: ... <403 reject> ...`.
+  const boundLocals = goCredentialBoundLocals(body);
+  for (const ifs of goPrunedDescendants(body, IF_T)) {
+    if (ifs.hasError) continue;
+    const init = ifs.childForFieldName("initializer");
+    const cond = ifs.childForFieldName("condition");
+    const cons = ifs.childForFieldName("consequence");
+    if (cons && (init || cond) && goGuardHasCredentialRead(init, cond, boundLocals) && goSubtreeHas403Reject(cons)) {
+      out.reject403Guarded = true;
+    }
+  }
+
+  return out;
+}
+
+/** A middleware body's three-way behavioral signal. */
+export function bodyAuthSignatureGo(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): GoBodySignal {
+  const s = scanGoBody(body, defs, true);
+  if (s.reject401 || s.reject403Guarded) return "reject";
+  if (s.opaqueHint || s.credentialRead) return "opaque";
+  return "none";
+}
+
+/** File-wide map of top-level function/method definitions by name; a name seen
+ *  more than once maps to null (duplicate: follow NEITHER). */
+export function collectGoFunctionDefs(root: SyntaxNode): Map<string, SyntaxNode | null> {
+  const defs = new Map<string, SyntaxNode | null>();
+  for (const def of root.descendantsOfType(["function_declaration", "method_declaration"])) {
+    if (!def || def.hasError) continue;
+    const name = def.childForFieldName("name")?.text; // identifier OR field_identifier
+    if (!name) continue;
+    defs.set(name, defs.has(name) ? null : def);
+  }
+  return defs;
+}
+
+/** The RESOLVED EFFECTIVE body of a function/method: through a single
+ *  return-of-closure (factory `func F() gin.HandlerFunc { return func(c){...} }`,
+ *  `return http.HandlerFunc(func(w,r){...})`) or a one-hop returned bare
+ *  identifier. NEVER prunes the returned handler closure (else mass false
+ *  not-auth); scanGoBody prunes FURTHER-nested closures inside it. */
+function resolveEffectiveBody(fnNode: SyntaxNode, defs: Map<string, SyntaxNode | null>): SyntaxNode | null {
+  const body = fnNode.childForFieldName("body");
+  if (!body) return null;
+  const stmts = goNamed(body);
+  if (stmts.length === 1 && stmts[0].type === "return_statement") {
+    const exprList = stmts[0].namedChild(0);
+    const val = exprList?.type === "expression_list" ? exprList.namedChild(0) : null;
+    if (val) {
+      if (val.type === "func_literal") return val.childForFieldName("body") ?? body;
+      if (val.type === "call_expression") {
+        const cargs = goNamed(val.childForFieldName("arguments"));
+        if (cargs.length === 1 && cargs[0].type === "func_literal") {
+          return cargs[0].childForFieldName("body") ?? body;
+        }
+      }
+      if (val.type === "identifier") {
+        const def = defs.get(val.text) ?? null;
+        if (def) return def.childForFieldName("body") ?? body; // one-hop
+      }
+    }
+  }
+  return body;
+}
+
+/** True when a name is auth-FLAVORED (drives unsure-vs-not-auth for opaque /
+ *  unreadable bodies — NEVER a bless). A veto segment cancels. */
+function goNameIsFlavored(name: string): boolean {
+  const segs = nameSegments(name);
+  if (segs.some((s) => GO_AUTH_VETO_SEGMENTS.has(s))) return false;
+  if (segs.some((s) => GO_AUTH_SEGMENTS.has(s))) return true;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (GO_AUTH_PAIRS.has(`${segs[i]} ${segs[i + 1]}`)) return true;
+  }
+  return false;
+}
+
+/** The LOCKED five-rule precedence. `body` is the RESOLVED EFFECTIVE body (or
+ *  null when imported/unresolvable). Rules 4/5 NEVER return "auth". */
+export function classifyGoMiddlewareAuth(
+  name: string, body: SyntaxNode | null, defs: Map<string, SyntaxNode | null>,
+): GoAuthOutcome {
+  const segs = nameSegments(name);
+  if (segs.some((s) => GO_AUTH_VETO_SEGMENTS.has(s))) return "not-auth"; // rule 1
+  if (body) {
+    const sig = bodyAuthSignatureGo(body, defs);
+    if (sig === "reject") return "auth"; // rule 2: a verified reject blesses even a boring name
+    if (sig === "none") return "not-auth"; // rule 3: a visible non-enforcing body, name never rescues
+    return goNameIsFlavored(name) ? "unsure" : "not-auth"; // rule 4: opaque never blesses on name
+  }
+  return goNameIsFlavored(name) ? "unsure" : "not-auth"; // rule 5: unreadable never blesses on name
+}
+
+/** True when a node is a PURE selector chain (identifiers + field selections
+ *  only, no call/index anywhere in the operand chain). Only a pure chain's .text
+ *  is a NAME — an impure chain would smuggle ARGUMENT text into the resolved
+ *  name. Mirror of the shipped Python discipline. */
+function isPureSelectorChain(node: SyntaxNode): boolean {
+  if (node.type === "identifier") return true;
+  if (node.type !== "selector_expression") return false;
+  const op = node.childForFieldName("operand");
+  return op !== null && isPureSelectorChain(op);
+}
+
+/** The NAME a middleware-position argument resolves to: identifier text, a PURE
+ *  dotted-selector text, or a call's OWN callee text when that callee is an
+ *  identifier or pure selector chain. Never its arguments, never an impure chain.
+ *  Unresolvable -> null (never a bless). */
+function goMiddlewareName(arg: SyntaxNode): string | null {
+  if (arg.type === "identifier") return arg.text;
+  if (arg.type === "selector_expression") return isPureSelectorChain(arg) ? arg.text : null;
+  if (arg.type === "call_expression") {
+    const fn = arg.childForFieldName("function");
+    if (fn && isPureSelectorChain(fn)) return fn.text;
+  }
+  return null;
+}
+
+function goNameHasSubsumingVeto(name: string): boolean {
+  return nameSegments(name).some((s) => GO_SUBSUMING_VETO_SEGMENTS.has(s));
+}
+function goNameIsTransparentWrap(name: string): boolean {
+  return nameSegments(name).some((s) => GO_TRANSPARENT_WRAP_SEGMENTS.has(s));
+}
+/** Whole-segment lane verdict (validation / rate-limit). */
+function goNameHasSegment(name: string, segments: Set<string>, pairs?: Set<string>): boolean {
+  const segs = nameSegments(name);
+  if (segs.some((s) => segments.has(s))) return true;
+  if (pairs) {
+    for (let i = 0; i < segs.length - 1; i++) {
+      if (pairs.has(`${segs[i]} ${segs[i + 1]}`)) return true;
+    }
+  }
+  return false;
+}
+const goNameIsVal = (n: string) => goNameHasSegment(n, GO_VAL_SEGMENTS);
+const goNameIsRate = (n: string) => goNameHasSegment(n, GO_RATE_SEGMENTS, GO_RATE_PAIRS);
+
+/** BODY-FIRST classification of a middleware-position argument: resolve the NAME,
+ *  resolve its in-file EFFECTIVE body (null when imported/opaque), classify via
+ *  classifyGoMiddlewareAuth. Wrap recursion is single-argument only (arity >= 2 is
+ *  Go DI, never classified), depth-capped, and only THROUGH a
+ *  recursion-transparent observability outer or an UNNAMED outer; a subsuming-veto
+ *  outer HALTS. Returns the outcome + the resolved name (for authUnsureHook). */
+function classifyGoMiddlewareArg(
+  arg: SyntaxNode, defs: Map<string, SyntaxNode | null>, depth = 0,
+): { outcome: GoAuthOutcome; name: string | null } {
+  if (depth > 5) return { outcome: "not-auth", name: null };
+  const name = goMiddlewareName(arg);
+  if (name !== null) {
+    // v1 resolves only a BARE-IDENTIFIER target to an in-file def (r.Use(mw) or
+    // r.Use(mwFactory())); a selector/method target stays null -> name-tier.
+    const calleeId =
+      arg.type === "identifier"
+        ? arg
+        : arg.type === "call_expression" && arg.childForFieldName("function")?.type === "identifier"
+          ? arg.childForFieldName("function")
+          : null;
+    const def = calleeId ? defs.get(calleeId.text) ?? null : null;
+    const body = def ? resolveEffectiveBody(def, defs) : null;
+    const outcome = classifyGoMiddlewareAuth(name, body, defs);
+    if (outcome !== "not-auth") return { outcome, name };
+    if (goNameHasSubsumingVeto(name)) return { outcome: "not-auth", name };
+  }
+  // Wrap recursion: single-arg call, through a transparent/unnamed outer only.
+  if (arg.type === "call_expression" && (name === null || goNameIsTransparentWrap(name))) {
+    const inner = goNamed(arg.childForFieldName("arguments"));
+    if (inner.length === 1) return classifyGoMiddlewareArg(inner[0], defs, depth + 1);
+  }
+  return { outcome: "not-auth", name };
+}
+
+/** Every argument of every `With(...)` link while unwinding a chi route's operand
+ *  chain (`r.With(a).With(b).Post(...)` harvests BOTH links). */
+function collectWithArgs(operand: SyntaxNode | null): SyntaxNode[] {
+  const args: SyntaxNode[] = [];
+  let cur: SyntaxNode | null = operand;
+  for (let hops = 0; cur && cur.type === "call_expression" && hops < 16; hops++) {
+    const fn = cur.childForFieldName("function");
+    if (fn?.type !== "selector_expression") break;
+    if (fn.childForFieldName("field")?.text === "With") args.push(...goNamed(cur.childForFieldName("arguments")));
+    cur = fn.childForFieldName("operand");
+  }
+  return args;
+}
+
+/** Per-route auth / validation / rate-limit verdicts + the unsure-hook name, from
+ *  the middleware-position args (With links + strictly-between-path-and-handler
+ *  args) plus, for Handle/HandleFunc forms, the wrap-callee handler arg. */
+function goRouteMiddleware(
+  named: SyntaxNode[], pathIdx: number, wrapCallee: SyntaxNode | null,
+  fnOperand: SyntaxNode | null, defs: Map<string, SyntaxNode | null>,
+): { hasAuth: boolean; hasValidation: boolean; hasRateLimit: boolean; unsureHook: string | undefined } {
+  const withArgs = fnOperand ? collectWithArgs(fnOperand) : [];
+  const middleArgs: SyntaxNode[] = [];
+  for (let i = pathIdx + 1; i < named.length - 1; i++) middleArgs.push(named[i]);
+  const mwArgs = [...withArgs, ...middleArgs];
+
+  let hasAuth = false;
+  let unsureHook: string | undefined;
+  const consider = (a: SyntaxNode) => {
+    const { outcome, name } = classifyGoMiddlewareArg(a, defs);
+    if (outcome === "auth") hasAuth = true;
+    else if (outcome === "unsure" && unsureHook === undefined && name !== null) unsureHook = name;
+  };
+  for (const a of mwArgs) consider(a);
+  if (wrapCallee && wrapCallee.type === "call_expression") consider(wrapCallee);
+  if (hasAuth) unsureHook = undefined; // a blessed route never hedges
+
+  // Lanes stay NAME-based and middleware-arg-scoped (auth-lane only reads bodies).
+  const laneNames = mwArgs.map(goMiddlewareName).filter((n): n is string => n !== null);
+  return {
+    hasAuth,
+    hasValidation: laneNames.some(goNameIsVal),
+    hasRateLimit: laneNames.some(goNameIsRate),
+    unsureHook,
+  };
+}
+
 export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectGoRouterNames(tree.rootNode);
+  const defs = collectGoFunctionDefs(tree.rootNode);
   const gated = (r: string | null): r is string =>
     r !== null && (routerNames.has(r) || GO_ROUTER_RECEIVER.test(r));
 
-  const emit = (method: string, path: string, call: SyntaxNode) => {
+  const emit = (
+    method: string, path: string, call: SyntaxNode,
+    mw: { hasAuth: boolean; hasValidation: boolean; hasRateLimit: boolean; unsureHook: string | undefined },
+  ) => {
     routes.push({
       method,
       path,
@@ -498,10 +1095,14 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       // fluent forms, i.e. the anchor, never a chained .Methods() call's own
       // row): the @vibedrift-public suppression binding depends on it.
       line: call.startPosition.row + 1,
-      hasAuth: false,        // Task 3 (per-route) + Task 4 (scope inheritance)
-      hasValidation: false,
-      hasRateLimit: false,
+      // Per-route body-first auth (Task 3); scope inheritance is Task 4.
+      hasAuth: mw.hasAuth,
+      hasValidation: mw.hasValidation,
+      hasRateLimit: mw.hasRateLimit,
       hasErrorHandler: false, // write-only field; JS and Python AST hard-code false
+      // authUnsureHook only on a NON-blessed, auth-flavored-opaque route; the key
+      // is ABSENT otherwise so every other Go route serializes byte-identically.
+      ...(mw.unsureHook !== undefined ? { authUnsureHook: mw.unsureHook } : {}),
     });
   };
 
@@ -510,7 +1111,8 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
     const fn = call.childForFieldName("function");
     if (!fn || fn.type !== "selector_expression") continue;
     const field = fn.childForFieldName("field")?.text ?? "";
-    const receiver = goReceiverName(fn.childForFieldName("operand"));
+    const fnOperand = fn.childForFieldName("operand");
+    const receiver = goReceiverName(fnOperand);
     const args = call.childForFieldName("arguments");
     const named = args?.namedChildren.filter((n): n is SyntaxNode => n !== null) ?? [];
     const arg0Raw = named.length > 0 ? goStringText(named[0]) : null;
@@ -521,7 +1123,9 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
     if (directVerb !== undefined) {
       if (!gated(receiver)) continue;
       if (arg0Raw === null || !arg0Raw.startsWith("/")) continue; // leading-slash gate
-      emit(directVerb, arg0Raw, call);
+      // Middleware are the args strictly between the path (arg0) and the handler
+      // (last); the last arg is the handler and is NEVER classified.
+      emit(directVerb, arg0Raw, call, goRouteMiddleware(named, 0, null, fnOperand, defs));
       continue;
     }
 
@@ -530,7 +1134,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
     if (ANY_FIELDS.has(field)) {
       if (!gated(receiver)) continue;
       if (arg0Raw === null || !arg0Raw.startsWith("/")) continue;
-      emit("ALL", arg0Raw, call);
+      emit("ALL", arg0Raw, call, goRouteMiddleware(named, 0, null, fnOperand, defs));
       continue;
     }
 
@@ -552,7 +1156,9 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       if (method === null) continue; // literal HEAD/OPTIONS
       const path = goStringText(named[1]);
       if (path === null || !path.startsWith("/")) continue;
-      emit(method, path, call);
+      // Verb-first: verb=arg0, path=arg1, so the middleware window starts after
+      // arg1; the handler (last arg) is never classified.
+      emit(method, path, call, goRouteMiddleware(named, 1, null, fnOperand, defs));
       continue;
     }
 
@@ -565,7 +1171,10 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       if (split === null) continue; // host pattern / lowercase verb / verb-alone / HEAD|OPTIONS embedded
       const method = split.method ?? resolveAnyFieldMethod(call); // embedded verb wins over the chain
       if (method === null) continue; // chain narrowed to HEAD/OPTIONS only
-      emit(method, split.path, call);
+      // The handler is the arg right after the path (arg1); for these forms it
+      // may be a WRAP callee (auth(handler)) — the only body-first position here.
+      const wrapCallee = named.length > 1 ? named[1] : null;
+      emit(method, split.path, call, goRouteMiddleware(named, 0, wrapCallee, fnOperand, defs));
       continue;
     }
   }

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -49,13 +49,13 @@ const BODY_METHODS = ["POST", "PUT", "PATCH", "ALL"];
 
 // ─── Hedged copy for auth routes whose hook could not be verified ────────────
 //
-// A route only carries `authUnsureHook` on the Python AST path, and only when
-// `hasAuth === false` (a blessed route never sets it). Task 4 turns the flat
-// "no auth" copy into a HEDGE that names the exact before_request-style hook the
-// user should verify. The route stays not-authed in every vote — this is copy
-// only. JS/TS/Go/regex routes never set the field, so they always take the flat
-// arm and render byte-identically. No em-dash / double hyphen in the hedged
-// strings (comma/colon/period only).
+// A route only carries `authUnsureHook` on the Python or Go AST path, and only
+// when `hasAuth === false` (a blessed route never sets it). Task 4 turns the
+// flat "no auth" copy into a HEDGE that names the exact before_request-style
+// hook the user should verify. The route stays not-authed in every vote — this
+// is copy only. JS/TS routes and the regex fallback never set the field, so
+// they always take the flat arm and render byte-identically. No em-dash /
+// double hyphen in the hedged strings (comma/colon/period only).
 
 /** Per-deviator hedged pattern naming the unresolved hook, e.g.
  *  `POST /x: auth not confirmed, double check hook 'verify_session'`. */

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -147,14 +147,14 @@ export interface RouteInfo {
   hasValidation: boolean;
   hasRateLimit: boolean;
   hasErrorHandler: boolean;
-  /** Python AST path only: the name of a before_request-style hook whose BODY is
+  /** Python or Go AST path only: the name of a middleware/hook whose BODY is
    *  auth-flavored but statically unverifiable (an opaque helper, an imported or
-   *  attribute target, a duplicate def). Present ONLY when `hasAuth === false`;
-   *  `hasAuth === true` always omits it. An "unsure" route still counts as
-   *  not-authed in every vote (never blesses) — this field only lets a renderer
-   *  hedge the finding copy to name the exact hook the user should double-check.
-   *  Never set on JS/TS/Go or the regex fallback, so those routes serialize
-   *  byte-identically. */
+   *  selector/attribute target, a duplicate def). Present ONLY when
+   *  `hasAuth === false`; `hasAuth === true` always omits it. An "unsure" route
+   *  still counts as not-authed in every vote (never blesses) — this field only
+   *  lets a renderer hedge the finding copy to name the exact middleware the user
+   *  should double-check. Never set on the JS/TS AST path or the regex fallback,
+   *  so those routes serialize byte-identically. */
   authUnsureHook?: string;
 }
 

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -36,6 +36,7 @@ import { SECURITY_SUBCATEGORIES } from "./types.js";
 import { pickIntentHint } from "./utils.js";
 import { extractJsRoutesAst, extractFileMiddlewareAst, SECURITY_AST } from "./security-ast.js";
 import { extractPythonRoutesAst, extractPythonFileMiddlewareAst } from "./security-ast-python.js";
+import { extractGoRoutesAst, extractGoFileMiddlewareAst } from "./security-ast-go.js";
 import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
 
 // Canonical mutating set (upper-cased), shared with the in-loop classifier via
@@ -174,6 +175,7 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
     // mentioning app.use(authMiddleware) matches the jsAuth regex), and noise in
     // this index is a file-wide bless.
     const pythonAst = file.language === "python" && !!file.tree && !file.tree.rootNode.hasError;
+    const goAst = file.language === "go" && !!file.tree && !file.tree.rootNode.hasError;
 
     // JS/TS — Express / Hono / Fastify / Koa. AST when a parsed tree is
     // available (structural: gated on a router/app receiver, not just
@@ -184,10 +186,11 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       jsAuth = mw.hasAuth;
       jsRateLimit = mw.hasRateLimit;
       jsValidation = mw.hasValidation;
-    } else if (pythonAst) {
-      // Cross-language noise: on a clean-parsed python file the js regex arms are
-      // pure noise (they match app.use(...) text inside docstrings/comments), so
-      // force them false rather than let them file-wide-bless a python route.
+    } else if (pythonAst || goAst) {
+      // Cross-language noise on either clean-tree language is a file-wide bless:
+      // on a clean-parsed python OR go file the js regex arms are pure noise (they
+      // match app.use(...) text inside docstrings/comments), so force them false
+      // rather than let them file-wide-bless that file's routes.
       jsAuth = false;
       jsRateLimit = false;
       jsValidation = false;
@@ -198,13 +201,21 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       jsValidation = /(?:router|app)\s*\.\s*use\s*\(\s*[^,)]*?(?:validate|validator|joi|zod|celebrate)/i.test(c);
     }
 
-    // Go — Echo / Gin / Chi
-    // e.Use(AuthMiddleware) | r.Use(authMiddleware) | g := e.Group(...); g.Use(...)
-    // Forced false on a clean-parsed python file for the same cross-language
-    // noise reason as the js arms above.
-    const goAuth = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Aa]uth|RequireAuth|VerifyToken|JWT|Bearer)/.test(c);
-    const goRateLimit = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Rr]ateLimit|[Tt]hrottle|[Ll]imiter)/.test(c);
-    const goValidation = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Vv]alidate|[Vv]alidator)/.test(c);
+    // Go: Gin / Echo / chi / Gorilla. AST when a clean parsed tree is available;
+    // regex fallback otherwise (keeping Phase A's !pythonAst guards
+    // byte-identical). Byte-compat: for every non-(python-or-go-with-clean-tree)
+    // file, ALL regex arms keep running on the raw content exactly as today.
+    let goAuth: boolean, goRateLimit: boolean, goValidation: boolean;
+    if (goAst) {
+      const mw = extractGoFileMiddlewareAst(file.tree!);
+      goAuth = mw.hasAuth;
+      goRateLimit = mw.hasRateLimit;
+      goValidation = mw.hasValidation;
+    } else {
+      goAuth = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Aa]uth|RequireAuth|VerifyToken|JWT|Bearer)/.test(c);
+      goRateLimit = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Rr]ateLimit|[Tt]hrottle|[Ll]imiter)/.test(c);
+      goValidation = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Vv]alidate|[Vv]alidator)/.test(c);
+    }
 
     // Python — Flask / FastAPI
     // @app.before_request def f() | @blueprint.before_request | app.add_middleware(AuthMW)
@@ -215,9 +226,12 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       pyRateLimit = mw.hasRateLimit;
       pyValidation = mw.hasValidation;
     } else {
-      pyAuth = /(?:@\w+\.before_request|@blueprint\.before_request|add_middleware\s*\([^,)]*[Aa]uth|@?\bjwt_required\b|@?\blogin_required\b)/.test(c);
-      pyRateLimit = /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
-      pyValidation = /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
+      // Forced false on a clean-parsed go file for the same cross-language noise
+      // reason as above (a go comment containing login_required currently sets
+      // pyAuth for that go file).
+      pyAuth = !goAst && /(?:@\w+\.before_request|@blueprint\.before_request|add_middleware\s*\([^,)]*[Aa]uth|@?\bjwt_required\b|@?\blogin_required\b)/.test(c);
+      pyRateLimit = !goAst && /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
+      pyValidation = !goAst && /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
     }
 
     index.set(file.relativePath, {
@@ -253,10 +267,27 @@ function inheritedRateLimit(perRoute: boolean, fileMw: FileMiddleware | undefine
 }
 
 function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
+  // AST only on a CLEAN parse: tree-sitter always returns a tree for broken Go
+  // (with ERROR nodes), and error recovery SWALLOWS later valid registrations
+  // into a broken call's argument_list as clean-looking nested calls (a
+  // cross-bless hazard). Any parse error routes the whole file to the regex,
+  // byte-identical to today's behavior INCLUDING the regex path's known
+  // over-blesses (see the pinned-legacy tests).
+  if (file.tree && !file.tree.rootNode.hasError) {
+    // No FileMiddleware argument: the AST path computes receiver-scoped
+    // inheritance from the tree itself (a file-level OR would false-bless
+    // mixed-receiver files, and the index entry may carry cross-language noise
+    // for non-go files).
+    routes.push(...extractGoRoutesAst(file.tree, file.relativePath));
+    return;
+  }
+  extractGoRoutesRegex(file, routes, fileMw.get(file.relativePath));
+}
+
+function extractGoRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddleware: FileMiddleware | undefined) {
   const lines = file.content.split("\n");
   const echoPattern = /\.\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/;
   const gorillaPattern = /HandleFunc\s*\(\s*"([^"]+)".*\.Methods\s*\(\s*"(\w+)"/;
-  const fileMiddleware = fileMw.get(file.relativePath);
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -138,7 +138,7 @@ function scoreColorFn(score: number, max: number): typeof chalk {
 }
 
 /**
- * True when this is an auth-consistency finding the Python body-signature
+ * True when this is an auth-consistency finding the Python or Go body-signature
  * analyzer could not confirm: its recommendation carries the appended "Double
  * check" hedge naming a before_request hook. For such a finding the flat
  * confident "unprotected routes" consequence is a FALSE claim, so the terminal

--- a/test/calibration/README.md
+++ b/test/calibration/README.md
@@ -159,6 +159,88 @@ measures a real behavior change, not a tautology.
   route resolves method exactly POST and enters the mutating auth vote.
   Red-first: pre-addendum a `methods=` variable resolved ALL, not POST.
 
+## Go security fixture (the multilang calibration gate)
+
+`go-security-fixture.ts` + `security-go.test.ts` are the enforced
+precision/recall gate for the Go AST security extractor
+(`src/drift/security-ast-go.ts`), mirroring the Python gate above
+function-for-function and running the same way (a normal vitest file,
+checked on every `npm test`).
+
+The corpus is realistic Gin/Gorilla multi-file code (real router
+constructors, `.Use(...)` scoping, wrapped-handler auth, chained
+`.Methods(...)` resolution), split into seven independent roots so each
+corpus roots its own `repoHasAuthMachinery` evidence and its own
+route-directory vote (`routeGroupKey` = dirname):
+
+- `gosrv/routes/` — 8 Gin route files, one mutating route each. Receiver
+  recognition is deliberately split across both of the extractor's paths:
+  four resolve structurally, via an in-file router-constructor assignment or
+  a `Group(...)` derivation (`r := gin.Default()`, `engine := gin.New()`,
+  `app = gin.New()` plain assignment, `api := r.Group("/api")`); four resolve
+  purely by naming convention on a func-param/struct-field receiver with no
+  local constructor at all (`func RegisterX(router *gin.Engine)`, two
+  `*gin.RouterGroup` params, one method-receiver file). Auth idiom is
+  independently split too: four files register `AuthMiddleware()`
+  receiver-scoped via `.Use(...)` before the route, four pass it as a
+  per-route leading arg.
+- `gosrv/middleware/auth.go` / `gosrv/main.go` — support files. `auth.go`
+  carries the repo-global `AuthMiddleware` machinery token (case-sensitive:
+  this is what `repoHasAuthMachinery` matches); `main.go` wires routes and
+  registers none of its own.
+- `muxsrv/routes/` — 5 Gorilla mux route files, one mutating route each,
+  each defining its own in-file `RequireAuth(next http.Handler)
+  http.Handler` and registering via the WRAPPED-HANDLER form
+  (`router.Handle(path, RequireAuth(http.HandlerFunc(h))).Methods("POST")`).
+  Gorilla is the secondary framework (over Echo/chi) specifically because
+  this one idiom puts the plan's two riskiest recognitions — the wrapped-
+  handler bless and the chained `.Methods` resolution — inside the measured
+  gate; Echo and chi stay covered by the unit catalog.
+- `hooks/routes/` — 5 uniformly PUBLIC webhook receivers (Stripe, GitHub,
+  Slack, Twilio, SendGrid), same negative-control shape as the Python row:
+  signature verification happens inside the handler body, never as a `.Use`
+  hook, so it's structurally invisible to the middleware scanner.
+- `bodycol/routes/`, `bodygate/routes/`, `bodyunsure/routes/` — the three
+  body-signature scenarios (S6-S8 below), each its own root for the same
+  machinery-isolation reason.
+
+**Why S0-S5 counts are unchanged despite the body-first rule:** the LOCKED
+decision is that Go never blesses a middleware on its name alone — an
+imported or opaque `AuthMiddleware`/`RequireAuth` now resolves UNSURE, not
+AUTH. So every authed fixture above DEFINES its middleware IN-FILE with a
+body that verifiably rejects (401 on a missing `Authorization` header), and
+blesses through rule 2 (the readable reject), never through the name. That
+keeps the S0-S5 arithmetic byte-identical to the pre-body-first plan while
+actually exercising the tighter rule.
+
+Nine scenarios, mirroring the Python S0-S8 (Go has no S9 analog: Go
+deliberately emits `"ALL"` for a variable-methods form instead of resolving
+it, so there's no same-file-literal-resolution case to pin):
+
+| # | Scenario | Corpus | Asserts |
+|---|----------|--------|---------|
+| S0 | Recognition + no-name-bless pin | gosrv + muxsrv (13 files) | 1 route/file, exact Gorilla POST method, imported selector hedges, in-file reject blesses |
+| S1 | Primary dominance vote, Gin | gosrv (8 files, 1 stripped) | dominantCount 7, score 88, precision/recall 1.0 |
+| S2 | Primary dominance vote, Gorilla | muxsrv (5 files, 1 stripped) | dominantCount 4, score 80, through the wrap-bless path |
+| S3 | Uniform-auth-gap fallback | gosrv (all 8 stripped) + auth.go | gap fires, severity error, precision/recall 1.0 |
+| S4 | Negative control | hooks (5 files) | non-vacuity first, then zero findings |
+| S5 | Uniformly-authed control | full gosrv + muxsrv corpus | non-vacuity first, then zero findings on every axis |
+| S6 | Name-auth-but-body-isnt collision | bodycol (5 files) | flat not-auth, NOT suppressed, no hedge |
+| S7 | Body-is-real-auth positive | bodygate (5 files) | boring `guard()` hook blesses on body alone |
+| S8 | Unresolvable-body UNSURE | bodyunsure (5 files) | hedged copy naming the hook, counts match S6, no leakage into S1 |
+
+**S6-S8 RED-FIRST rationale:** each scenario is a case where a name-only
+classifier gives the WRONG answer, and only resolves once body-first lands.
+S6's `authCheck` reads as auth by name but only logs the request path — a
+name-only path would bless it and the scenario would produce zero findings;
+body-first correctly reads the visible non-enforcing body and flags it. S7's
+`guard()` hook carries no auth-flavored name at all — a name-only path would
+never bless it, so scenario A would fail non-vacuity; body-first reads the
+401-on-missing-header body and blesses it. S8's imported
+`middleware.VerifyToken` has an auth-flavored name but an unreadable body — a
+name-only path would bless it outright (zero findings); body-first resolves
+it UNSURE instead (hedged, still flagged, never a bless).
+
 ## Adding a new injection type
 
 Drop a generator in `generators/`. Signature:

--- a/test/calibration/go-security-fixture.ts
+++ b/test/calibration/go-security-fixture.ts
@@ -1,0 +1,705 @@
+/**
+ * Calibration fixture for the Go AST security extractor (Task 7): a realistic
+ * Gin + Gorilla multi-file corpus with planted ground truth, used by
+ * test/calibration/security-go.test.ts to measure the primary dominance vote
+ * (analyzeSecurityProperty), the uniform-auth-gap fallback
+ * (analyzeUniformAuthGap), a negative control, and the three body-signature
+ * outcomes (collision / gate / unsure) added by the body-first classifier
+ * (Task 3-4). Mirrors python-security-fixture.ts function-for-function.
+ *
+ * LOCKED decision (see task-7-brief.md): blessing requires a verifiable
+ * reject in a READABLE IN-FILE body. An imported/opaque auth middleware
+ * NEVER blesses on its name alone — it resolves UNSURE at best. So every
+ * authed corpus below DEFINES its `AuthMiddleware` / `RequireAuth` /
+ * `guard` IN-FILE with a body that actually rejects (401-family), and
+ * blesses through rule 2 (the readable reject), never through the name.
+ *
+ * Directory layout mirrors seven independent "repos" so each corpus roots
+ * its own `repoHasAuthMachinery` evidence (repo-global over whatever files
+ * are in ctx.files, not scoped to a route group) and its own route-directory
+ * vote (`routeGroupKey` = dirname, so every corpus's route files share ONE
+ * parent directory):
+ *   gosrv/routes/*.go        8 Gin route files, one mutating route each
+ *   gosrv/middleware/auth.go the repo-global AuthMiddleware machinery token
+ *   gosrv/main.go             factory that wires routes, registers none itself
+ *   muxsrv/routes/*.go       5 Gorilla mux route files, one mutating route each
+ *   muxsrv/middleware/auth.go RequireAuth, retained for the authed-control list only
+ *   hooks/routes/*_hook.go   5 uniformly PUBLIC webhook receivers (negative control)
+ *   bodycol/routes/*.go      S6: 4 authed + 1 name-auth-but-body-isnt collision
+ *   bodygate/routes/*.go     S7: 5 routes whose ONLY auth is a boring guard() hook
+ *   bodyunsure/routes/*.go   S8: 4 authed + 1 imported-hook UNSURE
+ *
+ * Receiver recognition in the Gin group deliberately mixes two recognition
+ * paths (the Flask convention/structural mix, ported to Go): four routes
+ * resolve their receiver STRUCTURALLY, via an in-file router-constructor
+ * assignment or a Group(...) derivation (`r := gin.Default()`, `engine :=
+ * gin.New()`, `app = gin.New()` plain assignment, `api := r.Group("/api")`),
+ * and four resolve purely by NAMING CONVENTION on a func-param/struct-field
+ * receiver with no local constructor call at all (`func RegisterX(router
+ * *gin.Engine)`, two `*gin.RouterGroup` params, one method-receiver file).
+ * Auth idiom is independently split across BOTH: four files register auth
+ * receiver-scoped via `<recv>.Use(AuthMiddleware())` BEFORE the route, four
+ * pass it as a per-route leading arg `<recv>.POST(path, AuthMiddleware(),
+ * handler)` — two of each idiom land in each receiver-recognition group, so
+ * every corner of the 2x2 is exercised by a real route file.
+ */
+import type { BaselineFile } from "./baseline.js";
+
+function capitalize(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/** A Go struct-tag literal, e.g. jsonTag("sku") -> `` `json:"sku"` ``. Built via
+ *  a plain double-quoted string so no backtick-escaping is needed at any of
+ *  this file's (already backtick-delimited) call sites. */
+function jsonTag(key: string): string {
+  return "`json:\"" + key + "\"`";
+}
+
+// The in-file auth middleware every "authed" Gin fixture defines: a factory
+// returning a closure that 401s when the Authorization header is missing.
+// Identical text across every file that uses it, so a single strip() call
+// can remove it deterministically (see stripGinAuth below).
+const GIN_AUTH_BLOCK =
+`func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("Authorization") == "" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+}
+
+`;
+
+// ─── gosrv: 8 Gin route files, one mutating route each ───────────────────────
+const GOSRV_ROOT = "gosrv/routes";
+
+function ginRequestStruct(name: string, fields: Array<[string, string, string]>): string {
+  const cap = capitalize(name);
+  const lines = fields.map(([f, t, j]) => `\t${f} ${t} ${jsonTag(j)}`).join("\n");
+  return `type create${cap}Request struct {\n${lines}\n}`;
+}
+
+function ginHandler(name: string): string {
+  const cap = capitalize(name);
+  return `func create${cap}(c *gin.Context) {\n\tc.JSON(201, gin.H{"ok": true})\n}\n`;
+}
+
+// 1. users — structural (r := gin.Default()), Use-idiom.
+function usersFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/users.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("user", [["Email", "string", "email"], ["Name", "string", "name"]])}
+
+${GIN_AUTH_BLOCK}func RegisterUsers() {
+	r := gin.Default()
+	r.Use(AuthMiddleware())
+	r.POST("/users", createUser)
+}
+
+${ginHandler("user")}`,
+  };
+}
+
+// 2. orders — structural (engine := gin.New()), Use-idiom.
+function ordersFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/orders.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("order", [["SKU", "string", "sku"], ["Count", "int", "count"]])}
+
+${GIN_AUTH_BLOCK}func RegisterOrders() {
+	engine := gin.New()
+	engine.Use(AuthMiddleware())
+	engine.POST("/orders", createOrder)
+}
+
+${ginHandler("order")}`,
+  };
+}
+
+// 3. payments — structural (app = gin.New() plain assignment), per-route arg.
+function paymentsFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/payments.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("payment", [["Amount", "int", "amount"], ["Currency", "string", "currency"]])}
+
+var app *gin.Engine
+
+${GIN_AUTH_BLOCK}func RegisterPayments() {
+	app = gin.New()
+	app.POST("/payments", AuthMiddleware(), createPayment)
+}
+
+${ginHandler("payment")}`,
+  };
+}
+
+// 4. products — structural derived group (api := r.Group("/api")), per-route arg.
+function productsFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/products.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("product", [["Name", "string", "name"], ["Price", "float64", "price"]])}
+
+${GIN_AUTH_BLOCK}func RegisterProducts(r *gin.Engine) {
+	api := r.Group("/api")
+	api.POST("/products", AuthMiddleware(), createProduct)
+}
+
+${ginHandler("product")}`,
+  };
+}
+
+// 5. invoices — convention func-param (router *gin.Engine, no local ctor), Use-idiom.
+function invoicesFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/invoices.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("invoice", [["CustomerID", "string", "customerId"], ["Total", "float64", "total"]])}
+
+${GIN_AUTH_BLOCK}func RegisterInvoices(router *gin.Engine) {
+	router.Use(AuthMiddleware())
+	router.POST("/invoices", createInvoice)
+}
+
+${ginHandler("invoice")}`,
+  };
+}
+
+// 6. carts — convention func-param (*gin.RouterGroup, no local ctor), Use-idiom.
+function cartsFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/carts.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("cart", [["UserID", "string", "userId"]])}
+
+${GIN_AUTH_BLOCK}func RegisterCarts(grp *gin.RouterGroup) {
+	grp.Use(AuthMiddleware())
+	grp.POST("/carts", createCart)
+}
+
+${ginHandler("cart")}`,
+  };
+}
+
+// 7. sessions — convention func-param (*gin.RouterGroup, no local ctor), per-route arg.
+function sessionsFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/sessions.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("session", [["UserID", "string", "userId"]])}
+
+${GIN_AUTH_BLOCK}func RegisterSessions(apiGroup *gin.RouterGroup) {
+	apiGroup.POST("/sessions", AuthMiddleware(), createSession)
+}
+
+${ginHandler("session")}`,
+  };
+}
+
+// 8. notifications — convention method-receiver (s.router.POST), per-route arg.
+function notificationsFile(): BaselineFile {
+  return {
+    path: `${GOSRV_ROOT}/notifications.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("notification", [["UserID", "string", "userId"], ["Message", "string", "message"]])}
+
+type server struct {
+	router *gin.Engine
+}
+
+${GIN_AUTH_BLOCK}func (s *server) RegisterNotifications() {
+	s.router.POST("/notifications", AuthMiddleware(), createNotification)
+}
+
+${ginHandler("notification")}`,
+  };
+}
+
+export function ginAuthedGroup(): BaselineFile[] {
+  return [
+    usersFile(), ordersFile(), paymentsFile(), productsFile(),
+    invoicesFile(), cartsFile(), sessionsFile(), notificationsFile(),
+  ];
+}
+
+// Support files: kept OUT of ginAuthedGroup() so it stays one-route-per-file
+// exactly (S0's route-loss guard requires every element to yield exactly one
+// route). goAuthFile is the repo-global MACHINERY-token support file: the
+// route files now each carry their OWN in-file AuthMiddleware (that is what
+// blesses each route directly), so this file's role is purely to keep the
+// "the codebase uses auth elsewhere" evidence present once those in-file
+// copies are stripped (S3). The exported name is LOAD-BEARING: "AuthMiddleware"
+// (capital A, capital M) is what the case-sensitive repoHasAuthMachinery
+// regex matches.
+export const goAuthFile: BaselineFile = {
+  path: "gosrv/middleware/auth.go",
+  content:
+`package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AuthMiddleware is the shared repo auth gate. Route files under gosrv/routes
+// each define their OWN in-file copy (that is what actually blesses each
+// route); this file exists so "the codebase uses auth elsewhere" evidence
+// survives once those in-file copies are stripped.
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("Authorization") == "" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+}
+`,
+};
+
+export const goMainFile: BaselineFile = {
+  path: "gosrv/main.go",
+  content:
+`package main
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"example.com/gosrv/routes"
+)
+
+func main() {
+	r := gin.Default()
+	routes.RegisterProducts(r)
+	routes.RegisterInvoices(r)
+	r.Run(":8080")
+}
+`,
+};
+
+function sortedEligiblePaths(files: BaselineFile[], predicate: (path: string) => boolean): string[] {
+  return files
+    .map((f) => f.path)
+    .filter(predicate)
+    .sort();
+}
+
+/** Sorted gosrv/routes/*.go paths in `files` — the deterministic strip order
+ *  stripGinAuth uses, exposed so tests can compute which path(s) got stripped
+ *  without duplicating the sort/filter logic. */
+export function sortedGinRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${GOSRV_ROOT}/`) && p.endsWith(".go"));
+}
+
+/** Deterministically strips the in-file AuthMiddleware block AND its call site
+ *  (a `<recv>.Use(AuthMiddleware())` own-line for the Use idiom, or the inline
+ *  `AuthMiddleware(), ` argument for the per-route-arg idiom — idiom-agnostic,
+ *  so it works on either shape without per-file metadata) from the first
+ *  `count` gosrv route files, sorted by path. The route registration and its
+ *  path are untouched, so every stripped file remains a valid, still-mutating
+ *  route with hasAuth: false and NO machinery token of its own. */
+export function stripGinAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedGinRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    let content = f.content.replace(GIN_AUTH_BLOCK, "");
+    content = content
+      .split("\n")
+      .filter((line) => !/^\s*\S+\.Use\(AuthMiddleware\(\)\)\s*$/.test(line))
+      .join("\n");
+    content = content.replace(/AuthMiddleware\(\),\s*/g, "");
+    return { path: f.path, content };
+  });
+}
+
+// ─── muxsrv: 5 Gorilla mux route files, one mutating route each ─────────────
+const MUXSRV_ROOT = "muxsrv/routes";
+
+// 5 Gorilla files so one deviator gives 4/5 = 0.8 > 0.75 (n=4 can never clear
+// the strict gate). Each blesses through the WRAPPED-HANDLER form
+// (RequireAuth(http.HandlerFunc(handleX))) resolved via rule 2 (the readable
+// in-file reject inside the returned closure), never on the name.
+function muxRouteFile(name: string): BaselineFile {
+  const cap = capitalize(name);
+  return {
+    path: `${MUXSRV_ROOT}/${name}.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+${ginRequestStruct(name, [["ID", "string", "id"]])}
+
+func RequireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func Register${cap}() {
+	router := mux.NewRouter()
+	router.Handle("/${name}", RequireAuth(http.HandlerFunc(handle${cap}))).Methods("POST")
+}
+
+func handle${cap}(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+}
+`,
+  };
+}
+
+export function muxAuthedGroup(): BaselineFile[] {
+  return ["items", "accounts", "subscriptions", "tickets", "shipments"].map(muxRouteFile);
+}
+
+// Retained only for the uniformly-authed control's file list; the routes no
+// longer import it (they bless via their own in-file def). "RequireAuth"
+// (capital R) is not "requireAuth" (lowercase r) — the case-sensitive
+// repoHasAuthMachinery regex does not match it, so this file carries no
+// machinery-token evidence (gosrv's AuthMiddleware does that job in mixed
+// scenarios; S2 needs no gap fallback in the first place).
+export const muxAuthFile: BaselineFile = {
+  path: "muxsrv/middleware/auth.go",
+  content:
+`package middleware
+
+import "net/http"
+
+func RequireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+`,
+};
+
+/** Sorted muxsrv/routes/*.go paths in `files`, same purpose as
+ *  sortedGinRoutePaths above. */
+export function sortedMuxRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${MUXSRV_ROOT}/`) && p.endsWith(".go"));
+}
+
+/** Deterministically strips auth from the first `count` sorted mux route
+ *  files: replaces `RequireAuth(http.HandlerFunc(handleX))` with the bare
+ *  `http.HandlerFunc(handleX)`. The now-unused in-file RequireAuth def may
+ *  stay (its name does not match the machinery regex, so it never leaks
+ *  false "the repo uses auth elsewhere" evidence). */
+export function stripMuxAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedMuxRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const content = f.content.replace(/RequireAuth\(http\.HandlerFunc\((\w+)\)\)/, "http.HandlerFunc($1)");
+    return { path: f.path, content };
+  });
+}
+
+/** uniformly-authed control: the full Gin + Gorilla corpus, unchanged. */
+export function uniformlyAuthed(): BaselineFile[] {
+  return [...ginAuthedGroup(), goAuthFile, goMainFile, ...muxAuthedGroup(), muxAuthFile];
+}
+
+// ─── hooks: 5 uniformly PUBLIC webhook receivers (negative control) ─────────
+const HOOKS_ROOT = "hooks/routes";
+
+interface HookProvider { name: string; header: string; }
+const HOOK_PROVIDERS: HookProvider[] = [
+  { name: "stripe", header: "Stripe-Signature" },
+  { name: "github", header: "X-Hub-Signature-256" },
+  { name: "slack", header: "X-Slack-Signature" },
+  { name: "twilio", header: "X-Twilio-Signature" },
+  { name: "sendgrid", header: "X-Sendgrid-Signature" },
+];
+
+// Signature checking (if any) happens INSIDE the handler body via a helper
+// named isValidSignature — never as a Use hook, never as a wrap, and the
+// handler position is never classified by the middleware scanner in the
+// first place. Own directory root so it never shares repoHasAuthMachinery
+// evidence with the authed corpora.
+function hookFile(provider: HookProvider): BaselineFile {
+  const cap = capitalize(provider.name);
+  return {
+    path: `${HOOKS_ROOT}/${provider.name}_hook.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ${cap} webhook receiver. Requests are verified via payload signature
+// checking inside the handler, never via a gate that runs before it.
+
+func Register${cap}Webhook(${provider.name}Router *gin.RouterGroup) {
+	${provider.name}Router.POST("/webhooks/${provider.name}", handle${cap}Event)
+}
+
+func handle${cap}Event(c *gin.Context) {
+	if !isValidSignature(c.GetHeader("${provider.header}")) {
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+	c.JSON(200, gin.H{"received": true})
+}
+
+func isValidSignature(header string) bool {
+	return len(header) > 8
+}
+`,
+  };
+}
+
+export function publicByDesignControl(): BaselineFile[] {
+  return HOOK_PROVIDERS.map(hookFile);
+}
+
+// ─── S6-S8: body-signature calibration groups ────────────────────────────────
+//
+// Each group roots its own directory so the route-directory vote grouping and
+// repoHasAuthMachinery evidence never bleed between scenarios. Each helper
+// keeps "one route per file" so the non-vacuity guards stay exact.
+
+/** A Gin route file authed by an in-file AuthMiddleware factory, Use-scoped
+ *  BEFORE the route (rule-2 bless). Shared by bodyCollisionGroup (S6) and
+ *  bodyUnsureGroup (S8) for their four confidently-authed peers. */
+function ginUseAuthedFile(root: string, name: string): BaselineFile {
+  const cap = capitalize(name);
+  return {
+    path: `${root}/${name}.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct(name, [["Name", "string", "name"]])}
+
+${GIN_AUTH_BLOCK}func Register${cap}(router *gin.Engine) {
+	router.Use(AuthMiddleware())
+	router.POST("/${name}", create${cap})
+}
+
+${ginHandler(name)}`,
+  };
+}
+
+// ── S6: name-auth-but-body-isnt collision (negative) ─────────────────────────
+const S6_ROOT = "bodycol/routes";
+/** The one deviator in S6: its only gate is an in-file `authCheck` whose
+ *  visible body merely LOGS the request path and calls Next unconditionally.
+ *  Body-first classification resolves it flat not-auth (name looks like
+ *  auth, body is not), so the finding must NOT be suppressed. */
+export const bodyCollisionDeviatorPath = `${S6_ROOT}/notify.go`;
+export function bodyCollisionGroup(): BaselineFile[] {
+  const authed = ["widgets", "gadgets", "tools", "devices"].map((n) => ginUseAuthedFile(S6_ROOT, n));
+  const collision: BaselineFile = {
+    path: bodyCollisionDeviatorPath,
+    content:
+`package routes
+
+import (
+	"log"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct("notify", [["Message", "string", "message"]])}
+
+// authCheck's NAME looks like auth, but its BODY only logs the request path
+// and calls Next unconditionally: body-first classification resolves this
+// flat not-auth (a visible non-enforcing body, rule 3), never a bless and
+// never a hedge.
+func authCheck(c *gin.Context) {
+	log.Printf("auth %s", c.Request.URL.Path)
+	c.Next()
+}
+
+func RegisterNotify(r *gin.Engine) {
+	r.Use(authCheck)
+	r.POST("/notify", createNotify)
+}
+
+${ginHandler("notify")}`,
+  };
+  return [...authed, collision];
+}
+
+// ── S7: body-is-real-auth positive (boring guard() hook) ─────────────────────
+const S7_ROOT = "bodygate/routes";
+/** The exact Use block S7 files carry and stripBodyGate removes: a boring
+ *  name (`guard`) whose BODY reads the Authorization header and 401s, so ONLY
+ *  the body signature blesses (no auth-lexicon identifier anywhere in S7). */
+const GO_GUARD_BLOCK =
+`func guard(c *gin.Context) {
+	if c.GetHeader("Authorization") == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	c.Next()
+}
+
+`;
+function bodyGateFile(name: string): BaselineFile {
+  const cap = capitalize(name);
+  return {
+    path: `${S7_ROOT}/${name}.go`,
+    content:
+`package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct(name, [["Name", "string", "name"]])}
+
+${GO_GUARD_BLOCK}func Register${cap}(r *gin.Engine) {
+	r.Use(guard)
+	r.POST("/${name}", create${cap})
+}
+
+${ginHandler(name)}`,
+  };
+}
+export function bodyGateGroup(): BaselineFile[] {
+  return ["posts", "comments", "reviews", "tags", "media"].map(bodyGateFile);
+}
+export function sortedBodyGateRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${S7_ROOT}/`) && p.endsWith(".go"));
+}
+/** Removes the guard() Use block from the first `count` S7 files, sorted by
+ *  path, leaving a bare (now unauthed) still-mutating route. */
+export function stripBodyGate(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedBodyGateRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const content = f.content
+      .replace(GO_GUARD_BLOCK, "")
+      .split("\n")
+      .filter((line) => line.trim() !== "r.Use(guard)")
+      .join("\n");
+    return { path: f.path, content };
+  });
+}
+
+// ── S8: unresolvable-body UNSURE (imported auth-flavored middleware) ─────────
+const S8_ROOT = "bodyunsure/routes";
+/** The one deviator in S8: an IMPORTED auth-flavored middleware whose body is
+ *  not visible in this file, so it resolves UNSURE (hasAuth false,
+ *  authUnsureHook set, hedged copy), never a bless. */
+export const bodyUnsureDeviatorPath = `${S8_ROOT}/reports.go`;
+export function bodyUnsureGroup(): BaselineFile[] {
+  const authed = ["alpha", "beta", "gamma", "delta"].map((n) => ginUseAuthedFile(S8_ROOT, n));
+  const unsure: BaselineFile = {
+    path: bodyUnsureDeviatorPath,
+    content:
+`package routes
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"example.com/bodyunsure/middleware"
+)
+
+${ginRequestStruct("report", [["Title", "string", "title"]])}
+
+// The only gate is an IMPORTED auth-flavored middleware.VerifyToken: its body
+// is not visible in this file, so it resolves UNSURE (hedged copy naming the
+// hook), never a bless.
+func RegisterReports(router *gin.Engine) {
+	router.Use(middleware.VerifyToken)
+	router.POST("/reports", createReport)
+}
+
+${ginHandler("report")}`,
+  };
+  return [...authed, unsure];
+}

--- a/test/calibration/precision-recall.ts
+++ b/test/calibration/precision-recall.ts
@@ -22,6 +22,7 @@ import type { Finding } from "../../src/core/types.js";
 import { generateBaseline, type BaselineFile } from "./baseline.js";
 import { INJECTORS } from "./injectors.js";
 import { flaskAuthedGroup, pyAuthFile, pyAppFile, stripFlaskAuth } from "./python-security-fixture.js";
+import { ginAuthedGroup, goAuthFile, goMainFile, stripGinAuth } from "./go-security-fixture.js";
 import { classify, findingCategory, type CategoryMetrics, type DriftLabel, type ScoredFinding } from "./metrics.js";
 
 // Each injector's expected detector category (what a correct detector emits).
@@ -142,13 +143,32 @@ async function main(): Promise<void> {
     .map((s) => ({ ...s, category: "security_posture_py" }));
   mergeInto(agg, classify(pyScored, pyLabels));
 
+  // 4. Go security corpus (own root, own row label), mirroring the Python row
+  // above verbatim. Exercises the AST extractor's realistic Gin fixture
+  // through the FULL on-disk scan pipeline (not the direct detector call
+  // test/calibration/security-go.test.ts uses), kept out of the TS
+  // baseline/injector loop for the same isolation reason as the Python row:
+  // merging Go files into generateBaseline() would contaminate the
+  // naming/architecture rows and shift the clean-scan FP floor, and merging
+  // this row's counts into the JS "security_posture" category (or the Python
+  // row) would let a Go regression hide behind good JS/Python numbers.
+  const goBase = [...ginAuthedGroup(), goAuthFile, goMainFile];
+  const goVariant = stripGinAuth(goBase, 3); // 3 of 8 unauthed -> ratio 5/8 <= 0.75: primary vote silent, gap path
+  const goLabels = diffLabels(goBase, goVariant, "security_posture_go");
+  const goDir = join(root, "security_go");
+  await writeFixture(goDir, goVariant);
+  const goScored = scored(await scan(goDir))
+    .filter((s) => s.category === "security_posture")
+    .map((s) => ({ ...s, category: "security_posture_go" }));
+  mergeInto(agg, classify(goScored, goLabels));
+
   const allRows = finalize(agg);
   // Only the INJECTED categories have synthetic ground truth — those are the
   // ones we can fairly score. Other categories that fire on the templated
   // baseline (semantic_duplication, dead-code, phantom_scaffolding — the 6
   // near-identical, consumer-less handlers legitimately trip them) have no
   // ground truth here and are reported separately as un-measured.
-  const injectedCats = new Set([...Object.values(INJECTOR_CATEGORY), "security_posture_py"]);
+  const injectedCats = new Set([...Object.values(INJECTOR_CATEGORY), "security_posture_py", "security_posture_go"]);
   const rows = allRows.filter((r) => injectedCats.has(r.category));
   const unmeasured = allRows.filter((r) => !injectedCats.has(r.category) && (r.fp ?? 0) > 0);
 

--- a/test/calibration/security-go.test.ts
+++ b/test/calibration/security-go.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Task 7: the enforced precision/recall calibration gate for the Go security
+ * extractor (vitest discovers test/**\/*.test.ts, so this runs as part of
+ * `npm test`, not just `npm run calibrate`).
+ *
+ * Nine scenarios against test/calibration/go-security-fixture.ts's realistic
+ * Gin/Gorilla corpus, each computing precision/recall explicitly against
+ * planted ground truth (not just checking the finding fired). Mirrors
+ * security-python.test.ts's S0-S8 structure and ordering; Go has no S9
+ * analog (Go deliberately emits "ALL" for a variable-methods form instead of
+ * resolving it, so there is no same-file-literal-resolution scenario to
+ * pin).
+ *
+ * LOCKED decision (task-7-brief.md): blessing requires a verifiable reject in
+ * a READABLE IN-FILE body, never a name alone. So the authed corpora below
+ * (S1, S2, S5, and the four confident peers in S6/S8) bless because their
+ * middleware is DEFINED IN-FILE with a body that rejects, never because the
+ * middleware's NAME sounds like auth.
+ *
+ *   S0  recognition self-check — the route-loss guard, PLUS the no-name-bless
+ *       classifier pin (imported selector hedges, in-file reject blesses).
+ *   S1  primary dominance vote, Gin (8 files, 1 planted deviator).
+ *   S2  primary dominance vote, Gorilla (5 files, 1 planted deviator, through
+ *       the wrapped-handler bless path).
+ *   S3  uniform-auth-gap fallback (all 8 Gin routes stripped at once).
+ *   S4  negative control — uniformly public webhook receivers. Non-vacuity
+ *       (routes ARE extracted) is asserted BEFORE zero-findings.
+ *   S5  uniformly-authed control — zero findings on every axis.
+ *   S6  name-auth-but-body-isnt collision (authCheck that only logs): must
+ *       NOT suppress the finding.
+ *   S7  body-is-real-auth positive (a boring guard() hook): the body
+ *       signature alone blesses; no auth-lexicon name anywhere.
+ *   S8  unresolvable-body UNSURE (imported auth-flavored middleware): stays
+ *       flagged with HEDGED copy naming the hook; counts match S6; S1 stays
+ *       flat in the same run.
+ */
+import { describe, it, expect } from "vitest";
+import { securityConsistency } from "../../src/drift/security-consistency.js";
+import { SECURITY_SUBCATEGORIES } from "../../src/drift/types.js";
+import type { DriftFile } from "../../src/drift/types.js";
+import {
+  extractGoRoutesAst,
+  collectGoFunctionDefs,
+  classifyGoMiddlewareAuth,
+} from "../../src/drift/security-ast-go.js";
+import { fileWithTree } from "../helpers/drift-tree.js";
+import type { BaselineFile } from "./baseline.js";
+import {
+  ginAuthedGroup,
+  muxAuthedGroup,
+  publicByDesignControl,
+  uniformlyAuthed,
+  goAuthFile,
+  goMainFile,
+  sortedGinRoutePaths,
+  sortedMuxRoutePaths,
+  stripGinAuth,
+  stripMuxAuth,
+  bodyCollisionGroup,
+  bodyCollisionDeviatorPath,
+  bodyGateGroup,
+  sortedBodyGateRoutePaths,
+  stripBodyGate,
+  bodyUnsureGroup,
+  bodyUnsureDeviatorPath,
+} from "./go-security-fixture.js";
+
+async function toDriftFiles(files: BaselineFile[]): Promise<DriftFile[]> {
+  return Promise.all(files.map((f) => fileWithTree(f.path, f.content, "go")));
+}
+
+async function ctxFor(files: BaselineFile[]) {
+  const driftFiles = await toDriftFiles(files);
+  return {
+    files: driftFiles,
+    totalLines: driftFiles.reduce((s, f) => s + f.lineCount, 0),
+    dominantLanguage: "go",
+  };
+}
+
+function authFindings(findings: ReturnType<typeof securityConsistency.detect>) {
+  return findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.auth);
+}
+
+describe("Go calibration: S0 recognition self-check (route-loss guard + no-name-bless pin)", () => {
+  it("extracts exactly one route per file across all 13 gosrv + muxsrv route files, mixed receiver-recognition paths", async () => {
+    const routeFiles = [...ginAuthedGroup(), ...muxAuthedGroup()];
+    let total = 0;
+    for (const f of routeFiles) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      // A receiver-gate or wrap-recognition regression fails HERE with a count
+      // and the offending file's path, instead of silently vanishing from a
+      // vote count several layers down.
+      expect(routes, f.path).toHaveLength(1);
+      total += routes.length;
+    }
+    expect(total).toBe(13);
+  });
+
+  it("every muxsrv route resolves method exactly POST (a Methods-chain regression to ALL still passes S2/S5, so this is the only place that pins it)", async () => {
+    for (const f of muxAuthedGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes[0].method, f.path).toBe("POST");
+    }
+  });
+
+  it("extracts exactly 5 routes from the negative control", async () => {
+    let total = 0;
+    for (const f of publicByDesignControl()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("no-name-bless classifier pin: an imported selector with no in-file def HEDGES, never blesses; an in-file rejecting body DOES bless", async () => {
+    // Negative: a package-qualified selector with no in-file def to resolve
+    // is opaque, never a bless. If a name-bless-on-opaque regression landed,
+    // these would flip to "auth".
+    expect(classifyGoMiddlewareAuth("middleware.AuthMiddleware", null, new Map())).toBe("unsure");
+    expect(classifyGoMiddlewareAuth("middleware.RequireAuth", null, new Map())).toBe("unsure");
+
+    // Positive: this is HOW the S1/S2 corpus actually blesses — an in-file
+    // def whose body verifiably rejects. If in-file body resolution broke,
+    // S1-S5 would silently collapse (their finding counts would go to zero,
+    // not throw), so this is pinned as its own assertion.
+    const driftFile = await fileWithTree(
+      "x.go",
+      `package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func AuthMiddleware(c *gin.Context) {
+	if c.GetHeader("Authorization") == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	c.Next()
+}
+`,
+      "go",
+    );
+    const defs = collectGoFunctionDefs(driftFile.tree!.rootNode);
+    const def = defs.get("AuthMiddleware")!;
+    const body = def.childForFieldName("body")!;
+    expect(classifyGoMiddlewareAuth("AuthMiddleware", body, defs)).toBe("auth");
+  });
+});
+
+describe("Go calibration: S1 primary dominance vote, Gin", () => {
+  it("flags exactly the one stripped file among 8 Gin route files (dominantCount 7, consistencyScore 88)", async () => {
+    const strippedPath = sortedGinRoutePaths(ginAuthedGroup())[0];
+    const files = [...stripGinAuth(ginAuthedGroup(), 1), goAuthFile, goMainFile];
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(7);
+    expect(finding.totalRelevantFiles).toBe(8);
+    expect(finding.consistencyScore).toBe(88);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Go calibration: S2 primary dominance vote, Gorilla (through the wrapped-handler bless path)", () => {
+  it("flags exactly the one stripped file among 5 Gorilla route files (dominantCount 4, consistencyScore 80)", async () => {
+    const strippedPath = sortedMuxRoutePaths(muxAuthedGroup())[0];
+    const files = stripMuxAuth(muxAuthedGroup(), 1);
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Go calibration: S3 uniform-auth-gap fallback", () => {
+  it("flags all 8 mutating Gin routes when the primary vote goes silent but the repo uses auth elsewhere", async () => {
+    const plantedPaths = sortedGinRoutePaths(ginAuthedGroup());
+    // gosrv/middleware/auth.go retained (carries the repoHasAuthMachinery
+    // evidence); gosrv/main.go deliberately NOT included here — the gap must
+    // fire from auth.go's AuthMiddleware token alone.
+    const files = [...stripGinAuth(ginAuthedGroup(), 8), goAuthFile];
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.finding).toContain(
+      "8 mutating route(s) lack auth while the codebase uses auth elsewhere",
+    );
+    expect(finding.severity).toBe("error");
+    expect(finding.confidence).toBe(0.6);
+    expect(finding.deviatingFiles.map((d) => d.path).sort()).toEqual(plantedPaths);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set(plantedPaths);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Go calibration: S4 negative control (uniformly public by design)", () => {
+  const MACHINERY =
+    /\b(requireAuth|isAuthenticated|verifyToken|authMiddleware|ensureAuth|withAuth|jwt_required|login_required|AuthMiddleware|passport)\b/;
+
+  it("negative control contains no repo auth-machinery token (self-check)", () => {
+    for (const f of publicByDesignControl()) {
+      expect(MACHINERY.test(f.content), f.path).toBe(false);
+    }
+  });
+
+  it("non-vacuity FIRST: extracts exactly 5 mutating, unauthed routes before silence can mean anything", async () => {
+    let total = 0;
+    for (const f of publicByDesignControl()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(["POST", "PUT", "PATCH", "DELETE", "ALL"], f.path).toContain(routes[0].method);
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("THEN: produces zero security_posture findings", async () => {
+    const ctx = await ctxFor(publicByDesignControl());
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+});
+
+describe("Go calibration: S5 uniformly-authed control", () => {
+  it("non-vacuity FIRST: extracts 13 routes across the corpus, every one authed, before silence can mean anything", async () => {
+    let total = 0;
+    for (const f of uniformlyAuthed()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      for (const r of routes) {
+        expect(r.hasAuth, `${f.path} ${r.method} ${r.path}`).toBe(true);
+        total += 1;
+      }
+    }
+    expect(total).toBe(13);
+  });
+
+  it("produces zero security_posture findings across the whole Gin + Gorilla corpus, incl. validation and rate-limit", async () => {
+    const ctx = await ctxFor(uniformlyAuthed());
+    const findings = securityConsistency.detect(ctx as any);
+
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+    expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.validation)).toEqual([]);
+    expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.rateLimit)).toEqual([]);
+  });
+});
+
+// ─── S6-S8: body-signature scenarios ──────────────────────────────────────────
+// Each RED-FIRST-verified against a pre-body-first (name-only) classifier: S6's
+// authCheck name would have blessed the collision route (zero findings); S7's
+// scenario A would have failed non-vacuity (no body-bless, name-only sees
+// nothing under "guard"); S8's VerifyToken name would have blessed the
+// imported hook (zero findings). All three only pass once body-first lands.
+
+describe("Go calibration: S6 name-auth-but-body-isnt collision (negative)", () => {
+  it("non-vacuity FIRST: 5 routes; the authCheck collision route hasAuth false, the unsure key ABSENT", async () => {
+    let total = 0;
+    for (const f of bodyCollisionGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      if (f.path === bodyCollisionDeviatorPath) {
+        expect(routes[0].hasAuth).toBe(false);
+        expect("authUnsureHook" in routes[0]).toBe(false); // visible non-auth body: flat, not hedged
+      } else {
+        expect(routes[0].hasAuth, f.path).toBe(true);
+      }
+      total += 1;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("flags exactly the collision file (dominantCount 4, score 80), precision 1 recall 1, no-auth copy that is NOT hedged", async () => {
+    const ctx = await ctxFor(bodyCollisionGroup());
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([bodyCollisionDeviatorPath]);
+
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp.toLowerCase()).toContain("no auth");
+    expect(dp.toLowerCase()).not.toContain("double check");
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([bodyCollisionDeviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Go calibration: S7 body-is-real-auth positive (boring guard() hook)", () => {
+  const MACHINERY =
+    /\b(requireAuth|isAuthenticated|verifyToken|authMiddleware|ensureAuth|withAuth|jwt_required|login_required|AuthMiddleware|passport)\b/;
+
+  it("self-check: the S7 corpus contains no auth-lexicon identifier (only the BODY blesses)", () => {
+    for (const f of bodyGateGroup()) {
+      expect(MACHINERY.test(f.content), f.path).toBe(false);
+    }
+  });
+
+  it("scenario A (uniform): all 5 routes hasAuth true via the body signature, THEN zero security_posture findings", async () => {
+    let total = 0;
+    for (const f of bodyGateGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(true);
+      total += 1;
+    }
+    expect(total).toBe(5);
+
+    const ctx = await ctxFor(bodyGateGroup());
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+
+  it("scenario B: stripping the guard hook from the first sorted file flags exactly it, precision 1 recall 1", async () => {
+    const strippedPath = sortedBodyGateRoutePaths(bodyGateGroup())[0];
+    const ctx = await ctxFor(stripBodyGate(bodyGateGroup(), 1));
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    expect(auth[0].dominantCount).toBe(4);
+    expect(auth[0].totalRelevantFiles).toBe(5);
+    expect(auth[0].consistencyScore).toBe(80);
+    expect(auth[0].deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Go calibration: S8 unresolvable-body UNSURE (imported auth-flavored middleware)", () => {
+  it("non-vacuity FIRST: the unsure route is POST/hasAuth false with authUnsureHook 'middleware.VerifyToken'; the 4 peers omit the key", async () => {
+    for (const f of bodyUnsureGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      if (f.path === bodyUnsureDeviatorPath) {
+        expect(routes[0].method).toBe("POST");
+        expect(routes[0].hasAuth).toBe(false);
+        expect(routes[0].authUnsureHook).toBe("middleware.VerifyToken");
+      } else {
+        expect(routes[0].hasAuth, f.path).toBe(true);
+        expect("authUnsureHook" in routes[0], f.path).toBe(false);
+      }
+    }
+  });
+
+  it("flags the unsure file with HEDGED copy; counts match the S6 control; the S1 deviator stays FLAT in the same run", async () => {
+    const auth = authFindings(securityConsistency.detect((await ctxFor(bodyUnsureGroup())) as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([bodyUnsureDeviatorPath]);
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp).toContain("middleware.VerifyToken");
+    expect(dp.toLowerCase()).toContain("double check");
+    expect(dp).not.toMatch(/—|--/); // hedged deviator copy carries no em-dash / double hyphen
+
+    expect(finding.recommendation).toContain("Double check");
+    expect(finding.recommendation).toContain("middleware.VerifyToken");
+
+    // Vote-arithmetic invariance: S8's counts equal the S6 control (5 files, 1 deviator).
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([bodyUnsureDeviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+
+    // No hedge leakage: a plain stripped-auth deviator (S1 shape) stays flat.
+    const s1Path = sortedGinRoutePaths(ginAuthedGroup())[0];
+    const s1Files = [...stripGinAuth(ginAuthedGroup(), 1), goAuthFile, goMainFile];
+    const s1Auth = authFindings(securityConsistency.detect((await ctxFor(s1Files)) as any));
+    expect(s1Auth).toHaveLength(1);
+    expect(s1Auth[0].deviatingFiles.map((d) => d.path)).toEqual([s1Path]);
+    expect(s1Auth[0].deviatingFiles[0].detectedPattern.toLowerCase()).not.toContain("double check");
+  });
+});
+
+// ─── Fixture self-check ───────────────────────────────────────────────────────
+// Every strip*() helper is exercised at its maximal count (every eligible file
+// in the group stripped at once), proving the deterministic string surgery
+// never corrupts the surrounding Go source: each output still parses
+// error-free and still yields exactly one still-mutating, now-unauthed route.
+// A broken strip would otherwise show up ONLY as an unexplained vote-count
+// drop in S1/S2/S3/S7, several layers away from the actual bug.
+
+describe("Go calibration: fixture self-check (every strip*() output stays parseable and correctly unauthed)", () => {
+  it("stripGinAuth(ginAuthedGroup(), 8): every file parses error-free, one unauthed route, no leftover AuthMiddleware token", async () => {
+    for (const f of stripGinAuth(ginAuthedGroup(), 8)) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("AuthMiddleware");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(routes[0].method, f.path).toBe("POST");
+    }
+  });
+
+  it("stripMuxAuth(muxAuthedGroup(), 5): every file parses error-free, one unauthed route", async () => {
+    for (const f of stripMuxAuth(muxAuthedGroup(), 5)) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(routes[0].method, f.path).toBe("POST");
+    }
+  });
+
+  it("stripBodyGate(bodyGateGroup(), 5): every file parses error-free, one unauthed route, no leftover guard token", async () => {
+    for (const f of stripBodyGate(bodyGateGroup(), 5)) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("func guard(");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(routes[0].method, f.path).toBe("POST");
+    }
+  });
+});

--- a/test/helpers/drift-tree.ts
+++ b/test/helpers/drift-tree.ts
@@ -4,7 +4,7 @@ import type { DriftFile } from "../../src/drift/types.js";
 export async function fileWithTree(
   path: string,
   content: string,
-  language: "javascript" | "typescript" | "python" = "typescript",
+  language: "javascript" | "typescript" | "python" | "go" = "typescript",
 ): Promise<DriftFile> {
   const tree = await parseFile({
     path, relativePath: path, language, content, lineCount: content.split("\n").length,

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -1527,3 +1527,813 @@ describe("extractGoFileMiddlewareAst (file-level OR of confirmed lanes)", () => 
     expect(await mwIndex(`// just a comment\nfunc routes() {}\n`)).toEqual(NONE);
   });
 });
+
+// ─── Task 6: adversarial hardening ──────────────────────────────────────────
+//
+// Every fixture here is fed straight to extractGoRoutesAst / extractGoFileMiddlewareAst
+// on whatever tree tree-sitter produces (error-recovered or clean). The bar is
+// twofold: the extractor must never THROW on hostile input, and it must never emit
+// a route with hasAuth:true that the source does not actually protect. The
+// security-critical member of this group is the fused Use call: an unterminated
+// r.Use(...) that error recovery FUSES with the following route registrations into
+// one errored region. Blessing, or even extracting, out of that fused region would
+// let a broken middleware call silently protect routes it never actually wired.
+describe("malformed and adversarial input", () => {
+  it("CROSS-BLESS GUARD: an unterminated r.Use(...) fuses with the following routes; the region emits NOTHING and blesses nothing", async () => {
+    // PINNED EXACT SOURCE (probe-verified against the shipped tree-sitter-go
+    // grammar): the missing close-paren on r.Use fuses the Use call with BOTH
+    // POST registrations into one errored subtree. An unterminated Use can never
+    // become auth for anything — the cross-bless guard this test pins.
+    const f = await go("fuseduse.go",
+      PKG + `func routes() {\n\tr.Use(authMiddleware\n\tr.POST("/a", createA)\n\tr.POST("/b", createB)\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+    expect(extractGoFileMiddlewareAst(f.tree!)).toEqual({ hasAuth: false, hasValidation: false, hasRateLimit: false });
+  });
+
+  it("unclosed paren in a route call swallows the next valid registration; no throw, nothing emitted from the errored region", async () => {
+    // Probe-verified: error recovery nests `r.GET("/later", h)` INSIDE the broken
+    // POST call's own argument_list as a clean-looking nested call_expression.
+    // Both calls sit under a hasError ancestor, so the ancestor-error walk skips
+    // both. Detect-level recall (the regex fallback recovering /later) is pinned
+    // separately in security-consistency.test.ts.
+    const f = await go("unclosedcall.go",
+      PKG + `func routes() {\n\tr.POST("/broken", mw, h\n\tr.GET("/later", h)\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("surgical per-node skip: an error confined to one function body never suppresses a clean sibling function's route", async () => {
+    // `x := := 1` breaks `bad`'s body only; `good`'s r.POST("/good", h) parses
+    // clean. The ancestor-error walk stops below source_file, so the sibling
+    // function is unaffected — a per-construct skip, not a whole-file one.
+    const f = await go("surgical.go",
+      PKG + `func bad() {\n\tx := := 1\n\t_ = x\n}\n\nfunc good() {\n\tr.POST("/good", h)\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true); // cumulative at the file level
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => `${r.method} ${r.path}`))
+      .toEqual(["POST /good"]);
+  });
+
+  it("unterminated string in a route path: no throw, no route from the fused region", async () => {
+    const f = await go("unclosedstring.go",
+      PKG + `func routes() {\n\tr.POST("/oops, handler)\n\tr.GET("/later", h)\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("garbled binary-ish content, empty file, and comments-only file: [] routes, all-false middleware, no throw", async () => {
+    for (const src of [` \x00\x01 garbage {{{ func ( `, ``, `// just a comment\n/* block */\n`]) {
+      const f = await go("garbled.go", src);
+      expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+      expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+      expect(() => extractGoFileMiddlewareAst(f.tree!)).not.toThrow();
+      expect(extractGoFileMiddlewareAst(f.tree!)).toEqual({ hasAuth: false, hasValidation: false, hasRateLimit: false });
+    }
+  });
+
+  it("routes written inside comments or string literals do not extract", async () => {
+    const f = await go("stringroutes.go",
+      PKG +
+      `func routes() {\n` +
+      `\t// r.POST("/fake", h)\n` +
+      `\t/* r.POST("/fake2", h) */\n` +
+      `\ts := \`r.POST("/fake3", h)\`\n` +
+      `\tdoc := "r.POST(\\"/fake4\\", h)"\n` +
+      `\t_ = s\n\t_ = doc\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  describe("unicode", () => {
+    it("a unicode path with real in-file auth blesses normally (positive control)", async () => {
+      const src = PKG + authDef() + `func routes() {\n\tr.Use(authMiddleware)\n\tr.POST("/café", h)\n}\n`;
+      const f = await go("unicodepath.go", src);
+      const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+      expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual(["POST /café auth=true"]);
+    });
+
+    it("a unicode Use argument never blesses (ASCII lexicon: recognition miss, never a bless)", async () => {
+      const f = await go("unicodeuse.go", PKG + `func routes() {\n\tr.Use(認証)\n\tr.POST("/x", h)\n}\n`);
+      const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBeUndefined();
+    });
+
+    it("a unicode receiver does not extract", async () => {
+      const f = await go("unicoderecv.go", PKG + `func routes() {\n\tルーター.POST("/x", h)\n}\n`);
+      expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+    });
+  });
+
+  it("20-deep nested wrap: no throw, no bless (re-asserted from Task 3 inside the adversarial totality)", async () => {
+    let expr = "h";
+    for (let i = 0; i < 20; i++) expr = `logWrap(${expr})`;
+    const f = await go("deepwrap.go", PKG + `func routes() {\n\tmux.Handle("/x", ${expr})\n}\n`);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)[0].hasAuth).toBe(false);
+  });
+
+  it("no-throw totality: extractGoRoutesAst and extractGoFileMiddlewareAst never throw across every adversarial fixture", async () => {
+    const sources = [
+      PKG + `func routes() {\n\tr.Use(authMiddleware\n\tr.POST("/a", createA)\n\tr.POST("/b", createB)\n}\n`,
+      PKG + `func routes() {\n\tr.POST("/broken", mw, h\n\tr.GET("/later", h)\n}\n`,
+      PKG + `func bad() {\n\tx := := 1\n\t_ = x\n}\n\nfunc good() {\n\tr.POST("/good", h)\n}\n`,
+      PKG + `func routes() {\n\tr.POST("/oops, handler)\n\tr.GET("/later", h)\n}\n`,
+      ` \x00\x01 garbage {{{ func ( `,
+      ``,
+      `// just a comment\n/* block */\n`,
+      PKG + `func routes() {\n\tr.Use(認証)\n\tr.POST("/x", h)\n}\n`,
+      PKG + `func routes() {\n\tルーター.POST("/x", h)\n}\n`,
+    ];
+    for (const src of sources) {
+      const f = await go("totality.go", src);
+      expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+      expect(() => extractGoFileMiddlewareAst(f.tree!)).not.toThrow();
+    }
+  });
+});
+
+// ─── Task 6: documented trade-offs (collected pins, never change behavior) ───
+//
+// Consolidates the deliberate divergences this module carries, whether pinned
+// earlier (referenced by comment, not re-derived) or new to this task. Nothing
+// here is a false-bless: every item resolves to a documented UNDER-report, a
+// documented receiver-granularity OVER-bless (mirroring the Python module's own
+// accepted exposure), or a plain recognition miss.
+describe("Task 6: documented trade-offs", () => {
+  it("re-pins already-locked recognition trade-offs in one place (Tasks 1-2, unchanged)", async () => {
+    // .Methods("MKCOL") -> GET (fully literal, zero recognized verbs is not
+    // ambiguity; see the full pin at "method resolution" > mkcol parity).
+    const mkcol = await go("mkcol.go", PKG + `func routes() {\n\trouter.HandleFunc("/x", h).Methods("MKCOL")\n}\n`);
+    expect(extractGoRoutesAst(mkcol.tree!, mkcol.relativePath).map((r) => r.method)).toEqual(["GET"]);
+    // A chain split across statements resolves ALL (variable-carried chains are
+    // not tracked); see "Gorilla mux and stdlib recognition" for the full pin.
+    const split = await go("split.go", PKG + `func routes() {\n\troute := r.HandleFunc("/orders", h)\n\troute.Methods("POST")\n}\n`);
+    expect(extractGoRoutesAst(split.tree!, split.relativePath).map((r) => r.method)).toEqual(["ALL"]);
+    // e.Match(...) (composite-literal method list) is not a recognized anchor.
+    const match = await go("match.go", PKG + `func routes() {\n\te.Match([]string{"GET"}, "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(match.tree!, match.relativePath)).toEqual([]);
+    // Gorilla route-builder chains (HandlerFunc/Handler as the OUTER, registering
+    // field) are never unwound; see "documented trade-offs (pinned recall gaps..."
+    const builder = await go("builder.go", PKG + `func routes() {\n\tr.Methods("POST").Path("/orders").HandlerFunc(h)\n}\n`);
+    expect(extractGoRoutesAst(builder.tree!, builder.relativePath)).toEqual([]);
+    // Embedded-engine method receivers are not recognized (no struct field walk).
+    const embedded = await go("embedded.go",
+      PKG + `type Server struct {\n\t*gin.Engine\n}\n\nfunc (s *Server) routes() {\n\ts.POST("/orders", h)\n}\n`);
+    expect(extractGoRoutesAst(embedded.tree!, embedded.relativePath)).toEqual([]);
+  });
+
+  it("re-pins already-locked scope/lane trade-offs in one place (Task 4, unchanged)", async () => {
+    // Echo trailing single middleware -> false: the module always treats the
+    // LAST arg as the handler, so a REAL rejecting middleware placed after the
+    // handler (Echo's own m ...MiddlewareFunc order) is invisible to the
+    // classifier — never even hedged, a structural recall gap, never a bless.
+    const echoTrail = await go("echotrail.go",
+      PKG +
+      `func RequireAuth(c echo.Context) error {\n\tif c.Request().Header.Get("Authorization") == "" {\n\t\treturn c.NoContent(401)\n\t}\n\treturn nil\n}\n` +
+      `func routes() {\n\te.POST("/x", h, RequireAuth)\n}\n`);
+    const [et] = extractGoRoutesAst(echoTrail.tree!, echoTrail.relativePath);
+    expect(et.hasAuth).toBe(false);
+    expect(et.authUnsureHook).toBeUndefined();
+    // Composed wrap chain(logger, auth)(h): the outer call's function is itself
+    // a call, so it never resolves to a NAME; the wrap-recursion gate requires
+    // name===null OR a transparent wrap, and the inner (logger, auth) pair is
+    // arity>=2 (DI), so recursion never reaches "auth".
+    const composed = await go("composed.go", PKG + `func routes() {\n\tmux.Handle("/x", chain(logger, auth)(h))\n}\n`);
+    expect(extractGoRoutesAst(composed.tree!, composed.relativePath)[0].hasAuth).toBe(false);
+    // Cross-function Use never blesses (same-scope pin: Use is keyed to its own
+    // enclosing function body, never file-wide).
+    const cross = await go("cross.go",
+      PKG + authDef() + `func setup(r *gin.Engine) {\n\tr.Use(authMiddleware)\n}\nfunc routes(r *gin.Engine) {\n\tr.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(cross.tree!, cross.relativePath)[0].hasAuth).toBe(false);
+    // Conditional Use (`if cfg.AuthEnabled { r.Use(auth) }`) never marks:
+    // statically-ambiguous registration resolves false, never a bless.
+    const conditional = await go("conditional.go",
+      PKG + authDef() + `func routes() {\n\tif cfg.AuthEnabled {\n\t\tr.Use(authMiddleware)\n\t}\n\tr.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(conditional.tree!, conditional.relativePath)[0].hasAuth).toBe(false);
+    // Gin copy-at-creation: a parent Use registered AFTER a Group's creation call
+    // does not retroactively bless the group (accepted Gin runtime semantics).
+    const afterGroup = await go("aftergroup.go",
+      PKG + authDef() + `func routes() {\n\tapi := r.Group("/api")\n\tr.Use(authMiddleware)\n\tapi.POST("/items", h)\n}\n`);
+    expect(extractGoRoutesAst(afterGroup.tree!, afterGroup.relativePath)
+      .find((r) => r.path === "/items")!.hasAuth).toBe(false);
+  });
+
+  it("HEAD/OPTIONS are never extracted on ANY resolution path (verb field, .Methods chain, verb-first, Go 1.22 pattern)", async () => {
+    const f = await go("headoptions.go",
+      PKG +
+      `func routes() {\n` +
+      `\tr.HEAD("/a", h)\n` +
+      `\tr.OPTIONS("/b", h)\n` +
+      `\trouter.HandleFunc("/c", h).Methods("HEAD")\n` +
+      `\trouter.HandleFunc("/d", h).Methods("OPTIONS")\n` +
+      `\tr.Method("HEAD", "/e", h)\n` +
+      `\te.Add("OPTIONS", "/f", h)\n` +
+      `\tmux.HandleFunc("HEAD /g", h)\n` +
+      `\tmux.HandleFunc("OPTIONS /h", h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("a handler body calling c.ShouldBindJSON does NOT set hasValidation (validation lane is name-based only)", async () => {
+    const f = await go("bindjson.go",
+      PKG + `func h(c *gin.Context) {\n\tvar body Order\n\tc.ShouldBindJSON(&body)\n}\nfunc routes() {\n\tr.POST("/x", h)\n}\n`);
+    const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(rt.hasValidation).toBe(false);
+  });
+
+  it("single-arg DI residual NewHandler(auth.NewService(key)): the 'handler' veto segment closes this before recursion, never blesses", async () => {
+    // Pre-LOCKED plan carried this as an open false-bless exposure. The shipped
+    // veto set includes the "handler" segment specifically to close it: the
+    // outer name resolves not-auth at rule 1 and, being a NAMED (non-transparent)
+    // outer, wrap recursion into auth.NewService(key) never runs.
+    const f = await go("dihandler.go", PKG + `func routes() {\n\tmux.Handle("/x", NewHandler(auth.NewService(key)))\n}\n`);
+    const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("a selector/method Use callee (authSvc.Middleware) stays opaque/name-tier: v1 resolves only bare-identifier callees to an in-file body", async () => {
+    // authSvc.Middleware is an in-file METHOD with a real rejecting body, but
+    // classifyGoMiddlewareArg only resolves a bare-identifier callee to a def;
+    // a selector target is never looked up, so it stays name-tier. "authSvc"
+    // segments to auth+svc, which is flavored, so the recall gap surfaces as an
+    // UNSURE hedge, never a silent drop and never a bless.
+    const f = await go("selectormw.go",
+      PKG +
+      `type AuthSvc struct{}\nfunc (a *AuthSvc) Middleware(c *gin.Context) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(401)\n\t\treturn\n\t}\n\tc.Next()\n}\n` +
+      `func routes() {\n\tr.Use(authSvc.Middleware)\n\tr.POST("/x", h)\n}\n`);
+    const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("authSvc.Middleware");
+  });
+
+  it("KNOWN receiver-granularity OVER-BLESS: a partial-guard middleware blesses its WHOLE receiver, including the path it exempts", async () => {
+    // mw exempts /exempt via `if isPublic(...) { c.Next(); return }` and then
+    // credential-guards the rest with a real 401. bodyAuthSignatureGo sees a
+    // verified reject SOMEWHERE in the body (rule 2) and blesses the receiver at
+    // Use-scope granularity — it does not model per-branch exemptions. This
+    // mirrors the Python module's own accepted receiver-level over-bless.
+    // ACCEPTED VERDICT: NOT asserted authed:false — this is a recorded trade-off,
+    // not a regression to fix here (see open question 3 in the module header).
+    const f = await go("partialguard.go",
+      PKG +
+      `func mw(c *gin.Context) {\n\tif isPublic(c.Request.URL.Path) {\n\t\tc.Next()\n\t\treturn\n\t}\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n` +
+      `func routes() {\n\tr.Use(mw)\n\tr.GET("/exempt", h)\n\tr.POST("/protected", h)\n}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.find((r) => r.path === "/protected")!.hasAuth).toBe(true);
+    // The exempted route is blessed too — the documented over-bless.
+    expect(routes.find((r) => r.path === "/exempt")!.hasAuth).toBe(true);
+  });
+
+  it("a variable-status abort under a boring name resolves opaque -> not-auth (no flavored delegation, key absent)", async () => {
+    const f = await go("varstatus.go",
+      PKG + `func mw(c *gin.Context) {\n\tc.AbortWithStatus(code)\n}\nfunc routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`);
+    const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("AUDIT NOTE: the pre-LOCKED chi jwtauth.Verifier and single-arg-DI 'known false-bless exposures' described by the original task plan do NOT reproduce against the shipped LOCKED classifier", async () => {
+    // r.Use(jwtauth.Verifier(tokenAuth)): "jwtauth.Verifier" is a resolved,
+    // non-null, non-transparent NAME (a pure selector chain), so the wrap
+    // recursion gate (name===null || transparent) never fires and the inner
+    // "tokenAuth" (which WOULD be CORE-flavored) is never inspected. This
+    // fixture is pinned here as a plain never-false-bless entry (also present
+    // in NEVER_FALSE_BLESS_SWEEP_GO) rather than as a "known exposure": the
+    // module's own header already documents this restriction as CLOSING the
+    // chi jwtauth.Verifier / config-object / arity-1-DI exposures the
+    // pre-LOCKED name-only plan carried.
+    const f = await go("jwtauthverifier.go",
+      PKG + `func routes() {\n\tr.Use(jwtauth.Verifier(tokenAuth))\n\tr.POST("/x", h)\n}\n`);
+    const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+});
+
+// ─── Task 6: never-false-bless sweep ─────────────────────────────────────────
+//
+// Registry of every ambiguous / opaque / unresolvable Go fixture class from
+// Tasks 1-5. Every NEW go fixture added in a later task MUST be registered
+// here (verbatim Phase A mechanism, mirroring the shipped JS/Python modules).
+// `groundTruth` entries with `authed: true` are DOCUMENTATION ONLY (the sweep
+// loop below only checks `authed: false` entries) — they exist so a reader can
+// see the authed positive control sitting next to its unauthed sibling.
+const NEVER_FALSE_BLESS_SWEEP_GO: Array<{
+  name: string; source: string; groundTruth: Array<{ path: string; method: string; authed: boolean }>;
+}> = [
+  {
+    name: "unknown-middleware-middle-arg",
+    source: PKG + `func routes() {\n\tr.POST("/x", track(), h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "wrapped-unknown-callee",
+    source: PKG + `func routes() {\n\tmux.Handle("/x", wrap(h)).Methods("POST")\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "use-package-qualified-unknown-nonflavored",
+    source: PKG + `func routes() {\n\tr.Use(middleware.RequestID)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "use-after-route",
+    source: PKG + authDef() + `func routes() {\n\tr.POST("/a", h)\n\tr.Use(authMiddleware)\n\tr.POST("/b", h2)\n}\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: false },
+      { path: "/b", method: "POST", authed: true }, // doc: registered after Use, genuinely blessed
+    ],
+  },
+  {
+    name: "use-cross-function",
+    source: PKG + authDef() + `func setup(r *gin.Engine) {\n\tr.Use(authMiddleware)\n}\nfunc routes(r *gin.Engine) {\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "chi-closure-shadow",
+    source: PKG + authDef() +
+      `func routes() {\n\tr.Route("/admin", func(r chi.Router) {\n\t\tr.Use(authMiddleware)\n\t\tr.Post("/users", h)\n\t})\n\tr.Post("/public", pub)\n}\n`,
+    groundTruth: [
+      { path: "/public", method: "POST", authed: false },
+      { path: "/users", method: "POST", authed: true }, // doc: inner closure scope, genuinely blessed
+    ],
+  },
+  {
+    name: "group-use-never-blesses-parent",
+    source: PKG + authFactory() +
+      `func routes() {\n\tapi := r.Group("/api")\n\tapi.Use(RequireAuth())\n\tapi.POST("/items", h)\n\tr.POST("/public", h)\n}\n`,
+    groundTruth: [
+      { path: "/public", method: "POST", authed: false },
+      { path: "/items", method: "POST", authed: true }, // doc
+    ],
+  },
+  {
+    name: "parent-use-after-group-creation",
+    source: PKG + authDef() + `func routes() {\n\tapi := r.Group("/api")\n\tr.Use(authMiddleware)\n\tapi.POST("/items", h)\n}\n`,
+    groundTruth: [{ path: "/items", method: "POST", authed: false }],
+  },
+  {
+    name: "same-scope-rebind-poisoning",
+    source: PKG + authDef() + `func routes() {\n\tapi := r.Group("/a")\n\tapi.Use(authMiddleware)\n\tapi = r.Group("/b")\n\tapi.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "same-name-groups-independent",
+    source: PKG + authDef() +
+      `func first(r *gin.Engine) {\n\tapi := r.Group("/api")\n\tapi.Use(authMiddleware)\n\tapi.POST("/x", h)\n}\n` +
+      `func second(r *gin.Engine) {\n\tapi := r.Group("/api")\n\tapi.POST("/y", h)\n}\n`,
+    groundTruth: [
+      { path: "/x", method: "POST", authed: true }, // doc: paired own-scope positive control
+      { path: "/y", method: "POST", authed: false },
+    ],
+  },
+  {
+    name: "conditional-use",
+    source: PKG + authDef() + `func routes() {\n\tif cfg.AuthEnabled {\n\t\tr.Use(authMiddleware)\n\t}\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "di-constructor-injection-webhook",
+    source: PKG + `func routes() {\n\tmux.Handle("/webhook", NewWebhookHandler(cfg, auth.NewService(key)))\n}\n`,
+    groundTruth: [{ path: "/webhook", method: "ALL", authed: false }],
+  },
+  {
+    name: "di-constructor-injection-orders",
+    source: PKG + `func routes() {\n\tmux.Handle("/orders", NewOrdersHandler(db, jwtVerifier()))\n}\n`,
+    groundTruth: [{ path: "/orders", method: "ALL", authed: false }],
+  },
+  {
+    name: "impure-selector-use",
+    source: PKG + `func routes() {\n\tr.Use(factory.Make(authCfg).Logger())\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "impure-selector-bare-arg",
+    source: PKG + `func routes() {\n\tr.Use(registry.get("authCfg").Logger)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "builder-chain-wrap",
+    source: PKG + `func routes() {\n\tmux.Handle("/x", handlers.For(authConfig).Build(h))\n}\n`,
+    groundTruth: [{ path: "/x", method: "ALL", authed: false }],
+  },
+  {
+    name: "with-chain-no-auth",
+    source: PKG + `func routes() {\n\tr.With(paginate).With(audit).Post("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "author-segmentation-use",
+    source: PKG + `func routes() {\n\tr.Use(AuthorMiddleware)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "author-segmentation-middle-arg",
+    source: PKG + `func routes() {\n\tr.POST("/y", AuthorTracking(), h)\n}\n`,
+    groundTruth: [{ path: "/y", method: "POST", authed: false }],
+  },
+  {
+    name: "echo-trailing-middleware",
+    source: PKG +
+      `func RequireAuth(c echo.Context) error {\n\tif c.Request().Header.Get("Authorization") == "" {\n\t\treturn c.NoContent(401)\n\t}\n\treturn nil\n}\n` +
+      `func routes() {\n\te.POST("/x", h, RequireAuth)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "handler-position-identifier",
+    source: PKG + `func routes() {\n\tr.POST("/login", authLogin)\n}\n`,
+    groundTruth: [{ path: "/login", method: "POST", authed: false }],
+  },
+  {
+    name: "handler-position-401-body",
+    source: PKG +
+      `func h(c *gin.Context) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(401)\n\t\treturn\n\t}\n\tc.JSON(200, nil)\n}\n` +
+      `func routes() {\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "unicode-auth-middleware",
+    source: PKG + `func routes() {\n\tr.Use(認証)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "stdlib-bare",
+    source: PKG + `func routes() {\n\thttp.HandleFunc("/orders", h)\n}\n`,
+    groundTruth: [{ path: "/orders", method: "ALL", authed: false }],
+  },
+  {
+    name: "verb-first-unknown-middleware",
+    source: PKG + `func routes() {\n\tr.Handle("POST", "/x", metrics(), h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "composed-wrap",
+    source: PKG + `func routes() {\n\tmux.Handle("/x", chain(logger, auth)(h))\n}\n`,
+    groundTruth: [{ path: "/x", method: "ALL", authed: false }],
+  },
+  {
+    name: "subsuming-veto-wrap-set",
+    source: PKG +
+      `func realGate(next http.Handler) http.Handler {\n\treturn http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n\t\tif r.Header.Get("Authorization") == "" {\n\t\t\tw.WriteHeader(http.StatusUnauthorized)\n\t\t\treturn\n\t\t}\n\t\tnext.ServeHTTP(w, r)\n\t})\n}\n` +
+      `func requireAuth(next http.Handler) http.Handler {\n\treturn http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n\t\tif r.Header.Get("Authorization") == "" {\n\t\t\tw.WriteHeader(http.StatusUnauthorized)\n\t\t\treturn\n\t\t}\n\t\tnext.ServeHTTP(w, r)\n\t})\n}\n` +
+      `func routes() {\n\tmux.Handle("/a", optionalAuth(realGate))\n\tmux.Handle("/b", SkipAuth(realGate))\n\tmux.Handle("/c", DisableAuthInDev(realGate))\n\tmux.Handle("/d", parseJWT(realGate))\n\tmux.Handle("/e", logRequests(requireAuth(h)))\n}\n`,
+    groundTruth: [
+      { path: "/a", method: "ALL", authed: false },
+      { path: "/b", method: "ALL", authed: false },
+      { path: "/c", method: "ALL", authed: false },
+      { path: "/d", method: "ALL", authed: false },
+      { path: "/e", method: "ALL", authed: true }, // doc: transparent-vs-subsuming positive control
+    ],
+  },
+  {
+    name: "broken-parse-fused-use",
+    source: PKG + `func routes() {\n\tr.Use(authMiddleware\n\tr.POST("/a", createA)\n\tr.POST("/b", createB)\n}\n`,
+    groundTruth: [
+      { path: "/a", method: "POST", authed: false }, // non-emission: a dropped route cannot false-bless
+      { path: "/b", method: "POST", authed: false },
+    ],
+  },
+  {
+    name: "broken-parse-swallowed-route",
+    source: PKG + `func routes() {\n\tr.POST("/broken", mw, h\n\tr.GET("/later", h)\n}\n`,
+    groundTruth: [{ path: "/later", method: "GET", authed: false }], // non-emission
+  },
+
+  // ── BODY-FIRST required entries (all authed:false) ──
+  {
+    name: "visible-non-enforcing-body-use",
+    source: PKG +
+      `func authCheck(c *gin.Context) {\n\tlog.Printf("auth %s", c.Request.URL.Path)\n\tc.Next()\n}\n` +
+      `func routes() {\n\tr.Use(authCheck)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "visible-non-enforcing-body-middle-arg",
+    source: PKG +
+      `func authCheck(c *gin.Context) {\n\tlog.Printf("auth %s", c.Request.URL.Path)\n\tc.Next()\n}\n` +
+      `func routes() {\n\tr.POST("/y", authCheck, h)\n}\n`,
+    groundTruth: [{ path: "/y", method: "POST", authed: false }],
+  },
+  {
+    name: "logging-mw",
+    source: PKG + `func logMiddleware(c *gin.Context) {\n\tlog.Printf("request")\n\tc.Next()\n}\nfunc routes() {\n\tr.Use(logMiddleware)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "metrics-mw",
+    source: PKG + `func metricsMiddleware(c *gin.Context) {\n\tmetrics.Inc("req")\n\tc.Next()\n}\nfunc routes() {\n\tr.Use(metricsMiddleware)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "header-set-only-mw",
+    source: PKG + `func securityHeaders(c *gin.Context) {\n\tc.Header("X-Frame-Options", "DENY")\n\tc.Next()\n}\nfunc routes() {\n\tr.Use(securityHeaders)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "passthru-mw",
+    source: PKG + `func passthru(c *gin.Context) {\n\tc.Next()\n}\nfunc routes() {\n\tr.Use(passthru)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "abort-404-mw",
+    source: PKG + `func mw(c *gin.Context) {\n\tc.AbortWithStatus(http.StatusNotFound)\n}\nfunc routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "abort-500-mw",
+    source: PKG + `func mw(c *gin.Context) {\n\tc.AbortWithStatus(http.StatusInternalServerError)\n}\nfunc routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "bare-403-mw",
+    source: PKG + `func mw(c *gin.Context) {\n\tc.AbortWithStatus(http.StatusForbidden)\n}\nfunc routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "path-filter-403-mw",
+    source: PKG +
+      `func pathFilter(c *gin.Context) {\n\tif strings.HasPrefix(c.Request.URL.Path, "/admin") {\n\t\tc.AbortWithStatus(403)\n\t}\n}\n` +
+      `func routes() {\n\tr.Use(pathFilter)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "bot-gate-403-mw",
+    // Finding 4: MUST actually read User-Agent so the "agent" key veto is
+    // proven non-vacuously (a fixture that dodges User-Agent passes trivially).
+    source: PKG +
+      `func botGate(c *gin.Context) {\n\tif c.GetHeader("User-Agent") == "" {\n\t\tc.AbortWithStatus(403)\n\t\treturn\n\t}\n}\n` +
+      `func routes() {\n\tr.Use(botGate)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "csrf-403-mw",
+    source: PKG +
+      `func csrfCheck(c *gin.Context) {\n\tif c.GetHeader("X-CSRF-Token") != valid {\n\t\tc.AbortWithStatus(403)\n\t}\n}\n` +
+      `func routes() {\n\tr.Use(csrfCheck)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "query-param-get-403-mw",
+    // Finding 2: Query().Get's operand is a CALL, not a GO_CRED_GET_RECEIVERS
+    // identifier, so it is not a credential read and must not bless.
+    source: PKG +
+      `func mw(c *gin.Context) {\n\tif c.Request.URL.Query().Get("token") == "" {\n\t\tc.AbortWithStatus(403)\n\t\treturn\n\t}\n}\n` +
+      `func routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "cache-get-403-mw",
+    source: PKG +
+      `func mw(c *gin.Context) {\n\tif cache.Get("user") == nil {\n\t\tc.AbortWithStatus(403)\n\t\treturn\n\t}\n}\n` +
+      `func routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "store-get-403-mw",
+    source: PKG +
+      `func mw(c *gin.Context) {\n\tif store.Get("session") == nil {\n\t\tc.AbortWithStatus(403)\n\t\treturn\n\t}\n}\n` +
+      `func routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "credential-read-but-unrelated-403-guard-mw",
+    source: PKG +
+      `func mw(c *gin.Context) {\n\ttoken := c.GetHeader("Authorization")\n\tlog.Printf("token seen: %v", token != "")\n\tif !featureEnabled {\n\t\tc.AbortWithStatus(403)\n\t\treturn\n\t}\n\tc.Next()\n}\n` +
+      `func routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "status-variable-mw",
+    source: PKG + `func mw(c *gin.Context) {\n\tc.AbortWithStatus(code)\n}\nfunc routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "returned-non-executed-closure-reject",
+    source: PKG + `func mw(c *gin.Context) {\n\tgo func() {\n\t\tc.AbortWithStatus(401)\n\t}()\n\tc.Next()\n}\nfunc routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "veto-over-reject-set",
+    source: PKG +
+      ["OptionalAuth", "SkipAuth", "DisableAuth", "InsecureSkipAuth", "MockAuth", "testAuth"]
+        .map((n) => `func ${n}(c *gin.Context) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n`)
+        .join("") +
+      `func routes() {\n` +
+      ["OptionalAuth", "SkipAuth", "DisableAuth", "InsecureSkipAuth", "MockAuth", "testAuth"]
+        .map((n, i) => `\tr.Use(${n})\n\tr.POST("/v${i}", h${i})\n`).join("") +
+      `}\n`,
+    groundTruth: [0, 1, 2, 3, 4, 5].map((i) => ({ path: `/v${i}`, method: "POST", authed: false })),
+  },
+  {
+    name: "authlogger-veto",
+    source: PKG + `func routes() {\n\tr.POST("/x", authLogger, h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "parsejwt-veto",
+    source: PKG + `func routes() {\n\tr.POST("/x", parseJWT(secret), h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "newauthhandler-wrap-veto",
+    source: PKG + `func routes() {\n\tmux.Handle("/x", newAuthHandler(deps))\n}\n`,
+    groundTruth: [{ path: "/x", method: "ALL", authed: false }],
+  },
+  {
+    name: "authlogin-middle-arg-veto",
+    source: PKG + `func routes() {\n\tr.POST("/x", authLogin, mainHandler)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+
+  // ── Pre-LOCKED-plan exposures that do NOT reproduce (verified: see the
+  // "AUDIT NOTE" documented-trade-offs pin above) — pinned as plain
+  // never-false-bless entries, not as accepted over-blesses. ──
+  {
+    name: "jwtauth-verifier-wrap",
+    source: PKG + `func routes() {\n\tr.Use(jwtauth.Verifier(tokenAuth))\n\tr.POST("/x", h)\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "single-arg-di-residual",
+    source: PKG + `func routes() {\n\tmux.Handle("/x", NewHandler(auth.NewService(key)))\n}\n`,
+    groundTruth: [{ path: "/x", method: "ALL", authed: false }],
+  },
+];
+
+describe("never-false-bless sweep", () => {
+  it("no route with ground truth authed:false is ever emitted hasAuth:true", async () => {
+    for (const entry of NEVER_FALSE_BLESS_SWEEP_GO) {
+      const f = await go(`sweep/${entry.name}.go`, entry.source);
+      const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+      for (const gt of entry.groundTruth.filter((g) => !g.authed)) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        // Non-emission counts as not-blessed (a dropped route cannot false-bless).
+        expect(emitted?.hasAuth ?? false, `${entry.name}: ${gt.method} ${gt.path}`).toBe(false);
+      }
+    }
+  });
+
+  it("non-vacuity: every authed:false sweep entry (excluding the two broken-parse fixtures) actually emits its route(s)", async () => {
+    const nonEmitting = new Set(["broken-parse-fused-use", "broken-parse-swallowed-route"]);
+    for (const entry of NEVER_FALSE_BLESS_SWEEP_GO) {
+      if (nonEmitting.has(entry.name)) continue;
+      const f = await go(`sweep-nv/${entry.name}.go`, entry.source);
+      const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+      for (const gt of entry.groundTruth.filter((g) => !g.authed)) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        expect(emitted, `${entry.name}: ${gt.method} ${gt.path} must be EMITTED (non-vacuous)`).toBeDefined();
+      }
+    }
+  });
+});
+
+// ─── Task 6: UNSURE sweep + the three-way machine-statement invariant ────────
+
+const UNSURE_SWEEP_GO: Array<{
+  name: string; source: string; route: { path: string; method: string }; hook: string;
+}> = [
+  {
+    name: "imported-non-core-use",
+    source: PKG + `func routes() {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", h)\n}\n`,
+    route: { path: "/x", method: "POST" },
+    hook: "middleware.VerifyToken",
+  },
+  {
+    name: "imported-per-route-arg",
+    source: PKG + `func routes() {\n\tr.POST("/x", middleware.VerifyToken(), h)\n}\n`,
+    route: { path: "/x", method: "POST" },
+    hook: "middleware.VerifyToken",
+  },
+  {
+    name: "opaque-wrapper",
+    source: PKG + `func routes() {\n\tmux.Handle("/x", TokenRequired(handler)).Methods("POST")\n}\n`,
+    route: { path: "/x", method: "POST" },
+    hook: "TokenRequired",
+  },
+  {
+    name: "opaque-in-file-helper",
+    // checkAuth is an in-file, RESOLVABLE function whose body calls the
+    // unresolved checkSession(c) — opaque body (rule 4), flavored name -> unsure.
+    // ("requireLogin" is deliberately NOT used here: "login" is a VETO segment
+    // and would resolve flat not-auth, not unsure — see the veto-over-reject set.)
+    source: PKG +
+      `func checkAuth(c *gin.Context) {\n\tif !checkSession(c) {\n\t\tc.Next()\n\t\treturn\n\t}\n\tc.Next()\n}\n` +
+      `func routes() {\n\tr.Use(checkAuth)\n\tr.POST("/x", h)\n}\n`,
+    route: { path: "/x", method: "POST" },
+    hook: "checkAuth",
+  },
+  {
+    name: "echo-group-inline",
+    // jwt is CORE too, but middleware.VerifyToken is used here so the pin never
+    // depends on which specific CORE segment fired.
+    source: PKG + `func routes() {\n\tadmin := e.Group("/admin", middleware.VerifyToken)\n\tadmin.POST("/users", h)\n}\n`,
+    route: { path: "/users", method: "POST" },
+    hook: "middleware.VerifyToken",
+  },
+  {
+    name: "chi-With-unsure",
+    source: PKG + `func routes() {\n\tr.With(middleware.VerifyToken).Post("/x", h)\n}\n`,
+    route: { path: "/x", method: "POST" },
+    hook: "middleware.VerifyToken",
+  },
+  {
+    name: "first-of-two-unsure",
+    source: PKG + `func routes() {\n\tr.Use(middleware.VerifyToken)\n\tr.Use(middleware.CheckToken)\n\tr.POST("/x", h)\n}\n`,
+    route: { path: "/x", method: "POST" },
+    hook: "middleware.VerifyToken", // deterministic first-in-document-order wins
+  },
+];
+
+describe("unsure sweep", () => {
+  it("each UNSURE_SWEEP_GO route emits hasAuth:false and the exact expected authUnsureHook", async () => {
+    for (const entry of UNSURE_SWEEP_GO) {
+      const f = await go(`unsure/${entry.name}.go`, entry.source);
+      const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+      const rt = routes.find((r) => r.path === entry.route.path && r.method === entry.route.method);
+      expect(rt, `${entry.name}: route must be emitted (non-vacuous)`).toBeDefined();
+      expect(rt!.hasAuth, entry.name).toBe(false);
+      expect(rt!.authUnsureHook, entry.name).toBe(entry.hook);
+    }
+  });
+
+  it("MACHINE STATEMENT: authUnsureHook !== undefined implies hasAuth === false, and hasAuth === true implies no authUnsureHook key, over every route in both sweeps", async () => {
+    const allRoutes: Array<{ hasAuth: boolean; authUnsureHook?: string }> = [];
+    for (const entry of NEVER_FALSE_BLESS_SWEEP_GO) {
+      const f = await go(`machine-nfb/${entry.name}.go`, entry.source);
+      allRoutes.push(...extractGoRoutesAst(f.tree!, f.relativePath));
+    }
+    for (const entry of UNSURE_SWEEP_GO) {
+      const f = await go(`machine-unsure/${entry.name}.go`, entry.source);
+      allRoutes.push(...extractGoRoutesAst(f.tree!, f.relativePath));
+    }
+    expect(allRoutes.length).toBeGreaterThan(0);
+    for (const r of allRoutes) {
+      if (r.authUnsureHook !== undefined) expect(r.hasAuth).toBe(false);
+      if (r.hasAuth === true) expect("authUnsureHook" in r).toBe(false);
+    }
+  });
+
+  it("FileMiddleware honesty: every UNSURE_SWEEP_GO fixture's file-level hasAuth is false (unsure never enters the OR)", async () => {
+    for (const entry of UNSURE_SWEEP_GO) {
+      const f = await go(`unsure-fm/${entry.name}.go`, entry.source);
+      expect(extractGoFileMiddlewareAst(f.tree!).hasAuth, entry.name).toBe(false);
+    }
+  });
+
+  it("ambiguous-body generator sweep: every candidate ambiguous body placed in a Use hook over one POST route never yields hasAuth:true", async () => {
+    const bodies: Array<[string, string]> = [
+      ["AbortWithStatus(codeVar)", `func mw(c *gin.Context) {\n\tc.AbortWithStatus(code)\n}\n`],
+      ["AbortWithStatus(404)", `func mw(c *gin.Context) {\n\tc.AbortWithStatus(404)\n}\n`],
+      ["AbortWithStatus(500)", `func mw(c *gin.Context) {\n\tc.AbortWithStatus(500)\n}\n`],
+      ["bare AbortWithStatus(403)", `func mw(c *gin.Context) {\n\tc.AbortWithStatus(403)\n}\n`],
+      ["http.Error(w,...,404)", `func mw(w http.ResponseWriter, r *http.Request) {\n\thttp.Error(w, "not found", 404)\n}\n`],
+      ["WriteHeader(500)", `func mw(w http.ResponseWriter, r *http.Request) {\n\tw.WriteHeader(500)\n}\n`],
+      ["path-filter-403", `func mw(c *gin.Context) {\n\tif strings.HasPrefix(c.Request.URL.Path, "/admin") {\n\t\tc.AbortWithStatus(403)\n\t}\n}\n`],
+      ["csrf-403", `func mw(c *gin.Context) {\n\tif c.GetHeader("X-CSRF-Token") != valid {\n\t\tc.AbortWithStatus(403)\n\t}\n}\n`],
+      ["opaque-boring-call", `func mw(c *gin.Context) {\n\tdoStuff(c)\n}\n`],
+      ["only c.Next()", `func mw(c *gin.Context) {\n\tc.Next()\n}\n`],
+    ];
+    for (const [label, body] of bodies) {
+      const src = PKG + body + `func routes() {\n\tr.Use(mw)\n\tr.POST("/x", h)\n}\n`;
+      const f = await go(`ambiguous/${label.replace(/[^a-z0-9]+/gi, "-")}.go`, src);
+      const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+      expect(rt.hasAuth, label).toBe(false);
+    }
+  });
+
+  it("depth-cap / cycle safety: a mutual in-file helper cycle terminates, throws nothing, and blesses nothing", async () => {
+    const src = PKG +
+      `func a(c *gin.Context) {\n\tb(c)\n}\nfunc b(c *gin.Context) {\n\ta(c)\n}\n` +
+      `func routes() {\n\tr.Use(a)\n\tr.POST("/x", h)\n}\n`;
+    const f = await go("mutualcycle.go", src);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    const [rt] = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(rt.hasAuth).toBe(false);
+  });
+
+  it("depth-cap / cycle safety: a 20-deep returned-closure wrap terminates, throws nothing, and blesses nothing", async () => {
+    let expr = "h";
+    for (let i = 0; i < 20; i++) expr = `logWrap(${expr})`;
+    const f = await go("deepwrap2.go", PKG + `func routes() {\n\tmux.Handle("/x", ${expr})\n}\n`);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)[0].hasAuth).toBe(false);
+  });
+
+  it("no-throw totality: every adversarial-plus-unsure fixture never throws in either extractor", async () => {
+    const sources = [
+      ...NEVER_FALSE_BLESS_SWEEP_GO.map((e) => e.source),
+      ...UNSURE_SWEEP_GO.map((e) => e.source),
+    ];
+    for (const src of sources) {
+      const f = await go("totality2.go", src);
+      expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+      expect(() => extractGoFileMiddlewareAst(f.tree!)).not.toThrow();
+    }
+  });
+});

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { extractGoRoutesAst, SECURITY_AST_GO } from "../../../src/drift/security-ast-go.js";
+import { SECURITY_AST } from "../../../src/drift/security-ast.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 
 const go = (path: string, src: string) => fileWithTree(path, src, "go");
@@ -416,5 +417,336 @@ describe("extractGoRoutesAst: path-string forms", () => {
     const f = await go("grouppath.go",
       `package main\n\nfunc routes() {\n\tapi := r.Group("/api")\n\tapi.POST("", h)\n}\n`);
     expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("Gorilla mux and stdlib recognition", () => {
+  it("recognizes router.HandleFunc(...).Methods(\"POST\") as exactly one POST route (HandleFunc is the anchor)", async () => {
+    const f = await go("gorilla.go",
+      `package main\n\nfunc routes() {\n` +
+      `\trouter := mux.NewRouter()\n` +
+      `\trouter.HandleFunc("/orders", createOrder).Methods("POST")\n` +
+      `}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("resolves a multiline fluent chain with the line of the HandleFunc anchor, not the Methods call", async () => {
+    const f = await go("multiline.go",
+      `package main\n\nfunc routes() {\n` +
+      `\trouter := mux.NewRouter()\n` +
+      `\trouter.HandleFunc("/orders", h).\n` +
+      `\t\tMethods("POST")\n` +
+      `}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+    expect(routes[0].line).toBe(5);
+  });
+
+  it("walks chain ascent through an intermediate link: .Methods(\"POST\").Name(\"create\")", async () => {
+    const f = await go("chain-a.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/orders", h).Methods("POST").Name("create")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("walks chain ascent through an intermediate link in the other order: .Name(\"create\").Methods(\"POST\")", async () => {
+    const f = await go("chain-b.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/orders", h).Name("create").Methods("POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("recognizes router.Handle(...).Methods(\"PUT\") the same way as HandleFunc", async () => {
+    const f = await go("handle-chain.go",
+      `package main\n\nfunc routes() {\n\trouter.Handle("/x", handler).Methods("PUT")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["PUT /x"]);
+  });
+
+  it("disambiguates Gin's verb-first Handle(method, path, h)", async () => {
+    const f = await go("handle-verbfirst.go",
+      `package main\n\nfunc routes() {\n\tr.Handle("POST", "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("disambiguates Gorilla's path-first Handle(path, h) with no chain as ALL", async () => {
+    const f = await go("handle-pathfirst.go",
+      `package main\n\nfunc routes() {\n\trouter.Handle("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /x"]);
+  });
+
+  it("resolves a chain split across statements as ALL (variable-carried chains are not tracked), never double-counted", async () => {
+    const f = await go("split-chain.go",
+      `package main\n\nfunc routes() {\n\troute := r.HandleFunc("/orders", h)\n\troute.Methods("POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /orders"]);
+  });
+
+  it("resolves a Gorilla subrouter's HandleFunc(...).Methods(...) chain", async () => {
+    const f = await go("subrouter-chain.go",
+      `package main\n\nfunc routes() {\n\tapi := r.PathPrefix("/api").Subrouter()\n\tapi.HandleFunc("/orders", h).Methods("POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("recognizes stdlib http.HandleFunc as ALL (\"http\" special-cased for Handle/HandleFunc only)", async () => {
+    const f = await go("stdlib-http.go",
+      `package main\n\nfunc routes() {\n\thttp.HandleFunc("/orders", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /orders"]);
+  });
+
+  it("resolves a structurally-assigned http.NewServeMux() receiver's HandleFunc", async () => {
+    const f = await go("servemux.go",
+      `package main\n\nfunc routes() {\n\tmux := http.NewServeMux()\n\tmux.HandleFunc("/orders", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /orders"]);
+  });
+
+  it("resolves chi's any-method HandleFunc and Handle to ALL", async () => {
+    const f = await go("chi-any.go",
+      `package main\n\nfunc routes() {\n\tr.HandleFunc("/events", h)\n\tr.Handle("/events", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /events", "ALL /events"]);
+  });
+
+  it("does not recognize http.Post / http.Get as routes: \"http\" is not a receiver for verb fields", async () => {
+    const f = await go("http-client.go",
+      `package main\n\nfunc routes() {\n` +
+      `\thttp.Post("https://api.example.com/orders", ct, body)\n` +
+      `\thttp.Get(url)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("parses a Go 1.22 verb-in-path pattern (POST /orders)", async () => {
+    const f = await go("go122-post.go",
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("POST /orders", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("parses a Go 1.22 pattern with a path parameter (GET /items/{id})", async () => {
+    const f = await go("go122-get.go",
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("GET /items/{id}", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /items/{id}"]);
+  });
+
+  it("resolves a Go 1.22 pattern with double-space separation", async () => {
+    const f = await go("go122-doublespace.go",
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("POST  /orders", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("skips Go 1.22-shaped negatives: lowercase verb, host pattern, and a verb with no path", async () => {
+    const f = await go("go122-negatives.go",
+      `package main\n\nfunc routes() {\n` +
+      `\tmux.HandleFunc("post /x", h)\n` +
+      `\tmux.HandleFunc("example.com/route", h)\n` +
+      `\tmux.HandleFunc("POST", h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("method resolution", () => {
+  it.each(Array.from(SECURITY_AST_GO.VERB_FIELDS.entries()))(
+    "resolves verb-field casing %s to canonical %s",
+    async (field, canonical) => {
+      const f = await go("casing.go", `package main\n\nfunc routes() {\n\tr.${field}("/x", h)\n}\n`);
+      expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual([canonical]);
+    },
+  );
+
+  it("resolves a single-verb .Methods(\"POST\") to POST", async () => {
+    const f = await go("methods-post.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods("POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["POST"]);
+  });
+
+  it("resolves .Methods(\"GET\", \"POST\") to POST: first MUTATING verb in argument order", async () => {
+    const f = await go("methods-getpost.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods("GET", "POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["POST"]);
+  });
+
+  it("resolves .Methods(\"DELETE\", \"POST\") to DELETE: DELETE is first and already mutating", async () => {
+    const f = await go("methods-deletepost.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods("DELETE", "POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["DELETE"]);
+  });
+
+  it("resolves .Methods(\"GET\") to GET: emitted, simply outside the mutating vote", async () => {
+    const f = await go("methods-get.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods("GET")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["GET"]);
+  });
+
+  it("resolves .Methods(\"post\") lowercase to POST: gorilla uppercases at runtime", async () => {
+    const f = await go("methods-lower.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods("post")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["POST"]);
+  });
+
+  it("resolves .Methods(verbs...) with a non-literal arg to ALL: statically unresolvable stays in the mutating vote", async () => {
+    const f = await go("methods-spread.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods(verbs...)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["ALL"]);
+  });
+
+  it("resolves .Methods(\"MKCOL\") to GET: fully literal, zero recognized verbs is not ambiguity (mkcol parity)", async () => {
+    const f = await go("methods-mkcol.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/x", h).Methods("MKCOL")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["GET"]);
+  });
+
+  it("pins ABSENT Methods as ALL, never ANY, across HandleFunc/Handle with no chain, chi, and stdlib bare paths", async () => {
+    const f = await go("absent-methods.go",
+      `package main\n\nfunc routes() {\n` +
+      `\trouter.HandleFunc("/a", h)\n` +
+      `\trouter.Handle("/b", h)\n` +
+      `\tr.HandleFunc("/c", h)\n` +
+      `\tr.Handle("/d", h)\n` +
+      `\thttp.HandleFunc("/e", h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method))
+      .toEqual(["ALL", "ALL", "ALL", "ALL", "ALL"]);
+  });
+
+  it("ALL is in the shared mutating vocabulary and ANY is not", () => {
+    const mutating = [...SECURITY_AST.MUTATING].map((m) => m.toUpperCase());
+    expect(mutating).toContain("ALL");
+    expect(mutating).not.toContain("ANY");
+  });
+
+  it("resolves chi's verb-first Method(method, path, h)", async () => {
+    const f = await go("verbfirst-method.go",
+      `package main\n\nfunc routes() {\n\tr.Method("PATCH", "/y", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["PATCH /y"]);
+  });
+
+  it("resolves chi's verb-first MethodFunc(method, path, h)", async () => {
+    const f = await go("verbfirst-methodfunc.go",
+      `package main\n\nfunc routes() {\n\tr.MethodFunc("DELETE", "/z", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["DELETE /z"]);
+  });
+
+  it("resolves Echo's verb-first Add(method, path, h)", async () => {
+    const f = await go("verbfirst-add.go",
+      `package main\n\nfunc routes() {\n\te.Add("DELETE", "/z", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["DELETE /z"]);
+  });
+
+  it("resolves a verb-first call with a variable verb to ALL", async () => {
+    const f = await go("verbfirst-variable.go",
+      `package main\n\nfunc routes() {\n\tr.Method(verb, "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /x"]);
+  });
+
+  it("skips HEAD/OPTIONS on the chained .Methods(...) path", async () => {
+    const head = await go("chain-head.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("HEAD")\n}\n`);
+    expect(extractGoRoutesAst(head.tree!, head.relativePath)).toEqual([]);
+    const options = await go("chain-options.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("OPTIONS")\n}\n`);
+    expect(extractGoRoutesAst(options.tree!, options.relativePath)).toEqual([]);
+  });
+
+  it("filters HEAD before the first-mutating pick in a mixed .Methods(\"HEAD\", \"POST\")", async () => {
+    const f = await go("chain-headpost.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("HEAD", "POST")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["POST"]);
+  });
+
+  it("filters HEAD before the first-mutating pick in a mixed .Methods(\"HEAD\", \"GET\")", async () => {
+    const f = await go("chain-headget.go",
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("HEAD", "GET")\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["GET"]);
+  });
+
+  it("skips HEAD/OPTIONS on the verb-first resolution path", async () => {
+    const head = await go("verbfirst-head.go",
+      `package main\n\nfunc routes() {\n\tr.Method("HEAD", "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(head.tree!, head.relativePath)).toEqual([]);
+    const options = await go("verbfirst-options.go",
+      `package main\n\nfunc routes() {\n\te.Add("OPTIONS", "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(options.tree!, options.relativePath)).toEqual([]);
+    const ginHead = await go("verbfirst-gin-head.go",
+      `package main\n\nfunc routes() {\n\tr.Handle("HEAD", "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(ginHead.tree!, ginHead.relativePath)).toEqual([]);
+  });
+
+  it("skips HEAD/OPTIONS on the Go 1.22 verb-in-path resolution path", async () => {
+    const head = await go("go122-head.go",
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("HEAD /status", h)\n}\n`);
+    expect(extractGoRoutesAst(head.tree!, head.relativePath)).toEqual([]);
+    const options = await go("go122-options.go",
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("OPTIONS /cors", h)\n}\n`);
+    expect(extractGoRoutesAst(options.tree!, options.relativePath)).toEqual([]);
+  });
+
+  describe("documented trade-offs (pinned recall gaps, never a false-bless)", () => {
+    it("pins the Gorilla Route-builder chain form as unrecognized: HandlerFunc/Handler is the registering field, not an anchor", async () => {
+      const a = await go("builder-a.go",
+        `package main\n\nfunc routes() {\n\tr.Methods("POST").Path("/orders").HandlerFunc(h)\n}\n`);
+      expect(extractGoRoutesAst(a.tree!, a.relativePath)).toEqual([]);
+      const b = await go("builder-b.go",
+        `package main\n\nfunc routes() {\n\tr.Path("/orders").Handler(h)\n}\n`);
+      expect(extractGoRoutesAst(b.tree!, b.relativePath)).toEqual([]);
+      const c = await go("builder-c.go",
+        `package main\n\nfunc routes() {\n\tr.PathPrefix("/api").HandlerFunc(h)\n}\n`);
+      expect(extractGoRoutesAst(c.tree!, c.relativePath)).toEqual([]);
+    });
+  });
+
+  describe("vocabulary property", () => {
+    // Non-vacuous: the HEAD/OPTIONS-only fixtures below are recognized route
+    // registrations that must contribute ZERO methods on every one of the
+    // three resolution paths (chain, verb-first, Go 1.22), proving the skip
+    // is real rather than the property holding by omission.
+    const MUTATING_VOTE_FIXTURES: string[] = [
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/orders", h).Methods("POST")\n}\n`,
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("HEAD", "GET")\n}\n`,
+      `package main\n\nfunc routes() {\n\trouter.Handle("/x", h).Methods("PUT")\n}\n`,
+      `package main\n\nfunc routes() {\n\tr.Method("PATCH", "/y", h)\n}\n`,
+      `package main\n\nfunc routes() {\n\tr.MethodFunc("DELETE", "/z", h)\n}\n`,
+      `package main\n\nfunc routes() {\n\trouter.Handle("/x", h)\n}\n`,
+    ];
+    const HEAD_OPTIONS_ONLY_FIXTURES: string[] = [
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("HEAD")\n}\n`,
+      `package main\n\nfunc routes() {\n\trouter.HandleFunc("/status", h).Methods("OPTIONS")\n}\n`,
+      `package main\n\nfunc routes() {\n\tr.Method("HEAD", "/x", h)\n}\n`,
+      `package main\n\nfunc routes() {\n\te.Add("OPTIONS", "/x", h)\n}\n`,
+      `package main\n\nfunc routes() {\n\tr.Handle("HEAD", "/x", h)\n}\n`,
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("HEAD /status", h)\n}\n`,
+      `package main\n\nfunc routes() {\n\tmux.HandleFunc("OPTIONS /cors", h)\n}\n`,
+    ];
+
+    it("keeps every emitted method inside {GET,POST,PUT,PATCH,DELETE,ALL}; HEAD/OPTIONS/ANY/lowercase never leak", async () => {
+      const ALLOWED = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "ALL"]);
+      const collected: string[] = [];
+      for (let i = 0; i < MUTATING_VOTE_FIXTURES.length; i++) {
+        const f = await go(`vocab-mutating-${i}.go`, MUTATING_VOTE_FIXTURES[i]);
+        for (const r of extractGoRoutesAst(f.tree!, f.relativePath)) collected.push(r.method);
+      }
+      for (let i = 0; i < HEAD_OPTIONS_ONLY_FIXTURES.length; i++) {
+        const f = await go(`vocab-skip-${i}.go`, HEAD_OPTIONS_ONLY_FIXTURES[i]);
+        for (const r of extractGoRoutesAst(f.tree!, f.relativePath)) collected.push(r.method);
+      }
+      for (const m of collected) expect(ALLOWED.has(m)).toBe(true);
+      expect(collected).toEqual(expect.arrayContaining(["GET", "POST", "PUT", "PATCH", "DELETE", "ALL"]));
+      // Exactly the 6 MUTATING_VOTE_FIXTURES routes: the 7 HEAD/OPTIONS-only
+      // fixtures contributed nothing (non-vacuous skip).
+      expect(collected.length).toBe(6);
+    });
   });
 });

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect } from "vitest";
+import { extractGoRoutesAst, SECURITY_AST_GO } from "../../../src/drift/security-ast-go.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+
+const go = (path: string, src: string) => fileWithTree(path, src, "go");
+
+describe("go tree harness prerequisites", () => {
+  it("parses a trivial go file to a clean tree", async () => {
+    const f = await go("main.go", `package main\n\nfunc main() {}\n`);
+    expect(f.tree).toBeDefined();
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(f.language).toBe("go");
+  });
+
+  it("pins the load-bearing grammar facts this module is built on", async () => {
+    // Probe-verified 2026-07-13 against the pinned tree-sitter-wasms go grammar.
+    // A grammar bump that renames these fails HERE with a named fact, not as a
+    // silent recall collapse.
+    const f = await go("facts.go",
+      `package main\n\nfunc routes() {\n\tapi := r.Group("/api")\n\tapi.POST("/x", h)\n}\n`);
+    const decl = f.tree!.rootNode.descendantsOfType("short_var_declaration")[0]!;
+    expect(decl.childForFieldName("left")?.type).toBe("expression_list"); // NOT a bare identifier
+    expect(decl.childForFieldName("right")?.type).toBe("expression_list");
+    const call = f.tree!.rootNode.descendantsOfType("call_expression")
+      .find((c) => c?.text.startsWith("api.POST"))!;
+    const fn = call.childForFieldName("function")!;
+    expect(fn.type).toBe("selector_expression");
+    expect(fn.childForFieldName("field")?.type).toBe("field_identifier");
+    // Broken go source still returns a tree (never null), flagged via hasError.
+    const broken = await go("broken.go", `func {{{{`);
+    expect(broken.tree).toBeDefined();
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+  });
+});
+
+describe("extractGoRoutesAst: Gin and Echo verb routes", () => {
+  it("extracts a structurally-resolved Gin route with method, path, and line", async () => {
+    const f = await go("routes.go",
+      `package main\n\n` +
+      `func main() {\n` +
+      `\tr := gin.Default()\n` +
+      `\tr.POST("/orders", createOrder)\n` +
+      `}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=false",
+    ]);
+    expect(routes[0].line).toBe(5);
+    expect(routes[0].file).toBe("routes.go");
+  });
+
+  it("recognizes a convention-gated func-param receiver with no constructor in file", async () => {
+    // The dominant real-world Go layout: router built in main.go, routes
+    // registered on a parameter.
+    const f = await go("users.go",
+      `package routes\n\n` +
+      `func RegisterUsers(router *gin.Engine) {\n` +
+      `\trouter.POST("/users", create)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /users"]);
+  });
+
+  it("resolves a method-receiver chain to the nearest field name", async () => {
+    const f = await go("server.go",
+      `package main\n\n` +
+      `func (s *Server) routes() {\n` +
+      `\ts.router.POST("/orders", s.handleCreateOrder)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders"]);
+  });
+
+  it("ignores HTTP-client and non-router receivers", async () => {
+    const f = await go("client.go",
+      `package main\n\n` +
+      `func fetch() {\n` +
+      `\tclient.Post("/api", body)\n` +
+      `\tdb.Delete("/records")\n` +
+      `\ts.store.Put("/key", v)\n` +
+      `\tcache.Get("user:1")\n` +
+      `\tc.Get("user")\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractGoRoutesAst: additional Gin/Echo recognition forms", () => {
+  it("resolves a package-level var_spec constructor assignment (var e = echo.New())", async () => {
+    const f = await go("varspec.go",
+      `package main\n\nvar e = echo.New()\n\nfunc routes() {\n\te.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("resolves a plain assignment_statement constructor assignment (engine = gin.New())", async () => {
+    const f = await go("assign.go",
+      `package main\n\nfunc routes() {\n\tvar engine *gin.Engine\n\tengine = gin.New()\n\tengine.PUT("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["PUT /x"]);
+  });
+
+  it("resolves r.Any to the ALL sentinel verb", async () => {
+    const f = await go("any.go", `package main\n\nfunc routes() {\n\tr.Any("/everything", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /everything"]);
+  });
+
+  it("emits two RouteInfos for two routes in one file with distinct correct lines", async () => {
+    const f = await go("two.go",
+      `package main\n\nfunc routes() {\n\tr.POST("/a", h)\n\tr.GET("/b", h)\n}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}:${r.line}`)).toEqual([
+      "POST /a:4",
+      "GET /b:5",
+    ]);
+  });
+
+  it("does not dedup an identical registration repeated on two lines", async () => {
+    const f = await go("dup.go",
+      `package main\n\nfunc routes() {\n\tr.POST("/orders", h)\n\tr.POST("/orders", h)\n}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}:${r.line}`)).toEqual([
+      "POST /orders:4",
+      "POST /orders:5",
+    ]);
+  });
+
+  it("finds routes inside init(), a method body, and a func literal assigned to a variable (recursive walk)", async () => {
+    const f = await go("recursive.go",
+      `package main\n\n` +
+      `func init() {\n\tr.POST("/init", h)\n}\n\n` +
+      `type Server struct{}\n\n` +
+      `func (s *Server) setup() {\n\trouter.POST("/method", h)\n}\n\n` +
+      `var handler = func() {\n\tapp.POST("/closure", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /init", "POST /method", "POST /closure"]);
+  });
+
+  it("extracts a route inside a bare block following a Group derivation (block is transparent)", async () => {
+    const f = await go("blockgroup.go",
+      `package main\n\nfunc routes() {\n\tv1 := r.Group("/v1")\n\t{\n\t\tv1.POST("/a", h)\n\t}\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /a"]);
+  });
+
+  it("extracts a route whose handler is an inline func literal", async () => {
+    const f = await go("funclit.go",
+      `package main\n\nfunc routes() {\n\tr.GET("/ping", func(c *gin.Context) {\n\t\tc.String(200, "pong")\n\t})\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /ping"]);
+  });
+});
+
+describe("extractGoRoutesAst: fiber smoke (documentation pin, non-goal)", () => {
+  it("extracts app.Post via convention alone even though fiber.New is not a recognized constructor", async () => {
+    // Framework auto-detection is a non-goal; the gates are purely structural
+    // (constructor set) and conventional (receiver name), never a framework
+    // identity check. fiber.New() is deliberately absent from
+    // GO_ROUTER_CONSTRUCTORS, yet this route still extracts because "app"
+    // passes the naming convention and "Post" is a recognized Capitalized verb.
+    const f = await go("fiber.go",
+      `package main\n\nfunc routes() {\n\tapp := fiber.New()\n\tapp.Post("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+});
+
+describe("extractGoRoutesAst: chi verb routes", () => {
+  it("recognizes chi's Capitalized-only verb methods on a constructor-resolved router", async () => {
+    const f = await go("chi.go",
+      `package main\n\nfunc routes() {\n` +
+      `\tr := chi.NewRouter()\n` +
+      `\tr.Post("/orders", h)\n` +
+      `\tr.Get("/orders", h)\n` +
+      `\tr.Delete("/orders/{id}", h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual([
+      "POST /orders",
+      "GET /orders",
+      "DELETE /orders/{id}",
+    ]);
+  });
+
+  it("recognizes a chi With(...) chain as one route, auth=false in this task, line at the chain start", async () => {
+    const f = await go("with.go",
+      `package main\n\nfunc routes() {\n\tr.With(RequireAuth).Post("/orders", h)\n}\n`);
+    const routes = extractGoRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=false",
+    ]);
+    expect(routes[0].line).toBe(4);
+  });
+
+  it("extracts a route registered inside a chi Route(...) closure, path stays the literal with no prefix joining", async () => {
+    const f = await go("route.go",
+      `package main\n\nfunc routes() {\n\tr.Route("/admin", func(r chi.Router) {\n\t\tr.Post("/users", h)\n\t})\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /users"]);
+  });
+});
+
+describe("extractGoRoutesAst: receiver-gate convention table", () => {
+  const POSITIVES = [
+    "r", "router", "e", "g", "grp", "group", "app", "application", "server",
+    "srv", "engine", "api", "mux", "v1", "v2", "usersRouter", "adminGroup",
+    "apiMux", "appEngine",
+  ];
+  it.each(POSITIVES)("recognizes conventional receiver name %s with no in-file constructor", async (name) => {
+    const f = await go("recv-pos.go",
+      `package main\n\nfunc routes() {\n\t${name}.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  const NEGATIVES = ["c", "m", "db", "client", "cache", "store", "q", "req", "w", "ctx"];
+  it.each(NEGATIVES)("does not recognize non-conventional receiver name %s", async (name) => {
+    const f = await go("recv-neg.go",
+      `package main\n\nfunc routes() {\n\t${name}.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractGoRoutesAst: verb casing and pinned-out scope", () => {
+  it("ignores fully lowercase verb fields (api.post, r.get)", async () => {
+    const f = await go("lower.go",
+      `package main\n\nfunc routes() {\n\tapi.post("/x", h)\n\tr.get("/y", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not recognize OPTIONS or HEAD: neither is ever mutating, so exclusion is bless-safe", async () => {
+    const f = await go("optionshead.go",
+      `package main\n\nfunc routes() {\n\tr.OPTIONS("/x", h)\n\tr.HEAD("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not recognize the composite-literal Match form", async () => {
+    const f = await go("match.go",
+      `package main\n\nfunc routes() {\n\te.Match([]string{"GET"}, "/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractGoRoutesAst: structural resolution", () => {
+  it.each(Array.from(SECURITY_AST_GO.GO_ROUTER_CONSTRUCTORS))(
+    "resolves a spelling-defiant receiver assigned from %s(...)",
+    async (ctor) => {
+      const f = await go("ctor.go",
+        `package main\n\nfunc routes() {\n\tzzz := ${ctor}()\n\tzzz.POST("/x", h)\n}\n`);
+      expect(extractGoRoutesAst(f.tree!, f.relativePath)
+        .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+    },
+  );
+
+  it("recognizes a Group-derived receiver (api := r.Group(\"/api\"))", async () => {
+    const f = await go("derived.go",
+      `package main\n\nfunc routes() {\n\tapi := r.Group("/api")\n\tapi.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("recognizes a nested Group-derived receiver (sub := api.Group(\"/v2\"))", async () => {
+    const f = await go("nested.go",
+      `package main\n\nfunc routes() {\n\tapi := r.Group("/api")\n\tsub := api.Group("/v2")\n\tsub.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("recognizes a PathPrefix(...).Subrouter() derived receiver with chi-caps verbs", async () => {
+    const f = await go("subrouter.go",
+      `package main\n\nfunc routes() {\n\ts := r.PathPrefix("/api").Subrouter()\n\ts.Post("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("recognizes a derived receiver whose own name misses the convention regex (payments)", async () => {
+    const f = await go("payments.go",
+      `package main\n\nfunc routes() {\n\tpayments := r.Group("/payments")\n\tpayments.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("does not derive a receiver from an unresolved base (notrouter is neither convention-gated nor constructor-assigned)", async () => {
+    const f = await go("unresolvedbase.go",
+      `package main\n\nfunc routes() {\n\tsub := notrouter.Group("/x")\n\tsub.POST("/y", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("handles a multi-value short_var_declaration (r, err := buildRouter()) without resolving or throwing", async () => {
+    const f = await go("multival.go",
+      `package main\n\nfunc routes() {\n\tr, err := buildRouter()\n\t_ = err\n}\n`);
+    expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("resolves a 4-deep derivation chain (r -> api -> v1 -> admin)", async () => {
+    const f = await go("chain4.go",
+      `package main\n\nfunc routes() {\n` +
+      `\tr := gin.Default()\n` +
+      `\tapi := r.Group("/api")\n` +
+      `\tv1 := api.Group("/v1")\n` +
+      `\tadmin := v1.Group("/admin")\n` +
+      `\tadmin.POST("/x", h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("terminates on a 50-level derivation chain without hanging", async () => {
+    let src = `package main\n\nfunc routes() {\n\tr := gin.Default()\n`;
+    let prev = "r";
+    for (let i = 1; i <= 50; i++) {
+      src += `\tlvl${i} := ${prev}.Group("/${i}")\n`;
+      prev = `lvl${i}`;
+    }
+    src += `\t${prev}.POST("/x", h)\n}\n`;
+    const f = await go("chain50.go", src);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("does not extract unknownRecv.POST alone: no constructor, no convention (documented recall gap, mirrors the flask-restx ns pin)", async () => {
+    const f = await go("unknown.go",
+      `package main\n\nfunc routes() {\n\tunknownRecv.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not structurally resolve a gorilla-style NewRouter() under a non-conventional import alias (documented recall gap)", async () => {
+    // "rt" is neither a recognized constructor key (only gin.Default/gin.New/
+    // echo.New/chi.NewRouter are in GO_ROUTER_CONSTRUCTORS this task) nor a
+    // conventional receiver name, so the route is missed. Had the assigned
+    // name itself passed the convention regex (e.g. "router" or "mux"), it
+    // would extract independent of the package alias used to call NewRouter.
+    const f = await go("aliasgap.go",
+      `package main\n\nfunc routes() {\n\trt := gorillamux.NewRouter()\n\trt.POST("/x", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractGoRoutesAst: embedded-engine method receiver (pinned recall gap)", () => {
+  it("does not recognize a method receiver whose struct embeds a known engine type", async () => {
+    const f = await go("embedded.go",
+      `package main\n\n` +
+      `type Server struct {\n\t*gin.Engine\n}\n\n` +
+      `func (s *Server) routes() {\n\ts.POST("/orders", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractGoRoutesAst: path-string forms", () => {
+  it("accepts both interpreted and raw backtick string paths", async () => {
+    const f = await go("delims.go",
+      `package main\n\nfunc routes() {\n\tr.POST("/orders", h)\n\tr.GET(\`/raw\`, h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders", "GET /raw"]);
+  });
+
+  it("keeps an escaped quote in the path raw, never unescaped", async () => {
+    const f = await go("escape.go",
+      `package main\n\nfunc routes() {\n\tr.POST("/a\\"b", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(['/a\\"b']);
+  });
+
+  it("accepts the root path", async () => {
+    const f = await go("root.go", `package main\n\nfunc routes() {\n\tr.GET("/", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/"]);
+  });
+
+  it("skips an empty path string", async () => {
+    const f = await go("empty.go", `package main\n\nfunc routes() {\n\tr.GET("", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a path with no leading slash", async () => {
+    const f = await go("noslash.go", `package main\n\nfunc routes() {\n\tr.GET("orders", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("keeps framework parameter syntaxes verbatim", async () => {
+    const f = await go("params.go",
+      `package main\n\nfunc routes() {\n` +
+      `\tr.GET("/users/:id", h)\n` +
+      `\tr.GET("/users/{id}", h)\n` +
+      `\tr.GET("/users/{id:[0-9]+}", h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/users/:id", "/users/{id}", "/users/{id:[0-9]+}"]);
+  });
+
+  it("accepts a unicode path", async () => {
+    const f = await go("unicode.go", `package main\n\nfunc routes() {\n\tr.GET("/café", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)
+      .map((r) => r.path)).toEqual(["/café"]);
+  });
+
+  it("skips statically unresolvable paths: fmt.Sprintf, string concatenation, and a bare identifier", async () => {
+    const f = await go("unresolvable.go",
+      `package main\n\nfunc routes() {\n` +
+      `\tr.POST(fmt.Sprintf("/api/%s", v), h)\n` +
+      `\tr.POST("/a" + suffix, h)\n` +
+      `\tr.POST(pathVar, h)\n` +
+      `}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a bare identifier path even when a same-file const of that name holds a literal (no const folding, pinned gap)", async () => {
+    const f = await go("constvar.go",
+      `package main\n\nconst pathVar = "/x"\n\nfunc routes() {\n\tr.POST(pathVar, h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a group-relative empty path (leading-slash gate, not a group-prefix join)", async () => {
+    const f = await go("grouppath.go",
+      `package main\n\nfunc routes() {\n\tapi := r.Group("/api")\n\tapi.POST("", h)\n}\n`);
+    expect(extractGoRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -1,9 +1,42 @@
 import { describe, it, expect } from "vitest";
-import { extractGoRoutesAst, SECURITY_AST_GO } from "../../../src/drift/security-ast-go.js";
+import {
+  extractGoRoutesAst, SECURITY_AST_GO,
+  bodyAuthSignatureGo, classifyGoMiddlewareAuth, collectGoFunctionDefs,
+} from "../../../src/drift/security-ast-go.js";
 import { SECURITY_AST } from "../../../src/drift/security-ast.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
+import type { SyntaxNode } from "../../../src/core/types.js";
 
 const go = (path: string, src: string) => fileWithTree(path, src, "go");
+
+const PKG = "package main\n\n";
+
+/** Body node + file-wide defs for a named function/method (mirrors the Python
+ *  addendum's hookBody util). resolveEffectiveBody is exercised THROUGH the
+ *  classifier; direct bodyAuthSignatureGo fixtures put the reject in the DIRECT
+ *  body. */
+async function mwBody(src: string, fnName: string): Promise<{ body: SyntaxNode; defs: Map<string, SyntaxNode | null> }> {
+  const f = await go("mw.go", src);
+  const root = f.tree!.rootNode;
+  expect(root.hasError).toBe(false);
+  const defs = collectGoFunctionDefs(root);
+  const def = root.descendantsOfType(["function_declaration", "method_declaration"])
+    .find((d) => d?.childForFieldName("name")?.text === fnName)!;
+  return { body: def.childForFieldName("body")!, defs };
+}
+
+/** bodyAuthSignatureGo of a single-function fixture's DIRECT body. */
+async function sig(src: string, fnName = "f") {
+  const { body, defs } = await mwBody(src, fnName);
+  return bodyAuthSignatureGo(body, defs);
+}
+
+/** extractGoRoutesAst over a full go source. */
+async function routesOf(src: string) {
+  const f = await go("routes.go", PKG + src);
+  expect(f.tree!.rootNode.hasError).toBe(false);
+  return extractGoRoutesAst(f.tree!, f.relativePath);
+}
 
 describe("go tree harness prerequisites", () => {
   it("parses a trivial go file to a clean tree", async () => {
@@ -748,5 +781,452 @@ describe("method resolution", () => {
       // fixtures contributed nothing (non-vacuous skip).
       expect(collected.length).toBe(6);
     });
+  });
+});
+
+// ─── Task 3: body-first auth classification ──────────────────────────────────
+
+describe("Task 3 Step 1: grammar prerequisites for body-signature shapes", () => {
+  it("pins the reject / credential / effective-body node shapes", async () => {
+    // A tree-sitter-go bump that renames any of these fails HERE with a named
+    // shape, not deep in a bless assertion.
+    const abortSel = (await mwBody(
+      PKG + `func f(c *gin.Context) { c.AbortWithStatus(http.StatusUnauthorized) }\n`, "f")).body
+      .descendantsOfType("call_expression")[0]!;
+    expect(abortSel.childForFieldName("function")?.type).toBe("selector_expression");
+    const st = abortSel.childForFieldName("arguments")!.namedChildren[0]!;
+    expect(st.type).toBe("selector_expression");
+    expect(st.childForFieldName("field")?.text).toBe("StatusUnauthorized");
+
+    const abortInt = (await mwBody(PKG + `func f(c *gin.Context) { c.AbortWithStatus(401) }\n`, "f")).body
+      .descendantsOfType("int_literal")[0]!;
+    expect(abortInt.type).toBe("int_literal"); // NOT "integer"
+    expect(abortInt.text).toBe("401");
+
+    const echoErr = (await mwBody(PKG + `func f(c echo.Context) error { return &echo.HTTPError{Code: 401} }\n`, "f")).body;
+    const unary = echoErr.descendantsOfType("unary_expression")[0]!;
+    const comp = unary.namedChildren[0]!;
+    expect(comp.type).toBe("composite_literal");
+    const lv = comp.descendantsOfType("literal_value")[0]!;
+    const ke = lv.namedChildren.find((n) => n?.type === "keyed_element")!;
+    expect(ke.namedChildren[0]!.text).toBe("Code");
+
+    const httpErr = (await mwBody(PKG + `func f(w http.ResponseWriter) { http.Error(w, "no", http.StatusUnauthorized) }\n`, "f")).body
+      .descendantsOfType("call_expression")[0]!;
+    const hargs = httpErr.childForFieldName("arguments")!.namedChildren.filter((n): n is SyntaxNode => n !== null);
+    expect(hargs[hargs.length - 1].childForFieldName("field")?.text).toBe("StatusUnauthorized"); // status LAST
+
+    const factory = (await mwBody(PKG + `func F() gin.HandlerFunc { return func(c *gin.Context) { c.Next() } }\n`, "F")).body;
+    const ret = factory.descendantsOfType("return_statement")[0]!;
+    expect(ret.namedChild(0)!.type).toBe("expression_list");
+    expect(ret.namedChild(0)!.namedChild(0)!.type).toBe("func_literal");
+
+    const httpHandler = (await mwBody(
+      PKG + `func F(next http.Handler) http.Handler { return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { next.ServeHTTP(w, r) }) }\n`, "F")).body;
+    const retCall = httpHandler.descendantsOfType("return_statement")[0]!.namedChild(0)!.namedChild(0)!;
+    expect(retCall.type).toBe("call_expression");
+    expect(retCall.childForFieldName("arguments")!.namedChild(0)!.type).toBe("func_literal");
+
+    // if-init idiom: read lives in the initializer field
+    const ifInit = (await mwBody(
+      PKG + `func f(c *gin.Context) { if _, err := v(c.GetHeader("Authorization")); err != nil { c.AbortWithStatus(401) } }\n`, "f")).body
+      .descendantsOfType("if_statement")[0]!;
+    expect(ifInit.childForFieldName("initializer")?.type).toBe("short_var_declaration");
+    expect(ifInit.childForFieldName("condition")?.type).toBe("binary_expression");
+
+    // function vs method name field kinds
+    const fnDecl = (await go("g.go", PKG + `func plain() {}\n`)).tree!.rootNode
+      .descendantsOfType("function_declaration")[0]!;
+    expect(fnDecl.childForFieldName("name")?.type).toBe("identifier");
+    const mDecl = (await go("g.go", PKG + `func (s *S) M() {}\n`)).tree!.rootNode
+      .descendantsOfType("method_declaration")[0]!;
+    expect(mDecl.childForFieldName("name")?.type).toBe("field_identifier");
+  });
+});
+
+describe("Task 3: bodyAuthSignatureGo — reject", () => {
+  it("gin self-aborting 401 blesses alone (constant and bare-integer parity)", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.AbortWithStatus(401) }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"e": "no"}) }\n`)).toBe("reject");
+  });
+  it("write-then-stop forms bless only WITH a following return / Abort", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { c.JSON(http.StatusUnauthorized, gin.H{"e": "no"}); c.Abort() }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.String(401, "no"); return }\n`)).toBe("reject");
+  });
+  it("echo returned-reject forms bless", async () => {
+    expect(await sig(PKG + `func f(c echo.Context) error { return echo.NewHTTPError(http.StatusUnauthorized) }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(c echo.Context) error { return &echo.HTTPError{Code: 401} }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(c echo.Context) error { return c.NoContent(401) }\n`)).toBe("reject");
+  });
+  it("stdlib write+return and http.Error(401) bless", async () => {
+    expect(await sig(PKG + `func f(w http.ResponseWriter, r *http.Request) { if r.Header.Get("Authorization") == "" { w.WriteHeader(http.StatusUnauthorized); return }; next.ServeHTTP(w, r) }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(w http.ResponseWriter, r *http.Request) { if r.Header.Get("Authorization") == "" { http.Error(w, "unauthorized", http.StatusUnauthorized); return }; next.ServeHTTP(w, r) }\n`)).toBe("reject");
+  });
+  it("credential-guarded 403 blesses (bound local read from Authorization gates it)", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { tok := c.GetHeader("Authorization"); if tok == "" { c.AbortWithStatus(http.StatusForbidden); return } }\n`)).toBe("reject");
+  });
+  it("depth-agnostic: a reject in a for/switch/if branch counts", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { for _, x := range items { if !x { c.AbortWithStatus(401); return } } }\n`)).toBe("reject");
+    expect(await sig(PKG + `func f(c *gin.Context) { switch x { case 1: c.AbortWithStatus(401) } }\n`)).toBe("reject");
+  });
+  it("one-hop: a same-file helper that holds the reject blesses the caller", async () => {
+    const src = PKG +
+      `func check(c *gin.Context) { if !ok(c) { c.AbortWithStatus(401) } }\n` +
+      `func requireLogin(c *gin.Context) { check(c) }\n`;
+    expect(await sig(src, "requireLogin")).toBe("reject");
+  });
+});
+
+describe("Task 3: bodyAuthSignatureGo — none (never-false-bless)", () => {
+  it("visible non-enforcing bodies are none", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { log.Printf("auth %s", c.Request.URL.Path); c.Next() }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(w http.ResponseWriter, r *http.Request) { log.Println(r.Method); next.ServeHTTP(w, r) }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { metrics.Inc("req"); c.Next() }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.Header("X-Frame-Options", "DENY"); c.Next() }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.Next() }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(next echo.HandlerFunc) echo.HandlerFunc { return next }\n`)).toBe("none");
+  });
+  it("404 / 500 / lone-403 are NOT rejects", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { c.AbortWithStatus(http.StatusNotFound) }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.AbortWithStatus(http.StatusInternalServerError) }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.AbortWithStatus(http.StatusForbidden) }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c echo.Context) error { return echo.NewHTTPError(http.StatusNotFound) }\n`)).toBe("none");
+  });
+  it("200 writes are not rejects", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}); c.Next() }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.JSON(200, gin.H{}); c.Next() }\n`)).toBe("none");
+  });
+  it("CSRF 403 gate is none (X-CSRF-Token key vetoed -> guard not credential)", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { if c.GetHeader("X-CSRF-Token") != valid { c.AbortWithStatus(http.StatusForbidden) } }\n`)).toBe("none");
+  });
+  it("a reject inside a never-called nested closure (goroutine) does NOT count", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { go func() { c.AbortWithStatus(401) }(); c.Next() }\n`)).toBe("none");
+  });
+  it("NEVER-FALSE-BLESS: a 401 write that keeps calling next (no return/Abort) is none", async () => {
+    // write-then-continue is a bug, not a reject: the request still reaches next.
+    expect(await sig(PKG + `func f(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized); next.ServeHTTP(w, r) }\n`)).toBe("none");
+    expect(await sig(PKG + `func f(c *gin.Context) { c.JSON(http.StatusUnauthorized, gin.H{}); c.Next() }\n`)).toBe("none");
+  });
+});
+
+describe("Task 3: bodyAuthSignatureGo — opaque", () => {
+  it("unresolvable auth-flavored callees are opaque", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { checkSession(c) }\n`)).toBe("opaque");
+    expect(await sig(PKG + `func f(user User) { confirm(user) }\n`)).toBe("opaque");
+    expect(await sig(PKG + `func f(c *gin.Context) { doAuth(c) }\n`)).toBe("opaque");
+  });
+  it("variable / credential-read-without-reject bodies are opaque", async () => {
+    expect(await sig(PKG + `func f(c *gin.Context) { c.AbortWithStatus(code) }\n`)).toBe("opaque");
+    expect(await sig(PKG + `func f(c *gin.Context) { token := c.GetHeader("Authorization"); validateOrDie(token) }\n`)).toBe("opaque");
+  });
+  it("a duplicate same-file def (follow neither) is opaque under a flavored callee", async () => {
+    const src = PKG +
+      `func checkAuth(c *gin.Context) { a(c) }\n` +
+      `func checkAuth(c *gin.Context) { b(c) }\n` +
+      `func f(c *gin.Context) { checkAuth(c) }\n`;
+    expect(await sig(src, "f")).toBe("opaque");
+  });
+  it("a mutual-recursion cycle terminates and never false-blesses", async () => {
+    const src = PKG + `func a(c *gin.Context) { b(c) }\nfunc b(c *gin.Context) { a(c) }\n`;
+    expect(await sig(src, "a")).not.toBe("reject");
+  });
+});
+
+describe("Task 3: classifyGoMiddlewareAuth precedence (LOCKED)", () => {
+  it("rule 1 — veto beats a real body reject", async () => {
+    const src = PKG + `func mw(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() }\n`;
+    const { body, defs } = await mwBody(src, "mw");
+    for (const name of ["OptionalAuth", "SkipAuth", "DisableAuth", "InsecureSkipAuth", "MockAuth"]) {
+      expect(classifyGoMiddlewareAuth(name, body, defs)).toBe("not-auth");
+    }
+  });
+  it("rule 2 — a visible reject body blesses even a boring name", async () => {
+    const { body, defs } = await mwBody(
+      PKG + `func buildGuard(c *gin.Context) { if session.Get("user") == nil { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() }\n`, "buildGuard");
+    expect(classifyGoMiddlewareAuth("buildGuard", body, defs)).toBe("auth");
+  });
+  it("rule 3 — a visible non-enforcing body is not-auth whatever the name", async () => {
+    const none = await mwBody(PKG + `func authCheck(c *gin.Context) { log.Printf("auth %s", c.Request.URL.Path); c.Next() }\n`, "authCheck");
+    expect(classifyGoMiddlewareAuth("authCheck", none.body, none.defs)).toBe("not-auth");
+    const notFound = await mwBody(PKG + `func authCheck(c *gin.Context) { c.AbortWithStatus(http.StatusNotFound) }\n`, "authCheck");
+    expect(classifyGoMiddlewareAuth("authCheck", notFound.body, notFound.defs)).toBe("not-auth");
+  });
+  it("rule 4 — an opaque body NEVER blesses on name (flavored -> unsure, boring -> not-auth)", async () => {
+    const flavored = await mwBody(PKG + `func authenticate(c *gin.Context) { doAuth(c) }\n`, "authenticate");
+    expect(classifyGoMiddlewareAuth("authenticate", flavored.body, flavored.defs)).toBe("unsure");
+    const boring = await mwBody(PKG + `func setup(c *gin.Context) { doStuff(c) }\n`, "setup");
+    expect(bodyAuthSignatureGo(boring.body, boring.defs)).toBe("none"); // doStuff not flavored -> none, not opaque
+    expect(classifyGoMiddlewareAuth("setup", boring.body, boring.defs)).toBe("not-auth");
+    // an opaque body under a boring name is still not-auth (no name bless on opaque)
+    const boringOpaque = await mwBody(PKG + `func setup(c *gin.Context) { c.AbortWithStatus(code) }\n`, "setup");
+    expect(bodyAuthSignatureGo(boringOpaque.body, boringOpaque.defs)).toBe("opaque");
+    expect(classifyGoMiddlewareAuth("setup", boringOpaque.body, boringOpaque.defs)).toBe("not-auth");
+  });
+  it("rule 5 — an unreadable (null) body NEVER blesses on name", async () => {
+    const defs = new Map<string, SyntaxNode | null>();
+    for (const name of ["AuthMiddleware", "middleware.AuthMiddleware", "JWTMiddleware", "EnsureLoggedIn", "middleware.VerifyToken", "OAuth2Middleware", "BasicAuth", "TokenRequired"]) {
+      expect(classifyGoMiddlewareAuth(name, null, defs)).toBe("unsure");
+    }
+    for (const name of ["middleware.RequestID", "authLogger", "parseJWT", "newAuthHandler", "AuthMetrics"]) {
+      expect(classifyGoMiddlewareAuth(name, null, defs)).toBe("not-auth");
+    }
+  });
+});
+
+describe("Task 3: body-first per-route middleware args (LOCKED)", () => {
+  const auth1 = (name: string) =>
+    `func ${name}(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() }\n`;
+
+  it("IMPORTED/opaque auth-flavored middleware HEDGES (rule 5) — hasAuth false + key", async () => {
+    const cases: Array<[string, string]> = [
+      [`r.POST("/x", middleware.AuthMiddleware(), createX)`, "middleware.AuthMiddleware"],
+      [`r.POST("/x", requireAuth, h)`, "requireAuth"],
+      [`r.POST("/x", middleware.RequireAuth, h)`, "middleware.RequireAuth"],
+      [`r.POST("/x", JWTMiddleware, h)`, "JWTMiddleware"],
+      [`r.POST("/x", BasicAuth(), h)`, "BasicAuth"],
+      [`r.POST("/x", OAuth2Middleware, h)`, "OAuth2Middleware"],
+      [`r.POST("/x", JWTBearer, h)`, "JWTBearer"],
+    ];
+    for (const [reg, key] of cases) {
+      const [rt] = await routesOf(`func routes() {\n\t${reg}\n}\n`);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBe(key);
+    }
+  });
+
+  it("MIGRATION FLIP — pair-only imported names hedge (were name-only true)", async () => {
+    for (const [reg, key] of [
+      [`r.POST("/x", EnsureLoggedIn, h)`, "EnsureLoggedIn"],
+      [`r.POST("/x", TokenRequired, h)`, "TokenRequired"],
+      [`r.POST("/x", requireRole("admin"), h)`, "requireRole"],
+      [`r.POST("/x", middleware.VerifyToken(), h)`, "middleware.VerifyToken"],
+    ] as Array<[string, string]>) {
+      const [rt] = await routesOf(`func routes() {\n\t${reg}\n}\n`);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBe(key);
+    }
+  });
+
+  it("BODY-FIRST TWIN — an in-file rejecting body blesses (rule 2), key absent", async () => {
+    const flavored = await routesOf(auth1("EnsureLoggedIn") + `func routes() {\n\tr.POST("/x", EnsureLoggedIn, h)\n}\n`);
+    expect(flavored[0].hasAuth).toBe(true);
+    expect(flavored[0].authUnsureHook).toBeUndefined();
+    const boring = await routesOf(auth1("gate") + `func routes() {\n\tr.POST("/x", gate, h)\n}\n`);
+    expect(boring[0].hasAuth).toBe(true); // body-only bless under a boring name
+    expect(boring[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("VISIBLE non-enforcing in-file body never blesses despite auth name (rule 3), key absent", async () => {
+    const src = `func authCheck(c *gin.Context) { log.Printf("auth %s", c.Request.URL.Path); c.Next() }\n` +
+      `func routes() {\n\tr.POST("/x", authCheck, h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("CREDENTIAL-READ-NO-REJECT in-file body is opaque -> rule 4 hedge (never bless)", async () => {
+    const jwt = `func jwtMiddleware(c *gin.Context) { token := c.GetHeader("Authorization"); c.Set("user", token); c.Next() }\n`;
+    const load = `func loadUser(c *gin.Context) { token := c.GetHeader("Authorization"); c.Set("user", token); c.Next() }\n`;
+    const a = await routesOf(jwt + `func routes() {\n\tr.POST("/x", jwtMiddleware, h)\n}\n`);
+    expect(a[0].hasAuth).toBe(false);
+    expect(a[0].authUnsureHook).toBe("jwtMiddleware");
+    const b = await routesOf(load + `func routes() {\n\tr.POST("/y", loadUser, h)\n}\n`);
+    expect(b[0].hasAuth).toBe(false);
+    expect(b[0].authUnsureHook).toBe("loadUser");
+  });
+
+  it("nameSegments parity — 'author' is not 'auth'", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tr.POST("/x", AuthorTracking(), h)\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("impure-chain callees never smuggle argument text (false, key absent)", async () => {
+    const a = await routesOf(`func routes() {\n\tr.POST("/x", factory.Make(authCfg).Logger(), h)\n}\n`);
+    expect(a[0].hasAuth).toBe(false);
+    expect(a[0].authUnsureHook).toBeUndefined();
+    const b = await routesOf(`func routes() {\n\tr.POST("/y", registry.get("authCfg").Logger, h)\n}\n`);
+    expect(b[0].hasAuth).toBe(false);
+    expect(b[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("rule 1 veto wins even over a REAL in-file reject body (false, key absent)", async () => {
+    for (const name of ["MockAuth", "SkipAuth", "DisableAuth"]) {
+      const src = auth1(name) + `func routes() {\n\tr.POST("/x", ${name}, h)\n}\n`;
+      const [rt] = await routesOf(src);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBeUndefined();
+    }
+  });
+
+  it("veto negatives — imported, one route each, all false + key absent", async () => {
+    for (const reg of [
+      `r.POST("/x", OptionalAuth(), h)`, `r.POST("/x", SkipAuth, h)`, `r.POST("/x", BypassAuth(), h)`,
+      `r.POST("/x", MockAuth(), h)`, `r.POST("/x", FakeAuthMiddleware, h)`, `r.POST("/x", AuthMetrics(), h)`,
+      `r.POST("/x", authStats, h)`, `r.POST("/x", NoopAuth, h)`, `r.POST("/x", testAuth, h)`,
+      `r.POST("/x", devAuth, h)`, `r.POST("/x", DummyAuth(), h)`, `r.POST("/x", InsecureSkipAuth(), h)`,
+      `r.POST("/x", authLogger, h)`, `r.POST("/x", parseJWT(secret), h)`, `r.POST("/x", newAuthHandler(deps), h)`,
+      `r.POST("/x", authLogin, mainHandler)`,
+    ]) {
+      const [rt] = await routesOf(`func routes() {\n\t${reg}\n}\n`);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBeUndefined();
+    }
+  });
+
+  it("veto boundary — EnsureLoggedIn is NOT vetoed ('logged' != 'log') so it reaches unsure", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tr.POST("/x", EnsureLoggedIn, h)\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("EnsureLoggedIn");
+  });
+
+  it("verb-first middleware window starts AFTER the path arg (arg1)", async () => {
+    const factory = `func RequireAuth() gin.HandlerFunc { return func(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(401); return }; c.Next() } }\n`;
+    const [rt] = await routesOf(factory + `func routes() {\n\tr.Handle("POST", "/x", RequireAuth(), h)\n}\n`);
+    expect(rt.method).toBe("POST");
+    expect(rt.hasAuth).toBe(true); // in-file factory rejects; window includes arg2
+  });
+
+  it("chi With harvests every link (multi-link)", async () => {
+    const withAuth = await routesOf(`func routes() {\n\tr.With(RequireAuth).With(paginate).Post("/orders", h)\n}\n`);
+    expect(withAuth[0].hasAuth).toBe(false);
+    expect(withAuth[0].authUnsureHook).toBe("RequireAuth"); // inner link harvested
+    const noAuth = await routesOf(`func routes() {\n\tr.With(paginate).With(audit).Post("/x", h)\n}\n`);
+    expect(noAuth[0].hasAuth).toBe(false);
+    expect(noAuth[0].authUnsureHook).toBeUndefined();
+    const single = await routesOf(`func routes() {\n\tr.With(paginate, RequireAuth).Get("/orders", h)\n}\n`);
+    expect(single[0].authUnsureHook).toBe("RequireAuth"); // any With arg
+  });
+
+  it("handler-position identifier/selector is NEVER read, blessed, or hedged", async () => {
+    const login = await routesOf(`func routes() {\n\tr.POST("/login", authLogin)\n}\n`);
+    expect(login[0].hasAuth).toBe(false);
+    expect(login[0].authUnsureHook).toBeUndefined();
+    // handler body that reads Authorization + writes 401 is NOT read (body-first is middleware-only)
+    const src = `func h(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(401); return }; c.JSON(200, nil) }\n` +
+      `func routes() {\n\tr.POST("/x", h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+});
+
+describe("Task 3: body-first wrapped handlers (LOCKED)", () => {
+  it("BODY-FIRST wrap disambiguation via the RETURNED closure", async () => {
+    const rej = `func requireAuth(next http.Handler) http.Handler { return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { if r.Header.Get("Authorization") == "" { w.WriteHeader(http.StatusUnauthorized); return }; next.ServeHTTP(w, r) }) }\n`;
+    const yes = await routesOf(rej + `func routes() {\n\thttp.HandleFunc("/orders", requireAuth(createOrder))\n}\n`);
+    expect(yes[0].hasAuth).toBe(true);
+    const pass = `func logWrap(next http.Handler) http.Handler { return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { log.Println(r.URL.Path); next.ServeHTTP(w, r) }) }\n`;
+    const no = await routesOf(pass + `func routes() {\n\thttp.HandleFunc("/orders", logWrap(createOrder))\n}\n`);
+    expect(no[0].hasAuth).toBe(false);
+  });
+
+  it("nested transparent wrap recurses to the inner in-file auth wrap (blesses)", async () => {
+    const rej = `func requireAuth(next http.Handler) http.Handler { return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { if r.Header.Get("Authorization") == "" { w.WriteHeader(http.StatusUnauthorized); return }; next.ServeHTTP(w, r) }) }\n`;
+    for (const outer of ["logRequests", "metricsWrap"]) {
+      const src = rej + `func routes() {\n\tmux.Handle("/x", ${outer}(requireAuth(h)))\n}\n`;
+      const [rt] = await routesOf(src);
+      expect(rt.hasAuth).toBe(true);
+    }
+  });
+
+  it("SUBSUMING-veto wrap HALTS recursion even over a REAL inner reject (false, key absent)", async () => {
+    const rej = `func realGate(next http.Handler) http.Handler { return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { if r.Header.Get("Authorization") == "" { w.WriteHeader(http.StatusUnauthorized); return }; next.ServeHTTP(w, r) }) }\n`;
+    for (const reg of [
+      `mux.Handle("/x", optionalAuth(realGate))`,
+      `mux.Handle("/x", SkipAuth(realGate))`,
+      `mux.Handle("/x", DisableAuthInDev(realGate))`,
+      `mux.Handle("/x", parseJWT(realGate))`,
+    ]) {
+      const [rt] = await routesOf(rej + `func routes() {\n\t${reg}\n}\n`);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBeUndefined();
+    }
+  });
+
+  it("constructor-injection (DI) never classifies the injected arg (false, key absent)", async () => {
+    for (const reg of [
+      `mux.Handle("/webhook", NewWebhookHandler(cfg, auth.NewService(key)))`,
+      `mux.Handle("/orders", NewOrdersHandler(db, jwtVerifier()))`,
+      `mux.Handle("/di", NewHandler(auth.NewService(key)))`,
+    ]) {
+      const [rt] = await routesOf(`func routes() {\n\t${reg}\n}\n`);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBeUndefined();
+    }
+  });
+
+  it("boring / composed / builder wrap negatives (false, key absent)", async () => {
+    for (const reg of [
+      `mux.Handle("/x", wrap(h))`,
+      `mux.Handle("/x", timing(h))`,
+      `mux.Handle("/x", makeHandler(authService))`,
+      `mux.Handle("/x", chain(logger, auth)(h))`,
+      `mux.Handle("/x", handlers.For(authConfig).Build(h))`,
+    ]) {
+      const [rt] = await routesOf(`func routes() {\n\t${reg}\n}\n`);
+      expect(rt.hasAuth).toBe(false);
+      expect(rt.authUnsureHook).toBeUndefined();
+    }
+  });
+
+  it("UNSURE wrap — imported pair-name wrap hedges", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tmux.Handle("/x", TokenRequired(handler))\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("TokenRequired");
+  });
+
+  it("NEVER-FALSE-BLESS: a transparent wrap around an IMPORTED auth inner never blesses", async () => {
+    // requireAuth has no in-file body -> rule 5 unsure; recursion propagates the
+    // hedge, it does NOT fabricate a bless on the name alone.
+    const [rt] = await routesOf(`func routes() {\n\tmux.Handle("/x", logRequests(requireAuth(h)))\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("requireAuth");
+  });
+
+  it("20-deep nested wrap: no throw, no bless", async () => {
+    let expr = "h";
+    for (let i = 0; i < 20; i++) expr = `logWrap(${expr})`;
+    const [rt] = await routesOf(`func routes() {\n\tmux.Handle("/x", ${expr})\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+  });
+});
+
+describe("Task 3: per-route validation and rate-limit lanes", () => {
+  it("rate-limit lane (segment + pair)", async () => {
+    const a = await routesOf(`func routes() {\n\tr.POST("/x", middleware.RateLimit(), h)\n}\n`);
+    expect(a[0].hasRateLimit).toBe(true);
+    expect(a[0].hasAuth).toBe(false);
+    const b = await routesOf(`func routes() {\n\tr.POST("/y", RateLimiter(rate), h)\n}\n`);
+    expect(b[0].hasRateLimit).toBe(true);
+  });
+  it("validation lane", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tr.POST("/x", validateBody(schema), h)\n}\n`);
+    expect(rt.hasValidation).toBe(true);
+  });
+  it("segment discipline — substrings never match the lane", async () => {
+    const v1 = await routesOf(`func routes() {\n\tr.POST("/x", cacheInvalidator, h)\n}\n`);
+    expect(v1[0].hasValidation).toBe(false);
+    const v2 = await routesOf(`func routes() {\n\tr.POST("/y", InvalidateCache(), h)\n}\n`);
+    expect(v2[0].hasValidation).toBe(false);
+    const r1 = await routesOf(`func routes() {\n\tr.POST("/z", csvDelimiter, h)\n}\n`);
+    expect(r1[0].hasRateLimit).toBe(false);
+  });
+  it("a route path never blesses its lane (names come from args only)", async () => {
+    const v = await routesOf(`func routes() {\n\tr.POST("/validate", h)\n}\n`);
+    expect(v[0].hasValidation).toBe(false);
+    const r = await routesOf(`func routes() {\n\tr.POST("/ratelimit", h)\n}\n`);
+    expect(r[0].hasRateLimit).toBe(false);
+  });
+  it("a bare route keeps all three lanes false and independent", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tr.POST("/x", h)\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.hasValidation).toBe(false);
+    expect(rt.hasRateLimit).toBe(false);
+    // DELIBERATE DIVERGENCE (pinned): a handler body calling c.ShouldBindJSON does
+    // NOT set hasValidation on the AST path — lanes come from structural middleware
+    // names only, and hasErrorHandler is hard-coded false.
+    expect(rt.hasErrorHandler).toBe(false);
   });
 });

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
-  extractGoRoutesAst, SECURITY_AST_GO,
+  extractGoRoutesAst, extractGoFileMiddlewareAst, SECURITY_AST_GO,
   bodyAuthSignatureGo, classifyGoMiddlewareAuth, collectGoFunctionDefs,
 } from "../../../src/drift/security-ast-go.js";
 import { SECURITY_AST } from "../../../src/drift/security-ast.js";
@@ -1228,5 +1228,302 @@ describe("Task 3: per-route validation and rate-limit lanes", () => {
     // NOT set hasValidation on the AST path — lanes come from structural middleware
     // names only, and hasErrorHandler is hard-coded false.
     expect(rt.hasErrorHandler).toBe(false);
+  });
+});
+
+// ── Task 4: Use()/group-scoped middleware collector (body-first + unsure) ─────
+//
+// OPTION A (LOCKED owner decision governs; the brief's residual wide-core Step 2
+// pins were STALE): an imported / opaque / no-in-file-def Use hook NEVER blesses.
+// The AUTH lane (hasAuth true) is proven ONLY by in-file middleware whose body
+// verifiably rejects (rule 2); imported CORE names (authMiddleware, RequireAuth,
+// middleware.VerifyToken, ...) propagate the UNSURE lane (hasAuth false +
+// authUnsureHook) by the SAME receiver / structural-scope / row rules. The scope
+// model itself (row order, closure shadow, cross-function isolation, (name,scope)
+// poisoning, conditional-Use skip, copy-at-creation) is invariant to which lane
+// carries the signal.
+
+// An in-file middleware whose body verifiably rejects (rule 2 bless).
+const authDef = (name = "authMiddleware") =>
+  `func ${name}(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() }\n`;
+// Factory form (return-of-closure) with a rejecting inner body (rule 2 bless).
+const authFactory = (name = "RequireAuth") =>
+  `func ${name}() gin.HandlerFunc { return func(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() } }\n`;
+
+describe("Use scoping and group inheritance (AUTH lane via in-file bodies)", () => {
+  it("r.Use(<in-file rejecting body>) blesses a later same-scope route (key absent)", async () => {
+    const [rt] = await routesOf(authDef() + `func routes() {\n\tr.Use(authMiddleware)\n\tr.POST("/x", h)\n}\n`);
+    expect(rt.hasAuth).toBe(true);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("Use arg forms that bless: bare-call factory and multi-arg (in-file body)", async () => {
+    // bare-call factory: r.Use(RequireAuth()) resolved to an in-file rejecting body
+    const a = await routesOf(authFactory() + `func routes() {\n\tr.Use(RequireAuth())\n\tr.POST("/x", h)\n}\n`);
+    expect(a[0].hasAuth).toBe(true);
+    // multi-arg: only the in-file rejecting body confirms; gin.Logger() is ignored
+    const b = await routesOf(authDef() + `func routes() {\n\tr.Use(gin.Logger(), authMiddleware)\n\tr.POST("/x", h)\n}\n`);
+    expect(b[0].hasAuth).toBe(true);
+  });
+
+  it("BODY-FIRST bless under a BORING name (proves the collector reads bodies)", async () => {
+    const src =
+      `func guard(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() }\n` +
+      `func routes() {\n\tr.Use(guard)\n\tr.POST("/x", h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(true);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("BODY-FIRST NON-bless under an AUTH name (rule 3: visible non-enforcing, key absent)", async () => {
+    const src =
+      `func authCheck(c *gin.Context) { log.Printf("auth %s", c.Request.URL.Path); c.Next() }\n` +
+      `func routes() {\n\tr.Use(authCheck)\n\tr.POST("/x", h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("ROW ORDER (Gin runtime-truth, both directions in one fixture)", async () => {
+    // /a is registered BEFORE the Use -> unblessed at runtime; /b AFTER -> blessed.
+    const src = authDef() +
+      `func routes() {\n\tr.POST("/a", h)\n\tr.Use(authMiddleware)\n\tr.POST("/b", h2)\n}\n`;
+    const rts = await routesOf(src);
+    const a = rts.find((r) => r.path === "/a")!;
+    const b = rts.find((r) => r.path === "/b")!;
+    expect(a.hasAuth).toBe(false);
+    expect(b.hasAuth).toBe(true);
+  });
+
+  it("receiver isolation: r.Use(<body>) never blesses a sibling api.POST in the same func", async () => {
+    const src = authDef() +
+      `func routes() {\n\tr.Use(authMiddleware)\n\tr.POST("/blessed", h)\n\tapi.POST("/isolated", h)\n}\n`;
+    const rts = await routesOf(src);
+    expect(rts.find((r) => r.path === "/blessed")!.hasAuth).toBe(true);
+    expect(rts.find((r) => r.path === "/isolated")!.hasAuth).toBe(false);
+  });
+
+  it("group scoping: a group Use blesses the group's routes but never the parent sibling", async () => {
+    const src = authFactory() +
+      `func routes() {\n\tapi := r.Group("/api")\n\tapi.Use(RequireAuth())\n\tapi.POST("/items", h)\n\tr.POST("/public", h)\n}\n`;
+    const rts = await routesOf(src);
+    expect(rts.find((r) => r.path === "/items")!.hasAuth).toBe(true);
+    expect(rts.find((r) => r.path === "/public")!.hasAuth).toBe(false);
+  });
+
+  it("parent-to-group propagation is copy-at-creation (both directions)", async () => {
+    // Use BEFORE the Group creation blesses the group's routes.
+    const before = authDef() +
+      `func routes() {\n\tr.Use(authMiddleware)\n\tapi := r.Group("/api")\n\tapi.POST("/items", h)\n}\n`;
+    expect((await routesOf(before)).find((r) => r.path === "/items")!.hasAuth).toBe(true);
+    // Use AFTER the Group creation does NOT (accepted Gin copy-at-creation semantics).
+    const after = authDef() +
+      `func routes() {\n\tapi := r.Group("/api")\n\tr.Use(authMiddleware)\n\tapi.POST("/items", h)\n}\n`;
+    expect((await routesOf(after)).find((r) => r.path === "/items")!.hasAuth).toBe(false);
+  });
+
+  it("nested transitivity: v1 := api.Group inherits an r.Use registered before api", async () => {
+    const src = authDef() +
+      `func routes() {\n\tr.Use(authMiddleware)\n\tapi := r.Group("/api")\n\tv1 := api.Group("/v1")\n\tv1.POST("/x", h)\n}\n`;
+    expect((await routesOf(src)).find((r) => r.path === "/x")!.hasAuth).toBe(true);
+  });
+
+  it("Echo group-with-inline-middleware: the LAST arg after the path is a middleware candidate", async () => {
+    // e.Group("/admin", authMiddleware) -> the trailing arg (no handler position on
+    // a Group call) is the middleware; the in-file rejecting body blesses.
+    const src = authDef() +
+      `func routes() {\n\tadmin := e.Group("/admin", authMiddleware)\n\tadmin.POST("/users", h)\n}\n`;
+    expect((await routesOf(src)).find((r) => r.path === "/users")!.hasAuth).toBe(true);
+  });
+
+  it("chi closure SHADOW guard: an inner r.Use never blesses the outer receiver's route", async () => {
+    const src = authDef() +
+      `func routes() {\n` +
+      `\tr.Route("/admin", func(r chi.Router) {\n\t\tr.Use(authMiddleware)\n\t\tr.Post("/users", h)\n\t})\n` +
+      `\tr.Post("/public", pub)\n}\n`;
+    const rts = await routesOf(src);
+    expect(rts.find((r) => r.path === "/users")!.hasAuth).toBe(true);
+    expect(rts.find((r) => r.path === "/public")!.hasAuth).toBe(false);
+  });
+
+  it("chi closure derivation (positive): an outer Use BEFORE the Route blesses the closure; AFTER does not", async () => {
+    const before = authDef() +
+      `func routes() {\n\tr.Use(authMiddleware)\n\tr.Route("/admin", func(sub chi.Router) {\n\t\tsub.Post("/x", h)\n\t})\n}\n`;
+    expect((await routesOf(before)).find((r) => r.path === "/x")!.hasAuth).toBe(true);
+    const after = authDef() +
+      `func routes() {\n\tr.Route("/admin", func(sub chi.Router) {\n\t\tsub.Post("/x", h)\n\t})\n\tr.Use(authMiddleware)\n}\n`;
+    expect((await routesOf(after)).find((r) => r.path === "/x")!.hasAuth).toBe(false);
+  });
+
+  it("cross-function Use never blesses (same-scope pin)", async () => {
+    const src = authDef() +
+      `func setup(r *gin.Engine) {\n\tr.Use(authMiddleware)\n}\n` +
+      `func routes(r *gin.Engine) {\n\tr.POST("/x", h)\n}\n`;
+    expect((await routesOf(src)).find((r) => r.path === "/x")!.hasAuth).toBe(false);
+  });
+
+  it("same-name groups across functions inherit INDEPENDENTLY (both directions)", async () => {
+    const src = authDef() +
+      `func first(r *gin.Engine) {\n\tapi := r.Group("/api")\n\tapi.Use(authMiddleware)\n\tapi.POST("/x", h)\n}\n` +
+      `func second(r *gin.Engine) {\n\tapi := r.Group("/api")\n\tapi.POST("/y", h)\n}\n`;
+    const rts = await routesOf(src);
+    // The own-scope mark survives (per-name file-wide poisoning would kill this).
+    expect(rts.find((r) => r.path === "/x")!.hasAuth).toBe(true);
+    // Scope keying alone isolates the second func (its api has no Use).
+    expect(rts.find((r) => r.path === "/y")!.hasAuth).toBe(false);
+  });
+
+  it("same-scope rebind poisoning: 2+ bindings of one name in ONE scope never blesses", async () => {
+    const src = authDef() +
+      `func routes() {\n\tapi := r.Group("/a")\n\tapi.Use(authMiddleware)\n\tapi = r.Group("/b")\n\tapi.POST("/x", h)\n}\n`;
+    expect((await routesOf(src)).find((r) => r.path === "/x")!.hasAuth).toBe(false);
+  });
+
+  it("conditional Use never marks (never-false-bless); an unconditional Use blesses a conditional route", async () => {
+    // Table-driven: each conditional/loop wrapper around the Use suppresses the mark.
+    for (const open of ["if cfg.AuthEnabled {", "for i := 0; i < 1; i++ {", "switch x {\n\tcase 1:", "select {\n\tcase <-ch:"]) {
+      const close = open.includes("case") ? "\t}" : "}";
+      const src = authDef() +
+        `func routes() {\n\t${open}\n\t\tr.Use(authMiddleware)\n\t${close}\n\tr.POST("/x", h)\n}\n`;
+      const rts = await routesOf(src);
+      expect(rts.find((r) => r.path === "/x")!.hasAuth).toBe(false);
+    }
+    // Positive control: the mark is unconditional; only the ROUTE is conditional.
+    const ctrl = authDef() +
+      `func routes() {\n\tr.Use(authMiddleware)\n\tif debug {\n\t\tr.POST("/x", h)\n\t}\n}\n`;
+    expect((await routesOf(ctrl)).find((r) => r.path === "/x")!.hasAuth).toBe(true);
+  });
+
+  it("impure Use arg never marks (null resolution never poisons a later route)", async () => {
+    const a = await routesOf(`func routes() {\n\tr.Use(factory.Make(authCfg).Logger())\n\tr.POST("/x", h)\n}\n`);
+    expect(a.find((r) => r.path === "/x")!.hasAuth).toBe(false);
+    const b = await routesOf(`func routes() {\n\tr.Use(registry.get("authCfg").Logger)\n\tr.POST("/x", h)\n}\n`);
+    expect(b.find((r) => r.path === "/x")!.hasAuth).toBe(false);
+  });
+
+  it("Gorilla: router.Use(<body>) before a HandleFunc(...).Methods(POST) route blesses it", async () => {
+    const src = authDef() +
+      `func routes() {\n\trouter.Use(authMiddleware)\n\trouter.HandleFunc("/x", h).Methods("POST")\n}\n`;
+    expect((await routesOf(src)).find((r) => r.path === "/x")!.hasAuth).toBe(true);
+  });
+
+  it("non-router receiver gate on Use: a Use on a non-router receiver blesses nothing", async () => {
+    const src = authDef() +
+      `func routes() {\n\tq.Use(authMiddleware)\n\tr.POST("/x", h)\n}\n`;
+    const rt = (await routesOf(src)).find((r) => r.path === "/x")!;
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("lanes via Use: rate-limit and validation propagate independently, no auth cross-set", async () => {
+    const rate = await routesOf(`func routes() {\n\tr.Use(middleware.RateLimiter(rate))\n\tr.POST("/x", h)\n}\n`);
+    const rr = rate.find((r) => r.path === "/x")!;
+    expect(rr.hasRateLimit).toBe(true);
+    expect(rr.hasValidation).toBe(false);
+    expect(rr.hasAuth).toBe(false);
+    const val = await routesOf(`func routes() {\n\tr.Use(RequestValidator())\n\tr.POST("/x", h)\n}\n`);
+    const vr = val.find((r) => r.path === "/x")!;
+    expect(vr.hasValidation).toBe(true);
+    expect(vr.hasRateLimit).toBe(false);
+    expect(vr.hasAuth).toBe(false);
+  });
+});
+
+describe("Use scoping unsure state (imported / opaque hooks hedge, never bless)", () => {
+  it("imported non-core Use hook hedges the scope's routes", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", h)\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("middleware.VerifyToken");
+  });
+
+  it("group-scope unsure inherits to the group's routes but not the parent sibling", async () => {
+    const src =
+      `func routes() {\n\tapi := r.Group("/api")\n\tapi.Use(middleware.VerifyToken)\n\tapi.POST("/items", h)\n\tr.POST("/public", h)\n}\n`;
+    const rts = await routesOf(src);
+    const items = rts.find((r) => r.path === "/items")!;
+    expect(items.hasAuth).toBe(false);
+    expect(items.authUnsureHook).toBe("middleware.VerifyToken");
+    const pub = rts.find((r) => r.path === "/public")!;
+    expect(pub.hasAuth).toBe(false);
+    expect(pub.authUnsureHook).toBeUndefined();
+  });
+
+  it("in-file OPAQUE-body Use hook hedges (auth-flavored unresolved callee, non-core name)", async () => {
+    // tokenGuard: auth-flavored ("token"), NOT vetoed, body opaque (checkSession
+    // undefined -> auth-flavored unresolved callee -> opaque, rule 4 unsure).
+    const src =
+      `func tokenGuard(c *gin.Context) { if !checkSession(c) { c.Next(); return }; c.Next() }\n` +
+      `func routes() {\n\tr.Use(tokenGuard)\n\tr.POST("/x", h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("tokenGuard");
+  });
+
+  it("auth beats unsure in scope (a confirmed auth mark wins, key absent)", async () => {
+    const src = authFactory() +
+      `func routes() {\n\tr.Use(RequireAuth())\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(true);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("per-route auth clears scope unsure", async () => {
+    const src = authFactory() +
+      `func routes() {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", RequireAuth(), h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(true);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+
+  it("deterministic attribution: two unsure Use hooks -> FIRST in document order", async () => {
+    const src =
+      `func routes() {\n\tr.Use(middleware.VerifyToken)\n\tr.Use(middleware.CheckToken)\n\tr.POST("/x", h)\n}\n`;
+    const [rt] = await routesOf(src);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBe("middleware.VerifyToken");
+  });
+
+  it("imported NON-flavored Use hook: not-auth flat, key ABSENT (zero evidence never hedges)", async () => {
+    const [rt] = await routesOf(`func routes() {\n\tr.Use(middleware.RequestID)\n\tr.POST("/x", h)\n}\n`);
+    expect(rt.hasAuth).toBe(false);
+    expect(rt.authUnsureHook).toBeUndefined();
+  });
+});
+
+describe("extractGoFileMiddlewareAst (file-level OR of confirmed lanes)", () => {
+  const NONE = { hasAuth: false, hasValidation: false, hasRateLimit: false };
+  const mwIndex = async (src: string) => {
+    const f = await go("mw.go", PKG + src);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    return extractGoFileMiddlewareAst(f.tree!);
+  };
+
+  it("r.Use(<in-file body>) -> hasAuth true", async () => {
+    expect(await mwIndex(authDef() + `func routes() {\n\tr.Use(authMiddleware)\n}\n`))
+      .toEqual({ hasAuth: true, hasValidation: false, hasRateLimit: false });
+  });
+
+  it("a derived group's Use ORs into the file-level index", async () => {
+    expect(await mwIndex(authFactory() + `func routes() {\n\tapi := r.Group("/api")\n\tapi.Use(RequireAuth())\n}\n`))
+      .toEqual({ hasAuth: true, hasValidation: false, hasRateLimit: false });
+  });
+
+  it("inline group middleware ORs into the file-level index", async () => {
+    expect(await mwIndex(authDef() + `func routes() {\n\tadmin := e.Group("/admin", authMiddleware)\n}\n`))
+      .toEqual({ hasAuth: true, hasValidation: false, hasRateLimit: false });
+  });
+
+  it("python-parity: a per-route middleware arg is NOT a file-level bless", async () => {
+    expect(await mwIndex(authFactory() + `func routes() {\n\tr.POST("/x", RequireAuth(), h)\n}\n`)).toEqual(NONE);
+  });
+
+  it("UNSURE never launders into the OR (never-false-bless)", async () => {
+    expect(await mwIndex(`func routes() {\n\tr.Use(middleware.VerifyToken)\n}\n`)).toEqual(NONE);
+  });
+
+  it("unknown Use name / empty / comments-only -> NONE", async () => {
+    expect(await mwIndex(`func routes() {\n\tr.Use(track())\n}\n`)).toEqual(NONE);
+    expect(await mwIndex(`func routes() {}\n`)).toEqual(NONE);
+    expect(await mwIndex(`// just a comment\nfunc routes() {}\n`)).toEqual(NONE);
   });
 });

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../../src/drift/security-consistency.js";
-import { runDriftDetection } from "../../../src/drift/index.js";
+import { runDriftDetection, driftFindingToFinding } from "../../../src/drift/index.js";
 import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
 import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
+import { extractGoFileMiddlewareAst } from "../../../src/drift/security-ast-go.js";
 import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
   SECURITY_SUPPRESSION_ANALYZER_ID,
 } from "../../../src/drift/security-suppression.js";
+import { renderTerminalOutput } from "../../../src/output/terminal.js";
+import type { ScanResult, Finding } from "../../../src/core/types.js";
 
 function mkCtx(files: DriftFile[]): DriftContext {
   return {
@@ -1462,5 +1465,221 @@ describe("Go AST wiring (Task 4)", () => {
     const withoutGo = securityConsistency.detect({ files: [js], totalLines: js.lineCount, dominantLanguage: "typescript" } as any);
     const withGo = securityConsistency.detect({ files: [js, gof], totalLines: js.lineCount + gof.lineCount, dominantLanguage: "typescript" } as any);
     expect(withGo).toEqual(withoutGo);
+  });
+});
+
+// ── Task 5 (Go): the shipped hedge reused end-to-end, zero parallel code ─────
+//
+// Tasks 3-4 gave Go routes `authUnsureHook`; the hedge mechanism itself
+// (hedgedDeviatorPattern, hedgeRecommendationSuffix, and the terminal's
+// isHedgedAuthFinding/hedgedSecurityConsequence) is language-neutral and was
+// shipped for Python (#43). This block proves a Go-sourced unsure route flows
+// through the SAME mechanism with no Go-specific branch anywhere in the
+// pipeline, up to and including the terminal renderer.
+describe("Task 5 (Go): unsure-hook hedge reuses the shipped Python mechanism", () => {
+  const goTree = (p: string, c: string) => fileWithTree(p, c, "go");
+  const authFinding = (fs: any[]) => fs.find((f: any) => f.subCategory === "Auth middleware");
+  // In-file factory whose inner body verifiably rejects (rule 2 bless, not a
+  // name bless) — same fixture shape as Task 4's Go wiring tests.
+  const goAuthFactory =
+    `func AuthMiddleware() gin.HandlerFunc { return func(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() } }\n`;
+  const goPeer = (dir: string, n: number) =>
+    goTree(`${dir}/peer${n}.go`,
+      goAuthFactory + `func routes${n}(r *gin.Engine) {\n\tr.Use(AuthMiddleware())\n\tr.POST("/peer${n}", createX)\n}\n`);
+
+  it("dominance vote: a Go unsure Use hook renders the byte-for-byte hedged deviator, and the recommendation names it", async () => {
+    const peers = await Promise.all([goPeer("src/t5dom", 1), goPeer("src/t5dom", 2), goPeer("src/t5dom", 3), goPeer("src/t5dom", 4)]);
+    const unsure = await goTree("src/t5dom/orders.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/orders", createOrder)\n}\n`);
+    const findings = securityConsistency.detect(mkCtx([...peers, unsure]));
+
+    expect(findings.filter((f: any) => f.subCategory === "Auth middleware")).toHaveLength(1);
+    const a = authFinding(findings)!;
+    expect(a.deviatingFiles).toHaveLength(1);
+    // Byte-for-byte hedgedDeviatorPattern — the same function Python's hedge uses.
+    expect(a.deviatingFiles[0].detectedPattern).toBe(
+      "POST /orders: auth not confirmed, double check hook 'middleware.VerifyToken'",
+    );
+    expect(a.deviatingFiles[0].detectedPattern).not.toMatch(/—|--/);
+    expect(a.recommendation).toContain("Double check");
+    expect(a.recommendation).toContain("middleware.VerifyToken");
+  });
+
+  it("confident Go sibling: a plainly-unauthed route (no Use hook at all) keeps today's exact flat deviator", async () => {
+    const peers = await Promise.all([goPeer("src/t5domflat", 1), goPeer("src/t5domflat", 2), goPeer("src/t5domflat", 3), goPeer("src/t5domflat", 4)]);
+    const bare = await goTree("src/t5domflat/orders.go", `func routes(r *gin.Engine) {\n\tr.POST("/orders", createOrder)\n}\n`);
+    const a = authFinding(securityConsistency.detect(mkCtx([...peers, bare])))!;
+    expect(a.deviatingFiles[0].detectedPattern).toBe("POST /orders — no Auth middleware");
+    expect(a.recommendation).not.toMatch(/double check/i);
+    expect(a.recommendation).not.toContain("middleware.VerifyToken");
+  });
+
+  it("uniform-auth-gap (Go): the unsure route among uniformly-unauthed mutating routes hedges; peers keep the flat '— no auth' string; counts/severity/confidence unchanged", async () => {
+    const flat = (n: number) =>
+      goTree(`src/t5gap/f${n}.go`, `func routes${n}(r *gin.Engine) {\n\tr.POST("/f${n}", createX)\n}\n`);
+    const flats = await Promise.all([flat(1), flat(2), flat(3)]);
+    const unsure = await goTree("src/t5gap/x.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", createX)\n}\n`);
+    // Baseline evidence so analyzeUniformAuthGap doesn't stay silent: the repo
+    // knows how to auth elsewhere (matches the repoHasAuthMachinery symbol list).
+    const machinery = await goTree("src/t5gap/lib/auth.go", `func AuthMiddleware() {}\n`);
+    const a = authFinding(securityConsistency.detect(mkCtx([...flats, unsure, machinery])))!;
+
+    expect(a.finding).toBe("4 mutating route(s) lack auth while the codebase uses auth elsewhere");
+    expect(a.confidence).toBe(0.6);
+    expect(a.severity).toBe("error");
+    const byPath = new Map(a.deviatingFiles.map((d: any) => [d.path, d.detectedPattern]));
+    expect(byPath.get("src/t5gap/x.go")).toBe(
+      "POST /x: auth not confirmed, double check hook 'middleware.VerifyToken'",
+    );
+    expect(byPath.get("src/t5gap/f1.go")).toBe("POST /f1 — no auth");
+    expect(byPath.get("src/t5gap/f2.go")).toBe("POST /f2 — no auth");
+    expect(byPath.get("src/t5gap/f3.go")).toBe("POST /f3 — no auth");
+    expect(a.recommendation).toContain("Double check");
+    expect(a.recommendation).toContain("middleware.VerifyToken");
+  });
+
+  it("no cross-property leakage (Go): validation and rate-limit findings never carry the auth hedge for a route that also lacks them", async () => {
+    const peer = (n: number) =>
+      goTree(`src/t5leak/p${n}.go`,
+        goAuthFactory +
+        `func routes${n}(r *gin.Engine) {\n\tr.Use(AuthMiddleware())\n\tr.Use(middleware.RateLimiter(rate))\n\tr.Use(RequestValidator())\n\tr.POST("/p${n}", createX)\n}\n`);
+    const peers = await Promise.all([peer(1), peer(2), peer(3), peer(4)]);
+    const unsure = await goTree("src/t5leak/x.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", createX)\n}\n`);
+    const findings = securityConsistency.detect(mkCtx([...peers, unsure]));
+
+    const val = findings.find((f: any) => f.subCategory === "Input validation");
+    const rate = findings.find((f: any) => f.subCategory === "Rate limiting");
+    expect(val).toBeDefined();
+    expect(rate).toBeDefined();
+    for (const f of [val!, rate!]) {
+      for (const d of (f as any).deviatingFiles) {
+        expect(d.detectedPattern).not.toMatch(/double check/i);
+        expect(d.detectedPattern).not.toContain("middleware.VerifyToken");
+      }
+      expect((f as any).recommendation).not.toMatch(/double check/i);
+      expect((f as any).recommendation).not.toContain("middleware.VerifyToken");
+    }
+    // Sanity: the auth finding IS hedged in the same run — this proves the gate
+    // at `propertyName === SECURITY_SUBCATEGORIES.auth` is doing the excluding,
+    // not an accidental absence of the hook name anywhere in this corpus.
+    expect(authFinding(findings)!.deviatingFiles[0].detectedPattern).toContain(
+      "double check hook 'middleware.VerifyToken'",
+    );
+  });
+
+  it("vote-arithmetic invariance (Go): hedging changes COPY only, never dominantCount/total/consistency/severity/confidence", async () => {
+    const hedgedPeers = await Promise.all([goPeer("src/t5inv", 1), goPeer("src/t5inv", 2), goPeer("src/t5inv", 3), goPeer("src/t5inv", 4)]);
+    const unsure = await goTree("src/t5inv/orders.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/orders", createOrder)\n}\n`);
+    const hedged = authFinding(securityConsistency.detect(mkCtx([...hedgedPeers, unsure])))!;
+
+    // Control: same corpus, unsure Use line deleted so /orders reads confidently
+    // unauthed instead of unsure.
+    const ctrlPeers = await Promise.all([goPeer("src/t5invctrl", 1), goPeer("src/t5invctrl", 2), goPeer("src/t5invctrl", 3), goPeer("src/t5invctrl", 4)]);
+    const ctrl = await goTree("src/t5invctrl/orders.go", `func routes(r *gin.Engine) {\n\tr.POST("/orders", createOrder)\n}\n`);
+    const flatFinding = authFinding(securityConsistency.detect(mkCtx([...ctrlPeers, ctrl])))!;
+
+    for (const k of ["dominantCount", "totalRelevantFiles", "consistencyScore", "severity", "confidence"] as const) {
+      expect((hedged as any)[k]).toBe((flatFinding as any)[k]);
+    }
+    expect(hedged.deviatingFiles[0].detectedPattern).not.toBe(flatFinding.deviatingFiles[0].detectedPattern);
+  });
+
+  it("FileMiddleware honesty (Go, detect boundary): an unsure-only Use hook never sets file-level hasAuth", async () => {
+    const unsure = await goTree("src/t5honesty/x.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", createX)\n}\n`);
+    expect(unsure.tree!.rootNode.hasError).toBe(false);
+    const mw = extractGoFileMiddlewareAst(unsure.tree!);
+    expect(mw.hasAuth).toBe(false);
+  });
+});
+
+// ── Task 5 (Go): terminal hedge visibility ────────────────────────────────
+//
+// terminal.ts is the one render surface that hardcodes a confident consequence
+// ("Unprotected routes may be exposed in production") instead of passing
+// `recommendation`/`detectedPattern` straight through (#43 gated it on
+// isHedgedAuthFinding). html/csv/docx/json/fix-prompt never special-case the
+// hedge — they render `recommendation`/`detectedPattern` verbatim regardless of
+// source language, so a Go-sourced hedge already reaches them with no code
+// change (verified by inspection: none of those renderers branch on the hedge
+// or on language). Only terminal.ts needs an end-to-end pin.
+describe("Task 5 (Go): terminal hedge visibility", () => {
+  const goTree = (p: string, c: string) => fileWithTree(p, c, "go");
+  const goAuthFactory =
+    `func AuthMiddleware() gin.HandlerFunc { return func(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() } }\n`;
+  const goPeer = (dir: string, n: number) =>
+    goTree(`${dir}/peer${n}.go`,
+      goAuthFactory + `func routes${n}(r *gin.Engine) {\n\tr.Use(AuthMiddleware())\n\tr.POST("/peer${n}", createX)\n}\n`);
+
+  // The real pipeline computes `consistencyImpact` in the scoring engine, one
+  // stage past driftFindingToFinding (src/scoring/engine.ts), which is out of
+  // scope here. Mirror the shipped Python terminal-hedge test: give each
+  // finding a fixed consistencyImpact so it clears the Fix Plan's meaningful-
+  // impact floor, the same way `terminal-hedge.test.ts` does. Everything else
+  // (recommendation, detectedPattern) is the REAL Go extractor's output.
+  const toFinding = (d: any): Finding => ({
+    ...driftFindingToFinding(d),
+    consistencyImpact: 5,
+  });
+
+  const emptyCat = { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  function scanResultOf(findings: Finding[]): ScanResult {
+    return {
+      context: {
+        rootDir: "/tmp/proj",
+        dominantLanguage: "go",
+        languageBreakdown: new Map(),
+        totalLines: 500,
+        files: [],
+        intentHints: [],
+      },
+      compositeScore: 82,
+      maxCompositeScore: 100,
+      percentile: null,
+      peerLanguage: "go",
+      scores: {
+        architecturalConsistency: { ...emptyCat, applicable: false },
+        redundancy: { ...emptyCat, applicable: false },
+        dependencyHealth: { ...emptyCat, applicable: false },
+        securityPosture: { ...emptyCat },
+        intentClarity: { ...emptyCat, applicable: false },
+      },
+      hygieneScore: 0,
+      maxHygieneScore: 0,
+      hygieneScores: {},
+      findings,
+      driftFindings: [],
+      driftScores: {},
+      perFileScores: new Map(),
+      teaseMessages: [],
+      deepInsights: [],
+      scanTimeMs: 5,
+    } as unknown as ScanResult;
+  }
+
+  it("hedged Go finding: terminal does not show the flat confident consequence and surfaces the hook name plus 'double check'", async () => {
+    const peers = await Promise.all([goPeer("src/t5term", 1), goPeer("src/t5term", 2), goPeer("src/t5term", 3), goPeer("src/t5term", 4)]);
+    const unsure = await goTree("src/t5term/x.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", createX)\n}\n`);
+    const driftFindings = securityConsistency.detect(mkCtx([...peers, unsure]));
+    const out = renderTerminalOutput(scanResultOf(driftFindings.map(toFinding)));
+
+    expect(out).not.toContain("Unprotected routes may be exposed in production");
+    expect(out).toContain("middleware.VerifyToken");
+    expect(out.toLowerCase()).toContain("double check");
+  });
+
+  it("confident Go sibling finding: terminal keeps the flat consequence and shows no hedge", async () => {
+    const peers = await Promise.all([goPeer("src/t5term2", 1), goPeer("src/t5term2", 2), goPeer("src/t5term2", 3), goPeer("src/t5term2", 4)]);
+    const bare = await goTree("src/t5term2/x.go", `func routes(r *gin.Engine) {\n\tr.POST("/x", createX)\n}\n`);
+    const driftFindings = securityConsistency.detect(mkCtx([...peers, bare]));
+    const out = renderTerminalOutput(scanResultOf(driftFindings.map(toFinding)));
+
+    expect(out).toContain("Unprotected routes may be exposed in production");
+    expect(out.toLowerCase()).not.toContain("double check");
+    expect(out).not.toContain("middleware.VerifyToken");
   });
 });

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -1261,3 +1261,206 @@ describe("Task 4: hedged unsure-auth finding copy", () => {
     expect(hedged.deviatingFiles[0].detectedPattern).not.toBe(flat.deviatingFiles[0].detectedPattern);
   });
 });
+
+// ── Task 4 (Go): regex fallback pins (pre-wiring) ────────────────────────────
+//
+// The byte-compat requirement has ZERO .go coverage today. These pins document
+// the EXACT behavior of the tree-less Go regex path (via the plain `file()`
+// helper, which carries no tree) and MUST stay green BOTH before AND after the
+// seam edits — a tree-less / broken-parse go file always routes to the regex
+// extractor, so these can never silently change. Legacy over-blesses are pinned
+// AS-IS (documented, not endorsed).
+describe("go regex fallback pins (pre-wiring)", () => {
+  const goFile = (p: string, c: string) => file(p, c, "go");
+  const authFinding = (fs: any[]) => fs.find((f) => f.subCategory === "Auth middleware");
+  const devPaths = (f: any): string[] =>
+    f ? f.deviatingFiles.map((d: any) => d.evidence[0].code.split(" ")[1]) : [];
+  // A tree-less authed peer: file-level r.Use(authMiddleware) blesses its POST
+  // through the regex file-middleware index.
+  const authedPeer = (n: number) =>
+    goFile(`src/routes/peer${n}.go`,
+      `func routes${n}(r *gin.Engine) {\n\tr.Use(authMiddleware)\n\tr.POST("/peer${n}", createX)\n}\n`);
+  // A tree-less, genuinely-unauthed mutating route.
+  const bareDanger = () =>
+    goFile("src/routes/danger.go", `func routes(r *gin.Engine) {\n\tr.POST("/danger", createX)\n}\n`);
+
+  it("recall: a tree-less go file's r.GET / r.POST routes extract through detect (regex recall)", () => {
+    // Target file: a bare (unauthed) POST /y among 4 authed peers -> /y is the
+    // lone deviator, proving the regex extractor recovered the POST route.
+    const target = goFile("src/routes/target.go",
+      `func routes(r *gin.Engine) {\n\tr.GET("/g", h)\n\tr.POST("/y", createX)\n}\n`);
+    const files = [target, authedPeer(1), authedPeer(2), authedPeer(3), authedPeer(4)];
+    const f = authFinding(securityConsistency.detect(mkCtx(files)));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/y");
+  });
+
+  it("pinned legacy: tree-less go files keep the regex window over-bless", () => {
+    // A bare word `authMiddleware` in a COMMENT within the 21-line window
+    // (i-10 .. i+10) of an unauthed POST /legacy over-blesses it to authed. This
+    // is the legacy behavior the AST path replaces on CLEAN files; on tree-less
+    // files it survives unchanged, by design. Pinned as a decision, not silent.
+    const legacy = goFile("src/routes/legacy.go",
+      `func routes(r *gin.Engine) {\n\t// authMiddleware runs upstream\n\tr.POST("/legacy", createX)\n}\n`);
+    // 3 authed peers + the over-blessed /legacy (= 4 authed) + 1 genuine unauthed
+    // /danger -> 4/5 = 0.8 fires and cites /danger. If /legacy were NOT
+    // over-blessed it would be cited too and the vote would drop to 3/5 = 0.6
+    // (silent), so the finding firing on /danger alone proves the over-bless.
+    const files = [legacy, authedPeer(1), authedPeer(2), authedPeer(3), bareDanger()];
+    const f = authFinding(securityConsistency.detect(mkCtx(files)));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/danger");
+    expect(devPaths(f)).not.toContain("/legacy");
+  });
+
+  it("file index: a tree-less r.Use(authMiddleware) blesses a distant same-file route", () => {
+    // The Use sits >10 lines above the route, so the per-route TEXT window cannot
+    // reach it; only the file-level middleware index (which matches `.Use(auth`
+    // anywhere in the file) can bless /scoped. Observed via /scoped NOT being the
+    // deviator among peers where a genuine unauthed /danger is.
+    const scoped = goFile("src/routes/scoped.go",
+      [
+        `func setup(r *gin.Engine) {`,   // L1
+        `\tr.Use(authMiddleware)`,        // L2 (0-based row 1)
+        `}`,                              // L3
+        ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, // L4-15 padding
+        `func routes(r *gin.Engine) {`,  // L16
+        `\tr.POST("/scoped", createX)`,   // L17 (0-based row 16; window rows 6..26 excludes row 1)
+        `}`,                              // L18
+      ].join("\n"));
+    const files = [scoped, authedPeer(1), authedPeer(2), authedPeer(3), bareDanger()];
+    const f = authFinding(securityConsistency.detect(mkCtx(files)));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/danger");
+    expect(devPaths(f)).not.toContain("/scoped"); // file-index blessed it
+  });
+
+  it("known miss: chi lowercase r.Post in a tree-less go file is NOT extracted by the regex", () => {
+    // The echo regex pattern is UPPERCASE-verb only, so chi's `r.Post(...)` is a
+    // recall miss. 4 authed peers + 1 genuine unauthed /danger fire a 4/5 = 0.8
+    // finding; the chi file's would-be unauthed /chi, if it extracted, would drop
+    // the vote to 4/6 = 0.67 (silent). The finding firing on /danger AND /chi
+    // never appearing pins the miss (baseline for the AST recall delta).
+    const chi = goFile("src/routes/chi.go", `func routes(r chi.Router) {\n\tr.Post("/chi", createX)\n}\n`);
+    const files = [chi, authedPeer(1), authedPeer(2), authedPeer(3), authedPeer(4), bareDanger()];
+    const f = authFinding(securityConsistency.detect(mkCtx(files)));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/danger");
+    expect(devPaths(f)).not.toContain("/chi");
+  });
+});
+
+// ── Task 4 (Go): AST extractor wired into both seams ─────────────────────────
+//
+// Seam 1 (extractRoutes) and seam 2 (buildFileMiddlewareIndex) dispatch to the
+// Go AST extractor for clean-parsed go files, with the regex path retained as a
+// byte-identical fallback for tree-less / broken-parse go and every non-go file.
+describe("Go AST wiring (Task 4)", () => {
+  const goTree = (p: string, c: string) => fileWithTree(p, c, "go");
+  const authFinding = (fs: any[]) => fs.find((f) => f.subCategory === "Auth middleware");
+  const devPaths = (f: any): string[] =>
+    f ? f.deviatingFiles.map((d: any) => d.evidence[0].code.split(" ")[1]) : [];
+  // An in-file factory whose inner body verifiably rejects -> rule 2 bless (NOT a
+  // name bless). r.Use(AuthMiddleware()) blesses that scope's routes.
+  const goAuthFactory =
+    `func AuthMiddleware() gin.HandlerFunc { return func(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() } }\n`;
+  const goPeer = (dir: string, n: number) =>
+    goTree(`${dir}/peer${n}.go`,
+      goAuthFactory + `func routes${n}(r *gin.Engine) {\n\tr.Use(AuthMiddleware())\n\tr.POST("/peer${n}", createX)\n}\n`);
+
+  it("dispatch pair: a two-line Gorilla chain resolves POST via the AST but is missed by the tree-less regex", async () => {
+    // gorillaPattern requires HandleFunc + .Methods on the SAME line; a chain
+    // split across two lines defeats the regex but not the AST chain walk.
+    const gorillaSrc = `func routes(r *mux.Router) {\n\tr.HandleFunc("/danger", h).\n\t\tMethods("POST")\n}\n`;
+    const peers = await Promise.all([goPeer("src/gorilla", 1), goPeer("src/gorilla", 2), goPeer("src/gorilla", 3), goPeer("src/gorilla", 4)]);
+    // WITH a tree: the AST walks the cross-line chain and extracts POST /danger,
+    // the lone unauthed deviator (4/5 = 0.8 fires).
+    const withTree = await goTree("src/gorilla/g.go", gorillaSrc);
+    expect(withTree.tree!.rootNode.hasError).toBe(false);
+    const fWith = authFinding(securityConsistency.detect(mkCtx([...peers, withTree])));
+    expect(fWith).toBeDefined();
+    expect(devPaths(fWith)).toContain("/danger");
+    // TREE-LESS: the gorilla regex is same-line only, so /danger is never
+    // extracted; the peers are uniformly authed and nothing is flagged.
+    const treeless = file("src/gorilla/g.go", gorillaSrc, "go");
+    const fLess = authFinding(securityConsistency.detect(mkCtx([...peers, treeless])));
+    expect(devPaths(fLess)).not.toContain("/danger");
+  });
+
+  it("pinned legacy: parse-error go files keep the regex window over-bless", async () => {
+    // A go file with a parse error routes WHOLE to the regex extractor, which
+    // recovers the regex-visible /legacy route AND keeps the 21-line window
+    // over-bless (comment `authMiddleware`). On a CLEAN tree the AST would flag
+    // /legacy; on a broken tree it survives blessed, by design.
+    const brokenSrc =
+      `func routes(r *gin.Engine) {\n` +
+      `\t// authMiddleware runs upstream\n` +
+      `\tr.POST("/legacy", createX)\n` +
+      `\tx := = 1\n` +                       // parse error -> rootNode.hasError
+      `}\n`;
+    const broken = await goTree("src/broken/legacy.go", brokenSrc);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    const peers = await Promise.all([goPeer("src/broken", 1), goPeer("src/broken", 2), goPeer("src/broken", 3)]);
+    const danger = goTree("src/broken/danger.go", `func routes(r *gin.Engine) {\n\tr.POST("/danger", createX)\n}\n`);
+    const files = [broken, ...peers, await danger];
+    const f = authFinding(securityConsistency.detect(mkCtx(files)));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/danger");
+    expect(devPaths(f)).not.toContain("/legacy"); // regex window over-blessed it
+  });
+
+  it("cross-language noise (go direction): a comment app.use / string before_request never blesses a clean go route", async () => {
+    const noisy = await goTree("src/noise/orders.go",
+      `// Mirrors the Node service: app.use(authMiddleware) runs first\n` +
+      `func routes(r *gin.Engine) {\n` +
+      `\tmsg := "@app.before_request"\n` +
+      `\tr.POST("/orders", createX)\n` +
+      `}\n`);
+    expect(noisy.tree!.rootNode.hasError).toBe(false);
+    const peers = await Promise.all([goPeer("src/noise", 1), goPeer("src/noise", 2), goPeer("src/noise", 3), goPeer("src/noise", 4)]);
+    const f = authFinding(securityConsistency.detect(mkCtx([noisy, ...peers])));
+    expect(f).toBeDefined();
+    // The case-insensitive jsAuth regex matches `app.use(authMiddleware` in the
+    // comment and pyAuth matches `@app.before_request`, but a clean go tree forces
+    // both arms false, so /orders stays unauthed and is the flagged deviator.
+    expect(devPaths(f)).toContain("/orders");
+  });
+
+  it("file-middleware seam end-to-end: 4 body-backed r.Use files + 1 bare route -> one finding on the bare route", async () => {
+    const peers = await Promise.all([goPeer("src/api", 1), goPeer("src/api", 2), goPeer("src/api", 3), goPeer("src/api", 4)]);
+    const bare = await goTree("src/api/danger.go", `func routes(r *gin.Engine) {\n\tr.POST("/danger", createX)\n}\n`);
+    const findings = securityConsistency.detect(mkCtx([...peers, bare]));
+    const auths = findings.filter((f) => f.subCategory === "Auth middleware");
+    expect(auths).toHaveLength(1);
+    expect(auths[0].deviatingFiles).toHaveLength(1);
+    expect(auths[0].deviatingFiles[0].path).toBe("src/api/danger.go");
+    expect(auths[0].deviatingFiles[0].evidence[0].line).toBe(2); // the r.POST line
+  });
+
+  it("unsure survives the dispatch: the deviator's detectedPattern is the hedged shape", async () => {
+    const peers = await Promise.all([goPeer("src/hedge", 1), goPeer("src/hedge", 2), goPeer("src/hedge", 3), goPeer("src/hedge", 4)]);
+    const unsure = await goTree("src/hedge/x.go",
+      `func routes(r *gin.Engine) {\n\tr.Use(middleware.VerifyToken)\n\tr.POST("/x", createX)\n}\n`);
+    const findings = securityConsistency.detect(mkCtx([...peers, unsure]));
+    const auths = findings.filter((f) => f.subCategory === "Auth middleware");
+    expect(auths).toHaveLength(1);
+    expect(auths[0].deviatingFiles).toHaveLength(1);
+    const dev = auths[0].deviatingFiles[0].detectedPattern;
+    expect(dev).toContain("double check");
+    expect(dev).toContain("middleware.VerifyToken");
+  });
+
+  it("mixed-language byte-identity: adding a clean go route file (different dir) does not change JS-side findings", async () => {
+    const js = await fileWithTree("src/js/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+      `router.put("/items/:id", requireAuth, updateItem);\n` +
+      `router.patch("/items/:id", requireAuth, patchItem);\n` +
+      `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+      `router.post("/danger", wipeEverything);\n`);
+    const gof = await goTree("src/go/orders.go",
+      goAuthFactory + `func routes(r *gin.Engine) {\n\tr.Use(AuthMiddleware())\n\tr.POST("/o1", createX)\n\tr.POST("/o2", createY)\n}\n`);
+    const withoutGo = securityConsistency.detect({ files: [js], totalLines: js.lineCount, dominantLanguage: "typescript" } as any);
+    const withGo = securityConsistency.detect({ files: [js, gof], totalLines: js.lineCount + gof.lineCount, dominantLanguage: "typescript" } as any);
+    expect(withGo).toEqual(withoutGo);
+  });
+});

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -5,7 +5,7 @@ import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
 import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
-import { extractGoFileMiddlewareAst } from "../../../src/drift/security-ast-go.js";
+import { extractGoFileMiddlewareAst, extractGoRoutesAst } from "../../../src/drift/security-ast-go.js";
 import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
   SECURITY_SUPPRESSION_ANALYZER_ID,
@@ -1681,5 +1681,179 @@ describe("Task 5 (Go): terminal hedge visibility", () => {
     expect(out).toContain("Unprotected routes may be exposed in production");
     expect(out.toLowerCase()).not.toContain("double check");
     expect(out).not.toContain("middleware.VerifyToken");
+  });
+});
+
+// ── Task 6 (Go): adversarial detect-level fallback ────────────────────────────
+//
+// Companions to the direct-extractor pins in security-ast-go.test.ts
+// ("malformed and adversarial input"): here the SAME hazards are run through
+// securityConsistency.detect end-to-end, proving the whole-file hasError gate
+// preserves recall via the regex fallback exactly as it does for JS/Python.
+describe("Task 6 (Go): adversarial detect-level fallback", () => {
+  const goTree = (p: string, c: string) => fileWithTree(p, c, "go");
+  const authFinding = (fs: any[]) => fs.find((f: any) => f.subCategory === "Auth middleware");
+  const devPaths = (f: any): string[] =>
+    f ? f.deviatingFiles.map((d: any) => d.evidence[0].code.split(" ")[1]) : [];
+  const authedPeer = (dir: string, n: number) =>
+    goTree(`${dir}/peer${n}.go`, `func routes${n}(r *gin.Engine) {\n\tr.Use(authMiddleware)\n\tr.POST("/peer${n}", createX)\n}\n`);
+
+  it("swallowed-route hazard: the whole file (rootNode.hasError) still routes to regex and recovers the swallowed route's recall", async () => {
+    // The direct extractor emits NOTHING from this file (pinned in
+    // security-ast-go.test.ts). Here the mutating verb is POST rather than the
+    // brief's illustrative GET: GET is structurally outside every
+    // security-consistency auth vote (MUTATION_METHODS-gated), so a GET would
+    // never surface as an observable deviator regardless of recall — this swap
+    // is required to make recall OBSERVABLE end-to-end, not a change to the
+    // hazard itself (same unclosed-paren-swallows-the-next-call shape).
+    const broken = await goTree("src/swallow/danger.go",
+      `package main\n\n` + `func routes() {\n\tr.POST("/broken", mw, h\n\tr.POST("/later", h)\n}\n`);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    expect(extractGoRoutesAst(broken.tree!, broken.relativePath)).toEqual([]);
+
+    const peers = await Promise.all([
+      authedPeer("src/swallow", 1), authedPeer("src/swallow", 2),
+      authedPeer("src/swallow", 3), authedPeer("src/swallow", 4),
+    ]);
+    const f = authFinding(securityConsistency.detect(mkCtx([broken, ...peers])));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/later");
+  });
+
+  it("surgical-per-node-skip parity: a file-level parse error elsewhere still routes the WHOLE file to regex (python bodyerror parity)", async () => {
+    // The direct extractor's surgical per-node skip emits POST /good from this
+    // exact source (pinned in security-ast-go.test.ts) — but detect's dispatch
+    // gate is coarser than that per-node precision: ANY hasError anywhere in the
+    // file routes the WHOLE file to the regex fallback, never reaching the AST
+    // extractor's surgical logic at all. /good still recovers, just via a
+    // completely different mechanism (regex line-window), which this pins.
+    const broken = await goTree("src/surgical/mix.go",
+      `package main\n\n` + `func bad() {\n\tx := := 1\n\t_ = x\n}\n\nfunc good() {\n\tr.POST("/good", h)\n}\n`);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    expect(extractGoRoutesAst(broken.tree!, broken.relativePath).map((r) => `${r.method} ${r.path}`))
+      .toEqual(["POST /good"]); // the direct-extractor pin, re-asserted here for contrast
+
+    const peers = await Promise.all([
+      authedPeer("src/surgical", 1), authedPeer("src/surgical", 2),
+      authedPeer("src/surgical", 3), authedPeer("src/surgical", 4),
+    ]);
+    const f = authFinding(securityConsistency.detect(mkCtx([broken, ...peers])));
+    expect(f).toBeDefined();
+    expect(devPaths(f)).toContain("/good");
+  });
+});
+
+// ── Task 6 (Go): suppression pins ──────────────────────────────────────────────
+//
+// The `@vibedrift-public` annotation mechanism (security-suppression.ts) is
+// language-generic: it keys off `route.line` (the anchor call's OWN row) and AST
+// comment nodes when a tree is attached. These pins prove it binds correctly for
+// Go, including the Task 2 line-choice decision (a Gorilla chain's route.line is
+// the HandleFunc row, never a chained `.Methods(...)` continuation's row).
+describe("Task 6 (Go): suppression pins", () => {
+  const goTree = (p: string, c: string) => fileWithTree(p, c, "go");
+  const auth = (fs: any[]) => fs.find((f: any) => f.subCategory === "Auth middleware");
+  const audit = (fs: any[]) => fs.find((f: any) => f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+  const requireAuthDef =
+    `func requireAuth(c *gin.Context) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n`;
+  const authedFour = [
+    `\tr.POST("/a", requireAuth, ha)`,
+    `\tr.POST("/b", requireAuth, hb)`,
+    `\tr.POST("/c", requireAuth, hc)`,
+    `\tr.POST("/d", requireAuth, hd)`,
+  ];
+
+  it("// @vibedrift-public on the route's OWN line suppresses it; the audit finding cites that line", async () => {
+    const src = [
+      `package main`, ``,
+      ...requireAuthDef.split("\n").slice(0, -1),
+      ``,
+      `func routes(r *gin.Engine) {`,
+      ...authedFour,
+      `\tr.POST("/public", handlePublic) // @vibedrift-public`,
+      `}`,
+    ].join("\n");
+    const f = await goTree("src/suppress/api.go", src);
+    const findings = securityConsistency.detect(mkCtx([f]));
+
+    // /public leaves the vote entirely -> the remaining 4 /a../d are 4/4 authed,
+    // so no auth-drift finding fires.
+    expect(auth(findings)).toBeUndefined();
+    const a = audit(findings);
+    expect(a).toBeDefined();
+    expect(a!.deviatingFiles).toHaveLength(1);
+    expect(a!.deviatingFiles[0].path).toBe("src/suppress/api.go");
+    // The route's own registration line (the r.POST("/public"...) row).
+    const ownLine = src.split("\n").findIndex((l) => l.includes(`/public`)) + 1;
+    expect(a!.deviatingFiles[0].evidence[0].line).toBe(ownLine);
+  });
+
+  it("// @vibedrift-public on the line immediately ABOVE a multiline Gorilla chain suppresses it (binds to the HandleFunc row)", async () => {
+    const src = [
+      `package main`, ``,
+      ...requireAuthDef.split("\n").slice(0, -1),
+      ``,
+      `func routes(r *gin.Engine) {`,
+      ...authedFour,
+      `\t// @vibedrift-public`,
+      `\trouter.HandleFunc("/public", handlePublic).`,
+      `\t\tMethods("POST")`,
+      `}`,
+    ].join("\n");
+    const f = await goTree("src/suppress2/api.go", src);
+    const findings = securityConsistency.detect(mkCtx([f]));
+
+    expect(auth(findings)).toBeUndefined();
+    const a = audit(findings);
+    expect(a).toBeDefined();
+    expect(a!.deviatingFiles).toHaveLength(1);
+    const handleFuncLine = src.split("\n").findIndex((l) => l.includes(`HandleFunc("/public"`)) + 1;
+    expect(a!.deviatingFiles[0].evidence[0].line).toBe(handleFuncLine);
+  });
+
+  it("the SAME annotation placed beside the .Methods(\"POST\") continuation line does NOT suppress (proves route.line = the HandleFunc row is load-bearing)", async () => {
+    const src = [
+      `package main`, ``,
+      ...requireAuthDef.split("\n").slice(0, -1),
+      ``,
+      `func routes(r *gin.Engine) {`,
+      ...authedFour,
+      `\trouter.HandleFunc("/public", handlePublic).`,
+      `\t\tMethods("POST") // @vibedrift-public`,
+      `}`,
+    ].join("\n");
+    const f = await goTree("src/suppress3/api.go", src);
+    const findings = securityConsistency.detect(mkCtx([f]));
+
+    // Nothing suppressed -> no audit finding.
+    expect(audit(findings)).toBeUndefined();
+    // /public stays in the vote as the unauthed deviator (4 authed + 1 unauthed
+    // = 0.8 > 0.75), cited on its own HandleFunc row.
+    const a = auth(findings);
+    expect(a).toBeDefined();
+    const handleFuncLine = src.split("\n").findIndex((l) => l.includes(`HandleFunc("/public"`)) + 1;
+    expect(a!.deviatingFiles.some((d: any) => d.evidence[0].line === handleFuncLine)).toBe(true);
+  });
+
+  it("an @vibedrift-public annotation inside a Go string literal never suppresses (comment-awareness via AST comment nodes)", async () => {
+    const src = [
+      `package main`, ``,
+      ...requireAuthDef.split("\n").slice(0, -1),
+      ``,
+      `func routes(r *gin.Engine) {`,
+      ...authedFour,
+      `\tdoc := "publish under // @vibedrift-public to opt out"`,
+      `\tr.POST("/danger", handleDanger)`,
+      `}`,
+    ].join("\n");
+    const f = await goTree("src/suppress4/api.go", src);
+    const findings = securityConsistency.detect(mkCtx([f]));
+
+    // The string literal is not a comment node, so nothing is suppressed.
+    expect(audit(findings)).toBeUndefined();
+    const a = auth(findings);
+    expect(a).toBeDefined();
+    const dangerLine = src.split("\n").findIndex((l) => l.includes(`/danger`)) + 1;
+    expect(a!.deviatingFiles.some((d: any) => d.evidence[0].line === dangerLine)).toBe(true);
   });
 });

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,14 @@
 # CLI backlog
 
+- **Hedge recommendation noun is Python-flavored for Go/mixed findings.** The
+  shared `hedgeRecommendationSuffix` (`src/drift/security-consistency.ts`) and
+  the terminal's read-back regex (`src/output/terminal.ts`, `before_request
+  hook (...)`) hardcode the Flask/FastAPI noun "before_request hook", which is
+  inaccurate for a Go middleware/handler hedge (e.g. `middleware.VerifyToken`).
+  Neutralizing it requires changing the producer and the terminal regex in
+  lockstep (a language-aware branch so Python stays byte-identical), which is
+  reserved for the user-facing honesty pass. Parked.
+
 - **No per-call logging in the MCP server (tool calls are invisible).** The stdio
   server (`src/mcp/server.ts`) only writes startup (`vibedrift-mcp running on
   stdio`), a one-time baseline-index line, and `Fatal:` to stderr — never a line

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,24 @@
 # CLI backlog
 
+- **No per-call logging in the MCP server (tool calls are invisible).** The stdio
+  server (`src/mcp/server.ts`) only writes startup (`vibedrift-mcp running on
+  stdio`), a one-time baseline-index line, and `Fatal:` to stderr — never a line
+  per tool call. So there is no way to watch which in-loop tools fire, when, or
+  with what outcome. Add an env-gated per-call stderr log (e.g.
+  `VIBEDRIFT_MCP_LOG=1`): tool name, repo, and a one-word result
+  (`fits` / `ok` / `no_baseline` / …). Because MCP clients capture server stderr
+  into their logs (Claude Code: `mcp-logs-<server>/*.jsonl`; also streamed by
+  `claude --debug`), this makes tool usage `tail -f`-able without touching the
+  JSON-RPC channel on stdout. Parked.
+
+- **No first-class "MCP is active / being used" signal.** After enabling the
+  server a user cannot tell it is doing anything: the tools are pull-based (they
+  fire only when the agent chooses to call them), `/mcp` shows "connected" but not
+  "used", and the `indexing … for the first time` line fires once per repo per
+  session, not per call. Consider a lightweight liveness/usage signal (pairs with
+  the per-call log above) so "connected" is distinguishable from "actually
+  invoked." Parked.
+
 - **Terminal hedge detection is a prose-regex.** The terminal decides a security
   finding is hedged by testing its recommendation text with `/Double check/`
   (`src/output/terminal.ts`), which is brittle copy coupling: a wording change to


### PR DESCRIPTION
## What this does

Adds **Go** to the Security Consistency detector, reading route auth through a parsed syntax tree (tree-sitter) instead of the previous line-based regex. Covers Gin, Echo, chi, Gorilla mux, and the Go 1.22 stdlib router, and it reads middleware **behavior** rather than trusting names.

Builds on the Python body-first work from #43 and mirrors its conventions.

## The three outcomes (same model as Python)

- **Protected**: a middleware registered via `Use()`/group/wrapper has an in-file body that verifiably rejects unauthenticated requests, a `c.AbortWithStatus(401)`, an `echo.NewHTTPError(401)`, a `WriteHeader(401)` followed by a return, or a credential-guarded 403.
- **Open**: the body is visible and does none of that.
- **Unsure**: the middleware body cannot be read (imported from another package, or otherwise not in this repo). The route is treated as not protected and still flagged, but with hedged "double check" copy naming the middleware, rather than a flat claim that might be wrong.

## Design principle

Blessing requires a verifiable reject in a readable body. A middleware whose source is not in the repo is never marked protected on the strength of its name (`JWTMiddleware`, `RequireAuth`, ...); it resolves to unsure. Every ambiguous or unreadable case resolves toward not protected, and an unreadable method set keeps the route in the mutating-route check. A false "open" is a reviewable nuisance; a false "protected" hides a real gap.

## Safety and compatibility

- JavaScript, TypeScript, and Python findings are byte-identical: the Go branch only activates for Go files with a clean parse tree, and the shared middleware index is per-file-keyed with no cross-file state.
- The Go regex path is retained as a fallback for files that do not parse.
- The route auth vote and score are unchanged; unsure routes count as not protected.
- Receiver-scoped and chi-closure-aware: a guard on one router group does not bless another, and an inner closure's middleware does not bless outer routes.
- No em-dashes or double hyphens in user-facing strings.
- Covered by unit tests, an adversarial never-false-bless sweep, and a precision/recall calibration gate, and spot-checked against real Gin and Echo apps with no false "protected" verdicts.

## Known limitation

Real Go apps often wire auth cross-file (the middleware body lives in a different file), so those routes resolve to unsure rather than a clean protected verdict. Cross-file body resolution is tracked as follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
