### PR TITLE
Security Consistency: cross-file auth body resolution (Python + Go)

### DIFF
--- a/src/core/discovery.ts
+++ b/src/core/discovery.ts
@@ -138,40 +138,82 @@ export async function loadPackageJson(rootDir: string): Promise<PackageJson | nu
 }
 
 export async function loadGoMod(rootDir: string): Promise<GoMod | null> {
+  let raw: string;
   try {
-    const raw = await readFile(join(rootDir, "go.mod"), "utf-8");
-    const lines = raw.split("\n");
-    const result: GoMod = { module: "", require: [] };
-
-    // State-machine parser: track whether we're inside a `require (` block
-    let inRequire = false;
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith("module ")) {
-        result.module = trimmed.slice(7).trim();
-      } else if (trimmed.startsWith("go ")) {
-        result.goVersion = trimmed.slice(3).trim();
-      } else if (trimmed === "require (") {
-        inRequire = true;
-      } else if (trimmed === ")") {
-        inRequire = false;
-      } else if (inRequire && trimmed && !trimmed.startsWith("//")) {
-        const parts = trimmed.split(/\s+/);
-        if (parts.length >= 2) {
-          result.require.push({ path: parts[0], version: parts[1] });
-        }
-      } else if (trimmed.startsWith("require ") && !trimmed.includes("(")) {
-        const parts = trimmed.slice(8).trim().split(/\s+/);
-        if (parts.length >= 2) {
-          result.require.push({ path: parts[0], version: parts[1] });
-        }
-      }
-    }
-
-    return result.module ? result : null;
+    raw = await readFile(join(rootDir, "go.mod"), "utf-8");
   } catch {
     return null;
   }
+
+  const lines = raw.split("\n");
+  const result: GoMod = { module: "", require: [] };
+
+  // State-machine parser: track whether we're inside a `require (` / `replace (`
+  // block. `hasReplace` records ANY replace directive (block or single-line) —
+  // a replace remaps an import path to a different dir, which makes root-prefix
+  // package math unsafe, so it disables Go cross-file resolution downstream.
+  let inRequire = false;
+  let hasReplace = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("module ")) {
+      result.module = trimmed.slice(7).trim();
+    } else if (trimmed.startsWith("go ")) {
+      result.goVersion = trimmed.slice(3).trim();
+    } else if (trimmed === "require (") {
+      inRequire = true;
+    } else if (trimmed === "replace (") {
+      hasReplace = true;
+    } else if (trimmed === ")") {
+      inRequire = false;
+    } else if (inRequire && trimmed && !trimmed.startsWith("//")) {
+      const parts = trimmed.split(/\s+/);
+      if (parts.length >= 2) {
+        result.require.push({ path: parts[0], version: parts[1] });
+      }
+    } else if (trimmed.startsWith("require ") && !trimmed.includes("(")) {
+      const parts = trimmed.slice(8).trim().split(/\s+/);
+      if (parts.length >= 2) {
+        result.require.push({ path: parts[0], version: parts[1] });
+      }
+    } else if (trimmed.startsWith("replace ") && !trimmed.includes("(")) {
+      hasReplace = true; // single-line: `replace a => b`
+    }
+  }
+
+  if (!result.module) return null;
+  if (hasReplace) result.hasReplace = true;
+  if (await hasNestedGoMod(rootDir)) result.hasNestedModule = true;
+  return result;
+}
+
+/**
+ * True when a `go.mod` exists in ANY subdirectory under `rootDir` (the root's
+ * own go.mod does not count). A nested module breaks the single-root-prefix
+ * assumption Go cross-file package resolution relies on, so detecting one
+ * disables that resolution wholesale. Short-circuits on the first hit; skips
+ * the same vendored/ignored dirs the main file walk skips. Over-detection only
+ * ever over-disables (safe); a boolean result is order-independent.
+ */
+async function hasNestedGoMod(rootDir: string): Promise<boolean> {
+  async function walk(dir: string, isRoot: boolean): Promise<boolean> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;
+        if (await walk(join(dir, entry.name), false)) return true;
+      } else if (!isRoot && entry.isFile() && entry.name === "go.mod") {
+        return true;
+      }
+    }
+    return false;
+  }
+  return walk(rootDir, true);
 }
 
 export async function loadCargoToml(rootDir: string): Promise<CargoToml | null> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -120,6 +120,21 @@ export interface GoMod {
   module: string;
   goVersion?: string;
   require: { path: string; version: string }[];
+  /**
+   * True when go.mod declares any `replace` directive (single-line
+   * `replace a => b` or the `replace (` block form). A replace remaps an
+   * import path to a different directory, so the root-module-prefix math that
+   * maps a Go import path back to an in-repo file is unsafe. Consumed by
+   * `buildDriftContext` to DISABLE Go cross-file auth resolution wholesale
+   * (a never-false-bless guard).
+   */
+  hasReplace?: boolean;
+  /**
+   * True when a second `go.mod` exists in a subdirectory under the scan root.
+   * A nested module breaks the single-root-prefix assumption, so — like
+   * `hasReplace` — it disables Go cross-file auth resolution wholesale.
+   */
+  hasNestedModule?: boolean;
 }
 
 export interface CargoToml {

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -53,6 +53,14 @@ export function buildDriftContext(ctx: AnalysisContext): DriftContext {
     hasGitMetadata: ctx.hasGitMetadata ?? false,
     intentHints: ctx.intentHints ?? [],
     projectConfig: ctx.projectConfig,
+    // Go cross-file resolution needs a single module root to map an import
+    // path to an in-repo file. A `replace` directive (remaps a path to another
+    // dir) or a nested go.mod (breaks the root-prefix math) makes that mapping
+    // unsafe, so either forces the path undefined => Go cross-file disabled.
+    goModulePath:
+      ctx.goMod && !ctx.goMod.hasReplace && !ctx.goMod.hasNestedModule
+        ? ctx.goMod.module || undefined
+        : undefined,
   };
 }
 

--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -898,7 +898,7 @@ export function collectGoFunctionDefs(root: SyntaxNode): Map<string, SyntaxNode 
  *  `return http.HandlerFunc(func(w,r){...})`) or a one-hop returned bare
  *  identifier. NEVER prunes the returned handler closure (else mass false
  *  not-auth); scanGoBody prunes FURTHER-nested closures inside it. */
-function resolveEffectiveBody(fnNode: SyntaxNode, defs: Map<string, SyntaxNode | null>): SyntaxNode | null {
+export function resolveEffectiveBody(fnNode: SyntaxNode, defs: Map<string, SyntaxNode | null>): SyntaxNode | null {
   const body = fnNode.childForFieldName("body");
   if (!body) return null;
   const stmts = goNamed(body);

--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -140,6 +140,8 @@
 
 import type { Tree, SyntaxNode } from "../core/types.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
+import { resolveGoMiddlewareBody } from "./security-xfile-index.js";
+import type { CrossFileIndex } from "./security-xfile-index.js";
 
 /** A middleware body's three-way behavioral signal. 401-family blesses alone; a
  *  403 blesses only inside a credential-guarded reject; a bare/uncorroborated 403,
@@ -975,6 +977,24 @@ function goMiddlewareName(arg: SyntaxNode): string | null {
   return null;
 }
 
+/** True when `arg` is a RESOLVABLE pure-selector cross-file target: a bare pure
+ *  `selector_expression` (a middleware passed by reference, `mw.Require`), or a
+ *  `call_expression` whose `function` is a pure selector AND which carries AT MOST
+ *  ONE argument (an invoked factory `middleware.AuthMiddleware()`, or a single-arg
+ *  wrap `middleware.RequireAuth(h)`). An arity->=2 call is Go DI — never
+ *  classified (do not resolve it), the SAME rule the single-argument wrap
+ *  recursion applies, kept identical in-file and cross-file so a DI constructor
+ *  can never bless a route through the package-selector path. */
+function isPureSelectorTarget(arg: SyntaxNode): boolean {
+  if (arg.type === "selector_expression") return isPureSelectorChain(arg);
+  if (arg.type === "call_expression") {
+    const fn = arg.childForFieldName("function");
+    if (!fn || fn.type !== "selector_expression" || !isPureSelectorChain(fn)) return false;
+    return goNamed(arg.childForFieldName("arguments")).length <= 1;
+  }
+  return false;
+}
+
 function goNameHasSubsumingVeto(name: string): boolean {
   return nameSegments(name).some((s) => GO_SUBSUMING_VETO_SEGMENTS.has(s));
 }
@@ -1003,6 +1023,7 @@ const goNameIsRate = (n: string) => goNameHasSegment(n, GO_RATE_SEGMENTS, GO_RAT
  *  outer HALTS. Returns the outcome + the resolved name (for authUnsureHook). */
 function classifyGoMiddlewareArg(
   arg: SyntaxNode, defs: Map<string, SyntaxNode | null>, depth = 0,
+  importerRel?: string, index?: CrossFileIndex,
 ): { outcome: GoAuthOutcome; name: string | null } {
   if (depth > 5) return { outcome: "not-auth", name: null };
   const name = goMiddlewareName(arg);
@@ -1017,6 +1038,26 @@ function classifyGoMiddlewareArg(
           : null;
     const def = calleeId ? defs.get(calleeId.text) ?? null : null;
     const body = def ? resolveEffectiveBody(def, defs) : null;
+    // CROSS-FILE (Task 4): a package-qualified selector (middleware.AuthMiddleware)
+    // has calleeId === null, so `def` is null and the in-file classify below would
+    // hedge/decline. When there is NO in-file def AND the repo index is live,
+    // resolve the selector to its in-repo defining body and classify THAT. Every
+    // value-shadow / exported-only / package-name / external / duplicate guard
+    // lives in resolveGoMiddlewareBody — this CALLS it, never bypasses it — and
+    // blessing still requires the resolved body to VERIFIABLY reject. In-file defs
+    // keep precedence (this only fires when def === null); with the index absent
+    // the whole branch is skipped, byte-identical to today. This MUST win before
+    // the in-file early return: an auth-flavored selector's in-file classify is
+    // `unsure` and returns, which would leave a branch placed AFTER it dead.
+    if (def === null && index && importerRel && name !== null && isPureSelectorTarget(arg)) {
+      const x = resolveGoMiddlewareBody(importerRel, name, index);
+      if (x) {
+        const xbody = resolveEffectiveBody(x.def, x.defs);
+        const outcome = classifyGoMiddlewareAuth(name, xbody, x.defs);
+        if (outcome !== "not-auth") return { outcome, name };
+        if (goNameHasSubsumingVeto(name)) return { outcome: "not-auth", name };
+      }
+    }
     const outcome = classifyGoMiddlewareAuth(name, body, defs);
     if (outcome !== "not-auth") return { outcome, name };
     if (goNameHasSubsumingVeto(name)) return { outcome: "not-auth", name };
@@ -1024,7 +1065,7 @@ function classifyGoMiddlewareArg(
   // Wrap recursion: single-arg call, through a transparent/unnamed outer only.
   if (arg.type === "call_expression" && (name === null || goNameIsTransparentWrap(name))) {
     const inner = goNamed(arg.childForFieldName("arguments"));
-    if (inner.length === 1) return classifyGoMiddlewareArg(inner[0], defs, depth + 1);
+    if (inner.length === 1) return classifyGoMiddlewareArg(inner[0], defs, depth + 1, importerRel, index);
   }
   return { outcome: "not-auth", name };
 }
@@ -1049,6 +1090,7 @@ function collectWithArgs(operand: SyntaxNode | null): SyntaxNode[] {
 function goRouteMiddleware(
   named: SyntaxNode[], pathIdx: number, wrapCallee: SyntaxNode | null,
   fnOperand: SyntaxNode | null, defs: Map<string, SyntaxNode | null>,
+  importerRel?: string, index?: CrossFileIndex,
 ): { hasAuth: boolean; hasValidation: boolean; hasRateLimit: boolean; unsureHook: string | undefined } {
   const withArgs = fnOperand ? collectWithArgs(fnOperand) : [];
   const middleArgs: SyntaxNode[] = [];
@@ -1058,7 +1100,7 @@ function goRouteMiddleware(
   let hasAuth = false;
   let unsureHook: string | undefined;
   const consider = (a: SyntaxNode) => {
-    const { outcome, name } = classifyGoMiddlewareArg(a, defs);
+    const { outcome, name } = classifyGoMiddlewareArg(a, defs, 0, importerRel, index);
     if (outcome === "auth") hasAuth = true;
     else if (outcome === "unsure" && unsureHook === undefined && name !== null) unsureHook = name;
   };
@@ -1156,11 +1198,12 @@ function hasConditionalRegistrationAncestor(node: SyntaxNode, scope: SyntaxNode)
  *  sets hasAuth. */
 function lanesFromArgs(
   args: SyntaxNode[], defs: Map<string, SyntaxNode | null>,
+  importerRel?: string, index?: CrossFileIndex,
 ): { lanes: FileMiddleware; unsureHook?: string } {
   let hasAuth = false;
   let unsureHook: string | undefined;
   for (const a of args) {
-    const { outcome, name } = classifyGoMiddlewareArg(a, defs);
+    const { outcome, name } = classifyGoMiddlewareArg(a, defs, 0, importerRel, index);
     if (outcome === "auth") hasAuth = true;
     else if (outcome === "unsure" && unsureHook === undefined && name) unsureHook = name;
   }
@@ -1176,7 +1219,9 @@ function lanesFromArgs(
 
 /** Collect the file's Use marks, group/closure derivations, and (name, scope)
  *  poisoning in one pass set. Receiver-scoped; NO global bucket. */
-function collectGoMiddleware(tree: Tree): GoMiddlewareScopes {
+function collectGoMiddleware(
+  tree: Tree, importerRel?: string, index?: CrossFileIndex,
+): GoMiddlewareScopes {
   const root = tree.rootNode;
   const defs = collectGoFunctionDefs(root);
   const routerNames = collectGoRouterNames(root);
@@ -1199,7 +1244,7 @@ function collectGoMiddleware(tree: Tree): GoMiddlewareScopes {
       const scope = enclosingScope(call, root);
       if (hasConditionalRegistrationAncestor(call, scope)) continue;
       const named = goNamed(call.childForFieldName("arguments"));
-      const { lanes, unsureHook } = lanesFromArgs(named, defs);
+      const { lanes, unsureHook } = lanesFromArgs(named, defs, importerRel, index);
       marks.push({ receiver, scope, row: call.startPosition.row, lanes, unsureHook });
       continue;
     }
@@ -1240,7 +1285,7 @@ function collectGoMiddleware(tree: Tree): GoMiddlewareScopes {
       // On a Group creation call every arg AFTER the path is a middleware
       // candidate INCLUDING the last (no handler position).
       const inlineArgs = goNamed(valueNode.childForFieldName("arguments")).slice(1);
-      const { lanes, unsureHook } = lanesFromArgs(inlineArgs, defs);
+      const { lanes, unsureHook } = lanesFromArgs(inlineArgs, defs, importerRel, index);
       derivations.push({
         child: nameNode.text, childScope: scope,
         parent, parentScope: scope, row, inlineLanes: lanes, inlineUnsureHook: unsureHook,
@@ -1344,12 +1389,15 @@ export function extractGoFileMiddlewareAst(tree: Tree): FileMiddleware {
   };
 }
 
-export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
+export function extractGoRoutesAst(tree: Tree, filePath: string, index?: CrossFileIndex): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const root = tree.rootNode;
   const routerNames = collectGoRouterNames(root);
   const defs = collectGoFunctionDefs(root);
-  const scopes = collectGoMiddleware(tree);
+  // filePath IS the importer's relativePath. With `index` absent (the 2-arg
+  // call — every non-detect caller, and any repo with Go cross-file disabled),
+  // every selector stays in-file-only, byte-identical to today.
+  const scopes = collectGoMiddleware(tree, filePath, index);
   const gated = (r: string | null): r is string =>
     r !== null && (routerNames.has(r) || GO_ROUTER_RECEIVER.test(r));
 
@@ -1407,7 +1455,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       if (arg0Raw === null || !arg0Raw.startsWith("/")) continue; // leading-slash gate
       // Middleware are the args strictly between the path (arg0) and the handler
       // (last); the last arg is the handler and is NEVER classified.
-      emit(directVerb, arg0Raw, call, receiver ?? "", goRouteMiddleware(named, 0, null, fnOperand, defs));
+      emit(directVerb, arg0Raw, call, receiver ?? "", goRouteMiddleware(named, 0, null, fnOperand, defs, filePath, index));
       continue;
     }
 
@@ -1416,7 +1464,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
     if (ANY_FIELDS.has(field)) {
       if (!gated(receiver)) continue;
       if (arg0Raw === null || !arg0Raw.startsWith("/")) continue;
-      emit("ALL", arg0Raw, call, receiver ?? "", goRouteMiddleware(named, 0, null, fnOperand, defs));
+      emit("ALL", arg0Raw, call, receiver ?? "", goRouteMiddleware(named, 0, null, fnOperand, defs, filePath, index));
       continue;
     }
 
@@ -1440,7 +1488,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       if (path === null || !path.startsWith("/")) continue;
       // Verb-first: verb=arg0, path=arg1, so the middleware window starts after
       // arg1; the handler (last arg) is never classified.
-      emit(method, path, call, receiver ?? "", goRouteMiddleware(named, 1, null, fnOperand, defs));
+      emit(method, path, call, receiver ?? "", goRouteMiddleware(named, 1, null, fnOperand, defs, filePath, index));
       continue;
     }
 
@@ -1456,7 +1504,7 @@ export function extractGoRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
       // The handler is the arg right after the path (arg1); for these forms it
       // may be a WRAP callee (auth(handler)) — the only body-first position here.
       const wrapCallee = named.length > 1 ? named[1] : null;
-      emit(method, split.path, call, receiver ?? "", goRouteMiddleware(named, 0, wrapCallee, fnOperand, defs));
+      emit(method, split.path, call, receiver ?? "", goRouteMiddleware(named, 0, wrapCallee, fnOperand, defs, filePath, index));
       continue;
     }
   }

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -73,6 +73,8 @@
 
 import type { Tree, SyntaxNode } from "../core/types.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
+import type { CrossFileIndex } from "./security-xfile-index.js";
+import { resolvePyHookBody } from "./security-xfile-index.js";
 
 /** Three-way verdict for a before_request-style hook. `unsure` never blesses
  *  (hasAuth stays false); it only hedges the finding copy so the user is told
@@ -1265,7 +1267,12 @@ function isAuthDecorator(dec: SyntaxNode): boolean {
  *  SAME-FILE def body raises a verified reject (Depends(load_actor) where
  *  load_actor 401s) blesses. Bare Depends() or an unresolvable target resolves
  *  false. */
-function callsWithAuthDependency(scope: SyntaxNode, defs: Map<string, SyntaxNode | null>): boolean {
+function callsWithAuthDependency(
+  scope: SyntaxNode,
+  defs: Map<string, SyntaxNode | null>,
+  importerRel?: string,
+  index?: CrossFileIndex,
+): boolean {
   for (const call of scope.descendantsOfType("call")) {
     if (!call) continue;
     const fn = call.childForFieldName("function");
@@ -1282,6 +1289,24 @@ function callsWithAuthDependency(scope: SyntaxNode, defs: Map<string, SyntaxNode
     if (def) {
       const body = def.childForFieldName("body");
       if (body && bodyAuthSignature(body, defs) === "reject") return true;
+    } else if (!defs.has(name) && index && importerRel) {
+      // Imported dependency (NOT an in-file `defs.get(name) === null` duplicate,
+      // which the `!defs.has(name)` guard still refuses): resolve its in-repo
+      // defining body cross-file. The optional/settings veto is re-run on the
+      // RESOLVED ORIGINAL name (not the call-site alias), so an aliased optional
+      // dependency (load_actor -> get_current_user_optional) can never rule-2
+      // bless. The TARGET file's own defs (x.defs) back the body so its one-hop
+      // helpers resolve in the target, not the importer. Blessing still requires
+      // the resolved body to VERIFIABLY reject — no new bless path is introduced.
+      const x = resolvePyHookBody(index, importerRel, name);
+      if (
+        x &&
+        x.body &&
+        !nameSegments(x.originalName).some((s) => DEPENDS_VETO_SEGMENTS.has(s)) &&
+        bodyAuthSignature(x.body, x.defs) === "reject"
+      ) {
+        return true;
+      }
     }
   }
   return false;
@@ -1291,14 +1316,24 @@ function callsWithAuthDependency(scope: SyntaxNode, defs: Map<string, SyntaxNode
  *  node covers plain defaults (default_parameter), typed defaults
  *  (typed_default_parameter), and Annotated[T, Depends(...)] (typed_parameter,
  *  where the call nests under the TYPE field's generic_type). */
-function paramsHaveAuthDependency(definition: SyntaxNode, defs: Map<string, SyntaxNode | null>): boolean {
+function paramsHaveAuthDependency(
+  definition: SyntaxNode,
+  defs: Map<string, SyntaxNode | null>,
+  importerRel?: string,
+  index?: CrossFileIndex,
+): boolean {
   const params = definition.childForFieldName("parameters");
-  return params ? callsWithAuthDependency(params, defs) : false;
+  return params ? callsWithAuthDependency(params, defs, importerRel, index) : false;
 }
 
 /** Route-decorator-level dependencies kwarg:
  *  @router.post("/x", dependencies=[Depends(verify_token)]). */
-function routeCallHasAuthDependency(call: SyntaxNode, defs: Map<string, SyntaxNode | null>): boolean {
+function routeCallHasAuthDependency(
+  call: SyntaxNode,
+  defs: Map<string, SyntaxNode | null>,
+  importerRel?: string,
+  index?: CrossFileIndex,
+): boolean {
   const args = call.childForFieldName("arguments");
   if (!args) return false;
   const kw = args.namedChildren.find(
@@ -1308,7 +1343,7 @@ function routeCallHasAuthDependency(call: SyntaxNode, defs: Map<string, SyntaxNo
       n.childForFieldName("name")?.text === "dependencies",
   );
   const value = kw?.childForFieldName("value");
-  return value ? callsWithAuthDependency(value, defs) : false;
+  return value ? callsWithAuthDependency(value, defs, importerRel, index) : false;
 }
 
 /** Middleware scopes for one python file. Python file-level middleware attaches
@@ -1333,7 +1368,12 @@ interface PyMiddlewareScopes {
 
 const APP_SCOPED_RECEIVER = /^(?:app|application)$/;
 
-function collectPyMiddleware(tree: Tree, defs: Map<string, SyntaxNode | null>): PyMiddlewareScopes {
+function collectPyMiddleware(
+  tree: Tree,
+  defs: Map<string, SyntaxNode | null>,
+  importerRel?: string,
+  index?: CrossFileIndex,
+): PyMiddlewareScopes {
   const scopes: PyMiddlewareScopes = {
     global: { hasAuth: false, hasValidation: false, hasRateLimit: false },
     byReceiver: new Map(),
@@ -1367,8 +1407,12 @@ function collectPyMiddleware(tree: Tree, defs: Map<string, SyntaxNode | null>): 
     hookName: string,
     body: SyntaxNode | null,
     nameIsSimpleIdentifier: boolean,
+    // The defs the body's own one-hop helper calls resolve against. Defaults to
+    // THIS file's defs (the in-file path); a cross-file body MUST pass the TARGET
+    // file's defs so its helpers resolve in the target, not the importer.
+    defsForBody: Map<string, SyntaxNode | null> = defs,
   ) => {
-    const outcome = classifyHookAuth(hookName, body, defs, nameIsSimpleIdentifier);
+    const outcome = classifyHookAuth(hookName, body, defsForBody, nameIsSimpleIdentifier);
     if (outcome === "auth") mark(receiver, appWide, "hasAuth");
     else if (outcome === "unsure") markUnsure(receiver, appWide, hookName);
     // Validation / rate-limit lanes stay NAME-based and independent of the body:
@@ -1429,9 +1473,29 @@ function collectPyMiddleware(tree: Tree, defs: Map<string, SyntaxNode | null>): 
       if (!arg0) continue; // decorator-form empty call, or before_request() with no target
       const appWide = fn.childForFieldName("attribute")?.text === "before_app_request";
       if (arg0.type === "identifier") {
-        // Same-file def -> classify its body; imported (not in defs) -> name-tier.
-        const def = defs.get(arg0.text) ?? null;
-        applyHookOutcome(receiver, appWide, arg0.text, def ? def.childForFieldName("body") : null, true);
+        if (defs.has(arg0.text)) {
+          // In-file def (or an in-file duplicate mapping to null) takes precedence:
+          // classify its LOCAL body. A same-named cross-file def NEVER overrides a
+          // local one, and this branch is byte-identical to today's behavior.
+          const def = defs.get(arg0.text) ?? null;
+          applyHookOutcome(receiver, appWide, arg0.text, def ? def.childForFieldName("body") : null, true);
+        } else if (index && importerRel) {
+          // Imported hook: resolve its in-repo body cross-file, then classify via
+          // the SAME body-first classifier — no new bless path. The optional-auth
+          // veto is re-run on the RESOLVED ORIGINAL name (not the call-site alias),
+          // so an aliased optional hook (check -> get_current_user_optional) can
+          // never rule-2 bless: on a veto we supply a null body (name-tier only).
+          // The TARGET file's defs (x.defs) back the body so its one-hop helpers
+          // resolve in the target file, not the importer.
+          const x = resolvePyHookBody(index, importerRel, arg0.text);
+          const vetoed =
+            x !== null && nameSegments(x.originalName).some((s) => OPTIONAL_AUTH_VETO.has(s));
+          const body = vetoed ? null : (x?.body ?? null);
+          applyHookOutcome(receiver, appWide, arg0.text, body, true, vetoed ? undefined : x?.defs);
+        } else {
+          // Imported, no index: name-tier only (today's byte-identical behavior).
+          applyHookOutcome(receiver, appWide, arg0.text, null, true);
+        }
       } else if (arg0.type === "attribute") {
         applyHookOutcome(receiver, appWide, arg0.text, null, false); // Cls.method: hedge only
       } else if (arg0.type === "lambda") {
@@ -1479,7 +1543,7 @@ function collectPyMiddleware(tree: Tree, defs: Map<string, SyntaxNode | null>): 
     if (!fn || fn.type !== "identifier") continue;
     if (fn.text !== "APIRouter" && fn.text !== "FastAPI") continue;
     const value = kwargValue(right, "dependencies");
-    if (value && callsWithAuthDependency(value, defs)) mark(left.text, false, "hasAuth");
+    if (value && callsWithAuthDependency(value, defs, importerRel, index)) mark(left.text, false, "hasAuth");
   }
   return scopes;
 }
@@ -1498,12 +1562,19 @@ export function extractPythonFileMiddlewareAst(tree: Tree): FileMiddleware {
   };
 }
 
-export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
+export function extractPythonRoutesAst(
+  tree: Tree,
+  filePath: string,
+  index?: CrossFileIndex,
+): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const routerNames = collectRouterNames(tree.rootNode);
   const methodsVars = collectMethodsVars(tree.rootNode);
   const defs = collectFunctionDefs(tree.rootNode);
-  const scopes = collectPyMiddleware(tree, defs);
+  // filePath IS the importer's relativePath. With `index` absent (the 2-arg
+  // call), every cross-file branch below is skipped, so the whole path is
+  // byte-identical to today's in-file-only behavior.
+  const scopes = collectPyMiddleware(tree, defs, filePath, index);
   for (const dd of tree.rootNode.descendantsOfType("decorated_definition")) {
     // Error recovery can merge adjacent handlers' decorators into one dd;
     // blessing (or even extracting) across that boundary is forbidden.
@@ -1532,7 +1603,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
     const permissionClassRows = decorators
       .filter(isAuthPermissionClasses)
       .map((d) => d.startPosition.row);
-    const paramAuth = paramsHaveAuthDependency(definition, defs);
+    const paramAuth = paramsHaveAuthDependency(definition, defs, filePath, index);
     // Validation / rate-limit lanes match NON-ROUTE decorator CALLEE NAMES only
     // (@limiter.limit -> "limiter.limit", @validate_schema -> "validate_schema"),
     // never argument or path text: @app.post("/validate") is a path, not
@@ -1562,7 +1633,7 @@ export function extractPythonRoutesAst(tree: Tree, filePath: string): RouteInfo[
         (fromApiView &&
           permissionClassRows.some((row) => row > dec.startPosition.row)) ||
         paramAuth ||
-        routeCallHasAuthDependency(route.call, defs) ||
+        routeCallHasAuthDependency(route.call, defs, filePath, index) ||
         scopes.global.hasAuth ||
         (scopes.byReceiver.get(route.receiver)?.hasAuth ?? false);
       // A route is hedged "unsure" ONLY when it is not otherwise authed AND an

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -37,6 +37,8 @@ import { pickIntentHint } from "./utils.js";
 import { extractJsRoutesAst, extractFileMiddlewareAst, SECURITY_AST } from "./security-ast.js";
 import { extractPythonRoutesAst, extractPythonFileMiddlewareAst } from "./security-ast-python.js";
 import { extractGoRoutesAst, extractGoFileMiddlewareAst } from "./security-ast-go.js";
+import { buildXFileIndex } from "./security-xfile-index.js";
+import type { CrossFileIndex } from "./security-xfile-index.js";
 import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
 
 // Canonical mutating set (upper-cased), shared with the in-loop classifier via
@@ -245,13 +247,17 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
 
 // ─── Route extraction (per-route middleware via proximity) ──────────
 
-function extractRoutes(files: DriftFile[], fileMw: Map<string, FileMiddleware>): RouteInfo[] {
+function extractRoutes(
+  files: DriftFile[],
+  fileMw: Map<string, FileMiddleware>,
+  xfile: CrossFileIndex,
+): RouteInfo[] {
   const routes: RouteInfo[] = [];
   for (const file of files) {
     if (!file.language) continue;
     if (file.language === "go") extractGoRoutes(file, routes, fileMw);
     else if (file.language === "javascript" || file.language === "typescript") extractJsRoutes(file, routes, fileMw);
-    else if (file.language === "python") extractPythonRoutes(file, routes, fileMw);
+    else if (file.language === "python") extractPythonRoutes(file, routes, fileMw, xfile);
   }
   return routes;
 }
@@ -396,7 +402,12 @@ function balancedDecoratorArgs(lines: string[], start: number): string {
   return out;
 }
 
-function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
+function extractPythonRoutes(
+  file: DriftFile,
+  routes: RouteInfo[],
+  fileMw: Map<string, FileMiddleware>,
+  xfile: CrossFileIndex,
+) {
   // AST only on a CLEAN parse: tree-sitter always returns a tree for broken
   // Python (with ERROR nodes), and error recovery can erase the whole file's
   // decorator structure or merge adjacent handlers' decorators into one
@@ -408,7 +419,7 @@ function extractPythonRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<s
     // inheritance from the tree itself (a file-level OR would false-bless
     // mixed-receiver files, and the index entry may carry cross-language noise
     // for non-python files).
-    routes.push(...extractPythonRoutesAst(file.tree, file.relativePath));
+    routes.push(...extractPythonRoutesAst(file.tree, file.relativePath, xfile));
     return;
   }
   extractPythonRoutesRegex(file, routes, fileMw.get(file.relativePath));
@@ -533,6 +544,13 @@ export const securityConsistency: DriftDetector = {
   detect(ctx: DriftContext): DriftFinding[] {
     const findings: DriftFinding[] = [];
     const fileMw = buildFileMiddlewareIndex(ctx.files);
+    // Repo-wide cross-file symbol index: lets the Python AST route extractor
+    // resolve an imported before_request hook / FastAPI dependency to its in-repo
+    // defining body, but ONLY when resolution is exact and unambiguous (every
+    // ambiguity refuses). Blessing still flows through the existing body-first
+    // classifier — a resolved body must verifiably reject. An imported symbol that
+    // does not resolve stays UNSURE, byte-identical to today.
+    const xfile = buildXFileIndex(ctx.files);
     // Denominator-removing suppression: a route carrying an inline
     // `// @vibedrift-public` annotation, OR whose file matches a config
     // `security.allowlist` glob (ctx.projectConfig), is dropped BEFORE it
@@ -544,7 +562,7 @@ export const securityConsistency: DriftDetector = {
     // loading one (e.g. the MCP/baseline path), in which case the allowlist
     // arm simply no-ops and only annotations suppress.
     const { kept: routes, suppressed } = applyRouteSuppressions(
-      extractRoutes(ctx.files, fileMw),
+      extractRoutes(ctx.files, fileMw, xfile),
       ctx.files,
       ctx.projectConfig ?? null,
     );

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -255,7 +255,7 @@ function extractRoutes(
   const routes: RouteInfo[] = [];
   for (const file of files) {
     if (!file.language) continue;
-    if (file.language === "go") extractGoRoutes(file, routes, fileMw);
+    if (file.language === "go") extractGoRoutes(file, routes, fileMw, xfile);
     else if (file.language === "javascript" || file.language === "typescript") extractJsRoutes(file, routes, fileMw);
     else if (file.language === "python") extractPythonRoutes(file, routes, fileMw, xfile);
   }
@@ -272,7 +272,7 @@ function inheritedRateLimit(perRoute: boolean, fileMw: FileMiddleware | undefine
   return perRoute || (fileMw?.hasRateLimit ?? false);
 }
 
-function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
+function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>, xfile: CrossFileIndex) {
   // AST only on a CLEAN parse: tree-sitter always returns a tree for broken Go
   // (with ERROR nodes), and error recovery SWALLOWS later valid registrations
   // into a broken call's argument_list as clean-looking nested calls (a
@@ -283,8 +283,11 @@ function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<strin
     // No FileMiddleware argument: the AST path computes receiver-scoped
     // inheritance from the tree itself (a file-level OR would false-bless
     // mixed-receiver files, and the index entry may carry cross-language noise
-    // for non-go files).
-    routes.push(...extractGoRoutesAst(file.tree, file.relativePath));
+    // for non-go files). The cross-file index lets an imported package
+    // middleware selector resolve to its in-repo defining body (blessing still
+    // requires that body to verifiably reject); an unresolved / external / index-
+    // disabled selector stays UNSURE, byte-identical to the in-file-only path.
+    routes.push(...extractGoRoutesAst(file.tree, file.relativePath, xfile));
     return;
   }
   extractGoRoutesRegex(file, routes, fileMw.get(file.relativePath));
@@ -550,7 +553,7 @@ export const securityConsistency: DriftDetector = {
     // ambiguity refuses). Blessing still flows through the existing body-first
     // classifier — a resolved body must verifiably reject. An imported symbol that
     // does not resolve stays UNSURE, byte-identical to today.
-    const xfile = buildXFileIndex(ctx.files);
+    const xfile = buildXFileIndex(ctx.files, ctx.goModulePath);
     // Denominator-removing suppression: a route carrying an inline
     // `// @vibedrift-public` annotation, OR whose file matches a config
     // `security.allowlist` glob (ctx.projectConfig), is dropped BEFORE it

--- a/src/drift/security-xfile-index.ts
+++ b/src/drift/security-xfile-index.ts
@@ -1,0 +1,417 @@
+/**
+ * Repo-wide cross-file symbol index for the security auth detectors.
+ *
+ * The shipped Python/Go auth extractors read a middleware/hook body IN-FILE
+ * only, so a hook whose implementation is imported from another module resolves
+ * to UNSURE (never a bless). This index is the spine that lets a LATER task
+ * resolve an imported hook symbol to its in-repo defining file's body — but
+ * ONLY when the resolution is exact and unambiguous.
+ *
+ * GOVERNING INVARIANT — NEVER-FALSE-BLESS. A WRONG cross-file attribution (a
+ * route blessed from the wrong body) is the worst outcome. Every ambiguity in
+ * this module resolves to `null` (refuse), never a guess:
+ *   - resolution is PATH-ANCHORED (a relative import is resolved lexically to a
+ *     single candidate file), never NAME-SEARCHED across the repo — a sibling
+ *     file that happens to define the same symbol is NEVER consulted;
+ *   - two candidate files (`mod.py` AND `mod/__init__.py`) => refuse;
+ *   - a symbol defined twice in the target => refuse (collectFunctionDefs
+ *     poisons it to null);
+ *   - an absolute import, a beyond-root relative import, a wildcard import
+ *     anywhere in the importer, a name bound by more than one import, a name
+ *     shadowed by a same-file def/class/assignment, a target with a parse
+ *     error, and a re-export chain deeper than one hop => all refuse.
+ *
+ * DETERMINISM. The build is order-independent: it sorts by relativePath and
+ * keys everything by path, so the same repo yields the same index regardless of
+ * the caller's file ordering. It never re-parses — it reuses each DriftFile's
+ * pre-parsed tree — so a symbol maps to the SAME node reference across builds.
+ *
+ * SCOPE (Task 1). This task ships the Python half + the index skeleton. The Go
+ * half of the index is stubbed (empty maps, module path stored) and
+ * `resolveGoMiddlewareBody` returns null; both are populated in a later task.
+ * Nothing here is wired into the classifiers yet — with the index absent, the
+ * extractors behave exactly as today (byte-identical).
+ */
+
+import type { SyntaxNode } from "../core/types.js";
+import type { DriftFile } from "./types.js";
+import { collectFunctionDefs } from "./security-ast-python.js";
+
+/** Per-language cross-file lookup tables. */
+export interface CrossFileIndex {
+  py: {
+    /** Every python file's relativePath — BROKEN (parse-error) files included,
+     *  so candidate-file existence checks see the whole repo surface. */
+    files: Set<string>;
+    /** `collectFunctionDefs` per NON-broken python file, keyed by relativePath.
+     *  A broken file has no entry (the `fileDefs.has` gate then refuses it). */
+    fileDefs: Map<string, Map<string, SyntaxNode | null>>;
+    /** Root node per NON-broken python file, keyed by relativePath. Used to
+     *  reconstruct import tables (the importer's, and a re-export __init__'s).
+     *  Same keyset as `fileDefs`. */
+    roots: Map<string, SyntaxNode>;
+  };
+  go: {
+    /** Root go.mod module path; undefined disables Go cross-file wholesale. */
+    modulePath?: string;
+    /** Stub in Task 1 — populated with per-package data in a later task. */
+    files: Set<string>;
+    /** Stub in Task 1 — per-package function_declaration maps (NOT
+     *  method_declaration) come in a later task. */
+    packageFuncs: Map<string, Map<string, SyntaxNode | null>>;
+  };
+}
+
+/** A resolved cross-file hook: the DEFINING file's body node, that file's
+ *  full def map (for same-file helper hops inside `bodyAuthSignature`), and the
+ *  true (pre-alias, post-re-export) symbol name. */
+export interface PyResolvedHook {
+  body: SyntaxNode | null;
+  defs: Map<string, SyntaxNode | null>;
+  originalName: string;
+}
+
+/**
+ * Build the repo-wide index ONCE over all DriftFiles. Order-independent:
+ * sorts by relativePath and keys by path. `goModulePath` is stored on the Go
+ * half (undefined disables Go cross-file); the Go maps are stubbed empty in
+ * Task 1.
+ */
+export function buildXFileIndex(files: DriftFile[], goModulePath?: string): CrossFileIndex {
+  const index: CrossFileIndex = {
+    py: { files: new Set(), fileDefs: new Map(), roots: new Map() },
+    go: { modulePath: goModulePath, files: new Set(), packageFuncs: new Map() },
+  };
+
+  // Deterministic iteration: a stable code-unit sort of relativePath so the
+  // built maps (and their iteration order) are identical for any input order.
+  const sorted = [...files].sort((a, b) =>
+    a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+  );
+
+  for (const f of sorted) {
+    if (f.language !== "python" || !f.tree) continue;
+    const rel = f.relativePath;
+    // Conservative duplicate-path handling: a relativePath seen twice is a repo
+    // anomaly — poison it (drop its defs/root so it can never be a resolution
+    // target), but keep it in `files`. Refuse beats last-wins.
+    if (index.py.files.has(rel) && (index.py.fileDefs.has(rel) || index.py.roots.has(rel))) {
+      index.py.fileDefs.delete(rel);
+      index.py.roots.delete(rel);
+      continue;
+    }
+    index.py.files.add(rel);
+    const root = f.tree.rootNode;
+    if (!root.hasError) {
+      index.py.roots.set(rel, root);
+      index.py.fileDefs.set(rel, collectFunctionDefs(root));
+    }
+  }
+
+  return index;
+}
+
+// ─── Python resolution ───────────────────────────────────────────────────────
+
+/** A single relative-import binding: the dot count, the module subpath after
+ *  the dots, and the imported symbol's ORIGINAL (pre-alias) name. */
+interface RelativeBinding {
+  dots: number;
+  subpathSegments: string[];
+  originalName: string;
+}
+
+/** The reconstructed import surface of one python file. */
+interface PyImportTable {
+  /** Any `wildcard_import` anywhere in the file blanket-refuses resolution. */
+  wildcard: boolean;
+  /** How many imports (of ANY kind) bind each local name — >1 poisons it. */
+  bindCount: Map<string, number>;
+  /** Local name -> its relative-import target (only for relative from-imports
+   *  with a real module subpath). */
+  relativeTarget: Map<string, RelativeBinding>;
+  /** Local names also bound by a same-file def/class/module-scope assignment;
+   *  such a name is shadowed, so the import must not be resolved for it. */
+  moduleScopeShadows: Set<string>;
+}
+
+/**
+ * Resolve an imported hook symbol to the body of its in-repo defining file.
+ * Returns null for every refuse path (see the module invariant). `importerRel`
+ * must be a NON-broken python file known to the index.
+ */
+export function resolvePyHookBody(
+  index: CrossFileIndex,
+  importerRel: string,
+  localName: string,
+): PyResolvedHook | null {
+  const importerRoot = index.py.roots.get(importerRel);
+  if (!importerRoot) return null; // importer absent or broken tree
+
+  const table = buildPyImportTable(importerRoot);
+  if (table.wildcard) return null; // blanket refuse: a wildcard could bind localName
+
+  const resolved = resolveBinding(index, importerRel, table, localName);
+  if (!resolved) return null;
+
+  return lookupOrReexport(index, resolved.targetRel, resolved.originalName);
+}
+
+/** Resolve a local name through the importer's import table to a single
+ *  candidate target file, or null (poisoned / shadowed / absolute / no-target /
+ *  beyond-root / ambiguous / not-found). */
+function resolveBinding(
+  index: CrossFileIndex,
+  importerRel: string,
+  table: PyImportTable,
+  localName: string,
+): { targetRel: string; originalName: string } | null {
+  if (table.moduleScopeShadows.has(localName)) return null; // local shadow wins at runtime
+  if (table.bindCount.get(localName) !== 1) return null; // unbound (0) or poisoned (>1)
+  const binding = table.relativeTarget.get(localName);
+  if (!binding) return null; // bound, but by a non-relative import (absolute / plain)
+  const targetRel = resolveRelativePath(
+    importerRel,
+    binding.dots,
+    binding.subpathSegments,
+    index.py.files,
+  );
+  if (!targetRel) return null;
+  return { targetRel, originalName: binding.originalName };
+}
+
+/** Look up `originalName` in the target file's defs; on a miss, try ONE relative
+ *  re-export hop from that file's own imports. Every branch refuses on ambiguity. */
+function lookupOrReexport(
+  index: CrossFileIndex,
+  targetRel: string,
+  originalName: string,
+): PyResolvedHook | null {
+  const defs = index.py.fileDefs.get(targetRel);
+  if (!defs) return null; // target has no defs entry => parse error => refuse
+  const def = defs.get(originalName);
+  if (def === null) return null; // duplicate def in target => refuse
+  if (def !== undefined) {
+    if (!isTopLevelDef(def, index.py.roots.get(targetRel)!)) return null; // nested/method: not importable
+    return { body: def.childForFieldName("body"), defs, originalName };
+  }
+  return reexportHop(index, targetRel, originalName);
+}
+
+/** ONE relative re-export hop: reconstruct the target file's import table,
+ *  resolve `originalName`'s OWN relative import to a second file, and look the
+ *  re-export's pre-alias original name up there. Never hops again (cap 1), so a
+ *  chain deeper than one hop refuses. */
+function reexportHop(
+  index: CrossFileIndex,
+  targetRel: string,
+  originalName: string,
+): PyResolvedHook | null {
+  const targetRoot = index.py.roots.get(targetRel);
+  if (!targetRoot) return null;
+  const table = buildPyImportTable(targetRoot);
+  if (table.wildcard) return null;
+  const resolved = resolveBinding(index, targetRel, table, originalName);
+  if (!resolved) return null;
+
+  const defs = index.py.fileDefs.get(resolved.targetRel);
+  if (!defs) return null; // second target parse error => refuse
+  const def = defs.get(resolved.originalName);
+  // undefined here == the re-export points at yet ANOTHER re-export: depth
+  // exceeded (cap 1) => refuse. null == duplicate def => refuse.
+  if (def === null || def === undefined) return null;
+  if (!isTopLevelDef(def, index.py.roots.get(resolved.targetRel)!)) return null;
+  return { body: def.childForFieldName("body"), defs, originalName: resolved.originalName };
+}
+
+/**
+ * Lexically resolve a relative import to a single in-repo file, or null.
+ * `dots` counts the leading dots (1 = current package, N = up N-1 levels);
+ * `subpathSegments` is the module path after the dots. Refuses when the dots
+ * reach beyond the repo root, when both `<path>.py` and `<path>/__init__.py`
+ * exist (ambiguous), or when neither exists.
+ */
+function resolveRelativePath(
+  importerRel: string,
+  dots: number,
+  subpathSegments: string[],
+  files: Set<string>,
+): string | null {
+  if (subpathSegments.length === 0) return null; // bare `from . import X`: submodule, not a module symbol
+  const dirSegments = dirnameSegments(importerRel);
+  const upLevels = dots - 1;
+  if (upLevels > dirSegments.length) return null; // beyond repo root
+  const base = dirSegments.slice(0, dirSegments.length - upLevels);
+  const moduleSegments = [...base, ...subpathSegments];
+  const modulePath = moduleSegments.join("/");
+  const asModule = `${modulePath}.py`;
+  const asPackage = `${modulePath}/__init__.py`;
+  const hasModule = files.has(asModule);
+  const hasPackage = files.has(asPackage);
+  if (hasModule && hasPackage) return null; // ambiguous: two candidate files
+  if (hasModule) return asModule;
+  if (hasPackage) return asPackage;
+  return null; // not found
+}
+
+/** Path segments of the directory containing `rel` (empty for a root file). */
+function dirnameSegments(rel: string): string[] {
+  const parts = rel.split("/");
+  parts.pop(); // drop the filename
+  return parts.filter((p) => p.length > 0);
+}
+
+/**
+ * Reconstruct a python file's import surface from its TOP-LEVEL import
+ * statements. Absolute from-imports and plain `import` statements RECORD the
+ * name they bind (so they can poison a co-imported relative name) but never
+ * become resolvable targets. A wildcard anywhere in the file sets `wildcard`.
+ */
+function buildPyImportTable(root: SyntaxNode): PyImportTable {
+  const wildcard = root
+    .descendantsOfType("wildcard_import")
+    .some((n): n is SyntaxNode => n !== null);
+  const bindCount = new Map<string, number>();
+  const relativeTarget = new Map<string, RelativeBinding>();
+  const bump = (name: string) => bindCount.set(name, (bindCount.get(name) ?? 0) + 1);
+
+  for (const stmt of root.namedChildren) {
+    if (!stmt) continue;
+    if (stmt.type === "import_from_statement") {
+      const moduleName = stmt.childForFieldName("module_name");
+      const relative =
+        moduleName?.type === "relative_import" ? relativeDotsAndSubpath(moduleName) : null;
+      for (const nameNode of stmt.childrenForFieldName("name")) {
+        if (!nameNode) continue;
+        const bound = fromImportName(nameNode);
+        if (!bound) continue;
+        bump(bound.localName);
+        // A relative from-import with a real module subpath is the only
+        // resolvable form; absolute (dotted_name module) records the bind only.
+        if (relative && relative.subpath.length > 0) {
+          relativeTarget.set(bound.localName, {
+            dots: relative.dots,
+            subpathSegments: relative.subpath,
+            originalName: bound.originalName,
+          });
+        }
+      }
+    } else if (stmt.type === "import_statement") {
+      for (const nameNode of stmt.childrenForFieldName("name")) {
+        if (!nameNode) continue;
+        const local = plainImportName(nameNode);
+        if (local) bump(local); // plain imports are absolute: bind only, never a target
+      }
+    }
+  }
+
+  return { wildcard, bindCount, relativeTarget, moduleScopeShadows: moduleScopeShadows(root) };
+}
+
+/** Dots and module subpath of a `relative_import` module_name node. */
+function relativeDotsAndSubpath(moduleName: SyntaxNode): { dots: number; subpath: string[] } {
+  let dots = 0;
+  const subpath: string[] = [];
+  for (const child of moduleName.namedChildren) {
+    if (!child) continue;
+    if (child.type === "import_prefix") {
+      dots = child.text.length; // "." | ".." | "..."
+    } else if (child.type === "dotted_name") {
+      for (const id of child.namedChildren) {
+        if (id && id.type === "identifier") subpath.push(id.text);
+      }
+    }
+  }
+  return { dots, subpath };
+}
+
+/** Local + original name bound by one `name`-field entry of a from-import. */
+function fromImportName(nameNode: SyntaxNode): { localName: string; originalName: string } | null {
+  if (nameNode.type === "aliased_import") {
+    const originalName = nameNode.childForFieldName("name")?.text ?? "";
+    const localName = nameNode.childForFieldName("alias")?.text ?? "";
+    return localName && originalName ? { localName, originalName } : null;
+  }
+  if (nameNode.type === "dotted_name") {
+    return { localName: nameNode.text, originalName: nameNode.text };
+  }
+  return null;
+}
+
+/** Local name bound by one `name`-field entry of a plain `import` statement
+ *  (`import a.b` binds `a`; `import a.b as c` binds `c`). */
+function plainImportName(nameNode: SyntaxNode): string | null {
+  if (nameNode.type === "aliased_import") {
+    return nameNode.childForFieldName("alias")?.text ?? null;
+  }
+  if (nameNode.type === "dotted_name") {
+    return nameNode.namedChild(0)?.text ?? null; // top-level package binding
+  }
+  return null;
+}
+
+/** Names bound at module scope by a def/class/assignment — an import for such a
+ *  name is shadowed at runtime and must not be resolved cross-file. */
+function moduleScopeShadows(root: SyntaxNode): Set<string> {
+  const shadows = new Set<string>();
+  const addDefName = (node: SyntaxNode | null) => {
+    const n = node?.childForFieldName("name")?.text;
+    if (n) shadows.add(n);
+  };
+  for (const stmt of root.namedChildren) {
+    if (!stmt) continue;
+    if (stmt.type === "function_definition" || stmt.type === "class_definition") {
+      addDefName(stmt);
+    } else if (stmt.type === "decorated_definition") {
+      addDefName(stmt.childForFieldName("definition"));
+    } else if (stmt.type === "expression_statement") {
+      for (const asn of stmt.namedChildren) {
+        if (asn && asn.type === "assignment") {
+          const left = asn.childForFieldName("left");
+          if (left) for (const id of identifiersOf(left)) shadows.add(id);
+        }
+      }
+    }
+  }
+  return shadows;
+}
+
+/** Identifier texts of an assignment LHS (a bare name, or every name in a
+ *  tuple/list unpack target). */
+function identifiersOf(node: SyntaxNode): string[] {
+  if (node.type === "identifier") return [node.text];
+  return node
+    .descendantsOfType("identifier")
+    .filter((n): n is SyntaxNode => n !== null)
+    .map((n) => n.text);
+}
+
+/** True when a def is a module-level (importable) binding — its ancestor chain
+ *  up to the module root passes through no function/class/lambda body. A class
+ *  method or a nested function is NOT importable by a bare name, so resolving to
+ *  it would be a wrong-body false-bless. */
+function isTopLevelDef(def: SyntaxNode, root: SyntaxNode): boolean {
+  let p = def.parent;
+  while (p !== null && p.id !== root.id) {
+    if (
+      p.type === "function_definition" ||
+      p.type === "class_definition" ||
+      p.type === "lambda"
+    ) {
+      return false;
+    }
+    p = p.parent;
+  }
+  return true;
+}
+
+// ─── Go resolution (stub — populated in a later task) ────────────────────────
+
+/**
+ * Stub for Go cross-file middleware body resolution. Task 1 ships only the
+ * index skeleton (module path stored, maps empty); Go resolution arrives in a
+ * later task. Returns null so the Go extractor's behavior is unchanged today.
+ */
+export function resolveGoMiddlewareBody(): null {
+  return null;
+}

--- a/src/drift/security-xfile-index.ts
+++ b/src/drift/security-xfile-index.ts
@@ -26,16 +26,21 @@
  * the caller's file ordering. It never re-parses — it reuses each DriftFile's
  * pre-parsed tree — so a symbol maps to the SAME node reference across builds.
  *
- * SCOPE (Task 1). This task ships the Python half + the index skeleton. The Go
- * half of the index is stubbed (empty maps, module path stored) and
- * `resolveGoMiddlewareBody` returns null; both are populated in a later task.
- * Nothing here is wired into the classifiers yet — with the index absent, the
- * extractors behave exactly as today (byte-identical).
+ * SCOPE. This module ships both language halves of the index. The Python half
+ * (Task 1) resolves a relative import to its defining file's body. The Go half
+ * (Task 3) resolves a `pkg.Symbol` selector to a cross-PACKAGE
+ * `function_declaration` body: a package import path maps to a repo directory via
+ * the root go.mod module path, that directory's exported function_declaration
+ * bodies are collected, and `resolveGoMiddlewareBody` returns the single exact
+ * match (or null on any ambiguity). Nothing here is wired into the classifiers by
+ * THIS module — with the index absent, the extractors behave exactly as today
+ * (byte-identical); the wiring lives at each classifier's call site.
  */
 
 import type { SyntaxNode } from "../core/types.js";
 import type { DriftFile } from "./types.js";
 import { collectFunctionDefs } from "./security-ast-python.js";
+import { collectGoFunctionDefs } from "./security-ast-go.js";
 
 /** Per-language cross-file lookup tables. */
 export interface CrossFileIndex {
@@ -52,14 +57,60 @@ export interface CrossFileIndex {
     roots: Map<string, SyntaxNode>;
   };
   go: {
-    /** Root go.mod module path; undefined disables Go cross-file wholesale. */
+    /** Root go.mod module path; falsy (undefined / null / "") disables Go
+     *  cross-file wholesale — no go.mod, a `replace` directive, or a nested
+     *  go.mod all collapse it upstream, leaving every Go map below empty. */
     modulePath?: string;
-    /** Stub in Task 1 — populated with per-package data in a later task. */
+    /** Every Go file's relativePath (parse-broken files included, for parity
+     *  with `py.files`). Not itself a resolution surface — resolution is
+     *  package-directory based via `packages`. */
     files: Set<string>;
-    /** Stub in Task 1 — per-package function_declaration maps (NOT
-     *  method_declaration) come in a later task. */
-    packageFuncs: Map<string, Map<string, SyntaxNode | null>>;
+    /** pkgDir (a repo directory) -> its package. `defs` is
+     *  `function_declaration`-ONLY (never `method_declaration`), merged across the
+     *  package's NON-test .go files, sticky-null on a name defined twice. Each
+     *  per-symbol entry carries its OWN defining file's both-kinds defs so the
+     *  target body's in-file one-hop resolves against the right file. */
+    packages: Map<string, GoPackage>;
+    /** importer relativePath -> (qualifier -> pkgDir | null). The qualifier is
+     *  the import alias when present, else the target package's DECLARED name
+     *  (only USUALLY the import path's last segment). Two specs yielding one
+     *  qualifier -> null (ambiguous). */
+    fileImports: Map<string, Map<string, string | null>>;
+    /** importer relativePath -> identifiers bound as a VALUE anywhere in the file
+     *  (`:=`, `var`, `const`, params, method RECEIVERS, named RETURNS, func_literal
+     *  params, range targets, type-switch guards). A qualifier in this set is a
+     *  local value, not the package — refuse (the killer Go value-shadow vector). */
+    valueBound: Map<string, Set<string>>;
+    /** importer relativePaths that contain a `. "..."` dot-import; any selector in
+     *  such a file is refused (unqualified injection is ambiguous with in-file
+     *  identifiers). */
+    dotImports: Set<string>;
   };
+}
+
+/** One cross-package `function_declaration` entry: the def node, its defining
+ *  file's relativePath, and that file's OWN both-kinds defs (for the resolved
+ *  body's single in-file hop — never a pkgDir-arbitrary sibling's). */
+export interface GoPackageEntry {
+  def: SyntaxNode;
+  file: string;
+  fileDefs: Map<string, SyntaxNode | null>;
+}
+
+/** One Go package (= one directory). `pkgName` is the DECLARED `package` clause
+ *  name, or null when two non-test files in the dir disagree (a broken package,
+ *  refused wholesale). `defs` is function_declaration-only, sticky-null on a name
+ *  defined twice across the package's non-test files. */
+export interface GoPackage {
+  pkgName: string | null;
+  defs: Map<string, GoPackageEntry | null>;
+}
+
+/** A resolved cross-package middleware: the def node and its OWN defining-file
+ *  both-kinds defs (for the target body's in-file one-hop). */
+export interface GoResolvedMiddleware {
+  def: SyntaxNode;
+  defs: Map<string, SyntaxNode | null>;
 }
 
 /** A resolved cross-file hook: the DEFINING file's body node, that file's
@@ -77,10 +128,19 @@ export interface PyResolvedHook {
  * half (undefined disables Go cross-file); the Go maps are stubbed empty in
  * Task 1.
  */
-export function buildXFileIndex(files: DriftFile[], goModulePath?: string): CrossFileIndex {
+export function buildXFileIndex(files: DriftFile[], goModulePath?: string | null): CrossFileIndex {
   const index: CrossFileIndex = {
     py: { files: new Set(), fileDefs: new Map(), roots: new Map() },
-    go: { modulePath: goModulePath, files: new Set(), packageFuncs: new Map() },
+    go: {
+      // Normalize every falsy module path (null / "" / undefined) to undefined:
+      // the single "Go disabled" signal `resolveGoMiddlewareBody` gates on.
+      modulePath: goModulePath || undefined,
+      files: new Set(),
+      packages: new Map(),
+      fileImports: new Map(),
+      valueBound: new Map(),
+      dotImports: new Set(),
+    },
   };
 
   // Deterministic iteration: a stable code-unit sort of relativePath so the
@@ -108,7 +168,196 @@ export function buildXFileIndex(files: DriftFile[], goModulePath?: string): Cros
     }
   }
 
+  buildGoHalf(index, sorted, index.go.modulePath);
   return index;
+}
+
+// ─── Go index construction ───────────────────────────────────────────────────
+
+/** Fill the Go half of the index. `go.files` holds every Go file's relativePath
+ *  (parse-broken included). The resolution maps (packages / fileImports /
+ *  valueBound / dotImports) are built ONLY when a single-root module path is
+ *  supplied; otherwise Go cross-file stays disabled (all maps empty). */
+function buildGoHalf(index: CrossFileIndex, sorted: DriftFile[], goModulePath: string | undefined): void {
+  for (const f of sorted) {
+    if (f.language === "go") index.go.files.add(f.relativePath);
+  }
+  if (!goModulePath) return; // no go.mod / replace / nested module => Go disabled
+
+  // Non-test, clean-tree Go files only: a `*_test.go` co-locates a `package
+  // foo_test` clause (nulls pkgName) and in-test helpers (duplicate-null real
+  // defs), and a broken tree can never contribute a bless.
+  const goFiles = sorted.filter(
+    (f) => f.language === "go" && f.tree && !f.tree.rootNode.hasError && !isGoTestFile(f.relativePath),
+  );
+
+  // Build every package (= one directory) FIRST, so a plain import can key its
+  // qualifier by the target dir's declared package name.
+  const byDir = new Map<string, DriftFile[]>();
+  for (const f of goFiles) {
+    const dir = goDir(f.relativePath);
+    const bucket = byDir.get(dir);
+    if (bucket) bucket.push(f);
+    else byDir.set(dir, [f]);
+  }
+  for (const [dir, filesInDir] of byDir) {
+    index.go.packages.set(dir, buildGoPackage(filesInDir));
+  }
+
+  for (const f of goFiles) {
+    const root = f.tree!.rootNode;
+    const { imports, hasDot } = buildGoFileImports(root, goModulePath, index.go.packages);
+    index.go.fileImports.set(f.relativePath, imports);
+    if (hasDot) index.go.dotImports.add(f.relativePath);
+    index.go.valueBound.set(f.relativePath, collectGoValueBound(root));
+  }
+}
+
+/** True for a Go external-test / test file, excluded wholesale from the package
+ *  index (a co-located `package foo_test` clause or an in-test helper must never
+ *  perturb `pkgName` or duplicate-null a real def). */
+function isGoTestFile(rel: string): boolean {
+  return /_test\.go$/.test(rel);
+}
+
+/** Directory of a repo-relative path ("" for a root-level file). */
+function goDir(rel: string): string {
+  const i = rel.lastIndexOf("/");
+  return i < 0 ? "" : rel.slice(0, i);
+}
+
+/** Declared `package` name of a Go file (package_clause has NO name field; the
+ *  declared name is `namedChild(0)`), or null. */
+function goPackageName(root: SyntaxNode): string | null {
+  for (const child of root.namedChildren) {
+    if (child?.type === "package_clause") {
+      const id = child.namedChild(0);
+      return id?.type === "package_identifier" ? id.text : null;
+    }
+  }
+  return null;
+}
+
+/** Build one package from its non-test clean files: the agreed `pkgName` (null on
+ *  disagreement) and a function_declaration-only def map, sticky-null on any name
+ *  defined twice across the package's files. Each surviving entry carries its OWN
+ *  defining file's both-kinds defs. */
+function buildGoPackage(filesInDir: DriftFile[]): GoPackage {
+  let pkgName: string | null | undefined = undefined;
+  for (const f of filesInDir) {
+    const name = goPackageName(f.tree!.rootNode);
+    if (pkgName === undefined) pkgName = name;
+    else if (pkgName !== name) pkgName = null; // two non-test files disagree => refuse the pkg
+  }
+
+  const defs = new Map<string, GoPackageEntry | null>();
+  for (const f of filesInDir) {
+    const root = f.tree!.rootNode;
+    let fileDefs: Map<string, SyntaxNode | null> | null = null;
+    for (const decl of root.descendantsOfType("function_declaration")) {
+      if (!decl || decl.hasError) continue; // a parse-errored def never contributes
+      const name = decl.childForFieldName("name")?.text;
+      if (!name) continue;
+      if (defs.has(name)) {
+        defs.set(name, null); // sticky-null: a second definition (this file or a sibling)
+        continue;
+      }
+      if (fileDefs === null) fileDefs = collectGoFunctionDefs(root); // both kinds, for the in-file hop
+      defs.set(name, { def: decl, file: f.relativePath, fileDefs });
+    }
+  }
+  return { pkgName: pkgName ?? null, defs };
+}
+
+/** The importer's import surface: qualifier -> pkgDir (or null on ambiguity), and
+ *  whether the file carries any dot-import. A plain import keys by the target
+ *  dir's DECLARED package name; an alias is authoritative; a `dot` sets the poison
+ *  flag; a `blank_identifier` (side-effect import) is ignored. Two specs yielding
+ *  one qualifier collapse to null. */
+function buildGoFileImports(
+  root: SyntaxNode,
+  modulePath: string,
+  packages: Map<string, GoPackage>,
+): { imports: Map<string, string | null>; hasDot: boolean } {
+  const imports = new Map<string, string | null>();
+  const seen = new Set<string>();
+  let hasDot = false;
+  const add = (qualifier: string, dir: string | null) => {
+    if (seen.has(qualifier)) {
+      imports.set(qualifier, null); // two specs -> one qualifier -> ambiguous
+      return;
+    }
+    seen.add(qualifier);
+    imports.set(qualifier, dir);
+  };
+
+  for (const spec of root.descendantsOfType("import_spec")) {
+    if (!spec) continue;
+    const importPath = goStringLiteralText(spec.childForFieldName("path"));
+    if (importPath === null) continue;
+    const dir = goImportPathToDir(importPath, modulePath); // null => external
+    const nameNode = spec.childForFieldName("name");
+    if (nameNode) {
+      if (nameNode.type === "dot") {
+        hasDot = true;
+        continue;
+      }
+      if (nameNode.type === "blank_identifier") continue; // side-effect only
+      if (nameNode.type === "package_identifier") {
+        add(nameNode.text, dir); // alias is the authoritative qualifier
+      }
+      continue;
+    }
+    // Plain import: the qualifier is the target dir's DECLARED package name.
+    if (dir === null) continue; // external, unresolvable
+    const pkgName = packages.get(dir)?.pkgName ?? null;
+    if (pkgName === null) continue; // no known/agreeing package => no usable qualifier
+    add(pkgName, dir);
+  }
+  return { imports, hasDot };
+}
+
+/** Strip the delimiters of a Go string literal node (both kinds include them). */
+function goStringLiteralText(node: SyntaxNode | null): string | null {
+  if (!node) return null;
+  if (node.type !== "interpreted_string_literal" && node.type !== "raw_string_literal") return null;
+  return node.text.slice(1, -1);
+}
+
+/** Repo dir for an import path under `modulePath`, or null (external). Correct
+ *  only for a single root module with no path remapping — the plumbing forces
+ *  `modulePath` off on a `replace` or a nested go.mod. */
+function goImportPathToDir(importPath: string, modulePath: string): string | null {
+  if (importPath === modulePath) return "";
+  if (importPath.startsWith(modulePath + "/")) return importPath.slice(modulePath.length + 1);
+  return null;
+}
+
+/** Identifiers bound as a VALUE anywhere in the file. Over-collection is safe (it
+ *  only ADDS refusals): a qualifier that is also a local value must never be
+ *  attributed to a package function. Covers `:=`, `var`, `const`, all params
+ *  (including method receivers and named returns, which are `parameter_declaration`
+ *  nodes in the `receiver`/`result` fields), range targets, and type-switch guards. */
+function collectGoValueBound(root: SyntaxNode): Set<string> {
+  const bound = new Set<string>();
+  const addId = (n: SyntaxNode | null) => {
+    if (n && n.type === "identifier") bound.add(n.text);
+  };
+  const addList = (n: SyntaxNode | null) => {
+    if (!n) return;
+    if (n.type === "expression_list") for (const c of n.namedChildren) addId(c);
+    else addId(n);
+  };
+  for (const d of root.descendantsOfType("short_var_declaration")) if (d) addList(d.childForFieldName("left"));
+  for (const d of root.descendantsOfType("range_clause")) if (d) addList(d.childForFieldName("left"));
+  for (const d of root.descendantsOfType("type_switch_statement")) if (d) addList(d.childForFieldName("alias"));
+  for (const t of ["var_spec", "const_spec", "parameter_declaration"] as const) {
+    for (const d of root.descendantsOfType(t)) {
+      if (!d) continue;
+      for (const nm of d.childrenForFieldName("name")) addId(nm);
+    }
+  }
+  return bound;
 }
 
 // ─── Python resolution ───────────────────────────────────────────────────────
@@ -405,13 +654,54 @@ function isTopLevelDef(def: SyntaxNode, root: SyntaxNode): boolean {
   return true;
 }
 
-// ─── Go resolution (stub — populated in a later task) ────────────────────────
+// ─── Go resolution ───────────────────────────────────────────────────────────
 
 /**
- * Stub for Go cross-file middleware body resolution. Task 1 ships only the
- * index skeleton (module path stored, maps empty); Go resolution arrives in a
- * later task. Returns null so the Go extractor's behavior is unchanged today.
+ * Resolve a Go `qualifier.Symbol` selector to its cross-PACKAGE
+ * `function_declaration` body, or null (refuse). `selectorText` is a PURE
+ * selector's text (the caller guarantees purity via `goMiddlewareName`), so the
+ * structural split is a single-dot split. Every refuse path (see the module
+ * invariant + the Go refuse table) returns null:
+ *   - Go disabled (no/replaced/nested go.mod => falsy modulePath);
+ *   - not a simple `pkg.Symbol` (no dot, or a deeper field chain);
+ *   - the importer carries a dot-import (blanket refuse);
+ *   - the qualifier is bound as a LOCAL VALUE in the importer (the value-shadow
+ *     vector: a receiver/param/`:=`/var/const named like the package);
+ *   - the qualifier is not an import of the importer, or maps to null (ambiguous);
+ *   - the target package is unknown, or its files disagree on `pkgName`;
+ *   - the symbol is unexported (lowercase — a real cross-package ref is Capitalized);
+ *   - the symbol is undefined in the package, or defined twice (sticky-null),
+ *     or is a `method_declaration` (never in the function_declaration-only defs).
+ * On success returns the def plus the def's OWN defining-file both-kinds defs.
  */
-export function resolveGoMiddlewareBody(): null {
-  return null;
+export function resolveGoMiddlewareBody(
+  importerRel: string,
+  selectorText: string,
+  index: CrossFileIndex,
+): GoResolvedMiddleware | null {
+  if (!index.go.modulePath) return null; // Go cross-file disabled wholesale
+
+  // Structural split of a pure `qualifier.symbol`: exactly one dot.
+  const dot = selectorText.indexOf(".");
+  if (dot <= 0) return null; // no qualifier, or a leading dot
+  const qualifier = selectorText.slice(0, dot);
+  const symbol = selectorText.slice(dot + 1);
+  if (symbol.length === 0 || symbol.includes(".")) return null; // deeper chain, not pkg.Symbol
+
+  if (index.go.dotImports.has(importerRel)) return null; // dot-import blanket refuse
+  if (index.go.valueBound.get(importerRel)?.has(qualifier)) return null; // local value shadows the package
+
+  const dir = index.go.fileImports.get(importerRel)?.get(qualifier);
+  if (dir === undefined || dir === null) return null; // not imported here, or ambiguous qualifier
+
+  const pkg = index.go.packages.get(dir);
+  if (!pkg || pkg.pkgName === null) return null; // no package, or files disagree on pkgName
+
+  // EXPORTED-only (conservative v1): a cross-package reference is always Capitalized.
+  const first = symbol[0];
+  if (first < "A" || first > "Z") return null;
+
+  const entry = pkg.defs.get(symbol);
+  if (!entry) return null; // undefined (not defined) or null (duplicate across the package's files)
+  return { def: entry.def, defs: entry.fileDefs };
 }

--- a/src/drift/types.ts
+++ b/src/drift/types.ts
@@ -61,6 +61,16 @@ export interface DriftContext {
    * MCP/baseline path), in which case that arm no-ops.
    */
   projectConfig?: ProjectConfig;
+  /**
+   * Root go.mod module path, threaded for Go cross-file package resolution;
+   * undefined disables it. Set by `buildDriftContext` from
+   * `AnalysisContext.goMod.module`, but forced to undefined when the module
+   * has a `replace` directive or a nested go.mod exists (both break the
+   * root-prefix math), and whenever no go.mod was loaded (the MCP/baseline
+   * synthetic-context path). Consumers must treat undefined as "Go cross-file
+   * resolution off" — a never-false-bless guard.
+   */
+  goModulePath?: string;
 }
 
 export interface DriftFile {

--- a/test/calibration/README.md
+++ b/test/calibration/README.md
@@ -241,6 +241,41 @@ never bless it, so scenario A would fail non-vacuity; body-first reads the
 name-only path would bless it outright (zero findings); body-first resolves
 it UNSURE instead (hedged, still flagged, never a bless).
 
+## Cross-file auth resolution (S10-S11)
+
+Both `security-python.test.ts` and `security-go.test.ts` add two more
+scenarios, appended after S9/S8 respectively, measuring the cross-file
+resolution work: an imported before_request hook (Python) or a
+package-qualified middleware call (Go) whose body lives in a SEPARATE
+in-repo file, rather than in the route file itself. S0-S9 are single-file /
+in-file and reproduce byte-identically; cross-file resolution runs live in
+every scenario in both suites (it is always built by
+`securityConsistency.detect`), but it never changes an in-file verdict,
+since local defs take precedence over any cross-file candidate.
+
+- **S10** the cross-file POSITIVE: 5 route files each import a hook/middleware
+  from one shared, separate in-repo file (`pkg/auth.py` in Python,
+  `internal/middleware/auth.go` in Go), whose body verifiably rejects
+  (a 401 on a missing session/header). Non-vacuity is asserted first
+  (every route resolves `hasAuth: true`, no `authUnsureHook`), then a
+  uniform corpus produces zero findings, then stripping the import + call
+  from one file flags exactly it (dominantCount 4, score 80, precision/recall
+  1.0). Pre-cross-file (index absent), the same files resolve
+  `hasAuth: false` with a hedged `authUnsureHook` — the exact shape S8
+  measures — which is the regression S10 pins.
+- **S11** the cross-file NEGATIVE: the SAME 5 route files and bodies,
+  importing the identical hook/middleware from an out-of-repo source instead
+  (an absolute Python package, or a Go import path outside the module root).
+  Cross-file resolution runs live and still refuses, because an absolute
+  import is never a relative-resolution target (Python) and an out-of-repo
+  import path never maps under the module prefix (Go) — never because the
+  target merely doesn't exist. Every route stays hedged, byte-identical with
+  and without the index. Mixing 4 files from the S10 group with 1 from the
+  S11 group (same paths) reproduces the S8 shape exactly (dominantCount 4,
+  score 80, hedged copy naming the hook, no em-dash/double-hyphen), and a
+  plain S1-shape stripped deviator run in the same test stays flat, not
+  hedged (no leakage between the two failure modes).
+
 ## Adding a new injection type
 
 Drop a generator in `generators/`. Signature:

--- a/test/calibration/go-security-fixture.ts
+++ b/test/calibration/go-security-fixture.ts
@@ -537,6 +537,118 @@ export function publicByDesignControl(): BaselineFile[] {
   return HOOK_PROVIDERS.map(hookFile);
 }
 
+// ─── S10/S11: cross-file auth resolution (imported middleware, in-repo vs
+// external) ───────────────────────────────────────────────────────────────
+//
+// Mirrors python-security-fixture.ts's S10/S11: S10 proves the POSITIVE (a
+// package-qualified middleware.RequireAuth() call resolves cross-PACKAGE to
+// internal/middleware/auth.go's REJECTING body and blesses every importing
+// route); S11 proves the NEGATIVE (the SAME 5 route files, same call,
+// importing from an out-of-repo package path instead: cross-file resolution
+// runs live and still refuses, because the import path never maps under the
+// root module's prefix — see goImportPathToDir's null return in
+// security-xfile-index.ts). Both groups share the SAME 5 relativePaths
+// (handlers/<name>.go) and bodies; only the import path differs.
+const S10_ROOT = "handlers";
+const S10_NAMES = ["campaigns", "surveys", "audits", "reviews", "backups"];
+
+function xfileRouteFile(name: string, importPath: string): BaselineFile {
+  const cap = capitalize(name);
+  return {
+    path: `${S10_ROOT}/${name}.go`,
+    content:
+`package handlers
+
+import (
+	"${importPath}"
+
+	"github.com/gin-gonic/gin"
+)
+
+${ginRequestStruct(name, [["Name", "string", "name"]])}
+
+func Register${cap}(r *gin.Engine) {
+	r.Use(middleware.RequireAuth())
+	r.POST("/${name}", create${cap})
+}
+
+${ginHandler(name)}`,
+  };
+}
+
+/** S10: 5 route files, each `import "myapp/internal/middleware"` — a REAL
+ *  in-repo package resolvable to internal/middleware/auth.go below. */
+export function goCrossFileAuthedGroup(): BaselineFile[] {
+  return S10_NAMES.map((name) => xfileRouteFile(name, "myapp/internal/middleware"));
+}
+
+/** S10 support: the module root (threads goModulePath) and the shared
+ *  cross-PACKAGE middleware. RequireAuth's BODY (401 on a missing
+ *  Authorization header, the exact GIN_AUTH_BLOCK reject signature) is what
+ *  blesses the importing routes — never its name. */
+export const goCrossFileModFile: BaselineFile = {
+  path: "go.mod",
+  content: `module myapp\n\ngo 1.21\n`,
+};
+export const goCrossFileAuthFile: BaselineFile = {
+  path: "internal/middleware/auth.go",
+  content:
+`package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequireAuth is the shared cross-PACKAGE auth gate imported by every
+// handlers/*.go route file (import "myapp/internal/middleware"). Its BODY,
+// not its name, is what blesses the importing routes cross-file.
+func RequireAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("Authorization") == "" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+}
+`,
+};
+
+/** S11: the SAME 5 route files (same paths, same call) importing
+ *  middleware.RequireAuth() from an out-of-repo package path instead — no
+ *  internal/middleware dir needed for THIS group (nothing resolves
+ *  regardless: the import path never maps under the root module prefix). */
+export function goCrossFileExternalGroup(): BaselineFile[] {
+  return S10_NAMES.map((name) => xfileRouteFile(name, "github.com/foo/middleware"));
+}
+
+/** Sorted handlers/*.go paths in `files` — same predicate for either group
+ *  above, since they share paths. */
+export function sortedCrossFileGoRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${S10_ROOT}/`) && p.endsWith(".go"));
+}
+
+/** Deterministically strips the middleware import AND its Use() call from
+ *  the first `count` S10/S11 files, sorted by path, leaving a bare (now
+ *  unauthed, S1-shape) still-mutating route. Matches either group's import
+ *  path, so it works on files pulled from either. */
+export function stripCrossFileGoAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedCrossFileGoRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    let content = f.content
+      .replace('\t"myapp/internal/middleware"\n\n', "")
+      .replace('\t"github.com/foo/middleware"\n\n', "");
+    content = content
+      .split("\n")
+      .filter((line) => line.trim() !== "r.Use(middleware.RequireAuth())")
+      .join("\n");
+    return { path: f.path, content };
+  });
+}
+
 // ─── S6-S8: body-signature calibration groups ────────────────────────────────
 //
 // Each group roots its own directory so the route-directory vote grouping and

--- a/test/calibration/python-security-fixture.ts
+++ b/test/calibration/python-security-fixture.ts
@@ -480,3 +480,109 @@ export function stripMethodsVarAuth(files: BaselineFile[], count: number): Basel
     return { path: f.path, content: lines.join("\n") };
   });
 }
+
+// ── S10/S11: cross-file auth resolution (imported hook, in-repo vs external) ─
+//
+// S10 proves the POSITIVE: an imported before_request hook whose body lives in
+// a SEPARATE in-repo file (pkg/auth.py) blesses every importing route, because
+// cross-file resolution reads that file's REJECTING body (session read +
+// abort(401), the exact S7 gate() reject signature) — never because the
+// hook's name alone looks like auth. Pre-cross-file (index absent), these
+// same 5 files resolve hasAuth:false with authUnsureHook 'verify_session'
+// (the exact S8 shape) — that prior verdict is what S10 pins as a regression.
+//
+// S11 proves the NEGATIVE: the SAME 5 route files (same paths, same bodies),
+// importing verify_session from an EXTERNAL, absolute package instead, never
+// bless however live cross-file resolution is — an absolute import never
+// populates resolveBinding's relative-target map in security-xfile-index.ts,
+// so resolution refuses deterministically, not merely because a target file
+// happens to be absent. The route stays hedged (UNSURE), identical to the
+// pre-cross-file verdict.
+//
+// Both groups share the SAME 5 relativePaths (pkg/<name>_routes.py), so a
+// test can freely recombine files from either group at the same path to
+// build a mixed corpus (see S11's "mixed with S10" scenario below).
+const S10_ROOT = "pkg";
+const S10_NAMES = ["campaigns", "surveys", "audits", "reviews", "backups"];
+
+function crossFileRouteFile(name: string, importLine: string): BaselineFile {
+  const receiver = `${name}_bp`;
+  return {
+    path: `${S10_ROOT}/${name}_routes.py`,
+    content:
+`"""POST /${name}: create a ${name} record. Auth is enforced by a
+before_request hook imported from elsewhere; the hook is never redefined
+locally, so this route blesses only if the hook's body resolves correctly."""
+from flask import Blueprint, jsonify, request
+${importLine}
+
+${receiver} = Blueprint("${name}", __name__)
+${receiver}.before_request(verify_session)
+
+
+@${receiver}.route("/${name}", methods=["POST"])
+def create_${name}():
+    payload = request.get_json()
+    return jsonify(payload), 201
+`,
+  };
+}
+
+/** S10: 5 route files, each `from .auth import verify_session` — a REAL
+ *  relative import resolvable to the sibling pkg/auth.py below. */
+export function crossFileAuthedGroup(): BaselineFile[] {
+  return S10_NAMES.map((name) => crossFileRouteFile(name, "from .auth import verify_session"));
+}
+
+/** S10 support file: the shared cross-file hook. Its BODY (session read +
+ *  abort(401)) is what blesses the importing routes — never its name.
+ *  Carries no route of its own. */
+export const pkgAuthFile: BaselineFile = {
+  path: `${S10_ROOT}/auth.py`,
+  content:
+`"""Shared session-verification hook, imported by every pkg/*_routes.py
+blueprint (from .auth import verify_session). Its BODY, not its name, is what
+blesses the importing routes cross-file: a missing session 401s before any
+handler runs. Carries no route of its own."""
+from flask import session, abort
+
+
+def verify_session():
+    if not session.get("user_id"):
+        abort(401)
+`,
+};
+
+/** S11: the SAME 5 route files (same paths, same bodies) importing
+ *  verify_session from an EXTERNAL, absolute package instead — no in-repo
+ *  pkg/auth.py needed for THIS group (nothing resolves regardless, since an
+ *  absolute import is never a resolution target in the first place). */
+export function crossFileExternalGroup(): BaselineFile[] {
+  return S10_NAMES.map((name) => crossFileRouteFile(name, "from acme_sso import verify_session"));
+}
+
+/** Sorted pkg/*_routes.py paths in `files` — same predicate for either group
+ *  above, since they share paths. */
+export function sortedCrossFileRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${S10_ROOT}/`) && p.endsWith("_routes.py"));
+}
+
+/** Deterministically strips the import line AND the before_request
+ *  registration call from the first `count` S10/S11 files, sorted by path,
+ *  leaving a bare (now unauthed, S1-shape) still-mutating route. Matches
+ *  either group's import line, so it works on files pulled from either. */
+export function stripCrossFileAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedCrossFileRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const lines = f.content
+      .split("\n")
+      .filter(
+        (line) =>
+          line.trim() !== "from .auth import verify_session" &&
+          line.trim() !== "from acme_sso import verify_session" &&
+          !line.trim().endsWith(".before_request(verify_session)"),
+      );
+    return { path: f.path, content: lines.join("\n") };
+  });
+}

--- a/test/calibration/security-go.test.ts
+++ b/test/calibration/security-go.test.ts
@@ -33,6 +33,18 @@
  *   S8  unresolvable-body UNSURE (imported auth-flavored middleware): stays
  *       flagged with HEDGED copy naming the hook; counts match S6; S1 stays
  *       flat in the same run.
+ *
+ * Task 6 addendum (S10-S11) measures cross-file auth resolution (Tasks 1-5):
+ *   S10 a package-qualified middleware call whose body lives in a SEPARATE
+ *       in-repo package blesses via cross-file resolution.
+ *   S11 the SAME shape importing from an out-of-repo package path instead
+ *       stays hedged (UNSURE), never blesses.
+ * INVARIANCE CLAIM: S0-S9 above are single-file / in-file fixtures and
+ * reproduce BYTE-IDENTICALLY on this branch; their dominantCount /
+ * consistencyScore / precision / recall assertions are untouched. Cross-file
+ * resolution runs live in every scenario below (securityConsistency.detect
+ * always builds the index), but it never changes an in-file verdict: local
+ * defs take precedence over any cross-file candidate.
  */
 import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../src/drift/security-consistency.js";
@@ -43,6 +55,7 @@ import {
   collectGoFunctionDefs,
   classifyGoMiddlewareAuth,
 } from "../../src/drift/security-ast-go.js";
+import { buildXFileIndex } from "../../src/drift/security-xfile-index.js";
 import { fileWithTree } from "../helpers/drift-tree.js";
 import type { BaselineFile } from "./baseline.js";
 import {
@@ -63,10 +76,27 @@ import {
   stripBodyGate,
   bodyUnsureGroup,
   bodyUnsureDeviatorPath,
+  goCrossFileAuthedGroup,
+  goCrossFileAuthFile,
+  goCrossFileModFile,
+  goCrossFileExternalGroup,
+  sortedCrossFileGoRoutePaths,
+  stripCrossFileGoAuth,
 } from "./go-security-fixture.js";
 
 async function toDriftFiles(files: BaselineFile[]): Promise<DriftFile[]> {
   return Promise.all(files.map((f) => fileWithTree(f.path, f.content, "go")));
+}
+
+/** Extracts the `module` path from a go.mod BaselineFile in `files`, if
+ *  present, mirroring how buildDriftContext threads a real repo's go.mod into
+ *  DriftContext.goModulePath. Absent for every S0-S9 fixture (none carries a
+ *  go.mod file), so their ctx.goModulePath stays undefined exactly as before
+ *  (Go cross-file wholesale disabled), byte-identical to today. */
+function goModulePathFrom(files: BaselineFile[]): string | undefined {
+  const goMod = files.find((f) => f.path === "go.mod");
+  const m = goMod ? /^module\s+(\S+)/m.exec(goMod.content) : null;
+  return m ? m[1] : undefined;
 }
 
 async function ctxFor(files: BaselineFile[]) {
@@ -75,6 +105,7 @@ async function ctxFor(files: BaselineFile[]) {
     files: driftFiles,
     totalLines: driftFiles.reduce((s, f) => s + f.lineCount, 0),
     dominantLanguage: "go",
+    goModulePath: goModulePathFrom(files),
   };
 }
 
@@ -115,6 +146,14 @@ describe("Go calibration: S0 recognition self-check (route-loss guard + no-name-
       total += routes.length;
     }
     expect(total).toBe(5);
+  });
+
+  it("the cross-file def-only support files (internal/middleware/auth.go, go.mod) contribute zero routes (S10/S11 recognition guard)", async () => {
+    for (const f of [goCrossFileAuthFile, goCrossFileModFile]) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(0);
+    }
   });
 
   it("no-name-bless classifier pin: an imported selector with no in-file def HEDGES, never blesses; an in-file rejecting body DOES bless", async () => {
@@ -434,6 +473,130 @@ describe("Go calibration: S8 unresolvable-body UNSURE (imported auth-flavored mi
   });
 });
 
+// ─── S10/S11: cross-file auth resolution (Task 6) ─────────────────────────────
+// Measures the cross-file resolution built in Tasks 1-5: a package-qualified
+// middleware.RequireAuth() call resolves cross-PACKAGE when its body verifiably
+// rejects (S10); the SAME shape importing from an out-of-repo package path
+// instead never blesses, only hedges (S11). Both groups share the same 5
+// relativePaths (handlers/<name>.go), so S11's second test recombines files
+// from both to build a mixed corpus without a new fixture helper.
+
+describe("Go calibration: S10 cross-file positive (imported middleware blesses via cross-package resolution)", () => {
+  it("non-vacuity FIRST: every route resolves hasAuth true with authUnsureHook ABSENT via cross-file resolution; pre-cross-file (index absent) the SAME files resolve hasAuth false with authUnsureHook 'middleware.RequireAuth' (the exact S8 shape, the regression S10 pins)", async () => {
+    const group = goCrossFileAuthedGroup();
+    const files = [...group, goCrossFileAuthFile, goCrossFileModFile];
+    const driftFiles = await toDriftFiles(files);
+    const index = buildXFileIndex(driftFiles, goModulePathFrom(files));
+    let total = 0;
+    for (const f of group) {
+      const driftFile = driftFiles.find((d) => d.relativePath === f.path)!;
+      const withIndex = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath, index);
+      expect(withIndex, f.path).toHaveLength(1);
+      expect(withIndex[0].hasAuth, f.path).toBe(true);
+      expect("authUnsureHook" in withIndex[0], f.path).toBe(false);
+
+      const withoutIndex = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(withoutIndex[0].hasAuth, f.path).toBe(false);
+      expect(withoutIndex[0].authUnsureHook, f.path).toBe("middleware.RequireAuth");
+      total += withIndex.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("uniform corpus: zero security_posture findings", async () => {
+    const ctx = await ctxFor([...goCrossFileAuthedGroup(), goCrossFileAuthFile, goCrossFileModFile]);
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+
+  it("STRIP variant: stripping the first sorted file's cross-file auth flags exactly it (dominantCount 4, score 80), precision 1 recall 1", async () => {
+    const strippedPath = sortedCrossFileGoRoutePaths(goCrossFileAuthedGroup())[0];
+    const files = [...stripCrossFileGoAuth(goCrossFileAuthedGroup(), 1), goCrossFileAuthFile, goCrossFileModFile];
+    const ctx = await ctxFor(files);
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Go calibration: S11 cross-file external stays unsure (never blesses)", () => {
+  it("non-vacuity FIRST: every route hedges (hasAuth false, authUnsureHook 'middleware.RequireAuth'), byte-identical with and without the index (cross-file resolution runs live and still refuses the out-of-repo import path)", async () => {
+    const group = goCrossFileExternalGroup();
+    const files = [...group, goCrossFileModFile];
+    const driftFiles = await toDriftFiles(files);
+    const index = buildXFileIndex(driftFiles, goModulePathFrom(files));
+    let total = 0;
+    for (const f of group) {
+      const driftFile = driftFiles.find((d) => d.relativePath === f.path)!;
+      const withIndex = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath, index);
+      const withoutIndex = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(withIndex, f.path).toEqual(withoutIndex);
+      expect(withIndex, f.path).toHaveLength(1);
+      expect(withIndex[0].hasAuth, f.path).toBe(false);
+      expect(withIndex[0].authUnsureHook, f.path).toBe("middleware.RequireAuth");
+      total += withIndex.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("mixed with the S10 in-repo group (4 resolve, 1 external): flags the hedged file, dominantCount 4, score 80, no em-dash copy; counts match the S8 control", async () => {
+    const authed = goCrossFileAuthedGroup();
+    const external = goCrossFileExternalGroup();
+    const deviatorPath = sortedCrossFileGoRoutePaths(authed)[0];
+    const files = [
+      ...authed.filter((f) => f.path !== deviatorPath),
+      external.find((f) => f.path === deviatorPath)!,
+      goCrossFileAuthFile,
+      goCrossFileModFile,
+    ];
+    const ctx = await ctxFor(files);
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([deviatorPath]);
+
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp).toContain("middleware.RequireAuth");
+    expect(dp.toLowerCase()).toContain("double check");
+    expect(dp).not.toMatch(/—|--/); // hedged deviator copy carries no em-dash / double hyphen
+
+    expect(finding.recommendation).toContain("Double check");
+    expect(finding.recommendation).toContain("middleware.RequireAuth");
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([deviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+
+  it("NO-LEAK cross-check: an S1-shape plain stripped-auth deviator stays FLAT (not hedged) in the same run", async () => {
+    const s1Path = sortedGinRoutePaths(ginAuthedGroup())[0];
+    const s1Files = [...stripGinAuth(ginAuthedGroup(), 1), goAuthFile, goMainFile];
+    const s1Auth = authFindings(securityConsistency.detect((await ctxFor(s1Files)) as any));
+    expect(s1Auth).toHaveLength(1);
+    expect(s1Auth[0].deviatingFiles.map((d) => d.path)).toEqual([s1Path]);
+    expect(s1Auth[0].deviatingFiles[0].detectedPattern.toLowerCase()).not.toContain("double check");
+  });
+});
+
 // ─── Fixture self-check ───────────────────────────────────────────────────────
 // Every strip*() helper is exercised at its maximal count (every eligible file
 // in the group stripped at once), proving the deterministic string surgery
@@ -471,6 +634,18 @@ describe("Go calibration: fixture self-check (every strip*() output stays parsea
       const driftFile = await fileWithTree(f.path, f.content, "go");
       expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
       expect(f.content, f.path).not.toContain("func guard(");
+      const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(routes[0].method, f.path).toBe("POST");
+    }
+  });
+
+  it("stripCrossFileGoAuth(goCrossFileAuthedGroup(), 5): every file parses error-free, one unauthed route, no leftover middleware import", async () => {
+    for (const f of stripCrossFileGoAuth(goCrossFileAuthedGroup(), 5)) {
+      const driftFile = await fileWithTree(f.path, f.content, "go");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("middleware");
       const routes = extractGoRoutesAst(driftFile.tree!, driftFile.relativePath);
       expect(routes, f.path).toHaveLength(1);
       expect(routes[0].hasAuth, f.path).toBe(false);

--- a/test/calibration/security-python.test.ts
+++ b/test/calibration/security-python.test.ts
@@ -26,12 +26,25 @@
  *       with HEDGED copy naming the hook; counts match S6; S1 stays flat.
  *   S9  methods=variable resolved from a same-file ("POST",) literal: every
  *       route resolves POST. RED-FIRST: pre-addendum they resolved ALL.
+ *
+ * Task 6 addendum (S10-S11) measures cross-file auth resolution (Tasks 1-5):
+ *   S10 an imported before_request hook whose body lives in a SEPARATE
+ *       in-repo file blesses via cross-file resolution.
+ *   S11 the SAME shape importing from an EXTERNAL package instead stays
+ *       hedged (UNSURE), never blesses.
+ * INVARIANCE CLAIM: S0-S9 above are single-file / in-file fixtures and
+ * reproduce BYTE-IDENTICALLY on this branch; their dominantCount /
+ * consistencyScore / precision / recall assertions are untouched. Cross-file
+ * resolution runs live in every scenario below (securityConsistency.detect
+ * always builds the index), but it never changes an in-file verdict: local
+ * defs take precedence over any cross-file candidate.
  */
 import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../src/drift/security-consistency.js";
 import { SECURITY_SUBCATEGORIES } from "../../src/drift/types.js";
 import type { DriftFile } from "../../src/drift/types.js";
 import { extractPythonRoutesAst } from "../../src/drift/security-ast-python.js";
+import { buildXFileIndex } from "../../src/drift/security-xfile-index.js";
 import { fileWithTree } from "../helpers/drift-tree.js";
 import type { BaselineFile } from "./baseline.js";
 import {
@@ -55,6 +68,11 @@ import {
   methodsVarGroup,
   sortedMethodsVarRoutePaths,
   stripMethodsVarAuth,
+  crossFileAuthedGroup,
+  pkgAuthFile,
+  crossFileExternalGroup,
+  sortedCrossFileRoutePaths,
+  stripCrossFileAuth,
 } from "./python-security-fixture.js";
 
 async function toDriftFiles(files: BaselineFile[]): Promise<DriftFile[]> {
@@ -99,6 +117,12 @@ describe("Python calibration: S0 recognition self-check (route-loss guard)", () 
       total += routes.length;
     }
     expect(total).toBe(5);
+  });
+
+  it("the cross-file def-only support file (pkg/auth.py) contributes zero routes (S10/S11 recognition guard)", async () => {
+    const driftFile = await fileWithTree(pkgAuthFile.path, pkgAuthFile.content, "python");
+    const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+    expect(routes).toHaveLength(0);
   });
 });
 
@@ -404,5 +428,138 @@ describe("Python calibration: S9 methods=variable resolved from a same-file lite
     const tp = [...flagged].filter((p) => planted.has(p)).length;
     expect(tp / flagged.size).toBe(1); // precision
     expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+// ─── S10/S11: cross-file auth resolution (Task 6) ─────────────────────────────
+// Measures the cross-file resolution built in Tasks 1-5: a before_request hook
+// imported from a SEPARATE in-repo file blesses when its body verifiably
+// rejects (S10); the SAME shape importing from an EXTERNAL package instead
+// never blesses, only hedges (S11). Both groups share the same 5 relativePaths
+// (pkg/<name>_routes.py), so S11's second test recombines files from both to
+// build a mixed corpus without a new fixture helper.
+
+describe("Python calibration: S10 cross-file positive (imported hook blesses via cross-file resolution)", () => {
+  it("non-vacuity FIRST: every route resolves hasAuth true with authUnsureHook ABSENT via cross-file resolution; pre-cross-file (index absent) the SAME files resolve hasAuth false with authUnsureHook 'verify_session' (the exact S8 shape, the regression S10 pins)", async () => {
+    const group = crossFileAuthedGroup();
+    const files = [...group, pkgAuthFile];
+    const driftFiles = await toDriftFiles(files);
+    const index = buildXFileIndex(driftFiles);
+    let total = 0;
+    for (const f of group) {
+      const driftFile = driftFiles.find((d) => d.relativePath === f.path)!;
+      const withIndex = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath, index);
+      expect(withIndex, f.path).toHaveLength(1);
+      expect(withIndex[0].hasAuth, f.path).toBe(true);
+      expect("authUnsureHook" in withIndex[0], f.path).toBe(false);
+
+      const withoutIndex = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(withoutIndex[0].hasAuth, f.path).toBe(false);
+      expect(withoutIndex[0].authUnsureHook, f.path).toBe("verify_session");
+      total += withIndex.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("uniform corpus: zero security_posture findings", async () => {
+    const ctx = await ctxFor([...crossFileAuthedGroup(), pkgAuthFile]);
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+
+  it("STRIP variant: stripping the first sorted file's cross-file auth flags exactly it (dominantCount 4, score 80), precision 1 recall 1", async () => {
+    const strippedPath = sortedCrossFileRoutePaths(crossFileAuthedGroup())[0];
+    const files = [...stripCrossFileAuth(crossFileAuthedGroup(), 1), pkgAuthFile];
+    const ctx = await ctxFor(files);
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+
+  it("self-check: pkg/auth.py yields ZERO routes, and stripCrossFileAuth's output still parses cleanly with an unauthed route", async () => {
+    const authDriftFile = await fileWithTree(pkgAuthFile.path, pkgAuthFile.content, "python");
+    expect(extractPythonRoutesAst(authDriftFile.tree!, authDriftFile.relativePath)).toHaveLength(0);
+
+    for (const f of stripCrossFileAuth(crossFileAuthedGroup(), 5)) {
+      const driftFile = await fileWithTree(f.path, f.content, "python");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("verify_session");
+      const routes = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+    }
+  });
+});
+
+describe("Python calibration: S11 cross-file external stays unsure (never blesses)", () => {
+  it("non-vacuity FIRST: every route hedges (hasAuth false, authUnsureHook 'verify_session'), byte-identical with and without the index (cross-file resolution runs live and still refuses the absolute import)", async () => {
+    const group = crossFileExternalGroup();
+    const driftFiles = await toDriftFiles(group);
+    const index = buildXFileIndex(driftFiles);
+    let total = 0;
+    for (const f of group) {
+      const driftFile = driftFiles.find((d) => d.relativePath === f.path)!;
+      const withIndex = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath, index);
+      const withoutIndex = extractPythonRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(withIndex, f.path).toEqual(withoutIndex);
+      expect(withIndex, f.path).toHaveLength(1);
+      expect(withIndex[0].hasAuth, f.path).toBe(false);
+      expect(withIndex[0].authUnsureHook, f.path).toBe("verify_session");
+      total += withIndex.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("mixed with the S10 in-repo group (4 resolve, 1 external): flags the hedged file, dominantCount 4, score 80, no em-dash copy; counts match the S8 control", async () => {
+    const authed = crossFileAuthedGroup();
+    const external = crossFileExternalGroup();
+    const deviatorPath = sortedCrossFileRoutePaths(authed)[0];
+    const files = [
+      ...authed.filter((f) => f.path !== deviatorPath),
+      external.find((f) => f.path === deviatorPath)!,
+      pkgAuthFile,
+    ];
+    const ctx = await ctxFor(files);
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([deviatorPath]);
+
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp).toContain("verify_session");
+    expect(dp.toLowerCase()).toContain("double check");
+    expect(dp).not.toMatch(/—|--/); // hedged deviator copy carries no em-dash / double hyphen
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([deviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+
+  it("NO-LEAK cross-check: an S1-shape plain stripped-auth deviator stays FLAT (not hedged) in the same run", async () => {
+    const s1Path = sortedFlaskRoutePaths(flaskAuthedGroup())[0];
+    const s1Files = [...stripFlaskAuth(flaskAuthedGroup(), 1), pyAuthFile, pyAppFile];
+    const s1Auth = authFindings(securityConsistency.detect((await ctxFor(s1Files)) as any));
+    expect(s1Auth).toHaveLength(1);
+    expect(s1Auth[0].deviatingFiles.map((d) => d.path)).toEqual([s1Path]);
+    expect(s1Auth[0].deviatingFiles[0].detectedPattern.toLowerCase()).not.toContain("double check");
   });
 });

--- a/test/unit/core/gomod.test.ts
+++ b/test/unit/core/gomod.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadGoMod } from "../../../src/core/discovery.js";
+
+/**
+ * loadGoMod exposes two safety flags used to DISABLE Go cross-file package
+ * resolution wholesale: `hasReplace` (a replace directive remaps an import
+ * path to another dir, breaking root-prefix math) and `hasNestedModule` (a
+ * second module under the root breaks the prefix math too). Both are
+ * never-false-bless guards for the cross-file auth feature.
+ */
+describe("loadGoMod replace + nested-module detection", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vd-gomod-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("parses the module path and leaves the guards unset for a plain go.mod", async () => {
+    await writeFile(join(dir, "go.mod"), `module example.com/app\n\ngo 1.22\n`);
+    const mod = await loadGoMod(dir);
+    expect(mod?.module).toBe("example.com/app");
+    expect(mod?.hasReplace).toBeFalsy();
+    expect(mod?.hasNestedModule).toBeFalsy();
+  });
+
+  it("detects a single-line replace directive", async () => {
+    await writeFile(
+      join(dir, "go.mod"),
+      `module example.com/app\n\ngo 1.22\n\nreplace example.com/x => ./local/x\n`,
+    );
+    expect((await loadGoMod(dir))?.hasReplace).toBe(true);
+  });
+
+  it("detects a block-form replace directive", async () => {
+    await writeFile(
+      join(dir, "go.mod"),
+      `module example.com/app\n\ngo 1.22\n\nreplace (\n\texample.com/x => ./local/x\n)\n`,
+    );
+    expect((await loadGoMod(dir))?.hasReplace).toBe(true);
+  });
+
+  it("detects a nested go.mod under the scan root", async () => {
+    await writeFile(join(dir, "go.mod"), `module example.com/app\n`);
+    await mkdir(join(dir, "sub"), { recursive: true });
+    await writeFile(join(dir, "sub", "go.mod"), `module example.com/app/sub\n`);
+    expect((await loadGoMod(dir))?.hasNestedModule).toBe(true);
+  });
+
+  it("does not treat the root go.mod itself as a nested module", async () => {
+    await writeFile(join(dir, "go.mod"), `module example.com/app\n`);
+    await mkdir(join(dir, "sub"), { recursive: true });
+    await writeFile(join(dir, "sub", "handler.go"), `package sub\n`);
+    expect((await loadGoMod(dir))?.hasNestedModule).toBeFalsy();
+  });
+
+  it("returns null when there is no go.mod", async () => {
+    expect(await loadGoMod(dir)).toBeNull();
+  });
+});

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -4,10 +4,28 @@ import {
   bodyAuthSignatureGo, classifyGoMiddlewareAuth, collectGoFunctionDefs,
 } from "../../../src/drift/security-ast-go.js";
 import { SECURITY_AST } from "../../../src/drift/security-ast.js";
+import { buildXFileIndex } from "../../../src/drift/security-xfile-index.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import type { SyntaxNode } from "../../../src/core/types.js";
+import type { DriftFile } from "../../../src/drift/types.js";
 
 const go = (path: string, src: string) => fileWithTree(path, src, "go");
+
+/** Build a virtual Go repo (array of DriftFiles with parsed trees) from
+ *  [relativePath, source] pairs. Parsed SEQUENTIALLY (web-tree-sitter is not
+ *  concurrency-safe). */
+async function goRepo(files: [string, string][]): Promise<DriftFile[]> {
+  const out: DriftFile[] = [];
+  for (const [path, src] of files) out.push(await go(path, src));
+  return out;
+}
+
+/** The route file's parsed tree + its relativePath (the importer). */
+function routeFile(files: DriftFile[], rel = "handlers/routes.go") {
+  const f = files.find((x) => x.relativePath === rel)!;
+  expect(f.tree!.rootNode.hasError).toBe(false);
+  return f;
+}
 
 const PKG = "package main\n\n";
 
@@ -2335,5 +2353,185 @@ describe("unsure sweep", () => {
       expect(() => extractGoRoutesAst(f.tree!, f.relativePath)).not.toThrow();
       expect(() => extractGoFileMiddlewareAst(f.tree!)).not.toThrow();
     }
+  });
+});
+
+// ── Task 4: Go cross-file wiring (imported package middleware selectors) ──────
+//
+// Cross-file resolution ONLY supplies a body to the EXISTING classifier
+// (classifyGoMiddlewareArg -> classifyGoMiddlewareAuth via resolveGoMiddlewareBody).
+// Blessing still requires the resolved in-repo body to VERIFIABLY reject; every
+// value-shadow / exported-only / package-name / external guard lives in
+// resolveGoMiddlewareBody and is CALLED, never bypassed. Both Go middleware
+// paths are covered: the per-route inline form (goRouteMiddleware) and the
+// Use/group form (collectGoMiddleware -> lanesFromArgs). With the index absent
+// (the 2-arg call), every route is byte-identical to today.
+
+// An imported package middleware factory whose returned closure verifiably 401s.
+const XFILE_REJECT_FACTORY = `package middleware
+
+import "net/http"
+
+func AuthMiddleware() Handler {
+	return func(c *Ctx) {
+		if c.GetHeader("Authorization") == "" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+}
+`;
+
+describe("Task 4: Go cross-file wiring — HEADLINE both forms resolve + bless", () => {
+  it("per-route INLINE form: r.POST(\"/x\", middleware.AuthMiddleware(), createX) blesses cross-file", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(true);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("USE/group form: r.Use(middleware.AuthMiddleware()) blesses the later same-scope route", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.Use(middleware.AuthMiddleware())\n\tr.POST("/x", createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(true);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("aliased qualifier: import mw \"myapp/auth\" + r.Use(mw.Require) blesses a later same-scope route", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport mw "myapp/auth"\n\nfunc Register(r Router) {\n\tr.Use(mw.Require)\n\tr.POST("/x", createX)\n}\n`],
+      ["auth/auth.go", `package auth\n\nimport "net/http"\n\nfunc Require() Handler {\n\treturn func(c *Ctx) {\n\t\tif c.GetHeader("Authorization") == "" {\n\t\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\t\treturn\n\t\t}\n\t\tc.Next()\n\t}\n}\n`],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    const route = routes.find((r) => r.path === "/x")!;
+    expect(route.hasAuth).toBe(true);
+    expect(route.authUnsureHook).toBeUndefined();
+  });
+});
+
+describe("Task 4: Go cross-file wiring — wrap form + DI arity guard", () => {
+  // RequireAuth is a single-arg wrap (resolves + blesses); NewGuardedHandler is
+  // an arity-2 DI callee with an IDENTICAL rejecting body — it must STILL never
+  // bless (do not resolve an arity->=2 callee, mirroring the never-classify-DI
+  // rule). If the arity guard regressed, NewGuardedHandler would false-bless.
+  const WRAP_PKG = `package middleware
+
+import "net/http"
+
+func RequireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func NewGuardedHandler(next http.Handler, cfg Config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+`;
+
+  it("single-arg wrap mux.Handle(\"/x\", middleware.RequireAuth(handler)) resolves + blesses", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(mux Router) {\n\tmux.Handle("/x", middleware.RequireAuth(handler))\n}\n`],
+      ["internal/middleware/auth.go", WRAP_PKG],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(true);
+  });
+
+  it("arity-2 DI callee middleware.NewGuardedHandler(handler, cfg) stays UNCLASSIFIED even cross-file", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(mux Router) {\n\tmux.Handle("/x", middleware.NewGuardedHandler(handler, cfg))\n}\n`],
+      ["internal/middleware/auth.go", WRAP_PKG],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
+  });
+
+  it("method target: middleware.RequireAuth pointing at a method_declaration never blesses (stays unsure)", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.Use(middleware.RequireAuth)\n\tr.POST("/x", createX)\n}\n`],
+      ["internal/middleware/auth.go", `package middleware\n\nimport "net/http"\n\ntype Mw struct{}\n\nfunc (m *Mw) RequireAuth(c *Ctx) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n`],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    const route = routes.find((r) => r.path === "/x")!;
+    expect(route.hasAuth).toBe(false);
+    expect(route.authUnsureHook).toBe("middleware.RequireAuth");
+  });
+});
+
+describe("Task 4: Go cross-file wiring — byte-identity pins (external + in-file)", () => {
+  it("EXTERNAL package stays unsure, byte-identical with and without the index", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "github.com/foo/mw"\n\nfunc Register(r Router) {\n\tr.Use(mw.Auth)\n\tr.POST("/x", createX)\n}\n`],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const withIndex = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    const withoutIndex = extractGoRoutesAst(rf.tree!, rf.relativePath);
+    // Byte-identical: an external package refuses cross-file, leaving the exact
+    // unsure hedge the in-file-only path already emits.
+    expect(withIndex).toEqual(withoutIndex);
+    const route = withIndex.find((r) => r.path === "/x")!;
+    expect(route.hasAuth).toBe(false);
+    expect(route.authUnsureHook).toBe("mw.Auth");
+  });
+
+  it("IN-FILE precedence: a bare in-file AuthMiddleware blesses identically with and without the index", async () => {
+    const src = `package handlers\n\nimport "net/http"\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tif c.GetHeader("Authorization") == "" {\n\t\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\t\treturn\n\t\t}\n\t\tc.Next()\n\t}\n}\n\nfunc Register(r Router) {\n\tr.Use(AuthMiddleware())\n\tr.POST("/x", createX)\n}\n`;
+    const files = await goRepo([["handlers/routes.go", src]]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const withIndex = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    const withoutIndex = extractGoRoutesAst(rf.tree!, rf.relativePath);
+    expect(withIndex).toEqual(withoutIndex);
+    expect(withIndex.find((r) => r.path === "/x")!.hasAuth).toBe(true);
+  });
+
+  it("an imported rejecting factory is NOT resolved when goModulePath is absent (Go cross-file off)", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ]);
+    // No module path => the Go half is empty => the selector never resolves; the
+    // route stays unsure (auth-flavored opaque), byte-identical to the 2-arg call.
+    const index = buildXFileIndex(files, null);
+    const rf = routeFile(files);
+    const withIndex = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    const withoutIndex = extractGoRoutesAst(rf.tree!, rf.relativePath);
+    expect(withIndex).toEqual(withoutIndex);
+    expect(withIndex[0].hasAuth).toBe(false);
   });
 });

--- a/test/unit/drift/security-ast-go.test.ts
+++ b/test/unit/drift/security-ast-go.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   extractGoRoutesAst, extractGoFileMiddlewareAst, SECURITY_AST_GO,
   bodyAuthSignatureGo, classifyGoMiddlewareAuth, collectGoFunctionDefs,
+  resolveEffectiveBody,
 } from "../../../src/drift/security-ast-go.js";
 import { SECURITY_AST } from "../../../src/drift/security-ast.js";
-import { buildXFileIndex } from "../../../src/drift/security-xfile-index.js";
+import { buildXFileIndex, resolveGoMiddlewareBody } from "../../../src/drift/security-xfile-index.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import type { SyntaxNode } from "../../../src/core/types.js";
 import type { DriftFile } from "../../../src/drift/types.js";
@@ -2533,5 +2534,279 @@ describe("Task 4: Go cross-file wiring — byte-identity pins (external + in-fil
     const withoutIndex = extractGoRoutesAst(rf.tree!, rf.relativePath);
     expect(withIndex).toEqual(withoutIndex);
     expect(withIndex[0].hasAuth).toBe(false);
+  });
+});
+
+// ─── Task 5: adversarial never-false-bless sweep (cross-file, Go) ───────────
+//
+// GOVERNING INVARIANT — a WRONG cross-file attribution is a false-bless.
+// Every entry below registers a REAL rejecting body somewhere in the repo, so
+// a broken refuse guard would visibly bless the route; the sweep asserts it
+// never does. classifyGoMiddlewareAuth never blesses on name alone (unlike
+// the Python module), so no CORE-name trap exists here — every refusal is
+// driven by cross-file resolution / the arity gate, not a name shortcut.
+
+interface GoXFileSweepEntry {
+  name: string;
+  files: [string, string][];
+  routeFile: string;
+  goMod: string | null;
+  groundTruth: Array<{ path: string; method: string; authed: boolean }>;
+}
+
+// The seven Go value-shadow binding forms (Task 5 required catalog), each
+// combined with a REAL r.POST(...) route selecting `middleware.AuthMiddleware`
+// — the shadow lives in an UNRELATED function/decl in the SAME file (valueBound
+// is file-wide, not scope-aware, so this still poisons the qualifier).
+const GO_VALUE_SHADOW_FORMS: Array<[string, string]> = [
+  [":=", `func helper() {\n\tmiddleware := 0\n\t_ = middleware\n}\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+  ["var", `var middleware int\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+  ["const", `const middleware = 0\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+  ["param", `func helper(middleware int) {}\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+  ["RECEIVER", `type Server struct{}\n\nfunc (middleware *Server) Helper() {}\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+  ["named-return", `func helper() (middleware int) {\n\treturn\n}\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+  ["type-switch guard", `func helper(x interface{}) {\n\tswitch middleware := x.(type) {\n\tdefault:\n\t\t_ = middleware\n\t}\n}\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+];
+
+const NEVER_FALSE_BLESS_XFILE_GO: GoXFileSweepEntry[] = [
+  {
+    name: "external package (not under module path)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "github.com/foo/mw"\n\nfunc Register(r Router) {\n\tr.POST("/x", mw.Auth(), createX)\n}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "no go.mod (Go cross-file disabled wholesale)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: null,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    // The plumbing collapses goModulePath to null on a `replace` directive; at
+    // this layer that is simply a null module path, mechanically identical to
+    // "no go.mod" — pinned separately per the catalog for documentation.
+    name: "replace directive present (goModulePath forced null upstream)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: null,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "dot-import blanket refuse",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport (\n\t"myapp/internal/middleware"\n\t. "myapp/helpers"\n)\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  ...GO_VALUE_SHADOW_FORMS.map(([label, body]) => ({
+    name: `value-shadow — ${label}`,
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\n${body}`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ] as [string, string][],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  })),
+  {
+    name: "package-name mismatch (plain import, declared package != qualifier)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", `package authpkg\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t}\n}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "method-target (selector points at a method_declaration, not a function)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.Use(middleware.RequireAuth)\n\tr.POST("/x", createX)\n}\n`],
+      ["internal/middleware/auth.go", `package middleware\n\nimport "net/http"\n\ntype Mw struct{}\n\nfunc (m *Mw) RequireAuth(c *Ctx) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "duplicate-across-package-files (sticky-null)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+      ["internal/middleware/legacy.go", `package middleware\n\nfunc AuthMiddleware() Handler {\n\treturn nil\n}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "two-dir same-package-name (ambiguous qualifier)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport (\n\t"myapp/pkgA"\n\t"myapp/pkgB"\n)\n\nfunc Register(r Router) {\n\tr.POST("/x", foo.AuthMiddleware(), createX)\n}\n`],
+      ["pkgA/a.go", `package foo\n\nimport "net/http"\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t}\n}\n`],
+      ["pkgB/b.go", `package foo\n\nfunc Other() {}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "wrong-dir same-symbol: imported dir lacks it, a DIFFERENT dir defines a rejecting one (WRONG-FILE)",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/other.go", `package middleware\n\nfunc Other() {}\n`],
+      ["internal/authz/guard.go", `package middleware\n\nimport "net/http"\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t}\n}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "multi-file package: one-hop resolves against the def's OWN file, never a sibling's rejecting helper",
+    files: [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      // AuthMiddleware's OWN file's authImpl does NOT reject.
+      ["internal/middleware/auth.go", `package middleware\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tauthImpl(c)\n\t}\n}\n\nfunc authImpl(c *Ctx) {\n\tc.Next()\n}\n`],
+      // A DIFFERENT sibling file's SAME-NAMED authImpl DOES reject — must never
+      // drive the verdict.
+      ["internal/middleware/helpers.go", `package middleware\n\nimport "net/http"\n\nfunc authImpl(c *Ctx) {\n\tc.AbortWithStatus(http.StatusUnauthorized)\n}\n`],
+    ],
+    routeFile: "handlers/routes.go",
+    goMod: "myapp",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+];
+
+describe("NEVER-FALSE-BLESS adversarial sweep (cross-file, Go)", () => {
+  it("no ground-truth-unauthed route is ever emitted hasAuth:true (cross-file)", async () => {
+    for (const e of NEVER_FALSE_BLESS_XFILE_GO) {
+      const files = await goRepo(e.files);
+      const index = buildXFileIndex(files, e.goMod);
+      const rf = files.find((f) => f.relativePath === e.routeFile)!;
+      const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+      for (const gt of e.groundTruth.filter((g) => !g.authed)) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        // Non-vacuous: the route must actually have been extracted (the
+        // classifier genuinely ran).
+        expect(emitted, `${e.name}: route was never extracted`).toBeDefined();
+        expect(emitted?.hasAuth ?? false, `${e.name}: ${gt.method} ${gt.path}`).toBe(false);
+      }
+    }
+  });
+});
+
+describe("EXTERNAL-PARITY (cross-file adds zero blesses for out-of-repo Go symbols)", () => {
+  const EXTERNAL_FIXTURES_GO: Array<[string, [string, string][]]> = [
+    ["external package (github.com/...)", [
+      ["handlers/routes.go", `package handlers\n\nimport "github.com/foo/mw"\n\nfunc Register(r Router) {\n\tr.Use(mw.Auth)\n\tr.POST("/x", createX)\n}\n`],
+    ]],
+    ["method-target (never a function_declaration)", [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.Use(middleware.RequireAuth)\n\tr.POST("/x", createX)\n}\n`],
+      ["internal/middleware/auth.go", `package middleware\n\nimport "net/http"\n\ntype Mw struct{}\n\nfunc (m *Mw) RequireAuth(c *Ctx) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n`],
+    ]],
+    ["dot-import blanket refuse", [
+      ["handlers/routes.go", `package handlers\n\nimport (\n\t"myapp/internal/middleware"\n\t. "myapp/helpers"\n)\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", XFILE_REJECT_FACTORY],
+    ]],
+  ];
+
+  it("index-present and index-absent RouteInfo arrays are byte-identical for every external Go fixture", async () => {
+    for (const [name, spec] of EXTERNAL_FIXTURES_GO) {
+      const files = await goRepo(spec);
+      const index = buildXFileIndex(files, "myapp");
+      const rf = files.find((f) => f.relativePath === "handlers/routes.go")!;
+      const withIndex = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+      const withoutIndex = extractGoRoutesAst(rf.tree!, rf.relativePath);
+      expect(withIndex, name).toEqual(withoutIndex);
+    }
+  });
+});
+
+describe("WRONG-FILE guard (Go, the single most important cross-file pin)", () => {
+  it("imported dir lacking the symbol never falls back to a different dir's rejecting same-name def", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/other.go", `package middleware\n\nfunc Other() {}\n`],
+      ["internal/authz/guard.go", `package middleware\n\nimport "net/http"\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t}\n}\n`],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
+
+    // Direct proof: resolution is PATH-ANCHORED to the imported dir only —
+    // there is no repo-wide name-search fallback.
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+  });
+});
+
+describe("ONE-HOP-CEILING (Go): a second cross-package hop is never followed", () => {
+  it("a resolved factory whose reject lives behind a cross-PACKAGE call stays not-auth", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      // AuthMiddleware's body calls a DIFFERENT imported package's function — a
+      // SECOND cross-file (cross-package) hop the body scanner never walks.
+      ["internal/middleware/auth.go", `package middleware\n\nimport "myapp/internal/other"\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tother.Helper(c)\n\t}\n}\n`],
+      ["internal/other/helper.go", `package other\n\nimport "net/http"\n\nfunc Helper(c *Ctx) {\n\tc.AbortWithStatus(http.StatusUnauthorized)\n}\n`],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
+
+    // Non-vacuous: the FIRST hop resolves fine (AuthMiddleware's body IS
+    // found); the reject lives behind a SECOND, cross-package call the body
+    // scanner never walks (bodyAuthSignatureGo's hop is a same-file bare
+    // identifier only — a selector call to another package is invisible).
+    const resolved = resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index);
+    expect(resolved).not.toBeNull();
+    const effective = resolveEffectiveBody(resolved!.def, resolved!.defs);
+    expect(effective).not.toBeNull();
+    expect(bodyAuthSignatureGo(effective!, resolved!.defs)).not.toBe("reject");
+  });
+});
+
+// ─── Task 4 review — required arity-gate pin (mandatory addition) ───────────
+//
+// The shipped Task 4 DI test (NewGuardedHandler, above) passes via a NAME
+// VETO ("handler" is a GO_AUTH_VETO_SEGMENTS member baked into the callee
+// name "NewGuardedHandler"), which fires at classifyGoMiddlewareAuth's rule 1
+// BEFORE the arity gate is ever relevant — so that test alone does not prove
+// isPureSelectorTarget's `arity <= 1` gate is doing anything. This pin uses a
+// callee name ("Protect") carrying NO veto segment and NO GO_AUTH_SEGMENTS
+// flavor, wired to a body that genuinely 401s unconditionally, so ONLY the
+// arity gate can be preventing the bless. Verified to fail RED with the gate
+// removed (see task-5-report.md for the evidence).
+
+describe("Task 4 review — required arity-gate pin (protects isPureSelectorTarget's arity<=1 gate)", () => {
+  it("a non-veto, non-flavored arity-2 imported factory never blesses cross-file", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(mux Router) {\n\tmux.Handle("/x", middleware.Protect(handler, cfg))\n}\n`],
+      ["internal/middleware/auth.go", `package middleware\n\nfunc Protect(next Handler, cfg Config) Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t}\n}\n`],
+    ]);
+    const index = buildXFileIndex(files, "myapp");
+    const rf = routeFile(files);
+    const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    // "Protect" carries no veto segment and no auth-flavor segment, and the
+    // resolved body genuinely rejects unconditionally — the ONLY thing
+    // stopping a false-bless here is the arity<=1 gate refusing to even
+    // ATTEMPT cross-file resolution of a 2-argument call.
+    expect(routes[0].hasAuth).toBe(false);
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -8,12 +8,22 @@ import {
   SECURITY_AST_PY,
 } from "../../../src/drift/security-ast-python.js";
 import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
+import { buildXFileIndex } from "../../../src/drift/security-xfile-index.js";
 import { securityConsistency } from "../../../src/drift/security-consistency.js";
 import { SECURITY_SUBCATEGORIES } from "../../../src/drift/types.js";
 import type { SyntaxNode } from "../../../src/core/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 
 const py = (path: string, src: string) => fileWithTree(path, src, "python");
+
+/** Build a virtual multi-file python repo (DriftFiles with parsed trees) from
+ *  [relativePath, source] pairs. Parsed SEQUENTIALLY — web-tree-sitter is not
+ *  safe to drive concurrently. */
+async function repo(files: [string, string][]) {
+  const out = [];
+  for (const [path, src] of files) out.push(await py(path, src));
+  return out;
+}
 
 describe("py() test helper (harness prerequisites)", () => {
   it("parses a Python source file into a usable, error-free tree", async () => {
@@ -3341,5 +3351,201 @@ describe("Depends additive-only body bless", () => {
       "/x1 auth=true",
       "/x2 auth=false",
     ]);
+  });
+});
+
+describe("extractPythonRoutesAst: cross-file imported hook / dependency resolution", () => {
+  // HEADLINE — an imported before_request hook whose in-repo body verifiably
+  // rejects blesses every route on its receiver; without the index it stays UNSURE
+  // (never blesses), byte-identical to today.
+  it("imported rejecting before_request hook: unsure -> auth (with index)", async () => {
+    const files = await repo([
+      ["pkg/routes.py",
+        `from .auth import verify_session\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/orders")\ndef create_order():\n    return {}\n`],
+      ["pkg/auth.py",
+        `def verify_session():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "pkg/routes.py")!;
+
+    const withIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index);
+    expect(withIdx.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=true",
+    ]);
+    expect(withIdx.every((r) => r.authUnsureHook === undefined)).toBe(true);
+
+    // Index absent: today's behavior — unsure, never blessed (byte-identity guard).
+    const noIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath);
+    expect(noIdx.map((r) => `${r.path} auth=${r.hasAuth} hook=${r.authUnsureHook ?? ""}`)).toEqual([
+      "/orders auth=false hook=verify_session",
+    ]);
+  });
+
+  // Boring-named imported Depends: not a name-lexicon hit; blesses ONLY via the
+  // resolved rejecting body (rule 2), never a new name path.
+  it("boring-named imported Depends whose in-repo body rejects blesses", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from .deps import load_actor\n\n` +
+        `@router.get("/me")\ndef me(user=Depends(load_actor)):\n    return user\n`],
+      ["deps.py",
+        `def load_actor():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    expect(extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/me auth=true"]);
+    // Index absent: load_actor is no lexicon hit -> stays not-auth (byte-identity).
+    expect(extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/me auth=false"]);
+  });
+
+  // Direct optional dependency: the CALL-SITE veto short-circuits before any body
+  // or cross-file resolution.
+  it("direct imported Depends(get_current_user_optional) stays not-auth (name veto)", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from .deps import get_current_user_optional\n\n` +
+        `@router.get("/me")\ndef me(user=Depends(get_current_user_optional)):\n    return user\n`],
+      ["deps.py",
+        `def get_current_user_optional():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    expect(extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/me auth=false"]);
+  });
+
+  // ALIASED optional Depends (never-false-bless): the alias hides "optional"; the
+  // veto MUST run on the RESOLVED ORIGINAL name or the rejecting body false-blesses.
+  it("aliased imported Depends(load_actor -> get_current_user_optional) stays not-auth", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from .deps import get_current_user_optional as load_actor\n\n` +
+        `@router.get("/me")\ndef me(user=Depends(load_actor)):\n    return user\n`],
+      ["deps.py",
+        `def get_current_user_optional():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    expect(extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/me auth=false"]);
+  });
+
+  // ALIASED optional before_request hook (never-false-bless): resolved-name veto on
+  // the hook path. Alias `check` has no "optional" segment; the resolved original
+  // does, so the rejecting body must NOT bless.
+  it("aliased imported before_request(check -> get_current_user_optional) stays not-auth", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from .auth import get_current_user_optional as check\n` +
+        `app.before_request(check)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+      ["auth.py",
+        `def get_current_user_optional():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    const routes = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index);
+    expect(routes.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  // TARGET-file defs: the resolved body's one-hop helper must resolve in the TARGET
+  // file, not the importer. The importer defines a same-named _check that does NOT
+  // reject; the target's _check does. Blessing proves the TARGET defs were supplied.
+  it("resolved body's one-hop helper resolves against the TARGET file's defs", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from .auth import verify_session\n\n` +
+        `def _check():\n    return None\n\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+      ["auth.py",
+        `def verify_session():\n    _check()\n\n` +
+        `def _check():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    expect(extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index)
+      .map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=true"]);
+  });
+
+  // IN-FILE precedence / byte-identity: a locally-defined verify_session (visible
+  // non-enforcing body) classifies from the LOCAL def; a same-named cross-file
+  // rejecting def never overrides it. Index present === index absent.
+  it("in-file def takes precedence over a same-named cross-file def", async () => {
+    const files = await repo([
+      ["routes.py",
+        `def verify_session():\n    return None\n\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+      ["auth.py",
+        `def verify_session():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    const withIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index);
+    const noIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath);
+    expect(withIdx.map((r) => `${r.path} auth=${r.hasAuth}`)).toEqual(["/x auth=false"]);
+    expect(withIdx).toEqual(noIdx); // cross-file never consulted
+  });
+
+  // External / not-in-repo symbol: no candidate file -> refuse -> stays UNSURE,
+  // byte-identical to the pre-change serialization.
+  it("imported-from-nonexistent-module hook stays unsure (byte-identical)", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from external_auth import verify_session\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    const withIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index);
+    const noIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath);
+    expect(withIdx.map((r) => `${r.path} auth=${r.hasAuth} hook=${r.authUnsureHook ?? ""}`))
+      .toEqual(["/x auth=false hook=verify_session"]);
+    expect(withIdx).toEqual(noIdx);
+  });
+
+  // Target with a parse error: resolvePyHookBody refuses (no fileDefs entry) -> the
+  // route stays UNSURE. A broken target must never contribute a bless.
+  it("broken target file never blesses (stays unsure)", async () => {
+    const files = await repo([
+      ["routes.py",
+        `from .auth import verify_session\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+      // Deliberately unparseable.
+      ["auth.py", `def verify_session(\n    if if if\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    expect(extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index)
+      .map((r) => `${r.path} auth=${r.hasAuth} hook=${r.authUnsureHook ?? ""}`))
+      .toEqual(["/x auth=false hook=verify_session"]);
+  });
+
+  // Aliased-module ATTRIBUTE target (module-qualified form is DEFERRED in v1):
+  // a.check_user is an attribute arg0, never resolved cross-file, byte-identical,
+  // never blessed.
+  it("aliased-module attribute hook target is not resolved cross-file (byte-identical)", async () => {
+    const files = await repo([
+      ["routes.py",
+        `import myapp.auth as a\n` +
+        `app.before_request(a.check_user)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+      ["myapp/auth.py",
+        `def check_user():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const routeFile = files.find((f) => f.relativePath === "routes.py")!;
+    const withIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath, index);
+    const noIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath);
+    expect(withIdx.every((r) => r.hasAuth === false)).toBe(true);
+    expect(withIdx).toEqual(noIdx);
   });
 });

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -8,7 +8,7 @@ import {
   SECURITY_AST_PY,
 } from "../../../src/drift/security-ast-python.js";
 import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
-import { buildXFileIndex } from "../../../src/drift/security-xfile-index.js";
+import { buildXFileIndex, resolvePyHookBody } from "../../../src/drift/security-xfile-index.js";
 import { securityConsistency } from "../../../src/drift/security-consistency.js";
 import { SECURITY_SUBCATEGORIES } from "../../../src/drift/types.js";
 import type { SyntaxNode } from "../../../src/core/types.js";
@@ -3547,5 +3547,325 @@ describe("extractPythonRoutesAst: cross-file imported hook / dependency resoluti
     const noIdx = extractPythonRoutesAst(routeFile.tree!, routeFile.relativePath);
     expect(withIdx.every((r) => r.hasAuth === false)).toBe(true);
     expect(withIdx).toEqual(noIdx);
+  });
+});
+
+// ─── Task 5: adversarial never-false-bless sweep (cross-file, Python) ────────
+//
+// GOVERNING INVARIANT — a WRONG cross-file attribution (a route blessed from
+// the wrong body, or blessed when resolution should have refused) is a
+// false-bless. Every entry below registers a REAL rejecting body somewhere in
+// the repo, so a broken refuse guard would visibly bless the route; the sweep
+// asserts it never does. Hook names use "verify_session" (never "authenticate"
+// or another AUTH_CORE_SEGMENTS/DEPENDS_AUTH_SEGMENTS member) so no entry is
+// accidentally satisfied by the PRE-EXISTING name-only CORE bless
+// (classifyHookAuth rule 5) or the Depends name-lexicon hit — every refusal
+// here is driven by cross-file resolution, not a name shortcut.
+
+interface PyXFileSweepEntry {
+  name: string;
+  files: [string, string][];
+  routeFile: string;
+  groundTruth: Array<{ path: string; method: string; authed: boolean }>;
+}
+
+const REJECT = (name: string) =>
+  `def ${name}():\n    if session.get("user_id") is None:\n        abort(401)\n`;
+
+const PY_NEVER_FALSE_BLESS_XFILE: PyXFileSweepEntry[] = [
+  {
+    name: "absolute (dotted) import — never a resolvable target",
+    files: [
+      ["app/routes.py", `from app.auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "relative import beyond the repo root",
+    files: [
+      ["routes.py", `from ..auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "multi-candidate: module.py AND package/__init__.py both exist",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+      ["app/auth/__init__.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "duplicate def in the target file",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", `${REJECT("verify_session")}\ndef verify_session():\n    return None\n`],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "symbol absent in target, defined only by a sibling (WRONG-FILE)",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", `def helpers():\n    return 1\n`],
+      ["app/other.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "wildcard import binds the used name directly (wildcard-name)",
+    files: [
+      ["app/routes.py", `from .auth import *\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "wildcard elsewhere + explicit co-import (WILDCARD-PRESENT blanket refuse)",
+    files: [
+      ["app/routes.py", `from .other import *\nfrom .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+      ["app/other.py", `def other():\n    return 1\n`],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "re-export chain deeper than one hop (depth exceeded)",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth/__init__.py", `from .a import verify_session\n`],
+      ["app/auth/a.py", `from .b import verify_session\n`],
+      ["app/auth/b.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "target file has a parse error",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", `def verify_session(\n    if if if\n`],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "module-scope assignment shadows the imported name (local-shadow)",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\nverify_session = None\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "poisoned: two RELATIVE imports bind the same name",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\nfrom .other_auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+      ["app/other_auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "poisoned: relative + ABSOLUTE import bind the same name",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\nfrom thirdparty import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "poisoned: relative + `import x as name` bind the same name",
+    files: [
+      ["app/routes.py", `from .auth import verify_session\nimport thirdparty as verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "ALIASED-OPTIONAL: alias hides the optional-auth veto name",
+    files: [
+      ["app/routes.py", `from .auth import get_current_user_optional as check\napp.before_request(check)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("get_current_user_optional")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+  {
+    name: "attribute (module-qualified) hook target is never resolved cross-file",
+    files: [
+      ["app/routes.py", `import myapp.auth as a\napp.before_request(a.check_user)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["myapp/auth.py", REJECT("check_user")],
+    ],
+    routeFile: "app/routes.py",
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  },
+];
+
+describe("NEVER-FALSE-BLESS adversarial sweep (cross-file, Python)", () => {
+  it("no ground-truth-unauthed route is ever emitted hasAuth:true (cross-file)", async () => {
+    for (const e of PY_NEVER_FALSE_BLESS_XFILE) {
+      const files = await repo(e.files);
+      const index = buildXFileIndex(files);
+      const rf = files.find((f) => f.relativePath === e.routeFile)!;
+      const routes = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+      for (const gt of e.groundTruth.filter((g) => !g.authed)) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        // Non-vacuous: the route must actually have been extracted (the
+        // classifier genuinely ran) — a route that silently vanished would
+        // trivially satisfy the hasAuth assertion below without proving anything.
+        expect(emitted, `${e.name}: route was never extracted`).toBeDefined();
+        expect(emitted?.hasAuth ?? false, `${e.name}: ${gt.method} ${gt.path}`).toBe(false);
+      }
+    }
+  });
+});
+
+describe("EXTERNAL-PARITY (cross-file adds zero blesses for out-of-repo Python symbols)", () => {
+  const EXTERNAL_FIXTURES: Array<[string, [string, string][]]> = [
+    ["import from a module that does not exist in-repo", [
+      ["app/routes.py", `from .external_auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+    ]],
+    ["absolute (dotted) import of an in-repo-looking module", [
+      ["app/routes.py", `from app.auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ]],
+    ["attribute (module-qualified) target", [
+      ["app/routes.py", `import myapp.auth as a\napp.before_request(a.check_user)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["myapp/auth.py", REJECT("check_user")],
+    ]],
+    ["wildcard import present", [
+      ["app/routes.py", `from .auth import *\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("verify_session")],
+    ]],
+  ];
+
+  it("index-present and index-absent RouteInfo arrays are byte-identical for every external fixture", async () => {
+    for (const [name, spec] of EXTERNAL_FIXTURES) {
+      const files = await repo(spec);
+      const index = buildXFileIndex(files);
+      const rf = files.find((f) => f.relativePath === "app/routes.py")!;
+      const withIndex = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+      const withoutIndex = extractPythonRoutesAst(rf.tree!, rf.relativePath);
+      expect(withIndex, name).toEqual(withoutIndex);
+    }
+  });
+});
+
+describe("WRONG-FILE guard (Python, the single most important cross-file pin)", () => {
+  it("a boring TARGET-file body wins over a rejecting SIBLING with the same name", async () => {
+    const files = await repo([
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      // The EXACT import target: boring, visible, non-enforcing.
+      ["app/auth.py", `def verify_session():\n    return None\n`],
+      // A sibling with the SAME name that DOES reject — must never be consulted.
+      ["app/other.py", REJECT("verify_session")],
+    ]);
+    const index = buildXFileIndex(files);
+    const rf = files.find((f) => f.relativePath === "app/routes.py")!;
+    const routes = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    // The TARGET file's own boring body drives the verdict: a visible
+    // non-enforcing body is flat not-auth (rule 3), never hedged, and the
+    // sibling's reject is NEVER consulted — there is no repo-wide name search.
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+
+    // Direct proof: resolvePyHookBody resolves to the TARGET's own boring
+    // body specifically, never the sibling's rejecting one.
+    const resolved = resolvePyHookBody(index, "app/routes.py", "verify_session");
+    expect(resolved).not.toBeNull();
+    expect(bodyAuthSignature(resolved!.body!, resolved!.defs)).toBe("none");
+  });
+});
+
+describe("ONE-HOP-CEILING (Python): a second cross-file hop is never followed", () => {
+  it("a resolved hook whose reject needs a SECOND cross-file hop stays not-auth", async () => {
+    const files = await repo([
+      ["app/routes.py", `from .auth import verify_session\napp.before_request(verify_session)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      // The FIRST hop's target: verify_session calls a helper that is itself
+      // IMPORTED (a second cross-file hop), never defined in auth.py.
+      ["app/auth.py", `from .helpers import _check\n\ndef verify_session():\n    _check()\n`],
+      ["app/helpers.py", REJECT("_check")],
+    ]);
+    const index = buildXFileIndex(files);
+    const rf = files.find((f) => f.relativePath === "app/routes.py")!;
+    const routes = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
+
+    // Non-vacuous: the FIRST hop resolves fine (auth.py's verify_session IS
+    // found); the reject only lives two hops away (helpers.py's _check), which
+    // classification never reaches — it uses ONLY the defining file's own defs.
+    const resolved = resolvePyHookBody(index, "app/routes.py", "verify_session");
+    expect(resolved).not.toBeNull();
+    expect(resolved!.defs.has("_check")).toBe(false); // _check is not in auth.py's own defs
+    expect(bodyAuthSignature(resolved!.body!, resolved!.defs)).not.toBe("reject");
+  });
+});
+
+// ─── Task 2 review — required Python coverage pins (mandatory additions) ─────
+
+describe("Task 2 review — required Python coverage pins", () => {
+  it("DIRECT (non-aliased) imported optional HOOK stays not-auth via the resolved-name veto", async () => {
+    const files = await repo([
+      ["app/routes.py", `from .auth import get_current_user_optional\napp.before_request(get_current_user_optional)\n\n@app.post("/x")\ndef x():\n    return {}\n`],
+      ["app/auth.py", REJECT("get_current_user_optional")],
+    ]);
+    const index = buildXFileIndex(files);
+    const rf = files.find((f) => f.relativePath === "app/routes.py")!;
+
+    // Non-vacuous: resolution DOES succeed (the target body IS the rejecting
+    // one) — the optional-auth veto is what stops the bless, not a resolution
+    // failure.
+    const resolved = resolvePyHookBody(index, "app/routes.py", "get_current_user_optional");
+    expect(resolved).not.toBeNull();
+    expect(bodyAuthSignature(resolved!.body!, resolved!.defs)).toBe("reject");
+
+    const routes = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBeUndefined();
+  });
+
+  it("a TARGET body calling a helper that exists ONLY in the importer does not bless (helper-only-in-importer inverse)", async () => {
+    const files = await repo([
+      ["app/routes.py",
+        `from .auth import verify_session\n\n` +
+        `def _check():\n    if session.get("user_id") is None:\n        abort(401)\n\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/x")\ndef x():\n    return {}\n`],
+      // The TARGET file's verify_session calls _check — but _check exists
+      // ONLY in the importer above, never here.
+      ["app/auth.py", `def verify_session():\n    _check()\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const rf = files.find((f) => f.relativePath === "app/routes.py")!;
+
+    // Non-vacuous: resolution DOES succeed (the target body IS found) — but
+    // `_check` exists ONLY in the importer (routes.py), never in the target's
+    // (auth.py) own defs, so the one-hop MUST NOT reach across to it.
+    const resolved = resolvePyHookBody(index, "app/routes.py", "verify_session");
+    expect(resolved).not.toBeNull();
+    expect(resolved!.defs.has("_check")).toBe(false);
+    expect(bodyAuthSignature(resolved!.body!, resolved!.defs)).not.toBe("reject");
+
+    const routes = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].hasAuth).toBe(false);
   });
 });

--- a/test/unit/drift/security-xfile-index.test.ts
+++ b/test/unit/drift/security-xfile-index.test.ts
@@ -8,6 +8,32 @@ import {
   resolveGoMiddlewareBody,
 } from "../../../src/drift/security-xfile-index.js";
 import { bodyAuthSignature } from "../../../src/drift/security-ast-python.js";
+import { bodyAuthSignatureGo, resolveEffectiveBody } from "../../../src/drift/security-ast-go.js";
+
+/** Build a virtual Go repo (array of DriftFiles with parsed trees) from
+ *  [relativePath, source] pairs. Parsed SEQUENTIALLY (web-tree-sitter is not
+ *  concurrency-safe). */
+async function goRepo(files: [string, string][]): Promise<DriftFile[]> {
+  const out: DriftFile[] = [];
+  for (const [path, src] of files) out.push(await fileWithTree(path, src, "go"));
+  return out;
+}
+
+// A gin-style factory whose closure verifiably 401s (bodyAuthSignatureGo === "reject").
+const GO_REJECT_FACTORY = `package middleware
+
+import "net/http"
+
+func AuthMiddleware() Handler {
+\treturn func(c *Ctx) {
+\t\tif c.GetHeader("Authorization") == "" {
+\t\t\tc.AbortWithStatus(http.StatusUnauthorized)
+\t\t\treturn
+\t\t}
+\t\tc.Next()
+\t}
+}
+`;
 
 /** Build a virtual repo (array of DriftFiles with parsed trees) from
  *  [relativePath, source] pairs. Parsed SEQUENTIALLY — web-tree-sitter is not
@@ -51,20 +77,18 @@ describe("buildXFileIndex — construction", () => {
     expect(index.py.fileDefs.has("app/auth.py")).toBe(false);
   });
 
-  it("stores the go module path and stubs the go half empty (T1)", async () => {
+  it("stores the go module path and leaves the go half empty for a python-only repo", async () => {
     const index = buildXFileIndex(await repo([["a.py", `x = 1\n`]]), "example.com/app");
     expect(index.go.modulePath).toBe("example.com/app");
     expect(index.go.files.size).toBe(0);
-    expect(index.go.packageFuncs.size).toBe(0);
+    expect(index.go.packages.size).toBe(0);
+    expect(index.go.fileImports.size).toBe(0);
+    expect(index.go.valueBound.size).toBe(0);
   });
 
   it("go module path is undefined when not supplied (Go disabled)", async () => {
     const index = buildXFileIndex(await repo([["a.py", `x = 1\n`]]));
     expect(index.go.modulePath).toBeUndefined();
-  });
-
-  it("resolveGoMiddlewareBody is stubbed to null in T1", () => {
-    expect(resolveGoMiddlewareBody()).toBeNull();
   });
 });
 
@@ -267,5 +291,247 @@ describe("resolvePyHookBody — REFUSE cases (never-false-bless)", () => {
   it("returns null when the importer is not a known python file", async () => {
     const index = buildXFileIndex(await repo([["app/auth.py", REJECT_AUTH]]));
     expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+});
+
+// ─── Go cross-package resolution (T3) ────────────────────────────────────────
+
+describe("buildXFileIndex — Go half construction", () => {
+  it("populates packages/fileImports/valueBound for a go module", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+    ]), "myapp");
+    expect([...index.go.files].sort()).toEqual(["handlers/routes.go", "internal/middleware/auth.go"]);
+    expect(index.go.packages.has("internal/middleware")).toBe(true);
+    expect(index.go.packages.get("internal/middleware")!.pkgName).toBe("middleware");
+    // fileImports keys the importer by the target's DECLARED package name.
+    expect(index.go.fileImports.get("handlers/routes.go")!.get("middleware")).toBe("internal/middleware");
+    // `r` (a param) is value-bound in the importer; `middleware` (the package) is NOT.
+    expect(index.go.valueBound.get("handlers/routes.go")!.has("r")).toBe(true);
+    expect(index.go.valueBound.get("handlers/routes.go")!.has("middleware")).toBe(false);
+  });
+});
+
+describe("resolveGoMiddlewareBody — RESOLVE cases", () => {
+  it("resolves an imported package factory whose closure verifiably rejects", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+    ]), "myapp");
+    const r = resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index);
+    expect(r).not.toBeNull();
+    expect(r!.def.childForFieldName("name")!.text).toBe("AuthMiddleware");
+    expect(bodyAuthSignatureGo(resolveEffectiveBody(r!.def, r!.defs)!, r!.defs)).toBe("reject");
+  });
+
+  it("resolves through an ALIAS qualifier (alias is authoritative)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport mw "myapp/auth"\n\nfunc Register(r Router) {\n\tr.Use(mw.Require)\n}\n`],
+      ["auth/auth.go", `package auth\n\nfunc Require() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t\tc.Next()\n\t}\n}\n`],
+    ]), "myapp");
+    const r = resolveGoMiddlewareBody("handlers/routes.go", "mw.Require", index);
+    expect(r).not.toBeNull();
+    expect(r!.def.childForFieldName("name")!.text).toBe("Require");
+  });
+
+  it("resolves a symbol in a package that SPANS multiple files", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+      ["internal/middleware/logging.go", `package middleware\n\nfunc LogRequests() {}\n`],
+      ["internal/middleware/types.go", `package middleware\n\ntype Handler func()\n`],
+    ]), "myapp");
+    const r = resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index);
+    expect(r).not.toBeNull();
+    expect(r!.def.childForFieldName("name")!.text).toBe("AuthMiddleware");
+  });
+
+  it("resolves when the DECLARED package name is NOT the import path's last segment (package auth in authz/)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/authz"\n\nfunc Register(r Router) {\n\tr.Use(auth.RequireAuth())\n}\n`],
+      ["authz/guard.go", `package auth\n\nfunc RequireAuth() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t\tc.Next()\n\t}\n}\n`],
+    ]), "myapp");
+    // The call-site qualifier is `auth` (the declared package), NOT `authz` (the dir).
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "authz.RequireAuth", index)).toBeNull();
+    const r = resolveGoMiddlewareBody("handlers/routes.go", "auth.RequireAuth", index);
+    expect(r).not.toBeNull();
+    expect(r!.def.childForFieldName("name")!.text).toBe("RequireAuth");
+  });
+
+  it("resolves despite a co-located _test.go (excluded wholesale from the package index)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", `package middleware\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t\tc.Next()\n\t}\n}\n`],
+      // A `package middleware_test` clause AND an in-test duplicate helper: both
+      // would poison the package index if _test.go were not excluded.
+      ["internal/middleware/auth_test.go", `package middleware_test\n\nfunc AuthMiddleware() {}\n`],
+    ]), "myapp");
+    expect(index.go.packages.get("internal/middleware")!.pkgName).toBe("middleware");
+    const r = resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index);
+    expect(r).not.toBeNull();
+    expect(r!.def.childForFieldName("name")!.text).toBe("AuthMiddleware");
+  });
+
+  it("carries the def's OWN defining-file defs for the in-file one-hop (multi-file package)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      // AuthMiddleware returns the same-file helper `authImpl`, which REJECTS.
+      ["internal/middleware/auth.go", `package middleware\n\nimport "net/http"\n\nfunc AuthMiddleware() http.Handler { return authImpl }\n\nfunc authImpl(c *Ctx) {\n\tif c.GetHeader("Authorization") == "" {\n\t\tc.AbortWithStatus(http.StatusUnauthorized)\n\t\treturn\n\t}\n\tc.Next()\n}\n`],
+      // A DIFFERENT sibling authImpl that does NOT reject. If the wrong file's
+      // defs travelled, the one-hop would resolve to THIS non-rejecting body.
+      ["internal/middleware/helpers.go", `package middleware\n\nfunc authImpl(c *Ctx) {\n\tc.Next()\n}\n`],
+    ]), "myapp");
+    const r = resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index);
+    expect(r).not.toBeNull();
+    // The one-hop must resolve authImpl against auth.go's OWN defs -> reject.
+    expect(bodyAuthSignatureGo(resolveEffectiveBody(r!.def, r!.defs)!, r!.defs)).toBe("reject");
+  });
+});
+
+describe("resolveGoMiddlewareBody — REFUSE cases (never-false-bless)", () => {
+  it("refuses an EXTERNAL package (not under the module path)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "github.com/foo/mw"\n\nfunc Register(r Router) {\n\tr.Use(mw.Auth)\n}\n`],
+    ]), "myapp");
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "mw.Auth", index)).toBeNull();
+  });
+
+  it("refuses ALL Go resolution when goModulePath is null (no go.mod)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+    ]), null);
+    expect(index.go.packages.size).toBe(0);
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+  });
+
+  it("refuses ALL Go resolution when a replace directive forced goModulePath null", async () => {
+    // The plumbing collapses goModulePath to null on a `replace`; at this layer
+    // that is simply a null module path -> Go disabled.
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+    ]), null);
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+  });
+
+  it("refuses ANY selector in a file that has a DOT import", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport (\n\t"myapp/internal/middleware"\n\t. "myapp/helpers"\n)\n\nfunc Register(r Router) {}\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+    ]), "myapp");
+    expect(index.go.dotImports.has("handlers/routes.go")).toBe(true);
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+  });
+
+  for (const [label, importer] of [
+    [":= (short_var_declaration)", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tmiddleware := getMW()\n\tr.Use(middleware.Wrap())\n}\n`],
+    ["method RECEIVER", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc (middleware *Server) Register(r Router) {\n\tr.Use(middleware.AuthMiddleware())\n}\n`],
+    ["const (const_spec)", `package handlers\n\nimport "myapp/internal/middleware"\n\nconst middleware = 0\n`],
+    ["named RETURN", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc provide() (middleware Handler) {\n\treturn nil\n}\n`],
+  ] as const) {
+    it(`refuses a VALUE-SHADOWED qualifier — ${label}`, async () => {
+      const index = buildXFileIndex(await goRepo([
+        ["handlers/routes.go", importer],
+        ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+      ]), "myapp");
+      // The middleware package DOES define AuthMiddleware, so the ONLY reason to
+      // refuse is the value-shadowed qualifier.
+      expect(index.go.valueBound.get("handlers/routes.go")!.has("middleware")).toBe(true);
+      expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+    });
+  }
+
+  it("refuses a PACKAGE-NAME mismatch (plain import, declared package != qualifier)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", `package authpkg\n\nfunc AuthMiddleware() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t}\n}\n`],
+    ]), "myapp");
+    // The declared package is `authpkg`, so `middleware.` is not a live qualifier.
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+    // But the real qualifier resolves (proves only the mismatch refuses).
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "authpkg.AuthMiddleware", index)).not.toBeNull();
+  });
+
+  it("refuses a symbol that is a METHOD (not a package-level function_declaration)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", `package middleware\n\ntype Mw struct{}\n\nfunc (m *Mw) AuthMiddleware() {}\n`],
+    ]), "myapp");
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+  });
+
+  it("refuses a symbol defined in TWO files of the package (sticky-null duplicate)", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+      ["internal/middleware/legacy.go", `package middleware\n\nfunc AuthMiddleware() Handler {\n\treturn nil\n}\n`],
+    ]), "myapp");
+    expect(index.go.packages.get("internal/middleware")!.defs.get("AuthMiddleware")).toBeNull();
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+  });
+
+  it("refuses an UNEXPORTED (lowercase) cross-package symbol", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/auth"\n`],
+      ["auth/auth.go", `package auth\n\nfunc check() Handler {\n\treturn func(c *Ctx) {\n\t\tc.AbortWithStatus(401)\n\t}\n}\n`],
+    ]), "myapp");
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "auth.check", index)).toBeNull();
+  });
+
+  it("refuses a symbol whose ONLY definition is in a parse-errored file", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/other.go", `package middleware\n\nfunc Other() {}\n`],
+      // AuthMiddleware lives ONLY in this deliberately-unparseable file.
+      ["internal/middleware/auth.go", `package middleware\n\nfunc AuthMiddleware( {\n`],
+    ]), "myapp");
+    const broken = (await goRepo([["x.go", `package middleware\n\nfunc AuthMiddleware( {\n`]]))[0];
+    expect(broken.tree!.rootNode.hasError).toBe(true); // sanity: the fixture IS broken
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+    // The clean sibling def in the same package still resolves.
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.Other", index)).not.toBeNull();
+  });
+
+  it("refuses a bare (non-qualified) name and a deeper field chain", async () => {
+    const index = buildXFileIndex(await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+    ]), "myapp");
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "AuthMiddleware", index)).toBeNull();
+    expect(resolveGoMiddlewareBody("handlers/routes.go", "s.middleware.AuthMiddleware", index)).toBeNull();
+  });
+});
+
+describe("resolveGoMiddlewareBody — determinism (order-independence)", () => {
+  it("builds an equal go.packages map regardless of file order (duplicate -> null)", async () => {
+    const files = await goRepo([
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+      ["internal/middleware/legacy.go", `package middleware\n\nfunc AuthMiddleware() Handler { return nil }\n\nfunc LegacyOnly() {}\n`],
+      ["internal/mw2/other.go", `package mw2\n\nfunc Guard() {}\n`],
+    ]);
+    const a = buildXFileIndex(files, "myapp");
+    const b = buildXFileIndex(reversed(files), "myapp");
+
+    expect([...a.go.packages.keys()].sort()).toEqual([...b.go.packages.keys()].sort());
+    const nodeKey = (n: SyntaxNode | null | undefined) => (n == null ? String(n) : n.id);
+    for (const [dir, pkgA] of a.go.packages) {
+      const pkgB = b.go.packages.get(dir)!;
+      expect(pkgB.pkgName).toBe(pkgA.pkgName);
+      expect([...pkgA.defs.keys()].sort()).toEqual([...pkgB.defs.keys()].sort());
+      for (const [name, entryA] of pkgA.defs) {
+        const entryB = pkgB.defs.get(name)!;
+        // A duplicated symbol is sticky-null in BOTH orders (never first-wins).
+        expect(nodeKey(entryA?.def)).toBe(nodeKey(entryB?.def));
+        expect(entryA?.file).toBe(entryB?.file);
+        expect([...(entryA?.fileDefs.keys() ?? [])].sort()).toEqual([...(entryB?.fileDefs.keys() ?? [])].sort());
+      }
+    }
+    // The duplicated symbol is null; the unique sibling survives.
+    expect(a.go.packages.get("internal/middleware")!.defs.get("AuthMiddleware")).toBeNull();
+    expect(b.go.packages.get("internal/middleware")!.defs.get("AuthMiddleware")).toBeNull();
+    expect(a.go.packages.get("internal/middleware")!.defs.get("LegacyOnly")).not.toBeNull();
   });
 });

--- a/test/unit/drift/security-xfile-index.test.ts
+++ b/test/unit/drift/security-xfile-index.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from "vitest";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+import type { DriftFile } from "../../../src/drift/types.js";
+import type { SyntaxNode } from "../../../src/core/types.js";
+import {
+  buildXFileIndex,
+  resolvePyHookBody,
+  resolveGoMiddlewareBody,
+} from "../../../src/drift/security-xfile-index.js";
+import { bodyAuthSignature } from "../../../src/drift/security-ast-python.js";
+
+/** Build a virtual repo (array of DriftFiles with parsed trees) from
+ *  [relativePath, source] pairs. Parsed SEQUENTIALLY — web-tree-sitter is not
+ *  safe to drive concurrently (a Promise.all race yields undefined trees). */
+async function repo(files: [string, string][]): Promise<DriftFile[]> {
+  const out: DriftFile[] = [];
+  for (const [path, src] of files) out.push(await fileWithTree(path, src, "python"));
+  return out;
+}
+
+/** Shuffle a copy with a fixed permutation (reverse) — enough to prove the
+ *  index build is order-independent without RNG flakiness. */
+function reversed<T>(xs: T[]): T[] {
+  return [...xs].reverse();
+}
+
+const REJECT_AUTH = `def authenticate():\n    if not session.get("user_id"):\n        abort(401)\n`;
+
+describe("buildXFileIndex — construction", () => {
+  it("builds one index over all files: py.files holds every python path", async () => {
+    const files = await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]);
+    const index = buildXFileIndex(files);
+    expect([...index.py.files].sort()).toEqual(["app/auth.py", "app/routes.py"]);
+    expect(index.py.fileDefs.has("app/auth.py")).toBe(true);
+    expect(index.py.fileDefs.get("app/auth.py")!.has("authenticate")).toBe(true);
+  });
+
+  it("a broken (parse-error) file stays in py.files but gets NO fileDefs entry", async () => {
+    const files = await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      // Deliberately unparseable: unterminated def.
+      ["app/auth.py", `def authenticate(\n    if if if\n`],
+    ]);
+    const index = buildXFileIndex(files);
+    const broken = files.find((f) => f.relativePath === "app/auth.py")!;
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    expect(index.py.files.has("app/auth.py")).toBe(true);
+    expect(index.py.fileDefs.has("app/auth.py")).toBe(false);
+  });
+
+  it("stores the go module path and stubs the go half empty (T1)", async () => {
+    const index = buildXFileIndex(await repo([["a.py", `x = 1\n`]]), "example.com/app");
+    expect(index.go.modulePath).toBe("example.com/app");
+    expect(index.go.files.size).toBe(0);
+    expect(index.go.packageFuncs.size).toBe(0);
+  });
+
+  it("go module path is undefined when not supplied (Go disabled)", async () => {
+    const index = buildXFileIndex(await repo([["a.py", `x = 1\n`]]));
+    expect(index.go.modulePath).toBeUndefined();
+  });
+
+  it("resolveGoMiddlewareBody is stubbed to null in T1", () => {
+    expect(resolveGoMiddlewareBody()).toBeNull();
+  });
+});
+
+describe("buildXFileIndex — determinism (order-independence)", () => {
+  it("produces an identical py index regardless of file ordering", async () => {
+    const files = await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+      ["app/mw/auth.py", `def require_auth():\n    abort(401)\n`],
+      ["app/helpers.py", `def helpers():\n    return 1\n`],
+      ["broken.py", `def x(\n`],
+    ]);
+    const a = buildXFileIndex(files);
+    const b = buildXFileIndex(reversed(files));
+
+    // Same member set for py.files.
+    expect([...a.py.files].sort()).toEqual([...b.py.files].sort());
+
+    // Same keys for fileDefs, and every (rel,name) maps to the SAME underlying
+    // node (or the same null) in both builds — no last-wins drift. web-tree-
+    // sitter hands out a fresh JS wrapper per access, so identity is compared
+    // via the stable underlying-node `.id`, not object reference.
+    const nodeKey = (n: SyntaxNode | null | undefined) => (n == null ? String(n) : n.id);
+    expect([...a.py.fileDefs.keys()].sort()).toEqual([...b.py.fileDefs.keys()].sort());
+    for (const [rel, defsA] of a.py.fileDefs) {
+      const defsB = b.py.fileDefs.get(rel)!;
+      expect([...defsA.keys()].sort()).toEqual([...defsB.keys()].sort());
+      for (const [name, nodeA] of defsA) {
+        expect(nodeKey(defsB.get(name))).toBe(nodeKey(nodeA));
+      }
+    }
+  });
+
+  it("a symbol defined twice in one file is poisoned to null (not last-wins)", async () => {
+    const files = await repo([
+      ["app/auth.py", `def authenticate():\n    abort(401)\n\ndef authenticate():\n    return 1\n`],
+    ]);
+    const a = buildXFileIndex(files);
+    const b = buildXFileIndex(reversed(files));
+    expect(a.py.fileDefs.get("app/auth.py")!.get("authenticate")).toBeNull();
+    expect(b.py.fileDefs.get("app/auth.py")!.get("authenticate")).toBeNull();
+  });
+});
+
+describe("resolvePyHookBody — RESOLVE cases", () => {
+  it("resolves a single-dot relative import to the defining file's body", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]));
+    const r = resolvePyHookBody(index, "app/routes.py", "authenticate");
+    expect(r).not.toBeNull();
+    expect(r!.originalName).toBe("authenticate");
+    expect(r!.body!.text).toContain("abort(401)");
+    expect(bodyAuthSignature(r!.body!, r!.defs)).toBe("reject");
+  });
+
+  it("resolves a double-dot import with a subpackage", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/sub/routes.py", `from ..mw.auth import require_auth\n`],
+      ["app/mw/auth.py", `def require_auth():\n    abort(401)\n`],
+    ]));
+    const r = resolvePyHookBody(index, "app/sub/routes.py", "require_auth");
+    expect(r).not.toBeNull();
+    expect(r!.originalName).toBe("require_auth");
+    expect(r!.body!.text).toContain("abort(401)");
+  });
+
+  it("follows ONE __init__ re-export hop to the real defining file", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth/__init__.py", `from .impl import authenticate\n`],
+      ["app/auth/impl.py", REJECT_AUTH],
+    ]));
+    const r = resolvePyHookBody(index, "app/routes.py", "authenticate");
+    expect(r).not.toBeNull();
+    expect(r!.body!.text).toContain("abort(401)");
+  });
+
+  it("resolves an aliased import back to the target's true symbol name", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/sub/routes.py", `from ..auth import verify as v\n`],
+      ["app/auth.py", `def verify():\n    abort(401)\n`],
+    ]));
+    const r = resolvePyHookBody(index, "app/sub/routes.py", "v");
+    expect(r).not.toBeNull();
+    expect(r!.originalName).toBe("verify");
+    expect(r!.body!.text).toContain("abort(401)");
+  });
+});
+
+describe("resolvePyHookBody — REFUSE cases (never-false-bless)", () => {
+  it("refuses an absolute (dotted) import even when the file exists", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from app.auth import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses a relative import that reaches beyond the repo root", async () => {
+    const index = buildXFileIndex(await repo([
+      ["routes.py", `from ..auth import authenticate\n`],
+      ["auth.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses when BOTH module.py and package/__init__.py exist (ambiguous)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+      ["app/auth/__init__.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses a symbol defined twice in the target file", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", `def authenticate():\n    abort(401)\n\ndef authenticate():\n    return 1\n`],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("NEVER picks a same-name symbol from a sibling file (symbol-not-defined)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", `def helpers():\n    return 1\n`],
+      ["app/other.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses a wildcard import (name never enters the table)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import *\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses ALL resolution in a file that has any wildcard import (blanket)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .other import *\nfrom .auth import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+      ["app/other.py", `def other():\n    return 1\n`],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses when a re-export would need MORE than one hop (depth exceeded)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth/__init__.py", `from .a import authenticate\n`],
+      ["app/auth/a.py", `from .b import authenticate\n`],
+      ["app/auth/b.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses when the target file has a parse error (no fileDefs entry)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", `def authenticate(\n    if if if\n`],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses a name bound by a relative AND a non-relative import (poisoned)", async () => {
+    const absPoison = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\nfrom thirdparty import authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(absPoison, "app/routes.py", "authenticate")).toBeNull();
+
+    const aliasPoison = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\nimport x as authenticate\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(aliasPoison, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses when a same-file def shadows the imported name (local shadow)", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n\ndef authenticate():\n    return 1\n`],
+      ["app/auth.py", REJECT_AUTH],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("refuses when the target symbol is only a nested (non-importable) def", async () => {
+    const index = buildXFileIndex(await repo([
+      ["app/routes.py", `from .auth import authenticate\n`],
+      ["app/auth.py", `def outer():\n    def authenticate():\n        abort(401)\n    return authenticate\n`],
+    ]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+
+  it("returns null when the importer is not a known python file", async () => {
+    const index = buildXFileIndex(await repo([["app/auth.py", REJECT_AUTH]]));
+    expect(resolvePyHookBody(index, "app/routes.py", "authenticate")).toBeNull();
+  });
+});

--- a/test/unit/drift/security-xfile-index.test.ts
+++ b/test/unit/drift/security-xfile-index.test.ts
@@ -7,8 +7,10 @@ import {
   resolvePyHookBody,
   resolveGoMiddlewareBody,
 } from "../../../src/drift/security-xfile-index.js";
-import { bodyAuthSignature } from "../../../src/drift/security-ast-python.js";
-import { bodyAuthSignatureGo, resolveEffectiveBody } from "../../../src/drift/security-ast-go.js";
+import { bodyAuthSignature, extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
+import {
+  bodyAuthSignatureGo, resolveEffectiveBody, extractGoRoutesAst,
+} from "../../../src/drift/security-ast-go.js";
 
 /** Build a virtual Go repo (array of DriftFiles with parsed trees) from
  *  [relativePath, source] pairs. Parsed SEQUENTIALLY (web-tree-sitter is not
@@ -533,5 +535,97 @@ describe("resolveGoMiddlewareBody — determinism (order-independence)", () => {
     expect(a.go.packages.get("internal/middleware")!.defs.get("AuthMiddleware")).toBeNull();
     expect(b.go.packages.get("internal/middleware")!.defs.get("AuthMiddleware")).toBeNull();
     expect(a.go.packages.get("internal/middleware")!.defs.get("LegacyOnly")).not.toBeNull();
+  });
+});
+
+// ─── Task 5 catalog completion: remaining Go value-shadow binding forms ─────
+//
+// The REFUSE loop above (":=", "method RECEIVER", "const", "named RETURN")
+// predates the Task 5 adversarial catalog, which additionally requires "var",
+// a plain "param", and a "type-switch guard" binding form. Appended here
+// (rather than edited into the existing loop) to keep this file's prior pins
+// untouched. Same shape and same positive-control discipline: the middleware
+// package DOES define a genuinely rejecting AuthMiddleware, so the ONLY
+// reason each of these refuses is the value-shadowed qualifier.
+describe("resolveGoMiddlewareBody — REFUSE cases (value-shadow catalog completion)", () => {
+  for (const [label, importer] of [
+    ["var (var_spec)", `package handlers\n\nimport "myapp/internal/middleware"\n\nvar middleware int\n`],
+    ["param (parameter_declaration)", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(middleware int) {}\n`],
+    ["type-switch guard", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(x interface{}) {\n\tswitch middleware := x.(type) {\n\tdefault:\n\t\t_ = middleware\n\t}\n}\n`],
+  ] as const) {
+    it(`refuses a VALUE-SHADOWED qualifier — ${label}`, async () => {
+      const index = buildXFileIndex(await goRepo([
+        ["handlers/routes.go", importer],
+        ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+      ]), "myapp");
+      expect(index.go.valueBound.get("handlers/routes.go")!.has("middleware")).toBe(true);
+      expect(resolveGoMiddlewareBody("handlers/routes.go", "middleware.AuthMiddleware", index)).toBeNull();
+    });
+  }
+});
+
+// ─── Task 5: DETERMINISM (route-level, cross-file positives) ────────────────
+//
+// Step 5 of the adversarial sweep: for a Python cross-file positive and a Go
+// cross-file positive, permute the DriftFile order (def-before-route,
+// route-before-def, and a third fixed shuffle — a reverse-permutation is
+// enough to prove order-independence without RNG flakiness, matching this
+// file's own `reversed()` convention) and confirm the EXTRACTED ROUTES
+// (hasAuth / authUnsureHook included) are identical in every order, and that
+// an UNRELATED duplicate def in the same repo resolves to null in every order
+// too (poisoned, never first-wins).
+
+describe("DETERMINISM (route-level, cross-file positives)", () => {
+  it("Python: permuted file order yields identical routes; an unrelated duplicate stays null in every order", async () => {
+    const spec: [string, string][] = [
+      ["pkg/routes.py",
+        `from .auth import verify_session\n` +
+        `app.before_request(verify_session)\n\n` +
+        `@app.post("/orders")\ndef create_order():\n    return {}\n`],
+      ["pkg/auth.py",
+        `def verify_session():\n    if session.get("user_id") is None:\n        abort(401)\n`],
+      // Unrelated to the route: a same-file duplicate def, must poison to null
+      // in every permutation (never first-wins).
+      ["pkg/other.py", `def dup():\n    return 1\n\ndef dup():\n    return 2\n`],
+    ];
+    const orders = [spec, reversed(spec), [spec[1], spec[2], spec[0]]];
+    let prevRoutes: unknown;
+    for (const order of orders) {
+      const files = await repo(order);
+      const index = buildXFileIndex(files);
+      const rf = files.find((f) => f.relativePath === "pkg/routes.py")!;
+      const routes = extractPythonRoutesAst(rf.tree!, rf.relativePath, index);
+      expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth} hook=${r.authUnsureHook ?? ""}`)).toEqual([
+        "POST /orders auth=true hook=",
+      ]);
+      if (prevRoutes !== undefined) expect(routes).toEqual(prevRoutes);
+      prevRoutes = routes;
+      expect(index.py.fileDefs.get("pkg/other.py")!.get("dup")).toBeNull();
+    }
+  });
+
+  it("Go: permuted file order yields identical routes; an unrelated duplicate stays null in every order", async () => {
+    const spec: [string, string][] = [
+      ["handlers/routes.go", `package handlers\n\nimport "myapp/internal/middleware"\n\nfunc Register(r Router) {\n\tr.POST("/x", middleware.AuthMiddleware(), createX)\n}\n`],
+      ["internal/middleware/auth.go", GO_REJECT_FACTORY],
+      // Unrelated to the route: a same-package duplicate def, must poison to
+      // null in every permutation.
+      ["internal/dup/a.go", `package dup\n\nfunc Dup() {}\n`],
+      ["internal/dup/b.go", `package dup\n\nfunc Dup() {}\n`],
+    ];
+    const orders = [spec, reversed(spec), [spec[2], spec[3], spec[0], spec[1]]];
+    let prevRoutes: unknown;
+    for (const order of orders) {
+      const files = await goRepo(order);
+      const index = buildXFileIndex(files, "myapp");
+      const rf = files.find((f) => f.relativePath === "handlers/routes.go")!;
+      const routes = extractGoRoutesAst(rf.tree!, rf.relativePath, index);
+      expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth} hook=${r.authUnsureHook ?? ""}`)).toEqual([
+        "POST /x auth=true hook=",
+      ]);
+      if (prevRoutes !== undefined) expect(routes).toEqual(prevRoutes);
+      prevRoutes = routes;
+      expect(index.go.packages.get("internal/dup")!.defs.get("Dup")).toBeNull();
+    }
   });
 });

--- a/test/unit/drift/tree-plumbing.test.ts
+++ b/test/unit/drift/tree-plumbing.test.ts
@@ -21,3 +21,43 @@ describe("buildDriftContext tree plumbing", () => {
     expect(drift.files[0].tree).toBe(tree);
   });
 });
+
+describe("buildDriftContext goModulePath threading", () => {
+  const base = {
+    rootDir: "/r", files: [], packageJson: null, cargoToml: null,
+    requirementsTxt: null, envExample: null, totalLines: 0,
+    languageBreakdown: new Map(), dominantLanguage: "go",
+  };
+
+  const ctxWith = (goMod: unknown): AnalysisContext =>
+    ({ ...base, goMod } as unknown as AnalysisContext);
+
+  it("threads the root module path from go.mod", () => {
+    const drift = buildDriftContext(ctxWith({ module: "example.com/app", require: [] }));
+    expect(drift.goModulePath).toBe("example.com/app");
+  });
+
+  it("is undefined when there is no go.mod (Go cross-file disabled)", () => {
+    const drift = buildDriftContext(ctxWith(null));
+    expect(drift.goModulePath).toBeUndefined();
+  });
+
+  it("is undefined when go.mod declares a replace directive", () => {
+    const drift = buildDriftContext(
+      ctxWith({ module: "example.com/app", require: [], hasReplace: true }),
+    );
+    expect(drift.goModulePath).toBeUndefined();
+  });
+
+  it("is undefined when a nested go.mod exists under the scan root", () => {
+    const drift = buildDriftContext(
+      ctxWith({ module: "example.com/app", require: [], hasNestedModule: true }),
+    );
+    expect(drift.goModulePath).toBeUndefined();
+  });
+
+  it("is undefined when go.mod has an empty module path", () => {
+    const drift = buildDriftContext(ctxWith({ module: "", require: [] }));
+    expect(drift.goModulePath).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What this does

Makes the Security Consistency auth detector **cross-file aware** for Python and Go. Before, a route was only marked protected when the middleware or hook that guards it had its body in the same file; real apps almost always import their auth from another file, so those routes fell back to "unsure". This change follows the import to the symbol's defining file in the repo, reads that body, and classifies it with the existing body-first logic, so real apps get clean "protected" verdicts.

Builds on the Python (#43) and Go (#44) body-first work.

## How it works

- **Python**: a relative import (`from .auth import verify_session`) used as a `before_request` hook or a FastAPI `Depends`/`Security` dependency resolves to its defining file; if that body verifiably rejects unauthenticated requests, the route is protected.
- **Go**: an imported package middleware (`middleware.AuthMiddleware`) resolves to its function in that package's directory (via the module path from go.mod); if its body rejects, the route is protected.
- A repo-wide symbol index is built once per scan and reused; nothing is re-parsed.

## Safety: resolution is exact and conservative

The governing rule is unchanged: never mark an unauthed route as authed. A wrong cross-file attribution would be exactly that, so resolution refuses (and the route stays "unsure") whenever it is not certain: an aliased or ambiguous import, a symbol defined more than once, a name shadowed by a local value, a package whose source is not in the repo, or a target file that does not parse. Resolution only ever *supplies* a body to the existing classifier, which still requires a verifiable rejection to bless. Under-resolving is safe; wrong-resolving is forbidden.

Verified on real apps: routes moved from "unsure" to "protected" on multi-file Gin and FastAPI projects, and every protected verdict traced to a real rejecting body, with no false "protected".

## Compatibility

- In-file symbols classify exactly as before (byte-identical), and the JavaScript/TypeScript path is untouched.
- The index build is deterministic (order-independent), so scans stay reproducible.
- No em-dashes or double hyphens in user-facing strings.
- Covered by unit tests, an adversarial never-false-bless sweep across both languages, and calibration scenarios.

## Known limitations (follow-up)

- A middleware whose body has a setup statement before its returned closure (a common Echo `JWTWithConfig` shape) is not yet read.
- Auth applied to a router group that is passed between functions (cross-function wiring) is out of scope for this file-level resolution.
- Python absolute imports and multi-module Go repos are deferred; they stay "unsure" (safe) rather than risk a wrong attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
