### PR TITLE
Rust AST auth extractor for Security Consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ eval/reports/
 eval/discrimination/.cache/
 
 # Internal security sub-phase plans (local execution docs, not for the public repo)
-PLAN-security-conformance-phase*.md
+PLAN-security-conformance-*.md

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -273,6 +273,7 @@ const SCOPED_ID_T = new Set(["scoped_identifier"]);
 const CALL_EXPR_T = new Set(["call_expression"]);
 const IF_EXPR_T = new Set(["if_expression"]);
 const LET_DECL_T = new Set(["let_declaration"]);
+const RETURN_EXPR_T = new Set(["return_expression"]);
 
 /** Lowercase segments of an identifier, split on non-alphanumeric AND CamelCase
  *  boundaries. Copied VERBATIM from security-ast-go.ts:603 (whole-segment
@@ -621,6 +622,41 @@ function rustSubtreeHas403(node: SyntaxNode): boolean {
   return false;
 }
 
+/** True when `node`, sitting in a PRODUCE / return position, yields a 401
+ *  rejection value: a bare `StatusCode::UNAUTHORIZED`, a `(StatusCode::
+ *  UNAUTHORIZED, ..)` tuple, a `(STATUS,..).into_response()` / `STATUS
+ *  .into_response()` call, or an `Err(<produces 401>)` construction. Recurses
+ *  through `Err(..)` and `.into_response()`. Everything else — `Ok(..)`, a plain
+ *  identifier, a comparison, a non-status call — yields false. This is the ONLY
+ *  gate for a 401 bless: a 401 reached through here in a produce position (a
+ *  `return` value, a block tail, an `Err(..)`, an `.ok_or(..)`) rejects; a 401 in
+ *  an `if`/`while`/`match` condition/scrutinee, a comparison operand, a match-arm
+ *  pattern, or a plain call argument is never routed here. Mirrors Go's
+ *  produce-position gating (scanGoBody). */
+function rustProduces401(node: SyntaxNode | null): boolean {
+  if (!node) return false;
+  switch (node.type) {
+    case "scoped_identifier":
+      return rustRejectStatus(node) === "401";
+    case "tuple_expression": {
+      const first = node.namedChildren.find((c): c is SyntaxNode => c !== null) ?? null;
+      return first?.type === "scoped_identifier" && rustRejectStatus(first) === "401";
+    }
+    case "call_expression": {
+      const fn = node.childForFieldName("function");
+      if (fn?.type === "identifier" && fn.text === "Err") {
+        return rustProduces401(node.childForFieldName("arguments")?.namedChild(0) ?? null);
+      }
+      if (fn?.type === "field_expression" && fn.childForFieldName("field")?.text === "into_response") {
+        return rustProduces401(fn.childForFieldName("value"));
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
 interface RustBodySignals { reject401: boolean; reject403Guarded: boolean; opaqueHint: boolean; credentialRead: boolean; }
 
 /** Scan an effective from_fn body for the reject catalogue. reject401 blesses
@@ -634,45 +670,67 @@ interface RustBodySignals { reject401: boolean; reject403Guarded: boolean; opaqu
 function scanRustBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): RustBodySignals {
   const out: RustBodySignals = { reject401: false, reject403Guarded: false, opaqueHint: false, credentialRead: false };
 
-  // 1. A 401 named status constant in a PRODUCE position (pruned of nested
-  //    closures). Covers Err(STATUS) / tuple.into_response() / .ok_or(STATUS) /
-  //    bare tail / return Err(STATUS). A 401 that is the direct RHS of a `let`
-  //    binding (`let code = StatusCode::UNAUTHORIZED;`) is a REFERENCE, not a
-  //    reject, and is excluded — the invariant requires a verifiable rejection,
-  //    not a mention (the `.ok_or(STATUS)` case is not affected: its status node's
-  //    immediate parent is an `arguments`, never the `let_declaration`).
-  for (const si of rustPrunedDescendants(body, SCOPED_ID_T)) {
-    if (rustRejectStatus(si) === "401" && si.parent?.type !== "let_declaration") {
-      out.reject401 = true;
-      break;
-    }
+  // 1. A 401 named status blesses ONLY as a PRODUCED value (pruned of nested
+  //    closures): a `return <STATUS>` value or a block TAIL expression that is a
+  //    401, a `(STATUS,..).into_response()`, or an `Err(<produces 401>)`. A 401 in
+  //    a comparison operand (`== StatusCode::UNAUTHORIZED`), an `if`/`while`/`match`
+  //    condition/scrutinee, a `match`-arm PATTERN, or a plain call ARGUMENT (a
+  //    `headers.insert(..)` or a logging macro) is a MENTION, never a reject — the
+  //    invariant requires a verifiable rejection, not a mention. The `Err(..)`,
+  //    `.ok_or(..)` and `.ok_or_else(..)` produce forms are read in the call scan
+  //    (section 2). Mirrors Go's produce-position gating (scanGoBody).
+  for (const ret of rustPrunedDescendants(body, RETURN_EXPR_T)) {
+    if (ret.hasError) continue;
+    if (rustProduces401(ret.namedChild(0) ?? null)) { out.reject401 = true; break; }
   }
-  if (body.type === "scoped_identifier" && rustRejectStatus(body) === "401") out.reject401 = true;
+  if (!out.reject401) {
+    // A block TAIL expression (last child, no trailing `;`), or a bare-expression
+    // body (`|req, next| STATUS`). Non-produce last children (an
+    // `expression_statement`, a plain identifier) fail rustProduces401.
+    const named = body.namedChildren.filter((c): c is SyntaxNode => c !== null);
+    const tail = body.type === "block" ? (named[named.length - 1] ?? null) : body;
+    if (rustProduces401(tail)) out.reject401 = true;
+  }
 
-  // 2. Call-position scan: the ok_or_else closure (read explicitly), Actix
-  //    bare-identifier 401 constructors, credential reads, and opaque auth calls.
+  // 2. Call-position produce scan: `Err(<produces 401>)` (the idiomatic Axum
+  //    reject value), the `.ok_or(STATUS)` / `.ok_or_else(|| STATUS)` produce
+  //    forms (read explicitly), Actix bare-identifier 401 constructors, plus the
+  //    credential-read and opaque-auth-call signals. A `.into_response()` that is
+  //    NOT wrapped in a produce position (section 1) never reaches reject401 here.
   const boundLocals = rustCredentialBoundLocals(body);
   for (const call of rustPrunedDescendants(body, CALL_EXPR_T)) {
     if (call.hasError) continue;
     if (!out.credentialRead && rustIsCredentialReadCall(call)) out.credentialRead = true;
     const fn = call.childForFieldName("function");
-    if (fn?.type === "field_expression" && fn.childForFieldName("field")?.text === "ok_or_else") {
-      const closure = call.childForFieldName("arguments")?.namedChild(0) ?? null;
-      const cbody = closure?.type === "closure_expression" ? closure.childForFieldName("body") : null;
-      if (cbody) {
-        if (cbody.type === "scoped_identifier" && rustRejectStatus(cbody) === "401") out.reject401 = true;
-        else if (cbody.namedChildren.some((c) => c && c.type === "scoped_identifier" && rustRejectStatus(c) === "401")) {
-          out.reject401 = true;
-        } else {
-          for (const si of rustPrunedDescendants(cbody, SCOPED_ID_T)) {
-            if (rustRejectStatus(si) === "401") { out.reject401 = true; break; }
+    if (fn?.type === "field_expression") {
+      const field = fn.childForFieldName("field")?.text;
+      if (field === "ok_or") {
+        if (rustProduces401(call.childForFieldName("arguments")?.namedChild(0) ?? null)) out.reject401 = true;
+        continue;
+      }
+      if (field === "ok_or_else") {
+        const closure = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+        const cbody = closure?.type === "closure_expression" ? closure.childForFieldName("body") : null;
+        if (cbody) {
+          if (cbody.type === "scoped_identifier" && rustRejectStatus(cbody) === "401") out.reject401 = true;
+          else if (cbody.namedChildren.some((c) => c && c.type === "scoped_identifier" && rustRejectStatus(c) === "401")) {
+            out.reject401 = true;
+          } else {
+            for (const si of rustPrunedDescendants(cbody, SCOPED_ID_T)) {
+              if (rustRejectStatus(si) === "401") { out.reject401 = true; break; }
+            }
           }
         }
+        continue;
       }
-      continue;
+      continue; // any other method call is not a produce path (into_response gated in section 1)
     }
     if (fn?.type === "identifier") {
       const name = fn.text;
+      if (name === "Err") {
+        if (rustProduces401(call.childForFieldName("arguments")?.namedChild(0) ?? null)) out.reject401 = true;
+        continue;
+      }
       if (RUST_ERR_CTOR_401.has(name)) { out.reject401 = true; continue; }
       // An unresolvable (not-in-file, or duplicate) auth-flavored callee -> opaque.
       if (!defs.has(name) && rustNameHasHint(name)) out.opaqueHint = true;

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -6,13 +6,15 @@
  * security-ast-python.ts, and security-ast-go.ts. Rust has zero coverage
  * today; this is the first module for the language.
  *
- * TASK 1 SCOPE: route recognition only. `hasAuth` is unconditionally false
- * on every route this module emits — Task 3 fills the signal, Task 4 wires
- * this module into security-consistency.ts. Method/path resolution beyond
- * the single-verb-callee case (the `on(filter, h)` combinator, a chained
- * multi-verb `get(l).post(c)` link, Rocket's generic `#[route(GET, "/x")]`
- * macro) is Task 2; those shapes are recognized structurally as NOT a route
- * today (a recall gap, never a bless) rather than guessed.
+ * SCOPE (Task 1 + Task 2): route recognition and method/path resolution.
+ * `hasAuth` is unconditionally false on every route this module emits — Task 3
+ * fills the signal, Task 4 wires this module into security-consistency.ts.
+ * Task 2 resolves the full method surface: the `on(MethodFilter, h)`
+ * combinator and a chained multi-verb `get(l).post(c)` link (both verb-SHAPED
+ * but unresolvable/multi -> "ALL" or the first mutating verb, never a silent
+ * GET-drop) and Actix's generic `#[route("/x", method = "VERB")]` macro
+ * (verbs read from the token tree). An arg1 with NO verb shape at all (a bare
+ * identifier, an unrecognized callee) is still a deliberate SKIP.
  *
  * A find-replace port from a sibling module fails silently on five Rust
  * grammar traps (probe-verified against the pinned tree-sitter-wasms rust
@@ -82,18 +84,21 @@
  * modules' fallback can.
  *
  * PINNED RECALL GAPS (measured, never a false-bless; each is a route this
- * module will not find rather than one it misclassifies):
- *   - Axum's `on(MethodFilter, handler)` combinator (`ON_CALLEES` is
- *     forward-declared for Task 2; its `MethodFilter` argument is not parsed
- *     yet, so an `on(...)` call is simply not recognized as a route).
- *   - A chained multi-verb link (`get(l).post(c)`) as `.route`'s arg1: the
- *     outer callee is a `field_expression`, not an `identifier` or
- *     `scoped_identifier`, and `resolveAxumMethod` does not unwrap it, so
- *     the whole `.route(...)` call is skipped rather than guessing one verb.
- *   - Rocket's generic `#[route(GET, "/x")]` macro: `"route"` is
- *     deliberately absent from `ATTR_ROUTE_METHODS` (its method lives inside
- *     the token tree, not in the macro name), so it is unrecognized rather
- *     than resolved as a bogus `"ROUTE"` method.
+ * module will not find, or a method it over-approximates to "ALL", rather
+ * than one it misclassifies into or out of the mutating vote wrongly):
+ *   - Axum's `on(MethodFilter, handler)` precise verb is v1-DEFERRED: an
+ *     `on(...)` call IS recognized as a route, but its `MethodFilter` argument
+ *     is not parsed, so it resolves to "ALL" (stays in the mutating vote) —
+ *     an over-approximation, never a GET-drop.
+ *   - A method-router built as a separate `let mr = post(h); app.route("/x", mr)`
+ *     binding is NOT recognized: a bare-identifier arg1 is structurally
+ *     indistinguishable from a non-Axum `.route(path, someVar)` call (a config
+ *     or HTTP-client builder), so it is skipped rather than resolved via local
+ *     let-binding dataflow (deferred). A recall gap, never an over-capture.
+ *   - Rocket's generic `#[route(GET, "/x")]` form (verb as a bare POSITIONAL
+ *     token, not `method = "GET"`) is not read: only the Actix
+ *     `#[route("/x", method = "VERB")]` string form resolves its verb; a
+ *     positional-verb route macro falls through to "ALL" (any method).
  *   - `.nest("/api", api_routes())`: emits zero routes itself and the
  *     `"/api"` prefix is NOT applied to routes registered inside
  *     `api_routes()` (a separate expression/function entirely) — a
@@ -102,10 +107,10 @@
  *     in a separate STATEMENT from a later `.route(...)` call on that same
  *     variable is never associated with that route: recognition here is
  *     single-fluent-chain only. Scope inheritance is Task 4.
- *   - HEAD and OPTIONS are excluded from both `VERB_CALLEES` and
- *     `ATTR_ROUTE_METHODS` entirely (never recognized, mirroring the Go
- *     module's `VERB_FIELDS` convention): neither verb is ever emitted as a
- *     route by this module.
+ *   - HEAD and OPTIONS are excluded from `VERB_CALLEES` and
+ *     `ATTR_ROUTE_METHODS` (they live in `EXCLUDED_VERB_CALLEES` only so a
+ *     head/options-only method router is recognized-then-skipped): neither
+ *     verb is ever emitted as a route by this module.
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
@@ -121,24 +126,40 @@ const ROUTE_FIELD = "route";
 const VERB_CALLEES = new Map([
   ["get", "GET"], ["post", "POST"], ["put", "PUT"], ["patch", "PATCH"], ["delete", "DELETE"],
 ]);
+// Method-router verb callees that are NEVER mutating and never emitted as a
+// route: `head(h)` / `options(o)`. Kept separate from VERB_CALLEES (which the
+// module header documents as HEAD/OPTIONS-free) so a head/options callee is
+// still RECOGNIZED as a method-router shape — a head/options-only router is a
+// deliberate SKIP, not an unresolvable "ALL". Mapped to a canonical verb only
+// so the exclusion filter in `resolveAxumMethod` can drop them.
+const EXCLUDED_VERB_CALLEES = new Map([["head", "HEAD"], ["options", "OPTIONS"]]);
 // `any(handler)` registers a route for every method — the same "ALL"
 // sentinel Express's `.all()` resolves to, so it participates in the
 // mutating vote alongside a real mutating verb.
 const ANY_CALLEES = new Set(["any"]);
-// Axum's `on(MethodFilter, handler)` combinator: forward-declared for Task 2
-// (its `MethodFilter` argument is not parsed by this task; see PINNED RECALL
-// GAPS above), never consulted by `resolveAxumMethod` yet.
+// Axum's `on(MethodFilter, handler)` combinator. Its precise `MethodFilter`
+// verb is v1-DEFERRED (not parsed): an `on(...)` call is verb-SHAPED but its
+// verb is unresolvable, so it resolves to the "ALL" sentinel and stays in the
+// mutating vote (never a silent GET-drop). See PINNED RECALL GAPS.
 const ON_CALLEES = new Set(["on"]);
 // Actix-web-codegen / Rocket per-verb attribute macro names (`#[get(...)]`,
 // `#[post(...)]`, `#[actix_web::post(...)]`). HEAD and OPTIONS are
 // deliberately absent for the same reason VERB_CALLEES excludes them.
-// Rocket's generic `#[route(METHOD, "/x")]` is deliberately absent too (see
-// PINNED RECALL GAPS above): its method lives inside the token tree, not in
-// the macro name, and Task 1 does not read it out.
+// Actix's generic `#[route("/x", method = "VERB")]` is handled separately
+// (`ROUTE_MACRO`): its method lives inside the token tree, not the macro name.
 const ATTR_ROUTE_METHODS = new Set(["get", "post", "put", "patch", "delete"]);
-// Verbs a RESOLVED route.method may carry once emitted: forward-declared for
-// Task 2/3/4 use (Task 1's single-verb-callee resolution never needs to pick
-// among multiple candidates), mirroring the Go/Python modules' own constant.
+// The generic multi-method attribute macro (`#[route("/x", method = "POST")]`).
+// Its verb(s) live in the token tree as `method = "VERB"` pairs, read by
+// `attrMacroMethod`; no `method=` -> "ALL" (any method).
+const ROUTE_MACRO = "route";
+// The five HTTP verbs this module resolves by name (mutating set plus GET).
+// A statically-literal-but-unrecognized verb (e.g. `"TRACE"`) resolves GET
+// (DRF/Go precedent), distinct from an UNRESOLVABLE dynamic verb -> ALL.
+const RECOGNIZED_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+// The mutating verbs (plus the "ALL" sentinel) used to pick the winning method
+// across a multi-verb chain or route macro: the FIRST mutating verb wins the
+// resolution, so a mixed `get(l).post(c)` router stays in the mutating vote.
+// Mirrors the Go/Python modules' own constant.
 const MUTATING_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE", "ALL"]);
 
 export const SECURITY_AST_RUST = {
@@ -179,35 +200,85 @@ function inErroredContext(node: SyntaxNode): boolean {
 
 interface RustRoute { method: string; path: string; anchor: SyntaxNode; handler: string | null; }
 
-/** Method for a builder route's arg1: a verb-callee call recognized via
- *  VERB_CALLEES (a plain `post(h)` identifier callee, or a scoped
- *  `axum::routing::post(h)` whose `name` field is the verb) or ANY_CALLEES
- *  (`any(h)`, resolves the "ALL" sentinel). Anything else — a bare
- *  identifier (`handler_service`, not even a call), the `on(filter, h)`
- *  combinator, a chained `get(l).post(c)` multi-verb callee (a
- *  `field_expression`, not an identifier/scoped_identifier) — returns null,
- *  so the caller skips the route entirely. A recall gap here can only drop a
- *  route, never bless one. */
-function resolveAxumMethod(arg1: SyntaxNode): string | null {
-  if (arg1.type !== "call_expression") return null;
-  const fn = arg1.childForFieldName("function");
-  let name: string | null = null;
-  if (fn?.type === "identifier") name = fn.text;
-  else if (fn?.type === "scoped_identifier") name = fn.childForFieldName("name")?.text ?? null;
-  if (name === null) return null;
-  if (VERB_CALLEES.has(name)) return VERB_CALLEES.get(name)!;
-  if (ANY_CALLEES.has(name)) return "ALL";
-  return null;
+/** Collect the HTTP verbs a method-router expression registers. Walks the base
+ *  callee and any method-router chain: a plain/scoped verb call (`post(h)`,
+ *  `axum::routing::post(h)`), a chained multi-verb link (`get(l).post(c)`, a
+ *  `field_expression` whose value is the inner method-router call), `any(..)`
+ *  -> "ALL", `on(MethodFilter::VERB, ..)` -> "ALL" (verb v1-DEFERRED), and the
+ *  never-mutating `head`/`options` callees (recognized so a head/options-only
+ *  router is a deliberate skip, never mistaken for an unresolvable form).
+ *  Returns `{ verbs, sawVerbShape }` — `sawVerbShape` gates the route: only a
+ *  recognized BASE call (an inner verb/any/on callee) asserts the shape, so a
+ *  chain whose base is not a router callee is skipped even if an outer field
+ *  verb was collected (guards against a plain `receiver.post(h)` method call). */
+function collectMethodVerbs(arg1: SyntaxNode): { verbs: string[]; sawVerbShape: boolean } {
+  const verbs: string[] = [];
+  let sawVerbShape = false;
+  let cur: SyntaxNode | null = arg1;
+  for (let hops = 0; cur && hops < 16; hops++) {
+    if (cur.type !== "call_expression") break;
+    const fn = cur.childForFieldName("function");
+    if (fn?.type === "identifier") {
+      const name = fn.text;
+      if (VERB_CALLEES.has(name)) { verbs.push(VERB_CALLEES.get(name)!); sawVerbShape = true; }
+      else if (EXCLUDED_VERB_CALLEES.has(name)) { verbs.push(EXCLUDED_VERB_CALLEES.get(name)!); sawVerbShape = true; }
+      else if (ANY_CALLEES.has(name)) { verbs.push("ALL"); sawVerbShape = true; }
+      else if (ON_CALLEES.has(name)) { verbs.push("ALL"); sawVerbShape = true; } // v1: MethodFilter precise verb deferred
+      break; // base of the chain
+    }
+    if (fn?.type === "scoped_identifier") {
+      const name = fn.childForFieldName("name")?.text ?? "";
+      if (VERB_CALLEES.has(name)) { verbs.push(VERB_CALLEES.get(name)!); sawVerbShape = true; }
+      else if (EXCLUDED_VERB_CALLEES.has(name)) { verbs.push(EXCLUDED_VERB_CALLEES.get(name)!); sawVerbShape = true; }
+      break;
+    }
+    if (fn?.type === "field_expression") {
+      // A chain link (`get(l).post(c)`). Collect the outer verb but do NOT assert
+      // the method-router shape here: only a recognized BASE call (an inner
+      // verb/any/on callee) sets sawVerbShape. This skips a plain method call on
+      // a non-router receiver (`receiver.post(h)`, whose base is a bare
+      // identifier) rather than emitting it as a spurious mutating route.
+      const verb = fn.childForFieldName("field")?.text ?? "";
+      if (VERB_CALLEES.has(verb)) verbs.push(VERB_CALLEES.get(verb)!);
+      else if (EXCLUDED_VERB_CALLEES.has(verb)) verbs.push(EXCLUDED_VERB_CALLEES.get(verb)!);
+      cur = fn.childForFieldName("value"); // recurse into the inner method-router call
+      continue;
+    }
+    break;
+  }
+  return { verbs, sawVerbShape };
 }
 
-/** Handler name = arg1's own call's first identifier argument
- *  (`post(create_order)` -> "create_order"). RouteInfo has no handler slot;
- *  this is carried on RustRoute for Task 3's benefit only, unused downstream
- *  in Task 1. */
+/** Resolved method for an Axum builder arg1, or null to SKIP. Not a method
+ *  router (a bare identifier, an unrecognized callee) -> null. A verb-SHAPED
+ *  router whose usable verbs are all HEAD/OPTIONS -> null (never mutating). An
+ *  unresolvable-but-verb-shaped form (`on(..)`, `any(..)`) -> "ALL": it stays
+ *  in the mutating vote, never a silent GET-drop (mirror Go resolveAnyFieldMethod).
+ *  Otherwise the first mutating verb across the chain, else the first verb. */
+function resolveAxumMethod(arg1: SyntaxNode): string | null {
+  const { verbs, sawVerbShape } = collectMethodVerbs(arg1);
+  if (!sawVerbShape) return null; // arg1 is not a method router: skip the route
+  const usable = verbs.filter((v) => v !== "HEAD" && v !== "OPTIONS");
+  if (usable.length === 0) return null; // HEAD/OPTIONS-only -> skip (never mutating)
+  return usable.find((v) => MUTATING_VERBS.has(v)) ?? usable[0];
+}
+
+/** Handler name = the INNERMOST method-router call's first identifier argument
+ *  (`post(create_order)` -> "create_order"; `get(l).post(c)` -> "l", the base
+ *  call). RouteInfo has no handler slot; this is carried on RustRoute for
+ *  Task 3's benefit only, unused downstream today. Null when the base call's
+ *  first argument is not a plain identifier (e.g. `on(MethodFilter::POST, h)`,
+ *  whose first argument is the filter). */
 function axumHandlerName(arg1: SyntaxNode): string | null {
-  if (arg1.type !== "call_expression") return null;
-  const inner = arg1.childForFieldName("arguments")?.namedChild(0) ?? null;
-  return inner?.type === "identifier" ? inner.text : null;
+  let cur: SyntaxNode | null = arg1;
+  for (let hops = 0; cur && hops < 16; hops++) {
+    if (cur.type !== "call_expression") return null;
+    const fn = cur.childForFieldName("function");
+    if (fn?.type === "field_expression") { cur = fn.childForFieldName("value"); continue; }
+    const inner = cur.childForFieldName("arguments")?.namedChild(0) ?? null;
+    return inner?.type === "identifier" ? inner.text : null;
+  }
+  return null;
 }
 
 /** Recognize a builder .route(path, VERB(h)) anchor. Structural gate (Axum is fluent, no
@@ -231,13 +302,40 @@ function asBuilderRoute(call: SyntaxNode): RustRoute | null {
   return { method, path, anchor: field, handler: axumHandlerName(named[1]) };
 }
 
-/** Task 1 stub: reads only the macro name (`"route"` is never a member of
- *  ATTR_ROUTE_METHODS, so this never sees Rocket's generic macro — see
- *  PINNED RECALL GAPS). `tokenTree` is accepted for Task 2's benefit (which
- *  will need to read a VERB out of it for the generic macro) but unused
- *  today. */
-function attrMacroMethod(macro: string, _tokenTree: SyntaxNode | null): string {
-  return macro.toUpperCase();
+/** The `method = "VERB"` verbs of a generic `#[route(...)]` token tree, in
+ *  source order, uppercased. The token tree is FLAT: an `identifier "method"`
+ *  named child is followed (skipping the anonymous `=`) by a `string_literal`
+ *  value. A non-string value (a bare identifier / const) is not readable and
+ *  is skipped, so an empty result means "no readable method=". */
+function readRouteMacroMethods(tokenTree: SyntaxNode): string[] {
+  const kids = rustNamed(tokenTree);
+  const out: string[] = [];
+  for (let i = 0; i < kids.length; i++) {
+    if (kids[i].type !== "identifier" || kids[i].text !== "method") continue;
+    const val = kids[i + 1];
+    const text = val ? rustStringText(val) : null;
+    if (text !== null) out.push(text.toUpperCase());
+  }
+  return out;
+}
+
+/** Resolved method for an attribute macro, or null to SKIP (the macro resolves
+ *  to a non-mutating-only HEAD/OPTIONS set). A per-verb macro (`#[post(..)]`) is
+ *  the macro name upper-cased. The generic `#[route(.., method = "VERB")]`
+ *  macro reads its verbs from the token tree: no readable `method=` -> "ALL"
+ *  (any method); a fully-literal unrecognized verb -> GET (DRF/Go precedent);
+ *  HEAD/OPTIONS values are excluded, and a route whose only verbs are
+ *  HEAD/OPTIONS resolves null (skip). Among the rest, the first mutating verb,
+ *  else the first. */
+function attrMacroMethod(macro: string, tokenTree: SyntaxNode | null): string | null {
+  if (macro !== ROUTE_MACRO) return macro.toUpperCase();
+  const raw = tokenTree ? readRouteMacroMethods(tokenTree) : [];
+  if (raw.length === 0) return "ALL"; // no readable method= -> matches any method
+  const mapped = raw
+    .map((v) => (v === "HEAD" || v === "OPTIONS" ? null : RECOGNIZED_VERBS.has(v) ? v : "GET"))
+    .filter((v): v is string => v !== null);
+  if (mapped.length === 0) return null; // only HEAD/OPTIONS -> skip (never mutating)
+  return mapped.find((v) => MUTATING_VERBS.has(v)) ?? mapped[0];
 }
 
 /** Attribute-macro route on the function_item that FOLLOWS the attribute_item sibling. */
@@ -247,13 +345,15 @@ function asAttributeRoute(attrItem: SyntaxNode): RustRoute | null {
   const callee = attr.namedChild(0);
   const macro = callee?.type === "identifier" ? callee.text
     : callee?.type === "scoped_identifier" ? (callee.childForFieldName("name")?.text ?? "") : "";
-  if (!ATTR_ROUTE_METHODS.has(macro)) return null;
+  if (!ATTR_ROUTE_METHODS.has(macro) && macro !== ROUTE_MACRO) return null;
   const tokenTree = attr.childForFieldName("arguments") ?? null;
   const pathNode = tokenTree
     ? rustNamed(tokenTree).find((n) => n.type === "string_literal" || n.type === "raw_string_literal")
     : null;
   const path = pathNode ? rustStringText(pathNode) : null;
   if (path === null || !path.startsWith("/")) return null;
+  const method = attrMacroMethod(macro, tokenTree);
+  if (method === null) return null; // HEAD/OPTIONS-only route macro -> skip
   // The route attaches to the nearest following function_item sibling, skipping comments
   // and other attributes.
   let sib: SyntaxNode | null = attrItem.nextNamedSibling;
@@ -261,7 +361,6 @@ function asAttributeRoute(attrItem: SyntaxNode): RustRoute | null {
     sib = sib.nextNamedSibling;
   }
   if (sib?.type !== "function_item") return null;
-  const method = attrMacroMethod(macro, tokenTree);
   return { method, path, anchor: attrItem, handler: sib.childForFieldName("name")?.text ?? null };
 }
 

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -274,6 +274,7 @@ const CALL_EXPR_T = new Set(["call_expression"]);
 const IF_EXPR_T = new Set(["if_expression"]);
 const LET_DECL_T = new Set(["let_declaration"]);
 const RETURN_EXPR_T = new Set(["return_expression"]);
+const TRY_EXPR_T = new Set(["try_expression"]);
 
 /** Lowercase segments of an identifier, split on non-alphanumeric AND CamelCase
  *  boundaries. Copied VERBATIM from security-ast-go.ts:603 (whole-segment
@@ -622,18 +623,37 @@ function rustSubtreeHas403(node: SyntaxNode): boolean {
   return false;
 }
 
-/** True when `node`, sitting in a PRODUCE / return position, yields a 401
- *  rejection value: a bare `StatusCode::UNAUTHORIZED`, a `(StatusCode::
- *  UNAUTHORIZED, ..)` tuple, a `(STATUS,..).into_response()` / `STATUS
- *  .into_response()` call, or an `Err(<produces 401>)` construction. Recurses
- *  through `Err(..)` and `.into_response()`. Everything else — `Ok(..)`, a plain
- *  identifier, a comparison, a non-status call — yields false. This is the ONLY
- *  gate for a 401 bless: a 401 reached through here in a produce position (a
- *  `return` value, a block tail, an `Err(..)`, an `.ok_or(..)`) rejects; a 401 in
- *  an `if`/`while`/`match` condition/scrutinee, a comparison operand, a match-arm
- *  pattern, or a plain call argument is never routed here. Mirrors Go's
- *  produce-position gating (scanGoBody). */
-function rustProduces401(node: SyntaxNode | null): boolean {
+/** The tail VALUE expression of a block — its implicit-return value — or null.
+ *  Tree-sitter-rust wraps a trailing block-expression (`match`/`if`/`loop`/`block`)
+ *  in an `expression_statement` with NO semicolon; a value-discarding `foo();`
+ *  statement carries a trailing `;`. A bare non-block tail (a `scoped_identifier`,
+ *  a call, a tuple) is already unwrapped. Returns null when the last item is a
+ *  semicolon-terminated statement (value discarded — not a produce position). */
+function blockTailValue(block: SyntaxNode): SyntaxNode | null {
+  const named = block.namedChildren.filter((c): c is SyntaxNode => c !== null);
+  const last = named[named.length - 1] ?? null;
+  if (!last) return null;
+  if (last.type === "expression_statement") {
+    const semi = last.children.some((c) => c?.type === ";");
+    return semi ? null : (last.namedChild(0) ?? null);
+  }
+  return last;
+}
+
+/** True when `node`, evaluated in a PRODUCE position (a `return` value, a `?` try
+ *  operand, a block/body TAIL, a match-arm value, an if/else branch tail), yields
+ *  a 401 rejection. Recurses through: match-arm values, if/else branch tails, and
+ *  block tails (a 401 produced by ANY branch counts); `Err(<produces>)`, a bare
+ *  `(STATUS,..).into_response()` / `STATUS.into_response()`, `.ok_or(<produces>)`,
+ *  and the `.ok_or_else(|| <produce tail>)` closure body (its OWN tail, NOT any
+ *  mention); a bare 401 status / status-tuple / Actix `ErrorUnauthorized(..)` at
+ *  the leaf. Everything else — `Ok(..)`, a plain identifier, a comparison, a
+ *  non-reject call — yields false. This is the ONLY gate for a 401 bless: a 401 in
+ *  a comparison operand, a plain call ARGUMENT, a struct-literal field, a
+ *  never-returned let RHS, or an `if`/`while`/`match` CONDITION/SCRUTINEE/PATTERN
+ *  is a MENTION and is never routed here. Mirrors Go's produce-position gating
+ *  (scanGoBody). */
+function rustProducesReject(node: SyntaxNode | null): boolean {
   if (!node) return false;
   switch (node.type) {
     case "scoped_identifier":
@@ -644,14 +664,40 @@ function rustProduces401(node: SyntaxNode | null): boolean {
     }
     case "call_expression": {
       const fn = node.childForFieldName("function");
-      if (fn?.type === "identifier" && fn.text === "Err") {
-        return rustProduces401(node.childForFieldName("arguments")?.namedChild(0) ?? null);
+      if (fn?.type === "identifier") {
+        if (fn.text === "Err") return rustProducesReject(node.childForFieldName("arguments")?.namedChild(0) ?? null);
+        if (RUST_ERR_CTOR_401.has(fn.text)) return true; // Actix ErrorUnauthorized(..) in a produce position
+        return false;
       }
-      if (fn?.type === "field_expression" && fn.childForFieldName("field")?.text === "into_response") {
-        return rustProduces401(fn.childForFieldName("value"));
+      if (fn?.type === "field_expression") {
+        const field = fn.childForFieldName("field")?.text;
+        if (field === "into_response") return rustProducesReject(fn.childForFieldName("value"));
+        if (field === "ok_or") return rustProducesReject(node.childForFieldName("arguments")?.namedChild(0) ?? null);
+        if (field === "ok_or_else") {
+          const closure = node.childForFieldName("arguments")?.namedChild(0) ?? null;
+          const cbody = closure?.type === "closure_expression" ? closure.childForFieldName("body") : null;
+          return rustProducesReject(cbody); // the closure body's OWN produce tail, never any mention
+        }
       }
       return false;
     }
+    case "block":
+      return rustProducesReject(blockTailValue(node));
+    case "if_expression": {
+      if (rustProducesReject(node.childForFieldName("consequence"))) return true; // then-branch block tail
+      const alt = node.childForFieldName("alternative"); // else_clause -> block | if_expression (else-if)
+      return alt ? alt.namedChildren.some((c) => rustProducesReject(c)) : false;
+    }
+    case "match_expression": {
+      const mb = node.namedChildren.find((c): c is SyntaxNode => c?.type === "match_block");
+      return mb
+        ? mb.namedChildren.some((arm) => arm?.type === "match_arm" && rustProducesReject(arm.childForFieldName("value")))
+        : false;
+    }
+    case "return_expression":
+      return rustProducesReject(node.namedChild(0) ?? null);
+    case "try_expression":
+      return rustProducesReject(node.namedChild(0) ?? null); // `E?` propagates Err(E) as a return
     default:
       return false;
   }
@@ -661,80 +707,59 @@ interface RustBodySignals { reject401: boolean; reject403Guarded: boolean; opaqu
 
 /** Scan an effective from_fn body for the reject catalogue. reject401 blesses
  *  ALONE; reject403Guarded blesses only inside a credential-guarded 403 (mirror
- *  Go). Detects a 401 named status in any produce position (Err(STATUS),
- *  (STATUS,..).into_response(), .ok_or(STATUS), a bare tail STATUS, return
- *  Err(STATUS)) plus the ONE explicitly-read `.ok_or_else(|| STATUS)` closure and
- *  Actix `Err(ErrorUnauthorized(..))`. Nested closures are pruned (a reject in a
- *  non-inline closure never blesses). A credential read or an opaque auth-flavored
- *  call with no reject makes the body `opaque` (unsure on the name, never bless). */
+ *  Go). reject401 is decided ENTIRELY by rustProducesReject evaluated on the body's
+ *  actual produce positions (return values, `?` try operands, the block/body tail);
+ *  it recurses match arms, if/else branch tails, Err(STATUS), (STATUS,..)
+ *  .into_response(), .ok_or(STATUS), the .ok_or_else(|| STATUS) closure tail, and
+ *  Actix ErrorUnauthorized(..). A 401 in any NON-produce position (a comparison,
+ *  a call argument, a let RHS, a struct field, a condition/scrutinee/pattern) is a
+ *  MENTION and never blesses. Nested closures are pruned (a reject in a non-inline
+ *  closure never blesses). A credential read or an opaque auth-flavored call with
+ *  no reject makes the body `opaque` (unsure on the name, never a bless). */
 function scanRustBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): RustBodySignals {
   const out: RustBodySignals = { reject401: false, reject403Guarded: false, opaqueHint: false, credentialRead: false };
 
-  // 1. A 401 named status blesses ONLY as a PRODUCED value (pruned of nested
-  //    closures): a `return <STATUS>` value or a block TAIL expression that is a
-  //    401, a `(STATUS,..).into_response()`, or an `Err(<produces 401>)`. A 401 in
-  //    a comparison operand (`== StatusCode::UNAUTHORIZED`), an `if`/`while`/`match`
-  //    condition/scrutinee, a `match`-arm PATTERN, or a plain call ARGUMENT (a
-  //    `headers.insert(..)` or a logging macro) is a MENTION, never a reject — the
-  //    invariant requires a verifiable rejection, not a mention. The `Err(..)`,
-  //    `.ok_or(..)` and `.ok_or_else(..)` produce forms are read in the call scan
-  //    (section 2). Mirrors Go's produce-position gating (scanGoBody).
+  // 1. reject401 fires ONLY from a 401 produced in a PRODUCE position (pruned of
+  //    nested closures): a `return <produces>` value, a `<produces>?` try operand
+  //    (error propagation IS a reject-return), or the block/body TAIL value.
+  //    rustProducesReject recurses through match-arm values, if/else branch tails,
+  //    block tails, `Err(..)`, `.into_response()`, `.ok_or(..)`, and the
+  //    `.ok_or_else(|| ..)` closure produce tail. A 401 in a comparison operand
+  //    (`== Err(..)`), a plain call ARGUMENT, a struct-literal field, a
+  //    never-returned let RHS, an `if`/`while`/`match` CONDITION/SCRUTINEE, or a
+  //    `match`-arm PATTERN is a MENTION, never a reject — the invariant requires a
+  //    verifiable rejection, not a mention. Mirrors Go's produce-position gating.
   for (const ret of rustPrunedDescendants(body, RETURN_EXPR_T)) {
     if (ret.hasError) continue;
-    if (rustProduces401(ret.namedChild(0) ?? null)) { out.reject401 = true; break; }
+    if (rustProducesReject(ret.namedChild(0) ?? null)) { out.reject401 = true; break; }
   }
   if (!out.reject401) {
-    // A block TAIL expression (last child, no trailing `;`), or a bare-expression
-    // body (`|req, next| STATUS`). Non-produce last children (an
-    // `expression_statement`, a plain identifier) fail rustProduces401.
-    const named = body.namedChildren.filter((c): c is SyntaxNode => c !== null);
-    const tail = body.type === "block" ? (named[named.length - 1] ?? null) : body;
-    if (rustProduces401(tail)) out.reject401 = true;
+    // A `?` try operand anywhere in the body (`h.get(x).ok_or(STATUS)?`): the `?`
+    // propagates the constructed Err as a return, so it is a produce position.
+    for (const t of rustPrunedDescendants(body, TRY_EXPR_T)) {
+      if (t.hasError) continue;
+      if (rustProducesReject(t.namedChild(0) ?? null)) { out.reject401 = true; break; }
+    }
+  }
+  if (!out.reject401) {
+    // The block TAIL value (a bare-expression body `|req, next| STATUS`, or a
+    // trailing `match`/`if` implicit-return); blockTailValue unwraps the
+    // no-semicolon expression_statement tree-sitter wraps a block-expression in.
+    const tail = body.type === "block" ? blockTailValue(body) : body;
+    if (rustProducesReject(tail)) out.reject401 = true;
   }
 
-  // 2. Call-position produce scan: `Err(<produces 401>)` (the idiomatic Axum
-  //    reject value), the `.ok_or(STATUS)` / `.ok_or_else(|| STATUS)` produce
-  //    forms (read explicitly), Actix bare-identifier 401 constructors, plus the
-  //    credential-read and opaque-auth-call signals. A `.into_response()` that is
-  //    NOT wrapped in a produce position (section 1) never reaches reject401 here.
+  // 2. Behavioral SIGNALS (never a bless, so a position-agnostic scan is safe):
+  //    a structural credential-surface read, and an unresolvable auth-flavored
+  //    callee. Both only drive unsure-vs-not-auth on the hook name — neither sets
+  //    reject401 (that is decided ENTIRELY by the produce-position gate above).
   const boundLocals = rustCredentialBoundLocals(body);
   for (const call of rustPrunedDescendants(body, CALL_EXPR_T)) {
     if (call.hasError) continue;
     if (!out.credentialRead && rustIsCredentialReadCall(call)) out.credentialRead = true;
     const fn = call.childForFieldName("function");
-    if (fn?.type === "field_expression") {
-      const field = fn.childForFieldName("field")?.text;
-      if (field === "ok_or") {
-        if (rustProduces401(call.childForFieldName("arguments")?.namedChild(0) ?? null)) out.reject401 = true;
-        continue;
-      }
-      if (field === "ok_or_else") {
-        const closure = call.childForFieldName("arguments")?.namedChild(0) ?? null;
-        const cbody = closure?.type === "closure_expression" ? closure.childForFieldName("body") : null;
-        if (cbody) {
-          if (cbody.type === "scoped_identifier" && rustRejectStatus(cbody) === "401") out.reject401 = true;
-          else if (cbody.namedChildren.some((c) => c && c.type === "scoped_identifier" && rustRejectStatus(c) === "401")) {
-            out.reject401 = true;
-          } else {
-            for (const si of rustPrunedDescendants(cbody, SCOPED_ID_T)) {
-              if (rustRejectStatus(si) === "401") { out.reject401 = true; break; }
-            }
-          }
-        }
-        continue;
-      }
-      continue; // any other method call is not a produce path (into_response gated in section 1)
-    }
-    if (fn?.type === "identifier") {
-      const name = fn.text;
-      if (name === "Err") {
-        if (rustProduces401(call.childForFieldName("arguments")?.namedChild(0) ?? null)) out.reject401 = true;
-        continue;
-      }
-      if (RUST_ERR_CTOR_401.has(name)) { out.reject401 = true; continue; }
-      // An unresolvable (not-in-file, or duplicate) auth-flavored callee -> opaque.
-      if (!defs.has(name) && rustNameHasHint(name)) out.opaqueHint = true;
-    }
+    // An unresolvable (not-in-file, or duplicate) auth-flavored callee -> opaque.
+    if (fn?.type === "identifier" && !defs.has(fn.text) && rustNameHasHint(fn.text)) out.opaqueHint = true;
   }
 
   // 3. Guarded 403: an `if <credential-condition> { <403 reject> }`.

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -1,0 +1,329 @@
+/**
+ * AST-based route extraction for Rust (Axum builder routes, Actix/Rocket
+ * attribute-macro routes), used by security-consistency.ts in place of the
+ * regex line-window extractor whenever a parsed tree is available and clean.
+ * Mirrors the shipped JS/TS, Python, and Go designs in security-ast.ts,
+ * security-ast-python.ts, and security-ast-go.ts. Rust has zero coverage
+ * today; this is the first module for the language.
+ *
+ * TASK 1 SCOPE: route recognition only. `hasAuth` is unconditionally false
+ * on every route this module emits — Task 3 fills the signal, Task 4 wires
+ * this module into security-consistency.ts. Method/path resolution beyond
+ * the single-verb-callee case (the `on(filter, h)` combinator, a chained
+ * multi-verb `get(l).post(c)` link, Rocket's generic `#[route(GET, "/x")]`
+ * macro) is Task 2; those shapes are recognized structurally as NOT a route
+ * today (a recall gap, never a bless) rather than guessed.
+ *
+ * A find-replace port from a sibling module fails silently on five Rust
+ * grammar traps (probe-verified against the pinned tree-sitter-wasms rust
+ * grammar; see the G0 pin test in security-ast-rust.test.ts):
+ *   1. An `attribute_item` (`#[post("/x")]`) is a PRECEDING SIBLING of the
+ *      `function_item` it decorates, NEVER a child of it. Association walks
+ *      forward from the attribute via `nextNamedSibling`, skipping
+ *      `line_comment` / `block_comment` / intervening `attribute_item`
+ *      siblings (stacked attributes, doc comments between them); a macro
+ *      with no following `function_item` (end of file, or the next item is a
+ *      `struct_item`/`mod_item`/anything else) attaches to nothing and is
+ *      dropped.
+ *   2. `attribute` has NO `path` field of its own (that name is reserved for
+ *      a NESTED `scoped_identifier`'s own path/name pair, e.g.
+ *      `actix_web::post`). The macro callee is `attribute.namedChild(0)`
+ *      (an `identifier` for `post`, a `scoped_identifier` whose `name` field
+ *      is `post` for `actix_web::post`). The route path is the FIRST
+ *      `string_literal` (or `raw_string_literal`) found inside the
+ *      `token_tree` at `attribute.childForFieldName("arguments")` — Rocket's
+ *      `#[post("/users", data = "<user>")]` has a SECOND string literal
+ *      (`"<user>"`) in the same token tree; only the first is the path.
+ *   3. `string_literal` is a LEAF for path purposes: `.text.slice(1, -1)`
+ *      strips the two quote characters. (A literal containing an escape
+ *      sequence DOES carry `escape_sequence` named children — the leaf
+ *      assumption is about `namedChildCount === 0` for a plain literal, not
+ *      a universal claim — but `.text.slice(1, -1)` is correct either way
+ *      since it operates on raw source text, never on children.)
+ *      `raw_string_literal` is a leaf too, with a variable `r`/`r#`/`r##`
+ *      prefix; `rustStringText` strips it by regex and returns null on a
+ *      mismatch (a miss is safe, a guessed path is not). Raw-string route
+ *      paths are rare and simply skipped rather than mis-parsed.
+ *   4. Axum's builder has NO named receiver to key off of (unlike Gin's `r`
+ *      or Flask's `app`): `Router::new().route("/x", post(h))`,
+ *      `Router::<AppState>::new().route(...)`, and a route registered on a
+ *      plain variable (`app.route("/x", post(h))`) all share nothing but the
+ *      call SHAPE. Recognition is purely structural: a `call_expression`
+ *      whose `function` is a `field_expression` with `field.text ===
+ *      "route"`, exactly two named arguments, arg0 a leading-slash string,
+ *      arg1 resolving to a recognized verb callee. Passthrough links
+ *      (`.layer(...)`, `.with_state(...)`, `.fallback(...)`, `.merge(...)`,
+ *      `.nest(...)`) simply fail the `field.text === "route"` check and are
+ *      skipped without disturbing recognition of neighboring `.route(...)`
+ *      links in the same chain — no receiver-name bookkeeping is needed at
+ *      all, unlike the Go/Python modules.
+ *   5. A fluent chain of N `.route(...)` links is ONE deeply left-nested
+ *      `call_expression` tree, and `descendantsOfType` visits it PRE-ORDER
+ *      (outer before inner): the OUTERMOST node is the LAST-WRITTEN link,
+ *      and that node's `startPosition` is the start of the ENTIRE chain
+ *      (`Router::new()`'s own line), not the line where that link's own
+ *      `.route(` token sits. Naively pushing routes in traversal order and
+ *      reading `call.startPosition.row` for the anchor line would both
+ *      REVERSE route order and report the WRONG line for every link but the
+ *      first. This module anchors each builder route on the `field_identifier`
+ *      node (`fn.childForFieldName("field")`, the `route` token itself),
+ *      whose position is that specific link's own, and re-sorts the
+ *      collected builder matches by that position before emitting — the
+ *      attribute-macro pass needs no such fix, since `attribute_item`
+ *      siblings are flat, never nested inside each other.
+ *
+ * INVARIANT SCOPE: the never-false-bless guarantee (never mark an unauthed
+ * route as authed) holds on THIS AST path; every route emitted here carries
+ * `hasAuth: false` unconditionally (Task 1). There is no regex fallback for
+ * Rust anywhere in this codebase, so a construct sitting inside a parse
+ * error (`inErroredContext`) is simply skipped — a parse error can only
+ * shrink the recognized route set for that construct, never emit a wrong
+ * one, and never trigger a legacy regex over-bless the way the Go/Python
+ * modules' fallback can.
+ *
+ * PINNED RECALL GAPS (measured, never a false-bless; each is a route this
+ * module will not find rather than one it misclassifies):
+ *   - Axum's `on(MethodFilter, handler)` combinator (`ON_CALLEES` is
+ *     forward-declared for Task 2; its `MethodFilter` argument is not parsed
+ *     yet, so an `on(...)` call is simply not recognized as a route).
+ *   - A chained multi-verb link (`get(l).post(c)`) as `.route`'s arg1: the
+ *     outer callee is a `field_expression`, not an `identifier` or
+ *     `scoped_identifier`, and `resolveAxumMethod` does not unwrap it, so
+ *     the whole `.route(...)` call is skipped rather than guessing one verb.
+ *   - Rocket's generic `#[route(GET, "/x")]` macro: `"route"` is
+ *     deliberately absent from `ATTR_ROUTE_METHODS` (its method lives inside
+ *     the token tree, not in the macro name), so it is unrecognized rather
+ *     than resolved as a bogus `"ROUTE"` method.
+ *   - `.nest("/api", api_routes())`: emits zero routes itself and the
+ *     `"/api"` prefix is NOT applied to routes registered inside
+ *     `api_routes()` (a separate expression/function entirely) — a
+ *     cross-expression path gap, not a bless.
+ *   - A `.layer(...)` (or any middleware call) applied to a router VARIABLE
+ *     in a separate STATEMENT from a later `.route(...)` call on that same
+ *     variable is never associated with that route: recognition here is
+ *     single-fluent-chain only. Scope inheritance is Task 4.
+ *   - HEAD and OPTIONS are excluded from both `VERB_CALLEES` and
+ *     `ATTR_ROUTE_METHODS` entirely (never recognized, mirroring the Go
+ *     module's `VERB_FIELDS` convention): neither verb is ever emitted as a
+ *     route by this module.
+ */
+
+import type { Tree, SyntaxNode } from "../core/types.js";
+import type { RouteInfo } from "./security-consistency.js";
+
+// Field name for Axum's fluent builder registration (`Router::new().route(...)`).
+const ROUTE_FIELD = "route";
+
+// Axum routing-fn verb callees (`get(h)`, `post(h)`, `axum::routing::put(h)`),
+// keyed by the exact lowercase spelling Axum itself uses, mapped to the
+// canonical uppercase HTTP verb. HEAD and OPTIONS are deliberately absent
+// (mirrors Go's VERB_FIELDS convention): neither is ever emitted as a route.
+const VERB_CALLEES = new Map([
+  ["get", "GET"], ["post", "POST"], ["put", "PUT"], ["patch", "PATCH"], ["delete", "DELETE"],
+]);
+// `any(handler)` registers a route for every method — the same "ALL"
+// sentinel Express's `.all()` resolves to, so it participates in the
+// mutating vote alongside a real mutating verb.
+const ANY_CALLEES = new Set(["any"]);
+// Axum's `on(MethodFilter, handler)` combinator: forward-declared for Task 2
+// (its `MethodFilter` argument is not parsed by this task; see PINNED RECALL
+// GAPS above), never consulted by `resolveAxumMethod` yet.
+const ON_CALLEES = new Set(["on"]);
+// Actix-web-codegen / Rocket per-verb attribute macro names (`#[get(...)]`,
+// `#[post(...)]`, `#[actix_web::post(...)]`). HEAD and OPTIONS are
+// deliberately absent for the same reason VERB_CALLEES excludes them.
+// Rocket's generic `#[route(METHOD, "/x")]` is deliberately absent too (see
+// PINNED RECALL GAPS above): its method lives inside the token tree, not in
+// the macro name, and Task 1 does not read it out.
+const ATTR_ROUTE_METHODS = new Set(["get", "post", "put", "patch", "delete"]);
+// Verbs a RESOLVED route.method may carry once emitted: forward-declared for
+// Task 2/3/4 use (Task 1's single-verb-callee resolution never needs to pick
+// among multiple candidates), mirroring the Go/Python modules' own constant.
+const MUTATING_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE", "ALL"]);
+
+export const SECURITY_AST_RUST = {
+  VERB_CALLEES, ANY_CALLEES, ON_CALLEES, ATTR_ROUTE_METHODS, ROUTE_FIELD, MUTATING_VERBS,
+};
+
+/** Path/verb text of a Rust string literal. string_literal is a LEAF in the pinned
+ *  grammar (slice off the two quote chars). raw_string_literal has an r + variable-#
+ *  prefix, so strip r#*"…"#* by regex; a mismatch → null (skip, a miss is safe). Anything
+ *  else (const, macro_invocation, binary_expression) → null: statically unresolvable, the
+ *  route is skipped (a guessed path is never safe). */
+function rustStringText(node: SyntaxNode): string | null {
+  if (node.type === "string_literal") return node.text.slice(1, -1);
+  if (node.type === "raw_string_literal") {
+    const m = node.text.match(/^r(#*)"([\s\S]*)"\1$/);
+    return m ? m[2] : null;
+  }
+  return null;
+}
+
+/** Non-null named children. */
+function rustNamed(n: SyntaxNode | null | undefined): SyntaxNode[] {
+  return n ? n.namedChildren.filter((c): c is SyntaxNode => c !== null) : [];
+}
+
+/** True when node or any ancestor BELOW source_file carries a parse error (per-construct
+ *  surgical skip; there is no whole-file fallback for Rust — see the module header).
+ *  Mirror inErroredContext, security-ast-go.ts: Rust error recovery can swallow a later
+ *  valid registration into a broken call's arguments. */
+function inErroredContext(node: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = node;
+  while (cur && cur.type !== "source_file") {
+    if (cur.hasError) return true;
+    cur = cur.parent;
+  }
+  return false;
+}
+
+interface RustRoute { method: string; path: string; anchor: SyntaxNode; handler: string | null; }
+
+/** Method for a builder route's arg1: a verb-callee call recognized via
+ *  VERB_CALLEES (a plain `post(h)` identifier callee, or a scoped
+ *  `axum::routing::post(h)` whose `name` field is the verb) or ANY_CALLEES
+ *  (`any(h)`, resolves the "ALL" sentinel). Anything else — a bare
+ *  identifier (`handler_service`, not even a call), the `on(filter, h)`
+ *  combinator, a chained `get(l).post(c)` multi-verb callee (a
+ *  `field_expression`, not an identifier/scoped_identifier) — returns null,
+ *  so the caller skips the route entirely. A recall gap here can only drop a
+ *  route, never bless one. */
+function resolveAxumMethod(arg1: SyntaxNode): string | null {
+  if (arg1.type !== "call_expression") return null;
+  const fn = arg1.childForFieldName("function");
+  let name: string | null = null;
+  if (fn?.type === "identifier") name = fn.text;
+  else if (fn?.type === "scoped_identifier") name = fn.childForFieldName("name")?.text ?? null;
+  if (name === null) return null;
+  if (VERB_CALLEES.has(name)) return VERB_CALLEES.get(name)!;
+  if (ANY_CALLEES.has(name)) return "ALL";
+  return null;
+}
+
+/** Handler name = arg1's own call's first identifier argument
+ *  (`post(create_order)` -> "create_order"). RouteInfo has no handler slot;
+ *  this is carried on RustRoute for Task 3's benefit only, unused downstream
+ *  in Task 1. */
+function axumHandlerName(arg1: SyntaxNode): string | null {
+  if (arg1.type !== "call_expression") return null;
+  const inner = arg1.childForFieldName("arguments")?.namedChild(0) ?? null;
+  return inner?.type === "identifier" ? inner.text : null;
+}
+
+/** Recognize a builder .route(path, VERB(h)) anchor. Structural gate (Axum is fluent, no
+ *  named receiver): function is field_expression, field == "route", 2 named args, arg0 a
+ *  leading-slash string, arg1 resolving to a verb callee. Returns null otherwise (a
+ *  spurious match can only add a deviation-side route, never a bless). Anchored on the
+ *  field_identifier node, NOT the call itself — a fluent chain's outer call_expression
+ *  spans back to the chain's start line (see module header, grammar trap 5); the field
+ *  node is the one place this specific link's own source position lives. */
+function asBuilderRoute(call: SyntaxNode): RustRoute | null {
+  const fn = call.childForFieldName("function");
+  if (fn?.type !== "field_expression") return null;
+  const field = fn.childForFieldName("field");
+  if (field?.text !== ROUTE_FIELD) return null;
+  const named = rustNamed(call.childForFieldName("arguments"));
+  if (named.length !== 2) return null;
+  const path = rustStringText(named[0]);
+  if (path === null || !path.startsWith("/")) return null; // leading-slash gate
+  const method = resolveAxumMethod(named[1]);
+  if (method === null) return null; // not a recognized verb callee
+  return { method, path, anchor: field, handler: axumHandlerName(named[1]) };
+}
+
+/** Task 1 stub: reads only the macro name (`"route"` is never a member of
+ *  ATTR_ROUTE_METHODS, so this never sees Rocket's generic macro — see
+ *  PINNED RECALL GAPS). `tokenTree` is accepted for Task 2's benefit (which
+ *  will need to read a VERB out of it for the generic macro) but unused
+ *  today. */
+function attrMacroMethod(macro: string, _tokenTree: SyntaxNode | null): string {
+  return macro.toUpperCase();
+}
+
+/** Attribute-macro route on the function_item that FOLLOWS the attribute_item sibling. */
+function asAttributeRoute(attrItem: SyntaxNode): RustRoute | null {
+  const attr = rustNamed(attrItem).find((n) => n.type === "attribute");
+  if (!attr) return null;
+  const callee = attr.namedChild(0);
+  const macro = callee?.type === "identifier" ? callee.text
+    : callee?.type === "scoped_identifier" ? (callee.childForFieldName("name")?.text ?? "") : "";
+  if (!ATTR_ROUTE_METHODS.has(macro)) return null;
+  const tokenTree = attr.childForFieldName("arguments") ?? null;
+  const pathNode = tokenTree
+    ? rustNamed(tokenTree).find((n) => n.type === "string_literal" || n.type === "raw_string_literal")
+    : null;
+  const path = pathNode ? rustStringText(pathNode) : null;
+  if (path === null || !path.startsWith("/")) return null;
+  // The route attaches to the nearest following function_item sibling, skipping comments
+  // and other attributes.
+  let sib: SyntaxNode | null = attrItem.nextNamedSibling;
+  while (sib && (sib.type === "line_comment" || sib.type === "block_comment" || sib.type === "attribute_item")) {
+    sib = sib.nextNamedSibling;
+  }
+  if (sib?.type !== "function_item") return null;
+  const method = attrMacroMethod(macro, tokenTree);
+  return { method, path, anchor: attrItem, handler: sib.childForFieldName("name")?.text ?? null };
+}
+
+/** File-wide map of top-level and impl-method function definitions by name
+ *  (both share the `function_item` node type in Rust's flat grammar); a name
+ *  seen more than once maps to null (duplicate: follow NEITHER). Forward-
+ *  declared for Task 3's body-first auth resolution, unused by Task 1's own
+ *  extraction. Mirrors collectGoFunctionDefs. */
+export function collectRustFunctionDefs(root: SyntaxNode): Map<string, SyntaxNode | null> {
+  const defs = new Map<string, SyntaxNode | null>();
+  for (const def of root.descendantsOfType("function_item")) {
+    if (!def || def.hasError) continue;
+    const name = def.childForFieldName("name")?.text;
+    if (!name) continue;
+    defs.set(name, defs.has(name) ? null : def);
+  }
+  return defs;
+}
+
+export function extractRustRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
+  const routes: RouteInfo[] = [];
+  const root = tree.rootNode;
+
+  // Attribute-macro routes (Actix/Rocket). attribute_item siblings are flat
+  // (never nested inside each other), so traversal order already matches
+  // source order.
+  for (const attrItem of root.descendantsOfType("attribute_item")) {
+    if (!attrItem || inErroredContext(attrItem)) continue;
+    const r = asAttributeRoute(attrItem);
+    if (r) routes.push(emitRoute(r, filePath));
+  }
+
+  // Builder .route routes (Axum). Filtering to field=="route" yields exactly
+  // one anchor per route (the method-wrapper post(h)/get(h) calls have
+  // identifier functions, never a field_expression, so they are naturally
+  // skipped here — no double-visit). A fluent chain's pre-order traversal
+  // visits the LAST-WRITTEN link first (grammar trap 5); sort the collected
+  // matches by their own field-node position to restore source order before
+  // emitting.
+  const builderMatches: RustRoute[] = [];
+  for (const call of root.descendantsOfType("call_expression")) {
+    if (!call || inErroredContext(call)) continue;
+    const r = asBuilderRoute(call);
+    if (r) builderMatches.push(r);
+  }
+  builderMatches.sort((a, b) =>
+    a.anchor.startPosition.row - b.anchor.startPosition.row
+    || a.anchor.startPosition.column - b.anchor.startPosition.column);
+  for (const r of builderMatches) routes.push(emitRoute(r, filePath));
+
+  return routes;
+}
+
+function emitRoute(r: RustRoute, filePath: string): RouteInfo {
+  return {
+    method: r.method,
+    path: r.path,
+    file: filePath,
+    line: r.anchor.startPosition.row + 1, // anchor = the "route" field token (builder) or attribute_item (macro)
+    hasAuth: false,        // Task 3 fills the signal
+    hasValidation: false,  // deferred non-goal
+    hasRateLimit: false,   // deferred non-goal
+    hasErrorHandler: false, // write-only field; every AST path hard-codes false
+  };
+}

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -114,7 +114,7 @@
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
-import type { RouteInfo } from "./security-consistency.js";
+import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 
 // Field name for Axum's fluent builder registration (`Router::new().route(...)`).
 const ROUTE_FIELD = "route";
@@ -925,6 +925,15 @@ function extractorTypeUnsure(handler: string | null, defs: Map<string, SyntaxNod
     if (RUST_AUTH_EXTRACTOR_TYPES.has(tname) || rustNameIsFlavored(tname)) return tname;
   }
   return null;
+}
+
+/** Seam-2 parity shape. Axum auth is CHAIN-scoped (a .layer wraps only the routes in its
+ *  fluent subtree), so there is no safe FILE-level Rust auth OR: returning true here would
+ *  bless every route in the file, including siblings a layer never wrapped. v1 returns
+ *  all-false (never OR an UNSURE — honesty invariant, mirror extractGoFileMiddlewareAst,
+ *  security-ast-go.ts:1382). The route extractor computes auth itself from the tree. */
+export function extractRustFileMiddlewareAst(_tree: Tree): FileMiddleware {
+  return { hasAuth: false, hasValidation: false, hasRateLimit: false };
 }
 
 export function extractRustRoutesAst(tree: Tree, filePath: string): RouteInfo[] {

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -166,6 +166,126 @@ export const SECURITY_AST_RUST = {
   VERB_CALLEES, ANY_CALLEES, ON_CALLEES, ATTR_ROUTE_METHODS, ROUTE_FIELD, MUTATING_VERBS,
 };
 
+// ─── Body-first auth classification (Task 3) ─────────────────────────────────
+//
+// GOVERNING INVARIANT — NEVER-FALSE-BLESS. A route blesses ONLY when a covering
+// (ANCESTOR) `.layer`/`.route_layer` wraps a `middleware::from_fn(fn)` whose
+// in-file body VERIFIABLY rejects (401-family, or a credential-guarded 403).
+// There is NO name-only bless and NO type-name bless. Every opaque, imported,
+// unreadable, or veto case resolves `not-auth` or `unsure`; every auth-flavored
+// EXTRACTOR TYPE on a handler param resolves `unsure` (LOCKED, v1 does NOT read
+// the `FromRequest` impl even when it is in-file). Mirrors the Go design in
+// security-ast-go.ts (classifyGoMiddlewareAuth + bodyAuthSignatureGo).
+//
+// LAYER SCOPING (the crux): an Axum `.layer`/`.route_layer` wraps only the
+// routes registered BEFORE it. In the tree the layer call is the OUTER node and
+// the routes it wraps are its DESCENDANTS (a LEFT-associative chain nests as
+// route_B(layer_L(route_A(new())))). `coveringLayerArgs` walks UP from a route
+// call collecting ONLY ancestor layer args, so `.layer(auth).route(A)` — where A
+// is the OUTER node and the layer a descendant — never blesses A.
+
+/** Three-way behavioral signal of a from_fn body: a 401-family (or
+ *  credential-guarded 403) reject blesses; a credential-read / opaque-auth-call
+ *  body with no reject is `opaque` (drives unsure-vs-not-auth on the name); a
+ *  visible non-enforcing body is `none`. Mirrors GoBodySignal. */
+export type RustBodySignal = "reject" | "none" | "opaque";
+/** Precedence outcome. `unsure` is not-authed internally (never sets hasAuth) —
+ *  it only records the hook name so a renderer can hedge. Rules 4/5 (opaque /
+ *  unreadable) NEVER return "auth". Mirrors GoAuthOutcome. */
+export type RustAuthOutcome = "auth" | "not-auth" | "unsure";
+
+// Named status constants this module reads, mapped to code. Axum SCREAMING_CASE
+// (StatusCode::UNAUTHORIZED) and Rocket/Actix PascalCase (Status::Unauthorized /
+// HttpResponse::Unauthorized) both resolve. A bare integer literal (from_u16(401),
+// Err(401)) is DELIBERATELY absent: v1 requires the named constant (a construction
+// is not itself a reject; requiring the name is the safe-direction call).
+const RUST_STATUS_CONSTS = new Map<string, "401" | "403" | "404" | "500">([
+  ["UNAUTHORIZED", "401"], ["Unauthorized", "401"],
+  ["FORBIDDEN", "403"], ["Forbidden", "403"],
+  ["NOT_FOUND", "404"], ["NotFound", "404"],
+  ["INTERNAL_SERVER_ERROR", "500"], ["InternalServerError", "500"],
+]);
+// The receiver path a status constant hangs off of (the `path` field of a
+// scoped_identifier's LAST segment). `http::StatusCode::UNAUTHORIZED` has a
+// nested scoped path whose own last segment is "StatusCode"; matched by suffix.
+const STATUS_PATH_TAILS = new Set(["StatusCode", "Status", "HttpResponse"]);
+// Actix bare-identifier 401 error constructors (`Err(ErrorUnauthorized(..))`).
+const RUST_ERR_CTOR_401 = new Set(["ErrorUnauthorized"]);
+
+// Auth lexicons — VERBATIM copies of the Go sets (security-ast-go.ts). Keeping
+// them byte-identical means a rename smuggling attempt fails the same way in both
+// languages and the whole-segment discipline is shared.
+const RUST_AUTH_VETO_SEGMENTS = new Set([
+  "skip", "bypass", "mock", "disable", "disabled", "optional", "noop", "fake",
+  "stub", "dummy", "test", "dev", "insecure", "parse", "handler", "login",
+  "log", "logger", "logging", "metrics", "stats",
+]);
+const RUST_AUTH_SEGMENTS = new Set([
+  "auth", "auth2", "authenticate", "authenticated", "authentication",
+  "authorize", "authorization", "jwt", "oauth", "oauth2", "bearer",
+  "session", "token", "user", "users", "credential", "credentials",
+  "principal", "identity",
+]);
+const RUST_AUTH_PAIRS = new Set([
+  "logged in", "require auth", "require login", "require user", "require role",
+  "require session", "ensure user", "ensure auth", "ensure session",
+  "verify token", "verify user", "verify session", "token required",
+  "check auth", "check session", "is authenticated", "validate token",
+]);
+const RUST_OPAQUE_HINT_SEGMENTS = new Set([
+  ...RUST_AUTH_SEGMENTS, "check", "confirm", "guard", "verify", "require",
+  "ensure", "protect", "restrict",
+]);
+// Credential-surface reads (a `.get("Authorization")` etc.); the string key must
+// be credential-flavored and NOT csrf/xsrf/agent. Mirrors the Go credential set.
+const RUST_CRED_READ_FIELDS = new Set([
+  "get", "get_header", "header", "typed_header", "cookie", "cookies", "get_cookie",
+]);
+const RUST_CREDENTIAL_KEY_SEGMENTS = new Set([
+  "user", "uid", "token", "jwt", "auth", "authorization", "login",
+  "credentials", "session", "bearer", "cookie", "sid",
+]);
+const RUST_CREDENTIAL_KEY_VETO = new Set(["csrf", "xsrf", "agent"]);
+// Optionality wrappers on a handler-param TYPE veto the extractor lane entirely
+// (`Option<AuthUser>` / MaybeAuth / OptionalUser never even hedge).
+const RUST_OPTIONALITY_SEGMENTS = new Set(["option", "optional", "maybe"]);
+// Non-auth Axum/Actix extractor types: a handler param of one of these
+// contributes NOTHING (no bless, no hedge).
+const RUST_NON_AUTH_EXTRACTORS = new Set([
+  "Json", "Query", "Path", "State", "Form", "Extension", "Bytes", "RawQuery",
+  "TypedHeader", "Multipart", "Host", "ConnectInfo", "OriginalUri", "Request",
+]);
+// Auth-flavored extractor types whose NAME hedges (never blesses). The five
+// canonical names the brief pins plus a few common synonyms; `Claims` is here
+// because it is not segment-flavored on its own.
+const RUST_AUTH_EXTRACTOR_TYPES = new Set([
+  "AuthUser", "Claims", "RequireAuth", "Identity", "Bearer",
+  "AuthenticatedUser", "CurrentUser", "LoggedInUser", "Principal", "JwtClaims",
+]);
+// Axum middleware constructors whose LAST argument is the middleware handler.
+const FROM_FN_CALLEES = new Set(["from_fn", "from_fn_with_state"]);
+// Middleware-applying chain fields whose ANCESTOR position over a route makes it
+// a covering layer. `wrap` (Actix) is included for classification completeness;
+// body-first still gates any bless, so a non-rejecting wrap never blesses.
+const LAYER_FIELDS = new Set(["layer", "route_layer", "wrap"]);
+
+const SCOPED_ID_T = new Set(["scoped_identifier"]);
+const CALL_EXPR_T = new Set(["call_expression"]);
+const IF_EXPR_T = new Set(["if_expression"]);
+const LET_DECL_T = new Set(["let_declaration"]);
+
+/** Lowercase segments of an identifier, split on non-alphanumeric AND CamelCase
+ *  boundaries. Copied VERBATIM from security-ast-go.ts:603 (whole-segment
+ *  matching makes substring blessing structurally impossible). */
+function nameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((s) => s.length > 0);
+}
+
 /** Path/verb text of a Rust string literal. string_literal is a LEAF in the pinned
  *  grammar (slice off the two quote chars). raw_string_literal has an r + variable-#
  *  prefix, so strip r#*"…"#* by regex; a mismatch → null (skip, a miss is safe). Anything
@@ -198,7 +318,16 @@ function inErroredContext(node: SyntaxNode): boolean {
   return false;
 }
 
-interface RustRoute { method: string; path: string; anchor: SyntaxNode; handler: string | null; }
+interface RustRoute {
+  method: string;
+  path: string;
+  anchor: SyntaxNode;
+  handler: string | null;
+  // The route-registration `call_expression` (builder `.route(...)` link), the
+  // START of the covering-layer ancestor walk. Null for attribute-macro routes
+  // (Actix/Rocket have no builder layer chain; only the extractor lane applies).
+  call: SyntaxNode | null;
+}
 
 /** Collect the HTTP verbs a method-router expression registers. Walks the base
  *  callee and any method-router chain: a plain/scoped verb call (`post(h)`,
@@ -299,7 +428,7 @@ function asBuilderRoute(call: SyntaxNode): RustRoute | null {
   if (path === null || !path.startsWith("/")) return null; // leading-slash gate
   const method = resolveAxumMethod(named[1]);
   if (method === null) return null; // not a recognized verb callee
-  return { method, path, anchor: field, handler: axumHandlerName(named[1]) };
+  return { method, path, anchor: field, handler: axumHandlerName(named[1]), call };
 }
 
 /** The `method = "VERB"` verbs of a generic `#[route(...)]` token tree, in
@@ -361,7 +490,7 @@ function asAttributeRoute(attrItem: SyntaxNode): RustRoute | null {
     sib = sib.nextNamedSibling;
   }
   if (sib?.type !== "function_item") return null;
-  return { method, path, anchor: attrItem, handler: sib.childForFieldName("name")?.text ?? null };
+  return { method, path, anchor: attrItem, handler: sib.childForFieldName("name")?.text ?? null, call: null };
 }
 
 /** File-wide map of top-level and impl-method function definitions by name
@@ -380,9 +509,347 @@ export function collectRustFunctionDefs(root: SyntaxNode): Map<string, SyntaxNod
   return defs;
 }
 
+/** "401"|"403"|"404"|"500"|"other"|null for a Rust status node. v1 reads only the
+ *  NAMED constant (StatusCode::UNAUTHORIZED / Status::Unauthorized, FORBIDDEN/
+ *  Forbidden, ...); a bare integer_literal is NOT blessed (from_u16(401) is a
+ *  construction, not a reject — a miss is safe). Never guesses a bare local const. */
+function rustRejectStatus(n: SyntaxNode | null): "401" | "403" | "404" | "500" | "other" | null {
+  if (!n) return null;
+  if (n.type === "scoped_identifier") {
+    const pathText = n.childForFieldName("path")?.text ?? "";
+    const tail = pathText.split("::").pop() ?? pathText;
+    const name = n.childForFieldName("name")?.text ?? "";
+    if (STATUS_PATH_TAILS.has(tail)) return RUST_STATUS_CONSTS.get(name) ?? "other";
+  }
+  if (n.type === "integer_literal") return "other"; // v1: bare integer never blesses
+  return null;
+}
+
+/** Descendants of `node` of one of `types`, NOT descending into nested
+ *  `closure_expression` / `function_item` subtrees (a reject in a non-inline
+ *  closure/nested fn is not executed inline). Pre-order; the root is never
+ *  yielded. Mirror of goPrunedDescendants (security-ast-go.ts:635). The targeted
+ *  `.ok_or_else` closure is read explicitly, never via this walk. */
+function rustPrunedDescendants(node: SyntaxNode, types: Set<string>): SyntaxNode[] {
+  const out: SyntaxNode[] = [];
+  const visit = (n: SyntaxNode) => {
+    for (const child of n.namedChildren) {
+      if (!child || child.type === "closure_expression" || child.type === "function_item") continue;
+      if (types.has(child.type)) out.push(child);
+      visit(child);
+    }
+  };
+  visit(node);
+  return out;
+}
+
+/** True when a string key reads as a credential (segment hit, veto cancels). */
+function rustCredKeyIsCredential(key: string): boolean {
+  const segs = nameSegments(key);
+  if (segs.some((s) => RUST_CREDENTIAL_KEY_VETO.has(s))) return false;
+  return segs.some((s) => RUST_CREDENTIAL_KEY_SEGMENTS.has(s));
+}
+
+/** True when a call structurally reads a credential surface: `.get("Authorization")`
+ *  (only when the receiver chain text mentions a header/cookie surface, excluding
+ *  `cache.get(...)`), `.get_header(...)` / `.header(...)` / `.typed_header(...)`, or
+ *  a cookie accessor. The string key must be credential-flavored and NOT
+ *  csrf/xsrf/agent. Mirrors goIsCredentialReadCall. */
+function rustIsCredentialReadCall(call: SyntaxNode): boolean {
+  const fn = call.childForFieldName("function");
+  if (!fn || fn.type !== "field_expression") return false;
+  const field = fn.childForFieldName("field")?.text ?? "";
+  if (!RUST_CRED_READ_FIELDS.has(field)) return false;
+  const arg0 = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+  const key = arg0 && (arg0.type === "string_literal" || arg0.type === "raw_string_literal")
+    ? rustStringText(arg0)
+    : null;
+  const recvText = fn.childForFieldName("value")?.text ?? "";
+  const surfaceReceiver = /header|cookie/i.test(recvText);
+  if (field === "get") {
+    // A generic `.get(key)` counts only on a header/cookie surface with a
+    // credential-flavored key (guards against cache.get("token")).
+    return surfaceReceiver && key !== null && rustCredKeyIsCredential(key);
+  }
+  if (field === "cookie" || field === "cookies" || field === "get_cookie") return true;
+  // get_header / header / typed_header: credential-flavored key, or a bare
+  // header accessor with no string key (typed extractor).
+  return key === null || rustCredKeyIsCredential(key);
+}
+
+/** True when an unresolvable callee name is auth-flavored enough to be opaque. */
+function rustNameHasHint(name: string): boolean {
+  return nameSegments(name).some((s) => RUST_OPAQUE_HINT_SEGMENTS.has(s));
+}
+
+/** Local names bound to a structural credential read (`let t = req.headers()
+ *  .get("Authorization")`), pruned of nested closures. Lets `t.is_none()` count
+ *  as a credential guard. Mirror goCredentialBoundLocals. */
+function rustCredentialBoundLocals(body: SyntaxNode): Set<string> {
+  const bound = new Set<string>();
+  for (const decl of rustPrunedDescendants(body, LET_DECL_T)) {
+    if (decl.hasError) continue;
+    const pattern = decl.childForFieldName("pattern");
+    const value = decl.childForFieldName("value");
+    if (pattern?.type !== "identifier" || !value) continue;
+    if (value.type === "call_expression" && rustIsCredentialReadCall(value)) bound.add(pattern.text);
+  }
+  return bound;
+}
+
+/** True when an if-guard's condition structurally reads a credential surface or
+ *  references a credential-bound local (the guarded-403 bless gate). */
+function rustGuardHasCredentialRead(cond: SyntaxNode | null, boundLocals: Set<string>): boolean {
+  if (!cond) return false;
+  const calls = rustPrunedDescendants(cond, CALL_EXPR_T);
+  if (cond.type === "call_expression") calls.unshift(cond);
+  if (calls.some((c) => !c.hasError && rustIsCredentialReadCall(c))) return true;
+  if (boundLocals.size > 0) {
+    const ids = rustPrunedDescendants(cond, new Set(["identifier"]));
+    if (cond.type === "identifier") ids.unshift(cond);
+    if (ids.some((id) => boundLocals.has(id.text))) return true;
+  }
+  return false;
+}
+
+/** True when a subtree contains a 403 status constant (pruned). Only consulted
+ *  INSIDE a credential-guarded if-consequence — a bare 403 never blesses. */
+function rustSubtreeHas403(node: SyntaxNode): boolean {
+  for (const si of rustPrunedDescendants(node, SCOPED_ID_T)) {
+    if (rustRejectStatus(si) === "403") return true;
+  }
+  return false;
+}
+
+interface RustBodySignals { reject401: boolean; reject403Guarded: boolean; opaqueHint: boolean; credentialRead: boolean; }
+
+/** Scan an effective from_fn body for the reject catalogue. reject401 blesses
+ *  ALONE; reject403Guarded blesses only inside a credential-guarded 403 (mirror
+ *  Go). Detects a 401 named status in any produce position (Err(STATUS),
+ *  (STATUS,..).into_response(), .ok_or(STATUS), a bare tail STATUS, return
+ *  Err(STATUS)) plus the ONE explicitly-read `.ok_or_else(|| STATUS)` closure and
+ *  Actix `Err(ErrorUnauthorized(..))`. Nested closures are pruned (a reject in a
+ *  non-inline closure never blesses). A credential read or an opaque auth-flavored
+ *  call with no reject makes the body `opaque` (unsure on the name, never bless). */
+function scanRustBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): RustBodySignals {
+  const out: RustBodySignals = { reject401: false, reject403Guarded: false, opaqueHint: false, credentialRead: false };
+
+  // 1. A 401 named status constant in a PRODUCE position (pruned of nested
+  //    closures). Covers Err(STATUS) / tuple.into_response() / .ok_or(STATUS) /
+  //    bare tail / return Err(STATUS). A 401 that is the direct RHS of a `let`
+  //    binding (`let code = StatusCode::UNAUTHORIZED;`) is a REFERENCE, not a
+  //    reject, and is excluded — the invariant requires a verifiable rejection,
+  //    not a mention (the `.ok_or(STATUS)` case is not affected: its status node's
+  //    immediate parent is an `arguments`, never the `let_declaration`).
+  for (const si of rustPrunedDescendants(body, SCOPED_ID_T)) {
+    if (rustRejectStatus(si) === "401" && si.parent?.type !== "let_declaration") {
+      out.reject401 = true;
+      break;
+    }
+  }
+  if (body.type === "scoped_identifier" && rustRejectStatus(body) === "401") out.reject401 = true;
+
+  // 2. Call-position scan: the ok_or_else closure (read explicitly), Actix
+  //    bare-identifier 401 constructors, credential reads, and opaque auth calls.
+  const boundLocals = rustCredentialBoundLocals(body);
+  for (const call of rustPrunedDescendants(body, CALL_EXPR_T)) {
+    if (call.hasError) continue;
+    if (!out.credentialRead && rustIsCredentialReadCall(call)) out.credentialRead = true;
+    const fn = call.childForFieldName("function");
+    if (fn?.type === "field_expression" && fn.childForFieldName("field")?.text === "ok_or_else") {
+      const closure = call.childForFieldName("arguments")?.namedChild(0) ?? null;
+      const cbody = closure?.type === "closure_expression" ? closure.childForFieldName("body") : null;
+      if (cbody) {
+        if (cbody.type === "scoped_identifier" && rustRejectStatus(cbody) === "401") out.reject401 = true;
+        else if (cbody.namedChildren.some((c) => c && c.type === "scoped_identifier" && rustRejectStatus(c) === "401")) {
+          out.reject401 = true;
+        } else {
+          for (const si of rustPrunedDescendants(cbody, SCOPED_ID_T)) {
+            if (rustRejectStatus(si) === "401") { out.reject401 = true; break; }
+          }
+        }
+      }
+      continue;
+    }
+    if (fn?.type === "identifier") {
+      const name = fn.text;
+      if (RUST_ERR_CTOR_401.has(name)) { out.reject401 = true; continue; }
+      // An unresolvable (not-in-file, or duplicate) auth-flavored callee -> opaque.
+      if (!defs.has(name) && rustNameHasHint(name)) out.opaqueHint = true;
+    }
+  }
+
+  // 3. Guarded 403: an `if <credential-condition> { <403 reject> }`.
+  for (const ifs of rustPrunedDescendants(body, IF_EXPR_T)) {
+    if (ifs.hasError) continue;
+    const cond = ifs.childForFieldName("condition");
+    const cons = ifs.childForFieldName("consequence");
+    if (cons && rustGuardHasCredentialRead(cond, boundLocals) && rustSubtreeHas403(cons)) {
+      out.reject403Guarded = true;
+    }
+  }
+
+  return out;
+}
+
+/** A from_fn body's three-way behavioral signal. */
+export function bodyAuthSignatureRust(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): RustBodySignal {
+  const s = scanRustBody(body, defs);
+  if (s.reject401 || s.reject403Guarded) return "reject";
+  if (s.opaqueHint || s.credentialRead) return "opaque";
+  return "none";
+}
+
+/** True when a name is auth-FLAVORED (drives unsure-vs-not-auth for opaque /
+ *  unreadable bodies — NEVER a bless). A veto segment cancels. Mirror goNameIsFlavored. */
+function rustNameIsFlavored(name: string): boolean {
+  const segs = nameSegments(name);
+  if (segs.some((s) => RUST_AUTH_VETO_SEGMENTS.has(s))) return false;
+  if (segs.some((s) => RUST_AUTH_SEGMENTS.has(s))) return true;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (RUST_AUTH_PAIRS.has(`${segs[i]} ${segs[i + 1]}`)) return true;
+  }
+  return false;
+}
+
+/** The LOCKED five-rule precedence. `body` is the from_fn's in-file body (or null
+ *  when imported/unresolvable). Rules 4/5 (opaque / unreadable) NEVER return
+ *  "auth" — a name alone never blesses. Mirror classifyGoMiddlewareAuth. */
+export function classifyRustAuth(
+  name: string, body: SyntaxNode | null, defs: Map<string, SyntaxNode | null>,
+): RustAuthOutcome {
+  const segs = nameSegments(name);
+  if (segs.some((s) => RUST_AUTH_VETO_SEGMENTS.has(s))) return "not-auth"; // rule 1: veto beats a body reject
+  if (body) {
+    const sig = bodyAuthSignatureRust(body, defs);
+    if (sig === "reject") return "auth";                                   // rule 2: a verified reject blesses
+    if (sig === "none") return "not-auth";                                 // rule 3: visible non-enforcing body
+    return rustNameIsFlavored(name) ? "unsure" : "not-auth";               // rule 4: opaque never blesses on name
+  }
+  return rustNameIsFlavored(name) ? "unsure" : "not-auth";                 // rule 5: unreadable never blesses on name
+}
+
+/** The callee NAME of a call/identifier/scoped_identifier: identifier text, or a
+ *  scoped_identifier's last `name` segment. Never its arguments. */
+function rustCalleeName(node: SyntaxNode): string | null {
+  if (node.type === "identifier") return node.text;
+  if (node.type === "scoped_identifier") return node.childForFieldName("name")?.text ?? null;
+  if (node.type === "call_expression") {
+    const fn = node.childForFieldName("function");
+    return fn ? rustCalleeName(fn) : null;
+  }
+  return null;
+}
+
+/** Classify a `.layer`/`.route_layer`/`.wrap` argument. `from_fn(X)` /
+ *  `from_fn_with_state(state, X)` resolve X (the LAST arg) to its in-file
+ *  function_item body → classifyRustAuth. A non-from_fn layer arg (TraceLayer::new,
+ *  HttpAuthentication::bearer, a bare `auth_mw`) resolves body=null → rule 5
+ *  (unsure if auth-flavored, else not-auth). NEVER blessed on the name. */
+function classifyRustLayerArg(
+  arg: SyntaxNode, defs: Map<string, SyntaxNode | null>,
+): { outcome: RustAuthOutcome; name: string | null } {
+  if (arg.type === "call_expression") {
+    const fn = arg.childForFieldName("function");
+    const calleeName = fn ? rustCalleeName(fn) : null;
+    if (calleeName && FROM_FN_CALLEES.has(calleeName)) {
+      const args = rustNamed(arg.childForFieldName("arguments"));
+      const handler = args.length ? args[args.length - 1] : null; // from_fn: only arg; with_state: LAST arg
+      if (handler?.type === "identifier") {
+        const hname = handler.text;
+        const def = defs.get(hname) ?? null;
+        const hbody = def ? def.childForFieldName("body") : null;
+        return { outcome: classifyRustAuth(hname, hbody, defs), name: hname };
+      }
+      if (handler?.type === "closure_expression") {
+        // Inline `from_fn(|req, next| { ... })`: read the closure body directly;
+        // an empty name means the body must carry the whole verdict (no name bless).
+        const cbody = handler.childForFieldName("body");
+        return { outcome: cbody ? classifyRustAuth("", cbody, defs) : "not-auth", name: null };
+      }
+      return { outcome: "not-auth", name: null };
+    }
+    // Non-from_fn layer constructor (TraceLayer::new_for_http(), Logger::default(),
+    // HttpAuthentication::bearer(v)): body is unreadable -> rule 5 on the callee name.
+    return { outcome: classifyRustAuth(calleeName ?? "", null, defs), name: calleeName };
+  }
+  if (arg.type === "identifier") {
+    return { outcome: classifyRustAuth(arg.text, null, defs), name: arg.text };
+  }
+  if (arg.type === "scoped_identifier") {
+    const name = arg.childForFieldName("name")?.text ?? "";
+    return { outcome: classifyRustAuth(name, null, defs), name: name || null };
+  }
+  return { outcome: "not-auth", name: null };
+}
+
+/** Walk UP from a route's `.route` call collecting the ARG NODES of every ANCESTOR
+ *  `.layer`/`.route_layer`/`.wrap` call. NEVER-FALSE-BLESS crux: the layer call is
+ *  the OUTER node and the routes it wraps are its DESCENDANTS, so a covering layer
+ *  is always an ANCESTOR of the route. The walk stops the moment it leaves the
+ *  fluent chain (parent is no longer a chain-link whose receiver is the current
+ *  node), so `.layer(auth).route(A)` — where A is the OUTER node and the layer a
+ *  DESCENDANT — collects nothing and never blesses A. */
+function coveringLayerArgs(routeCall: SyntaxNode): SyntaxNode[] {
+  const out: SyntaxNode[] = [];
+  let cur: SyntaxNode = routeCall;
+  for (let hops = 0; hops < 64; hops++) {
+    const parent = cur.parent;
+    if (!parent || parent.type !== "field_expression") break;             // left the chain
+    if (!(parent.childForFieldName("value")?.equals(cur) ?? false)) break; // cur is not the receiver
+    const grand = parent.parent;
+    if (!grand || grand.type !== "call_expression") break;
+    if (!(grand.childForFieldName("function")?.equals(parent) ?? false)) break;
+    if (LAYER_FIELDS.has(parent.childForFieldName("field")?.text ?? "")) {
+      for (const a of rustNamed(grand.childForFieldName("arguments"))) out.push(a);
+    }
+    cur = grand; // climb past this chain link (layer collected above, route/other skipped)
+  }
+  return out;
+}
+
+/** The OUTER type name of a handler-param type node: `AuthUser` -> "AuthUser",
+ *  `Option<AuthUser>` -> "Option" (outer, so the optionality veto fires),
+ *  `Json<T>` -> "Json", `&AuthUser` -> "AuthUser", `web::Json<T>` -> "Json". */
+function rustTypeName(node: SyntaxNode | null): string | null {
+  if (!node) return null;
+  if (node.type === "type_identifier") return node.text;
+  if (node.type === "generic_type") return rustTypeName(node.childForFieldName("type"));
+  if (node.type === "scoped_type_identifier") return node.childForFieldName("name")?.text ?? null;
+  if (node.type === "reference_type") return rustTypeName(node.childForFieldName("type"));
+  return null;
+}
+
+/** Auth-extractor-typed handler param → the type NAME (UNSURE, never a bless in
+ *  v1). Resolve the handler identifier → in-file function_item → each param's
+ *  OUTER type name. An Option/Maybe/Optional wrapper vetoes the param entirely; a
+ *  non-auth extractor (Json/Query/Path/State/Form/...) contributes nothing. v1
+ *  does NOT read the type's `FromRequest` impl even when it is in-file (LOCKED —
+ *  the biggest documented recall cost). Returns the FIRST auth-extractor type
+ *  name, or null. */
+function extractorTypeUnsure(handler: string | null, defs: Map<string, SyntaxNode | null>): string | null {
+  if (!handler) return null;
+  const def = defs.get(handler) ?? null;
+  const params = def?.childForFieldName("parameters");
+  if (!params) return null;
+  for (const p of rustNamed(params)) {
+    if (p.type !== "parameter") continue;
+    const tname = rustTypeName(p.childForFieldName("type"));
+    if (!tname) continue;
+    const segs = nameSegments(tname);
+    if (segs.some((s) => RUST_OPTIONALITY_SEGMENTS.has(s))) continue; // optionality veto -> no hedge
+    if (RUST_NON_AUTH_EXTRACTORS.has(tname)) continue;                // Json/Path/State/... -> nothing
+    if (RUST_AUTH_EXTRACTOR_TYPES.has(tname) || rustNameIsFlavored(tname)) return tname;
+  }
+  return null;
+}
+
 export function extractRustRoutesAst(tree: Tree, filePath: string): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const root = tree.rootNode;
+  // File-wide function-def map for body-first auth resolution (Task 3): from_fn
+  // middleware handlers and handler-param extractor lookups both key off it.
+  const defs = collectRustFunctionDefs(root);
 
   // Attribute-macro routes (Actix/Rocket). attribute_item siblings are flat
   // (never nested inside each other), so traversal order already matches
@@ -390,7 +857,7 @@ export function extractRustRoutesAst(tree: Tree, filePath: string): RouteInfo[] 
   for (const attrItem of root.descendantsOfType("attribute_item")) {
     if (!attrItem || inErroredContext(attrItem)) continue;
     const r = asAttributeRoute(attrItem);
-    if (r) routes.push(emitRoute(r, filePath));
+    if (r) routes.push(emitRoute(r, filePath, defs));
   }
 
   // Builder .route routes (Axum). Filtering to field=="route" yields exactly
@@ -409,20 +876,42 @@ export function extractRustRoutesAst(tree: Tree, filePath: string): RouteInfo[] 
   builderMatches.sort((a, b) =>
     a.anchor.startPosition.row - b.anchor.startPosition.row
     || a.anchor.startPosition.column - b.anchor.startPosition.column);
-  for (const r of builderMatches) routes.push(emitRoute(r, filePath));
+  for (const r of builderMatches) routes.push(emitRoute(r, filePath, defs));
 
   return routes;
 }
 
-function emitRoute(r: RustRoute, filePath: string): RouteInfo {
+function emitRoute(r: RustRoute, filePath: string, defs: Map<string, SyntaxNode | null>): RouteInfo {
+  // Finalize per-route auth (Task 3). For each covering (ancestor) layer arg,
+  // classify body-first: ANY "auth" blesses (hasAuth = true, hook cleared — a
+  // blessed route never hedges). Else the FIRST "unsure" covering layer name, or
+  // (if none) the auth-extractor type on the handler param, fills authUnsureHook.
+  // A mutating route with no signal stays hasAuth=false with no hedge.
+  let hasAuth = false;
+  let authUnsureHook: string | undefined;
+  for (const arg of r.call ? coveringLayerArgs(r.call) : []) {
+    const { outcome, name } = classifyRustLayerArg(arg, defs);
+    if (outcome === "auth") hasAuth = true;
+    else if (outcome === "unsure" && authUnsureHook === undefined && name) authUnsureHook = name;
+  }
+  if (hasAuth) {
+    authUnsureHook = undefined; // a blessed route never hedges
+  } else if (authUnsureHook === undefined) {
+    const ext = extractorTypeUnsure(r.handler, defs);
+    if (ext) authUnsureHook = ext;
+  }
+
   return {
     method: r.method,
     path: r.path,
     file: filePath,
     line: r.anchor.startPosition.row + 1, // anchor = the "route" field token (builder) or attribute_item (macro)
-    hasAuth: false,        // Task 3 fills the signal
+    hasAuth,               // Task 3: body-first, covering-ancestor-layer only
     hasValidation: false,  // deferred non-goal
     hasRateLimit: false,   // deferred non-goal
     hasErrorHandler: false, // write-only field; every AST path hard-codes false
+    // authUnsureHook only on a NON-blessed, auth-flavored-opaque route; the key
+    // is ABSENT otherwise so every other Rust route serializes byte-identically.
+    ...(authUnsureHook !== undefined ? { authUnsureHook } : {}),
   };
 }

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -269,7 +269,6 @@ const FROM_FN_CALLEES = new Set(["from_fn", "from_fn_with_state"]);
 // body-first still gates any bless, so a non-rejecting wrap never blesses.
 const LAYER_FIELDS = new Set(["layer", "route_layer", "wrap"]);
 
-const SCOPED_ID_T = new Set(["scoped_identifier"]);
 const CALL_EXPR_T = new Set(["call_expression"]);
 const IF_EXPR_T = new Set(["if_expression"]);
 const LET_DECL_T = new Set(["let_declaration"]);
@@ -614,15 +613,6 @@ function rustGuardHasCredentialRead(cond: SyntaxNode | null, boundLocals: Set<st
   return false;
 }
 
-/** True when a subtree contains a 403 status constant (pruned). Only consulted
- *  INSIDE a credential-guarded if-consequence — a bare 403 never blesses. */
-function rustSubtreeHas403(node: SyntaxNode): boolean {
-  for (const si of rustPrunedDescendants(node, SCOPED_ID_T)) {
-    if (rustRejectStatus(si) === "403") return true;
-  }
-  return false;
-}
-
 /** The tail VALUE expression of a block — its implicit-return value — or null.
  *  Tree-sitter-rust wraps a trailing block-expression (`match`/`if`/`loop`/`block`)
  *  in an `expression_statement` with NO semicolon; a value-discarding `foo();`
@@ -642,112 +632,122 @@ function blockTailValue(block: SyntaxNode): SyntaxNode | null {
 
 /** True when `node`, evaluated in a PRODUCE position (a `return` value, a `?` try
  *  operand, a block/body TAIL, a match-arm value, an if/else branch tail), yields
- *  a 401 rejection. Recurses through: match-arm values, if/else branch tails, and
- *  block tails (a 401 produced by ANY branch counts); `Err(<produces>)`, a bare
+ *  a `target`-status rejection (401 by default; 403 for the credential-guarded
+ *  403 lane). Recurses through: match-arm values, if/else branch tails, and
+ *  block tails (a reject produced by ANY branch counts); `Err(<produces>)`, a bare
  *  `(STATUS,..).into_response()` / `STATUS.into_response()`, `.ok_or(<produces>)`,
  *  and the `.ok_or_else(|| <produce tail>)` closure body (its OWN tail, NOT any
- *  mention); a bare 401 status / status-tuple / Actix `ErrorUnauthorized(..)` at
- *  the leaf. Everything else — `Ok(..)`, a plain identifier, a comparison, a
- *  non-reject call — yields false. This is the ONLY gate for a 401 bless: a 401 in
- *  a comparison operand, a plain call ARGUMENT, a struct-literal field, a
- *  never-returned let RHS, or an `if`/`while`/`match` CONDITION/SCRUTINEE/PATTERN
- *  is a MENTION and is never routed here. Mirrors Go's produce-position gating
- *  (scanGoBody). */
-function rustProducesReject(node: SyntaxNode | null): boolean {
+ *  mention); a bare STATUS / status-tuple leaf. The Actix bare-identifier ctor
+ *  catalogue (`RUST_ERR_CTOR_401`) is 401-only in v1 scope (no Actix 403 ctor is
+ *  read — see the module header PINNED RECALL GAPS), so it only fires when
+ *  `target === "401"`. Everything else — `Ok(..)`, a plain identifier, a
+ *  comparison, a non-reject call — yields false. This is the ONLY gate for a
+ *  bless of either status: a reject in a comparison operand, a plain call
+ *  ARGUMENT, a struct-literal field, a never-returned let RHS, or an
+ *  `if`/`while`/`match` CONDITION/SCRUTINEE/PATTERN is a MENTION and is never
+ *  routed here. Mirrors Go's produce-position gating (scanGoBody). */
+function rustProducesReject(node: SyntaxNode | null, target: "401" | "403" = "401"): boolean {
   if (!node) return false;
   switch (node.type) {
     case "scoped_identifier":
-      return rustRejectStatus(node) === "401";
+      return rustRejectStatus(node) === target;
     case "tuple_expression": {
       const first = node.namedChildren.find((c): c is SyntaxNode => c !== null) ?? null;
-      return first?.type === "scoped_identifier" && rustRejectStatus(first) === "401";
+      return first?.type === "scoped_identifier" && rustRejectStatus(first) === target;
     }
     case "call_expression": {
       const fn = node.childForFieldName("function");
       if (fn?.type === "identifier") {
-        if (fn.text === "Err") return rustProducesReject(node.childForFieldName("arguments")?.namedChild(0) ?? null);
-        if (RUST_ERR_CTOR_401.has(fn.text)) return true; // Actix ErrorUnauthorized(..) in a produce position
+        if (fn.text === "Err") {
+          return rustProducesReject(node.childForFieldName("arguments")?.namedChild(0) ?? null, target);
+        }
+        if (RUST_ERR_CTOR_401.has(fn.text)) return target === "401"; // Actix ErrorUnauthorized(..): 401-only in v1 scope
         return false;
       }
       if (fn?.type === "field_expression") {
         const field = fn.childForFieldName("field")?.text;
-        if (field === "into_response") return rustProducesReject(fn.childForFieldName("value"));
-        if (field === "ok_or") return rustProducesReject(node.childForFieldName("arguments")?.namedChild(0) ?? null);
+        if (field === "into_response") return rustProducesReject(fn.childForFieldName("value"), target);
+        if (field === "ok_or") {
+          return rustProducesReject(node.childForFieldName("arguments")?.namedChild(0) ?? null, target);
+        }
         if (field === "ok_or_else") {
           const closure = node.childForFieldName("arguments")?.namedChild(0) ?? null;
           const cbody = closure?.type === "closure_expression" ? closure.childForFieldName("body") : null;
-          return rustProducesReject(cbody); // the closure body's OWN produce tail, never any mention
+          return rustProducesReject(cbody, target); // the closure body's OWN produce tail, never any mention
         }
       }
       return false;
     }
     case "block":
-      return rustProducesReject(blockTailValue(node));
+      return rustProducesReject(blockTailValue(node), target);
     case "if_expression": {
-      if (rustProducesReject(node.childForFieldName("consequence"))) return true; // then-branch block tail
+      if (rustProducesReject(node.childForFieldName("consequence"), target)) return true; // then-branch block tail
       const alt = node.childForFieldName("alternative"); // else_clause -> block | if_expression (else-if)
-      return alt ? alt.namedChildren.some((c) => rustProducesReject(c)) : false;
+      return alt ? alt.namedChildren.some((c) => rustProducesReject(c, target)) : false;
     }
     case "match_expression": {
       const mb = node.namedChildren.find((c): c is SyntaxNode => c?.type === "match_block");
       return mb
-        ? mb.namedChildren.some((arm) => arm?.type === "match_arm" && rustProducesReject(arm.childForFieldName("value")))
+        ? mb.namedChildren.some(
+            (arm) => arm?.type === "match_arm" && rustProducesReject(arm.childForFieldName("value"), target),
+          )
         : false;
     }
     case "return_expression":
-      return rustProducesReject(node.namedChild(0) ?? null);
+      return rustProducesReject(node.namedChild(0) ?? null, target);
     case "try_expression":
-      return rustProducesReject(node.namedChild(0) ?? null); // `E?` propagates Err(E) as a return
+      return rustProducesReject(node.namedChild(0) ?? null, target); // `E?` propagates Err(E) as a return
     default:
       return false;
   }
+}
+
+/** True when `node` (a from_fn body, or an if-consequence block) contains a
+ *  `target`-status reject in a PRODUCE position: a `return <produces>` value, a
+ *  `<produces>?` try operand, or the block/subtree TAIL. Pruned of nested
+ *  closures via `rustPrunedDescendants` (a reject in a non-inline closure is not
+ *  executed inline and never counts). Parameterized generalization of the
+ *  three-pronged produce sweep `scanRustBody` step 1 uses for 401, reused
+ *  UNCHANGED for the credential-guarded 403 lane (step 3) — mirrors Go's
+ *  `goSubtreeHas403Reject` produce-gating semantics. */
+function rustSubtreeProducesReject(node: SyntaxNode, target: "401" | "403"): boolean {
+  for (const ret of rustPrunedDescendants(node, RETURN_EXPR_T)) {
+    if (!ret.hasError && rustProducesReject(ret.namedChild(0) ?? null, target)) return true;
+  }
+  for (const t of rustPrunedDescendants(node, TRY_EXPR_T)) {
+    if (!t.hasError && rustProducesReject(t.namedChild(0) ?? null, target)) return true;
+  }
+  const tail = node.type === "block" ? blockTailValue(node) : node;
+  return rustProducesReject(tail, target);
 }
 
 interface RustBodySignals { reject401: boolean; reject403Guarded: boolean; opaqueHint: boolean; credentialRead: boolean; }
 
 /** Scan an effective from_fn body for the reject catalogue. reject401 blesses
  *  ALONE; reject403Guarded blesses only inside a credential-guarded 403 (mirror
- *  Go). reject401 is decided ENTIRELY by rustProducesReject evaluated on the body's
- *  actual produce positions (return values, `?` try operands, the block/body tail);
- *  it recurses match arms, if/else branch tails, Err(STATUS), (STATUS,..)
- *  .into_response(), .ok_or(STATUS), the .ok_or_else(|| STATUS) closure tail, and
- *  Actix ErrorUnauthorized(..). A 401 in any NON-produce position (a comparison,
- *  a call argument, a let RHS, a struct field, a condition/scrutinee/pattern) is a
- *  MENTION and never blesses. Nested closures are pruned (a reject in a non-inline
- *  closure never blesses). A credential read or an opaque auth-flavored call with
- *  no reject makes the body `opaque` (unsure on the name, never a bless). */
+ *  Go). Both are decided ENTIRELY by rustSubtreeProducesReject/rustProducesReject
+ *  evaluated on the relevant subtree's actual produce positions (return values,
+ *  `?` try operands, the block/subtree tail); the recursion covers match arms,
+ *  if/else branch tails, Err(STATUS), (STATUS,..).into_response(), .ok_or(STATUS),
+ *  the .ok_or_else(|| STATUS) closure tail, and (401-only) Actix
+ *  ErrorUnauthorized(..). A reject in any NON-produce position (a comparison, a
+ *  call argument, a let RHS, a struct field, a condition/scrutinee/pattern) is a
+ *  MENTION and never blesses, for EITHER status. Nested closures are pruned (a
+ *  reject in a non-inline closure never blesses). A credential read or an opaque
+ *  auth-flavored call with no reject makes the body `opaque` (unsure on the name,
+ *  never a bless). */
 function scanRustBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): RustBodySignals {
   const out: RustBodySignals = { reject401: false, reject403Guarded: false, opaqueHint: false, credentialRead: false };
 
   // 1. reject401 fires ONLY from a 401 produced in a PRODUCE position (pruned of
   //    nested closures): a `return <produces>` value, a `<produces>?` try operand
-  //    (error propagation IS a reject-return), or the block/body TAIL value.
-  //    rustProducesReject recurses through match-arm values, if/else branch tails,
-  //    block tails, `Err(..)`, `.into_response()`, `.ok_or(..)`, and the
-  //    `.ok_or_else(|| ..)` closure produce tail. A 401 in a comparison operand
-  //    (`== Err(..)`), a plain call ARGUMENT, a struct-literal field, a
-  //    never-returned let RHS, an `if`/`while`/`match` CONDITION/SCRUTINEE, or a
-  //    `match`-arm PATTERN is a MENTION, never a reject — the invariant requires a
-  //    verifiable rejection, not a mention. Mirrors Go's produce-position gating.
-  for (const ret of rustPrunedDescendants(body, RETURN_EXPR_T)) {
-    if (ret.hasError) continue;
-    if (rustProducesReject(ret.namedChild(0) ?? null)) { out.reject401 = true; break; }
-  }
-  if (!out.reject401) {
-    // A `?` try operand anywhere in the body (`h.get(x).ok_or(STATUS)?`): the `?`
-    // propagates the constructed Err as a return, so it is a produce position.
-    for (const t of rustPrunedDescendants(body, TRY_EXPR_T)) {
-      if (t.hasError) continue;
-      if (rustProducesReject(t.namedChild(0) ?? null)) { out.reject401 = true; break; }
-    }
-  }
-  if (!out.reject401) {
-    // The block TAIL value (a bare-expression body `|req, next| STATUS`, or a
-    // trailing `match`/`if` implicit-return); blockTailValue unwraps the
-    // no-semicolon expression_statement tree-sitter wraps a block-expression in.
-    const tail = body.type === "block" ? blockTailValue(body) : body;
-    if (rustProducesReject(tail)) out.reject401 = true;
-  }
+  //    (error propagation IS a reject-return), or the block/body TAIL value. A 401
+  //    in a comparison operand (`== Err(..)`), a plain call ARGUMENT, a
+  //    struct-literal field, a never-returned let RHS, an `if`/`while`/`match`
+  //    CONDITION/SCRUTINEE, or a `match`-arm PATTERN is a MENTION, never a reject —
+  //    the invariant requires a verifiable rejection, not a mention. Mirrors Go's
+  //    produce-position gating.
+  out.reject401 = rustSubtreeProducesReject(body, "401");
 
   // 2. Behavioral SIGNALS (never a bless, so a position-agnostic scan is safe):
   //    a structural credential-surface read, and an unresolvable auth-flavored
@@ -762,12 +762,16 @@ function scanRustBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>): R
     if (fn?.type === "identifier" && !defs.has(fn.text) && rustNameHasHint(fn.text)) out.opaqueHint = true;
   }
 
-  // 3. Guarded 403: an `if <credential-condition> { <403 reject> }`.
+  // 3. Guarded 403: an `if <credential-condition> { <403 reject> }`. The 403 must
+  //    be PRODUCED inside the consequence block (a `return`/`?`/block-tail reject),
+  //    the same produce-position gate as reject401 above (T3 fix #3) — a 403
+  //    sitting in a call argument, comparison operand, struct field, or discarded
+  //    `let` inside the guard is a MENTION, never a reject, and must not bless.
   for (const ifs of rustPrunedDescendants(body, IF_EXPR_T)) {
     if (ifs.hasError) continue;
     const cond = ifs.childForFieldName("condition");
     const cons = ifs.childForFieldName("consequence");
-    if (cons && rustGuardHasCredentialRead(cond, boundLocals) && rustSubtreeHas403(cons)) {
+    if (cons && rustGuardHasCredentialRead(cond, boundLocals) && rustSubtreeProducesReject(cons, "403")) {
       out.reject403Guarded = true;
     }
   }

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -37,6 +37,7 @@ import { pickIntentHint } from "./utils.js";
 import { extractJsRoutesAst, extractFileMiddlewareAst, SECURITY_AST } from "./security-ast.js";
 import { extractPythonRoutesAst, extractPythonFileMiddlewareAst } from "./security-ast-python.js";
 import { extractGoRoutesAst, extractGoFileMiddlewareAst } from "./security-ast-go.js";
+import { extractRustRoutesAst, extractRustFileMiddlewareAst } from "./security-ast-rust.js";
 import { buildXFileIndex } from "./security-xfile-index.js";
 import type { CrossFileIndex } from "./security-xfile-index.js";
 import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
@@ -178,6 +179,12 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
     // this index is a file-wide bless.
     const pythonAst = file.language === "python" && !!file.tree && !file.tree.rootNode.hasError;
     const goAst = file.language === "go" && !!file.tree && !file.tree.rootNode.hasError;
+    // Rust is AST-only (no regex fallback anywhere): a clean-parsed rust file is
+    // handled by the Rust lane below and forces every js/go/py regex arm false for
+    // the same cross-language-noise reason as pythonAst/goAst (a rust doc-comment
+    // mentioning app.use(...) matches the jsAuth regex). A tree-less / errored rust
+    // file has no lane at all -> its index entry stays all-false, byte-identical.
+    const rustAst = file.language === "rust" && !!file.tree && !file.tree.rootNode.hasError;
 
     // JS/TS — Express / Hono / Fastify / Koa. AST when a parsed tree is
     // available (structural: gated on a router/app receiver, not just
@@ -188,11 +195,11 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       jsAuth = mw.hasAuth;
       jsRateLimit = mw.hasRateLimit;
       jsValidation = mw.hasValidation;
-    } else if (pythonAst || goAst) {
-      // Cross-language noise on either clean-tree language is a file-wide bless:
-      // on a clean-parsed python OR go file the js regex arms are pure noise (they
-      // match app.use(...) text inside docstrings/comments), so force them false
-      // rather than let them file-wide-bless that file's routes.
+    } else if (pythonAst || goAst || rustAst) {
+      // Cross-language noise on any clean-tree language is a file-wide bless: on a
+      // clean-parsed python, go OR rust file the js regex arms are pure noise (they
+      // match app.use(...) text inside docstrings/comments/doc-comments), so force
+      // them false rather than let them file-wide-bless that file's routes.
       jsAuth = false;
       jsRateLimit = false;
       jsValidation = false;
@@ -214,9 +221,9 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       goRateLimit = mw.hasRateLimit;
       goValidation = mw.hasValidation;
     } else {
-      goAuth = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Aa]uth|RequireAuth|VerifyToken|JWT|Bearer)/.test(c);
-      goRateLimit = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Rr]ateLimit|[Tt]hrottle|[Ll]imiter)/.test(c);
-      goValidation = !pythonAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Vv]alidate|[Vv]alidator)/.test(c);
+      goAuth = !pythonAst && !rustAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Aa]uth|RequireAuth|VerifyToken|JWT|Bearer)/.test(c);
+      goRateLimit = !pythonAst && !rustAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Rr]ateLimit|[Tt]hrottle|[Ll]imiter)/.test(c);
+      goValidation = !pythonAst && !rustAst && /\.\s*Use\s*\(\s*[^,)]*?(?:[Vv]alidate|[Vv]alidator)/.test(c);
     }
 
     // Python — Flask / FastAPI
@@ -228,18 +235,39 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
       pyRateLimit = mw.hasRateLimit;
       pyValidation = mw.hasValidation;
     } else {
-      // Forced false on a clean-parsed go file for the same cross-language noise
-      // reason as above (a go comment containing login_required currently sets
-      // pyAuth for that go file).
-      pyAuth = !goAst && /(?:@\w+\.before_request|@blueprint\.before_request|add_middleware\s*\([^,)]*[Aa]uth|@?\bjwt_required\b|@?\blogin_required\b)/.test(c);
-      pyRateLimit = !goAst && /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
-      pyValidation = !goAst && /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
+      // Forced false on a clean-parsed go OR rust file for the same cross-language
+      // noise reason as above (a go comment / rust doc-comment containing
+      // login_required currently sets pyAuth for that file).
+      pyAuth = !goAst && !rustAst && /(?:@\w+\.before_request|@blueprint\.before_request|add_middleware\s*\([^,)]*[Aa]uth|@?\bjwt_required\b|@?\blogin_required\b)/.test(c);
+      pyRateLimit = !goAst && !rustAst && /(?:@\w+\.\w+\s*\([^)]*[Ll]imit|RateLimiter|Limiter\(|add_middleware\s*\([^,)]*[Ll]imit)/.test(c);
+      pyValidation = !goAst && !rustAst && /add_middleware\s*\([^,)]*[Vv]alid/.test(c);
+    }
+
+    // Rust — Axum / Actix / Rocket. AST when a clean parsed tree is available;
+    // there is NO regex fallback for Rust (an absent / errored tree yields
+    // all-false lanes). extractRustFileMiddlewareAst returns all-false
+    // unconditionally: Axum .layer auth is CHAIN-scoped (wraps only its fluent
+    // subtree), so there is no safe FILE-level Rust auth OR — the route extractor
+    // computes covering-layer auth from the tree itself. This lane exists for seam
+    // parity; it never blesses (mirror how the Go/Python AST paths ignore this OR
+    // for auth). For every non-(rust-with-clean-tree) file it is all-false, so the
+    // final OR below is byte-identical to today.
+    let rustAuth: boolean, rustRateLimit: boolean, rustValidation: boolean;
+    if (rustAst) {
+      const mw = extractRustFileMiddlewareAst(file.tree!);
+      rustAuth = mw.hasAuth;
+      rustRateLimit = mw.hasRateLimit;
+      rustValidation = mw.hasValidation;
+    } else {
+      rustAuth = false;
+      rustRateLimit = false;
+      rustValidation = false;
     }
 
     index.set(file.relativePath, {
-      hasAuth: jsAuth || goAuth || pyAuth,
-      hasValidation: jsValidation || goValidation || pyValidation,
-      hasRateLimit: jsRateLimit || goRateLimit || pyRateLimit,
+      hasAuth: jsAuth || goAuth || pyAuth || rustAuth,
+      hasValidation: jsValidation || goValidation || pyValidation || rustValidation,
+      hasRateLimit: jsRateLimit || goRateLimit || pyRateLimit || rustRateLimit,
     });
   }
   return index;
@@ -258,8 +286,24 @@ function extractRoutes(
     if (file.language === "go") extractGoRoutes(file, routes, fileMw, xfile);
     else if (file.language === "javascript" || file.language === "typescript") extractJsRoutes(file, routes, fileMw);
     else if (file.language === "python") extractPythonRoutes(file, routes, fileMw, xfile);
+    else if (file.language === "rust") extractRustRoutes(file, routes);
   }
   return routes;
+}
+
+function extractRustRoutes(file: DriftFile, routes: RouteInfo[]) {
+  // AST ONLY, and ONLY on a CLEAN parse. There is NO regex fallback for Rust
+  // anywhere in this codebase: an absent or errored tree yields zero Rust routes
+  // (unchanged from before this module was wired in). A parse error can only
+  // shrink the recognized route set for that file, never emit a wrong route, and
+  // Rust has no legacy regex path whose over-blesses we would need to preserve.
+  // No FileMiddleware argument: Axum .layer scope is CHAIN-scoped, so the AST path
+  // computes covering-layer auth from the tree itself (a file-level OR would
+  // false-bless siblings a layer never wrapped, and the seam-2 index entry is
+  // all-false for rust anyway).
+  if (file.tree && !file.tree.rootNode.hasError) {
+    routes.push(...extractRustRoutesAst(file.tree, file.relativePath));
+  }
 }
 
 function inheritedAuth(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {

--- a/test/calibration/README.md
+++ b/test/calibration/README.md
@@ -276,6 +276,99 @@ since local defs take precedence over any cross-file candidate.
   plain S1-shape stripped deviator run in the same test stays flat, not
   hedged (no leakage between the two failure modes).
 
+## Rust security fixture (the multilang calibration gate)
+
+`rust-security-fixture.ts` + `security-rust.test.ts` are the enforced
+precision/recall gate for the Rust AST security extractor
+(`src/drift/security-ast-rust.ts`), mirroring the Python/Go gates above and
+running the same way (a normal vitest file, checked on every `npm test`).
+
+**The v1 boundary governs the whole corpus:** Rust v1 blesses a route ONLY
+when a covering (ancestor) `.layer`/`.route_layer` wraps a
+`middleware::from_fn`/`from_fn_with_state` whose in-file body VERIFIABLY
+rejects (401-family). There is no name-only bless and no type-name bless. So
+every authed fixture below DEFINES its `require_auth`/`gate` middleware
+IN-FILE with a body that actually rejects, and blesses through the readable
+reject, never through the name. Extractor-typed auth (an `AuthUser`/`Identity`
+handler param) and Actix/Rocket auth resolve UNSURE at best — v1 does not read
+a `FromRequest` impl even when it is in-file, and Actix attribute-macro routes
+have no builder layer chain at all to walk.
+
+The corpus is realistic Axum/Actix multi-file code (real `Router::new()`
+builder chains, `.route_layer`/`.layer` scoping, `from_fn`/`from_fn_with_state`
+resolution, Actix attribute macros), split into independent roots so each
+corpus roots its own `repoHasAuthMachinery` evidence and its own
+route-directory vote (`routeGroupKey` = dirname):
+
+- `rustsrv/routes/` — 8 Axum files, 2 mutating routes each (POST + DELETE),
+  authed via a single `.route_layer(middleware::from_fn(require_auth))`
+  covering both.
+- `rustsrv/auth_tokens.rs` — the repo-global `login_required` machinery token
+  (case-sensitive: this is what `repoHasAuthMachinery` matches;
+  Rust-idiomatic `require_auth` is deliberately NOT in that regex, mirroring
+  the Python fixture's `auth.py` trick).
+- `statesrv/routes/` — 5 Axum files, one mutating route each, authed via
+  `.layer(middleware::from_fn_with_state(state.clone(), require_auth))`
+  (LAST-arg resolution) — a SECOND bless mechanism, proving the dominance
+  vote is not a single code path.
+- `hooks/routes/` — 5 uniformly PUBLIC Axum webhook receivers, same
+  negative-control shape as the Python/Go rows: signature verification
+  happens inside the handler body via a `check_signature` helper, never as a
+  `from_fn` layer, so it's structurally invisible to the covering-layer walk.
+  **This is why the negative control lives in its own corpus root:**
+  `repoHasAuthMachinery` is repo-global over whatever files are in
+  `ctx.files`, not scoped to a route group, so mixing it into an authed
+  corpus would let that corpus's own machinery leak in.
+- `bodycol/routes/`, `bodygate/routes/`, `bodyunsure/routes/` — the three
+  body-signature scenarios (S6-S8), each its own root for the same
+  machinery-isolation reason.
+- `actixsrv/` — Actix attribute-macro handlers (`#[get(...)]`/`#[post(...)]`).
+  Measures the v1 boundary explicitly: method+path recognition works
+  identically to Axum, but auth never blesses (an auth-flavored extractor
+  type hedges, a non-auth extractor type or a scope-level `.wrap` resolves
+  flat not-auth — the `.wrap` is structurally invisible to an attribute-macro
+  route, since v1's covering-layer walk only ever starts from a builder
+  `.route(...)` call node).
+
+Nine scenarios (S0-S8), mirroring the Python/Go S0-S8, plus an Actix
+addendum:
+
+| # | Scenario | Corpus | Asserts |
+|---|----------|--------|---------|
+| S0 | Recognition + no-name-bless pin | rustsrv + statesrv + hooks (18 files) | 2 routes/file (Axum), 1 route/file (state), 1 unauthed route/file (hooks), def-only file yields 0 routes, unresolved name hedges, in-file reject blesses |
+| S1 | Primary dominance vote, `from_fn` | rustsrv (8 files, 1 stripped) | dominantCount 14, totalRelevantFiles 16, consistencyScore 88, precision/recall 1.0 |
+| S2 | Primary dominance vote, `from_fn_with_state` | statesrv (5 files, 1 stripped) | dominantCount 4, score 80, through the LAST-arg resolution path |
+| S3 | Uniform-auth-gap fallback | rustsrv (all 8 stripped) + auth_tokens.rs | gap fires, severity error, precision/recall 1.0 |
+| S4 | Negative control | hooks (5 files) | non-vacuity first, then zero findings |
+| S5 | Uniformly-authed control | full rustsrv + statesrv corpus | non-vacuity first, then zero findings on every axis |
+| S6 | Name-auth-but-body-isnt collision | bodycol (5 files) | flat not-auth, NOT suppressed, no hedge |
+| S7 | Body-is-real-auth positive | bodygate (5 files) | boring `gate()` hook blesses on body alone |
+| S8 | Unresolvable-body UNSURE | bodyunsure (5 files) | hedged copy naming the hook, counts match S6, no leakage into S1 |
+
+**S1's arithmetic note (audit-first):** the task brief's shorthand describes
+S1 by file count ("dominantCount 7, totalRelevantFiles 8"). The fixture
+carries 2 mutating routes per file, so the actual applicable-routes
+denominator is 16, not 8, and stripping one file's layer removes auth from
+its 2 routes. The ratio is identical (7/8 == 14/16 == 0.875, consistencyScore
+rounds to 88 either way), but the literal `dominantCount`/`totalRelevantFiles`
+fields are asserted as 14/16 — verified against
+`analyzeSecurityProperty`'s own arithmetic, not copied from the brief.
+
+**Isolated trend row (`npm run calibrate`):** a Rust corpus loop runs after
+the Go row in `precision-recall.ts`, relabeled to a dedicated
+`security_posture_rust` category (never merged into the shared TS baseline or
+the JS/Python/Go `security_posture` rows, for the same isolation reasons
+those rows document). Measured on the first run: precision 1.00, recall 1.00
+(TP 3, FP 0, FN 0) — every one of the 3 stripped files in the gap-path
+variant was caught. The task brief flagged that Rust recall was *expected* to
+be lower than Python/Go given the conservative v1; that did not materialize
+here because this corpus's deviators use the canonical from_fn-strip shape
+(the same shape S1/S3 measure), which the extractor resolves cleanly. This is
+a real, verified number, not a floor — a future corpus exercising a harder
+recall case (e.g. an extractor-typed deviator) could legitimately measure
+lower without failing the gate (the enforced floor is the `security-floor`
+row at >= 0.95, unaffected by this row).
+
 ## Adding a new injection type
 
 Drop a generator in `generators/`. Signature:

--- a/test/calibration/precision-recall.ts
+++ b/test/calibration/precision-recall.ts
@@ -23,6 +23,7 @@ import { generateBaseline, type BaselineFile } from "./baseline.js";
 import { INJECTORS } from "./injectors.js";
 import { flaskAuthedGroup, pyAuthFile, pyAppFile, stripFlaskAuth } from "./python-security-fixture.js";
 import { ginAuthedGroup, goAuthFile, goMainFile, stripGinAuth } from "./go-security-fixture.js";
+import { axumAuthedGroup, rustAuthTokensFile, stripAxumAuth } from "./rust-security-fixture.js";
 import { classify, findingCategory, type CategoryMetrics, type DriftLabel, type ScoredFinding } from "./metrics.js";
 
 // Each injector's expected detector category (what a correct detector emits).
@@ -162,13 +163,37 @@ async function main(): Promise<void> {
     .map((s) => ({ ...s, category: "security_posture_go" }));
   mergeInto(agg, classify(goScored, goLabels));
 
+  // 5. Rust security corpus (own root, own row label), mirroring the Python/Go
+  // rows above verbatim. Exercises the AST extractor's realistic Axum fixture
+  // through the FULL on-disk scan pipeline (not the direct detector call
+  // test/calibration/security-rust.test.ts uses), kept out of the TS
+  // baseline/injector loop for the same isolation reason as the Python/Go
+  // rows: merging Rust files into generateBaseline() would contaminate the
+  // naming/architecture rows and shift the clean-scan FP floor, and merging
+  // this row's counts into the JS/Python/Go "security_posture" rows would let
+  // a Rust regression hide behind good numbers from the other languages.
+  const rustBase = [...axumAuthedGroup(), rustAuthTokensFile];
+  const rustVariant = stripAxumAuth(rustBase, 3); // 3 of 8 files stripped -> ratio 5/8 <= 0.75: primary vote silent, gap path
+  const rustLabels = diffLabels(rustBase, rustVariant, "security_posture_rust");
+  const rustDir = join(root, "security_rust");
+  await writeFixture(rustDir, rustVariant);
+  const rustScored = scored(await scan(rustDir))
+    .filter((s) => s.category === "security_posture")
+    .map((s) => ({ ...s, category: "security_posture_rust" }));
+  mergeInto(agg, classify(rustScored, rustLabels));
+
   const allRows = finalize(agg);
   // Only the INJECTED categories have synthetic ground truth — those are the
   // ones we can fairly score. Other categories that fire on the templated
   // baseline (semantic_duplication, dead-code, phantom_scaffolding — the 6
   // near-identical, consumer-less handlers legitimately trip them) have no
   // ground truth here and are reported separately as un-measured.
-  const injectedCats = new Set([...Object.values(INJECTOR_CATEGORY), "security_posture_py", "security_posture_go"]);
+  const injectedCats = new Set([
+    ...Object.values(INJECTOR_CATEGORY),
+    "security_posture_py",
+    "security_posture_go",
+    "security_posture_rust",
+  ]);
   const rows = allRows.filter((r) => injectedCats.has(r.category));
   const unmeasured = allRows.filter((r) => !injectedCats.has(r.category) && (r.fp ?? 0) > 0);
 

--- a/test/calibration/rust-security-fixture.ts
+++ b/test/calibration/rust-security-fixture.ts
@@ -1,0 +1,534 @@
+/**
+ * Calibration fixture for the Rust AST security extractor (Task 6): a
+ * realistic Axum + Actix multi-file corpus with planted ground truth, used by
+ * test/calibration/security-rust.test.ts to measure the primary dominance
+ * vote (analyzeSecurityProperty) through TWO independent bless mechanisms
+ * (from_fn and from_fn_with_state), the uniform-auth-gap fallback
+ * (analyzeUniformAuthGap), a negative control, the three body-signature
+ * outcomes (collision / gate / unsure), and the Actix v1 boundary. Mirrors
+ * go-security-fixture.ts / python-security-fixture.ts function-for-function.
+ *
+ * LOCKED decision (see security-ast-rust.ts and task-6-brief.md): Rust v1
+ * blesses ONLY via a covering (ancestor) `.layer`/`.route_layer` wrapping
+ * `middleware::from_fn(fn)` / `middleware::from_fn_with_state(state, fn)`
+ * whose in-file body VERIFIABLY rejects (401-family). There is NO name-only
+ * bless and NO type-name bless. So every authed corpus below DEFINES its
+ * `require_auth` / `gate` middleware IN-FILE with a body that actually
+ * rejects, and blesses through rule 2 (the readable reject), never through
+ * the name — an imported or extractor-typed auth surface resolves UNSURE at
+ * best, never a bless.
+ *
+ * Directory layout mirrors independent "repos" so each corpus roots its own
+ * `repoHasAuthMachinery` evidence (repo-global over whatever files are in
+ * ctx.files, not scoped to a route group) and its own route-directory vote
+ * (`routeGroupKey` = dirname, so every corpus's route files share ONE parent
+ * directory):
+ *   rustsrv/routes/*.rs      8 Axum files, 2 mutating routes each (POST +
+ *                            DELETE), one `.route_layer(from_fn(require_auth))`
+ *                            covering both — the S1 bless mechanism.
+ *   rustsrv/auth_tokens.rs   the repo-global `login_required` machinery token
+ *                            (case-sensitive: this is what `repoHasAuthMachinery`
+ *                            matches; Rust-idiomatic `require_auth` is NOT in
+ *                            that regex, mirroring the Python fixture's
+ *                            `auth.py` trick).
+ *   statesrv/routes/*.rs     5 Axum files, one mutating route each, authed via
+ *                            `.layer(from_fn_with_state(state.clone(), require_auth))`
+ *                            (LAST-arg fn resolution) — the S2 bless mechanism,
+ *                            proving S1 is not a single code path.
+ *   hooks/routes/*.rs        5 uniformly PUBLIC Axum webhook receivers
+ *                            (negative control): signature checking happens
+ *                            INSIDE the handler body via a helper
+ *                            `check_signature`, never as a `from_fn` layer,
+ *                            never with an auth-lexicon name.
+ *   bodycol/routes/*.rs      S6: 4 authed + 1 name-auth-but-body-isnt collision.
+ *   bodygate/routes/*.rs     S7: 5 routes whose ONLY auth is a boring `gate()`
+ *                            hook (no auth-lexicon identifier anywhere).
+ *   bodyunsure/routes/*.rs   S8: 4 authed + 1 imported-hook UNSURE.
+ *   actixsrv/*.rs            Actix attribute-macro handlers (method+path
+ *                            recognition only): a `.wrap`/request-guard/
+ *                            extractor-typed auth surface, never blessed —
+ *                            v1 does not bless Actix/Rocket auth.
+ */
+import type { BaselineFile } from "./baseline.js";
+
+// The in-file auth middleware every "authed" Axum fixture defines: a 401 on a
+// missing Authorization header. Identical text across every file that uses
+// it, so a single strip() call can remove its CALL SITE deterministically
+// (see stripAxumAuth below) while leaving the (now unused) definition intact —
+// mirrors the brief's "byte-identical MINUS the .route_layer(...) link".
+const REQUIRE_AUTH_BLOCK =
+`async fn require_auth(req: Request, next: Next) -> Result<Response, StatusCode> {
+    let tok = req.headers().get("Authorization");
+    if tok.is_none() { return Err(StatusCode::UNAUTHORIZED); }
+    Ok(next.run(req).await)
+}
+
+`;
+
+function sortedEligiblePaths(files: BaselineFile[], predicate: (path: string) => boolean): string[] {
+  return files
+    .map((f) => f.path)
+    .filter(predicate)
+    .sort();
+}
+
+// ─── rustsrv: 8 Axum route files, 2 mutating routes each (S0/S1) ────────────
+const RUSTSRV_ROOT = "rustsrv/routes";
+const RUSTSRV_ENTITIES = [
+  "orders", "users", "products", "payments", "invoices", "carts", "sessions", "notifications",
+];
+
+function axumRouteFile(name: string): BaselineFile {
+  return {
+    path: `${RUSTSRV_ROOT}/${name}.rs`,
+    content:
+`use axum::{Router, routing::post, routing::delete, middleware, http::StatusCode};
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+${REQUIRE_AUTH_BLOCK}async fn create_${name}() -> Response {
+    todo!()
+}
+
+async fn delete_${name}() -> Response {
+    todo!()
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/${name}", post(create_${name}))
+        .route("/${name}/:id", delete(delete_${name}))
+        .route_layer(middleware::from_fn(require_auth))
+}
+`,
+  };
+}
+
+export function axumAuthedGroup(): BaselineFile[] {
+  return RUSTSRV_ENTITIES.map(axumRouteFile);
+}
+
+// Support file: kept OUT of axumAuthedGroup() so it stays two-routes-per-file
+// exactly (S0's route-loss guard requires every element to yield exactly the
+// planted count). Each route file now carries its OWN in-file require_auth
+// (that is what actually blesses each route); this file's role is purely to
+// keep "the codebase uses auth elsewhere" evidence present once those in-file
+// copies are stripped (S3). LOAD-BEARING: `login_required` (the literal
+// identifier) is what the case-sensitive repoHasAuthMachinery regex matches —
+// Rust-idiomatic `require_auth` is deliberately NOT in that token list,
+// mirroring the Python fixture's pysrv/auth.py trick.
+export const rustAuthTokensFile: BaselineFile = {
+  path: "rustsrv/auth_tokens.rs",
+  content:
+`//! Deprecated auth token bridge, superseded by the from_fn-based
+//! \`require_auth\` middleware defined in each route module.
+
+#[deprecated(note = "use the require_auth middleware instead")]
+pub fn login_required() -> bool {
+    false
+}
+`,
+};
+
+/** Sorted rustsrv/routes/*.rs paths in `files` — the deterministic strip
+ *  order stripAxumAuth uses, exposed so tests can compute which path(s) got
+ *  stripped without duplicating the sort/filter logic. */
+export function sortedAxumRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${RUSTSRV_ROOT}/`) && p.endsWith(".rs"));
+}
+
+/** Deterministically strips the `.route_layer(middleware::from_fn(require_auth))`
+ *  call-site line from the first `count` rustsrv route files, sorted by path.
+ *  The routes and the (now unused) require_auth definition are untouched, so
+ *  every stripped file remains valid, still-mutating routes with
+ *  hasAuth: false and no covering layer at all. */
+export function stripAxumAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedAxumRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const content = f.content
+      .split("\n")
+      .filter((line) => line.trim() !== ".route_layer(middleware::from_fn(require_auth))")
+      .join("\n");
+    return { path: f.path, content };
+  });
+}
+
+// ─── statesrv: 5 Axum files, from_fn_with_state bless (S2) ──────────────────
+const STATESRV_ROOT = "statesrv/routes";
+const STATESRV_ENTITIES = ["teams", "projects", "tags", "comments", "attachments"];
+
+// 5 files so one deviator gives 4/5 = 0.8 > 0.75 (the arithmetic floor: n=4
+// can never clear the strict > 0.75 gate). Blesses through the LAST-arg
+// from_fn_with_state form, resolved via rule 2 (the readable in-file reject),
+// never the name — a SECOND bless mechanism from S1's, proving the dominance
+// vote is not a single code path.
+function stateRouteFile(name: string): BaselineFile {
+  return {
+    path: `${STATESRV_ROOT}/${name}.rs`,
+    content:
+`use axum::{Router, routing::post, middleware, http::StatusCode};
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+
+#[derive(Clone)]
+struct AppState;
+
+async fn require_auth(State(_state): State<AppState>, req: Request, next: Next) -> Result<Response, StatusCode> {
+    let tok = req.headers().get("Authorization");
+    if tok.is_none() { return Err(StatusCode::UNAUTHORIZED); }
+    Ok(next.run(req).await)
+}
+
+async fn create_${name}(State(_state): State<AppState>) -> Response {
+    todo!()
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/${name}", post(create_${name}))
+        .layer(middleware::from_fn_with_state(state.clone(), require_auth))
+        .with_state(state)
+}
+`,
+  };
+}
+
+export function axumStateAuthedGroup(): BaselineFile[] {
+  return STATESRV_ENTITIES.map(stateRouteFile);
+}
+
+/** Sorted statesrv/routes/*.rs paths in `files`, same purpose as
+ *  sortedAxumRoutePaths above. */
+export function sortedStateRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${STATESRV_ROOT}/`) && p.endsWith(".rs"));
+}
+
+/** Deterministically strips the `.layer(middleware::from_fn_with_state(...))`
+ *  call-site line from the first `count` statesrv route files, sorted by
+ *  path, leaving a bare (now unauthed) still-mutating route. */
+export function stripStateAuth(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedStateRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const content = f.content
+      .split("\n")
+      .filter((line) => line.trim() !== ".layer(middleware::from_fn_with_state(state.clone(), require_auth))")
+      .join("\n");
+    return { path: f.path, content };
+  });
+}
+
+/** uniformly-authed control: axumAuthedGroup + axumStateAuthedGroup + support
+ *  files, unchanged. */
+export function uniformlyAuthed(): BaselineFile[] {
+  return [...axumAuthedGroup(), rustAuthTokensFile, ...axumStateAuthedGroup()];
+}
+
+// ─── hooks: 5 uniformly PUBLIC webhook receivers (negative control, S4) ─────
+const HOOKS_ROOT = "hooks/routes";
+
+interface HookProvider { name: string; header: string; }
+const HOOK_PROVIDERS: HookProvider[] = [
+  { name: "stripe", header: "Stripe-Signature" },
+  { name: "github", header: "X-Hub-Signature-256" },
+  { name: "slack", header: "X-Slack-Signature" },
+  { name: "twilio", header: "X-Twilio-Signature" },
+  { name: "sendgrid", header: "X-Sendgrid-Signature" },
+];
+
+// Signature checking (if any) happens INSIDE the handler body via a helper
+// named check_signature — never as a from_fn layer, never with an
+// auth-lexicon name, and never even reaches the covering-layer walk (there is
+// no `.layer`/`.route_layer` at all). Own directory root so it never shares
+// repoHasAuthMachinery evidence with the authed corpora. Deliberately no
+// "limit"/"validate" token and no CLAUDE.md/AGENTS.md file in this corpus.
+function hookFile(provider: HookProvider): BaselineFile {
+  return {
+    path: `${HOOKS_ROOT}/${provider.name}_hook.rs`,
+    content:
+`use axum::{Router, routing::post, http::StatusCode};
+use axum::extract::Request;
+use axum::response::{IntoResponse, Response};
+
+// ${provider.name} webhook receiver. Requests are verified via payload
+// signature checking inside the handler, never via a gate that runs before it.
+
+async fn handle_${provider.name}_event(req: Request) -> Response {
+    let sig = req.headers().get("${provider.header}");
+    if !check_signature(sig) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    StatusCode::OK.into_response()
+}
+
+fn check_signature(header: Option<&axum::http::HeaderValue>) -> bool {
+    header.is_some()
+}
+
+pub fn routes() -> Router {
+    Router::new().route("/webhooks/${provider.name}", post(handle_${provider.name}_event))
+}
+`,
+  };
+}
+
+export function publicByDesignControl(): BaselineFile[] {
+  return HOOK_PROVIDERS.map(hookFile);
+}
+
+// ─── S6-S8: body-signature calibration groups ────────────────────────────────
+//
+// Each group roots its own directory so the route-directory vote grouping and
+// repoHasAuthMachinery evidence never bleed between scenarios. Each helper
+// keeps "one route per file" so the non-vacuity guards stay exact.
+
+// ── S6: name-auth-but-body-isnt collision (negative) ─────────────────────────
+const S6_ROOT = "bodycol/routes";
+const S6_AUTHED_NAMES = ["widgets", "gadgets", "tools", "devices"];
+
+function s6AuthedFile(name: string): BaselineFile {
+  return {
+    path: `${S6_ROOT}/${name}.rs`,
+    content:
+`use axum::{Router, routing::post, middleware, http::StatusCode};
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+${REQUIRE_AUTH_BLOCK}async fn create_${name}() -> Response {
+    todo!()
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/${name}", post(create_${name}))
+        .route_layer(middleware::from_fn(require_auth))
+}
+`,
+  };
+}
+
+/** The one deviator in S6: its only gate is an in-file `auth_check` whose
+ *  visible body merely LOGS the request path and forwards unconditionally.
+ *  Body-first classification resolves it flat not-auth (name looks like
+ *  auth, body is not), so the finding must NOT be suppressed. */
+export const bodyCollisionDeviatorPath = `${S6_ROOT}/notify.rs`;
+
+export function bodyCollisionGroup(): BaselineFile[] {
+  const authed = S6_AUTHED_NAMES.map(s6AuthedFile);
+  const collision: BaselineFile = {
+    path: bodyCollisionDeviatorPath,
+    content:
+`use axum::{Router, routing::post, middleware};
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+// auth_check's NAME looks like auth, but its BODY only logs the request path
+// and forwards unconditionally: body-first classification resolves this flat
+// not-auth (a visible non-enforcing body, rule 3), never a bless and never a
+// hedge.
+async fn auth_check(req: Request, next: Next) -> Response {
+    tracing::info!("auth check saw {}", req.uri().path());
+    next.run(req).await
+}
+
+async fn create_notify() -> Response {
+    todo!()
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/notify", post(create_notify))
+        .route_layer(middleware::from_fn(auth_check))
+}
+`,
+  };
+  return [...authed, collision];
+}
+
+// ── S7: body-is-real-auth positive (boring gate() hook) ──────────────────────
+const S7_ROOT = "bodygate/routes";
+const S7_NAMES = ["posts", "comments", "reviews", "tags", "media"];
+
+/** The exact from_fn block S7 files carry and stripBodyGate removes: a boring
+ *  name (`gate`) whose BODY reads the Authorization header and 401s, so ONLY
+ *  the body signature blesses (no auth-lexicon identifier anywhere in S7). */
+const GATE_BLOCK =
+`async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {
+    if req.headers().get("Authorization").is_none() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(next.run(req).await)
+}
+
+`;
+
+function bodyGateFile(name: string): BaselineFile {
+  return {
+    path: `${S7_ROOT}/${name}.rs`,
+    content:
+`use axum::{Router, routing::post, middleware, http::StatusCode};
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+${GATE_BLOCK}async fn create_${name}() -> Response {
+    todo!()
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/${name}", post(create_${name}))
+        .route_layer(middleware::from_fn(gate))
+}
+`,
+  };
+}
+
+export function bodyGateGroup(): BaselineFile[] {
+  return S7_NAMES.map(bodyGateFile);
+}
+
+export function sortedBodyGateRoutePaths(files: BaselineFile[]): string[] {
+  return sortedEligiblePaths(files, (p) => p.startsWith(`${S7_ROOT}/`) && p.endsWith(".rs"));
+}
+
+/** Removes the gate() from_fn call-site line from the first `count` S7 files,
+ *  sorted by path, leaving a bare (now unauthed) still-mutating route. */
+export function stripBodyGate(files: BaselineFile[], count: number): BaselineFile[] {
+  const targets = new Set(sortedBodyGateRoutePaths(files).slice(0, count));
+  return files.map((f) => {
+    if (!targets.has(f.path)) return f;
+    const content = f.content
+      .split("\n")
+      .filter((line) => line.trim() !== ".route_layer(middleware::from_fn(gate))")
+      .join("\n");
+    return { path: f.path, content };
+  });
+}
+
+// ── S8: unresolvable-body UNSURE (imported require_auth) ─────────────────────
+const S8_ROOT = "bodyunsure/routes";
+const S8_AUTHED_NAMES = ["alpha", "beta", "gamma", "delta"];
+
+function s8AuthedFile(name: string): BaselineFile {
+  return {
+    path: `${S8_ROOT}/${name}.rs`,
+    content:
+`use axum::{Router, routing::post, middleware, http::StatusCode};
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+${REQUIRE_AUTH_BLOCK}async fn create_${name}() -> Response {
+    todo!()
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/${name}", post(create_${name}))
+        .route_layer(middleware::from_fn(require_auth))
+}
+`,
+  };
+}
+
+/** The one deviator in S8: an IMPORTED require_auth middleware whose body is
+ *  not visible in this file, so it resolves UNSURE (hasAuth false,
+ *  authUnsureHook set, hedged copy), never a bless. */
+export const bodyUnsureDeviatorPath = `${S8_ROOT}/reports.rs`;
+
+export function bodyUnsureGroup(): BaselineFile[] {
+  const authed = S8_AUTHED_NAMES.map(s8AuthedFile);
+  const unsure: BaselineFile = {
+    path: bodyUnsureDeviatorPath,
+    content:
+`use axum::{Router, routing::post, middleware};
+use axum::response::Response;
+use some_crate::middleware::require_auth;
+
+// The only gate is an IMPORTED require_auth middleware: its body is not
+// visible in this file, so it resolves UNSURE (hedged copy naming the hook),
+// never a bless.
+async fn create_report() -> Response {
+    todo!()
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/reports", post(create_report))
+        .route_layer(middleware::from_fn(require_auth))
+}
+`,
+  };
+  return [...authed, unsure];
+}
+
+// ─── actixsrv: Actix attribute-macro recognition (v1 boundary) ──────────────
+//
+// v1 blesses ONLY Axum from_fn/from_fn_with_state middleware. Actix routes
+// (attribute macros) have no builder layer chain at all — `r.call` is null
+// for every attribute-macro route, so the covering-layer walk never even
+// runs. This corpus measures that boundary explicitly: method+path
+// recognition works identically to Axum, but auth NEVER blesses — it either
+// hedges via an auth-flavored extractor type (Identity) or resolves flat
+// not-auth (a non-auth extractor type, or a builder-level `.wrap` that is
+// structurally invisible to an attribute-macro route).
+const ACTIX_ROOT = "actixsrv";
+
+export function actixRecognitionGroup(): BaselineFile[] {
+  return [
+    {
+      path: `${ACTIX_ROOT}/orders.rs`,
+      content:
+`use actix_web::{post, HttpResponse};
+
+struct Identity;
+
+#[post("/orders")]
+async fn create_order(user: Identity) -> HttpResponse {
+    HttpResponse::Created().finish()
+}
+`,
+    },
+    {
+      path: `${ACTIX_ROOT}/products.rs`,
+      content:
+`use actix_web::{get, web, HttpResponse};
+
+#[get("/products/{id}")]
+async fn get_product(id: web::Path<u32>) -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+`,
+    },
+    {
+      path: `${ACTIX_ROOT}/reviews.rs`,
+      content:
+`use actix_web::{delete, web, HttpResponse};
+use actix_web_httpauth::middleware::HttpAuthentication;
+
+#[delete("/reviews/{id}")]
+async fn delete_review(id: web::Path<u32>) -> HttpResponse {
+    HttpResponse::NoContent().finish()
+}
+
+// A request-guard '.wrap' applied at the scope/App level is structurally
+// invisible to an attribute-macro route: v1's covering-layer walk only ever
+// starts from a builder '.route(...)' call node (r.call), which attribute
+// routes never have.
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/reviews")
+            .wrap(HttpAuthentication::bearer(validator))
+            .service(delete_review),
+    );
+}
+`,
+    },
+  ];
+}

--- a/test/calibration/security-rust.test.ts
+++ b/test/calibration/security-rust.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Task 6: the enforced precision/recall calibration gate for the Rust
+ * security extractor (vitest discovers test/**\/*.test.ts, so this runs as
+ * part of `npm test`, not just `npm run calibrate`).
+ *
+ * Scenarios S0-S8 against test/calibration/rust-security-fixture.ts's
+ * realistic Axum + Actix corpus, each computing precision/recall explicitly
+ * against planted ground truth (not just checking the finding fired).
+ * Mirrors security-go.test.ts / security-python.test.ts's S0-S8 structure.
+ *
+ * LOCKED decision (security-ast-rust.ts, task-6-brief.md): Rust v1 blesses a
+ * route ONLY when a covering (ancestor) `.layer`/`.route_layer` wraps a
+ * `middleware::from_fn`/`from_fn_with_state` whose in-file body VERIFIABLY
+ * rejects (401-family). There is no name-only bless and no type-name bless.
+ * So the authed corpora below (S1, S2, S5, and the four confident peers in
+ * S6/S8) bless because their middleware is DEFINED IN-FILE with a body that
+ * rejects, never because the middleware's NAME sounds like auth.
+ *
+ *   S0  recognition self-check — the route-loss guard, PLUS the no-name-bless
+ *       classifier pin (an unresolved name hedges, an in-file reject blesses).
+ *   S1  primary dominance vote, Axum from_fn (8 files, 2 routes each, 1
+ *       planted deviator).
+ *   S2  primary dominance vote, Axum from_fn_with_state (5 files, 1 planted
+ *       deviator) — a SECOND bless mechanism, proving S1 is not a single code
+ *       path.
+ *   S3  uniform-auth-gap fallback (all 8 Axum route files stripped at once).
+ *   S4  negative control — uniformly public webhook receivers. Non-vacuity
+ *       (routes ARE extracted) is asserted BEFORE zero-findings.
+ *   S5  uniformly-authed control — zero findings on every axis.
+ *   S6  name-auth-but-body-isnt collision (auth_check that only logs): must
+ *       NOT suppress the finding.
+ *   S7  body-is-real-auth positive (a boring gate() hook): the body signature
+ *       alone blesses; no auth-lexicon name anywhere.
+ *   S8  unresolvable-body UNSURE (imported require_auth): stays flagged with
+ *       HEDGED copy naming the hook; counts match S6; S1 stays flat in the
+ *       same run.
+ *   Actix addendum: method+path recognition works identically to Axum, but
+ *       `.wrap`/request-guard/extractor-typed auth never blesses (the v1
+ *       boundary).
+ *
+ * ARITHMETIC NOTE (audit-first): the task brief's S1 shorthand describes
+ * "dominantCount 7, totalRelevantFiles 8" by file count. The actual fixture
+ * carries 2 mutating routes per file (POST + DELETE) per the brief's own
+ * "realistic code shape", so the applicable-ROUTES denominator is 16, not 8,
+ * and stripping 1 file's layer removes auth from its 2 routes. The RATIO is
+ * identical (7/8 == 14/16 == 0.875, consistencyScore rounds to 88 either
+ * way), but the literal dominantCount/totalRelevantFiles fields are computed
+ * and asserted here as 14/16 — verified against analyzeSecurityProperty's own
+ * arithmetic (src/drift/security-consistency.ts), not copied from the brief.
+ */
+import { describe, it, expect } from "vitest";
+import { securityConsistency } from "../../src/drift/security-consistency.js";
+import { SECURITY_SUBCATEGORIES } from "../../src/drift/types.js";
+import type { DriftFile } from "../../src/drift/types.js";
+import {
+  extractRustRoutesAst,
+  classifyRustAuth,
+  collectRustFunctionDefs,
+} from "../../src/drift/security-ast-rust.js";
+import { fileWithTree } from "../helpers/drift-tree.js";
+import type { BaselineFile } from "./baseline.js";
+import {
+  axumAuthedGroup,
+  axumStateAuthedGroup,
+  rustAuthTokensFile,
+  sortedAxumRoutePaths,
+  sortedStateRoutePaths,
+  stripAxumAuth,
+  stripStateAuth,
+  publicByDesignControl,
+  uniformlyAuthed,
+  bodyCollisionGroup,
+  bodyCollisionDeviatorPath,
+  bodyGateGroup,
+  sortedBodyGateRoutePaths,
+  stripBodyGate,
+  bodyUnsureGroup,
+  bodyUnsureDeviatorPath,
+  actixRecognitionGroup,
+} from "./rust-security-fixture.js";
+
+async function toDriftFiles(files: BaselineFile[]): Promise<DriftFile[]> {
+  return Promise.all(files.map((f) => fileWithTree(f.path, f.content, "rust")));
+}
+
+async function ctxFor(files: BaselineFile[]) {
+  const driftFiles = await toDriftFiles(files);
+  return {
+    files: driftFiles,
+    totalLines: driftFiles.reduce((s, f) => s + f.lineCount, 0),
+    dominantLanguage: "rust",
+  };
+}
+
+function authFindings(findings: ReturnType<typeof securityConsistency.detect>) {
+  return findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.auth);
+}
+
+const MACHINERY =
+  /\b(requireAuth|isAuthenticated|verifyToken|authMiddleware|ensureAuth|withAuth|jwt_required|login_required|AuthMiddleware|passport)\b/;
+
+describe("Rust calibration: S0 recognition self-check (route-loss guard + no-name-bless pin)", () => {
+  it("axumAuthedGroup extracts exactly 2 routes per file (POST + DELETE, both authed), 16 total", async () => {
+    let total = 0;
+    for (const f of axumAuthedGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      // A recognition or in-file body-resolution regression fails HERE with a
+      // count and the offending file's path, instead of silently vanishing
+      // from a vote count several layers down.
+      expect(routes, f.path).toHaveLength(2);
+      expect(routes.map((r) => r.method)).toEqual(["POST", "DELETE"]);
+      expect(routes.every((r) => r.hasAuth), f.path).toBe(true);
+      total += routes.length;
+    }
+    expect(total).toBe(16);
+  });
+
+  it("axumStateAuthedGroup extracts exactly 1 route per file (from_fn_with_state bless), 5 total", async () => {
+    let total = 0;
+    for (const f of axumStateAuthedGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].method).toBe("POST");
+      expect(routes[0].hasAuth, f.path).toBe(true);
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("the negative control extracts exactly 5 unauthed routes (non-vacuity)", async () => {
+    let total = 0;
+    for (const f of publicByDesignControl()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("the support / def-only file contributes zero routes", async () => {
+    const driftFile = await fileWithTree(rustAuthTokensFile.path, rustAuthTokensFile.content, "rust");
+    const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+    expect(routes).toHaveLength(0);
+  });
+
+  it("no-name-bless classifier pin: 'require_auth' and 'AuthUser' hedge on name alone; an in-file rejecting body DOES bless", async () => {
+    // Negative: an unresolvable (body-less) name is opaque at best, never a
+    // bless on its own. If a name-bless-on-opaque regression landed, these
+    // would flip to "auth".
+    expect(classifyRustAuth("require_auth", null, new Map())).toBe("unsure");
+    expect(classifyRustAuth("AuthUser", null, new Map())).toBe("unsure");
+
+    // Positive: this is HOW the S1/S2/S6/S8 corpus actually blesses — an
+    // in-file def whose body verifiably rejects. If in-file body resolution
+    // broke, S1-S5 would silently collapse (their finding counts would go to
+    // zero, not throw), so this is pinned as its own assertion.
+    const driftFile = await fileWithTree(
+      "x.rs",
+      `async fn require_auth(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+        `    let tok = req.headers().get("Authorization");\n` +
+        `    if tok.is_none() { return Err(StatusCode::UNAUTHORIZED); }\n` +
+        `    Ok(next.run(req).await)\n}\n`,
+      "rust",
+    );
+    const defs = collectRustFunctionDefs(driftFile.tree!.rootNode);
+    const def = defs.get("require_auth")!;
+    const body = def.childForFieldName("body")!;
+    expect(classifyRustAuth("require_auth", body, defs)).toBe("auth");
+  });
+});
+
+describe("Rust calibration: S1 primary dominance vote, Axum from_fn", () => {
+  it("flags exactly the one stripped file's routes among 8 Axum route files (dominantCount 14, consistencyScore 88)", async () => {
+    const strippedPath = sortedAxumRoutePaths(axumAuthedGroup())[0];
+    const files = [...stripAxumAuth(axumAuthedGroup(), 1), rustAuthTokensFile];
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    // 8 files x 2 mutating routes = 16 applicable routes; stripping 1 file's
+    // layer removes auth from its 2 routes: 14/16 = 0.875 (same ratio as the
+    // brief's file-count shorthand 7/8) -> consistencyScore rounds to 88.
+    expect(finding.dominantCount).toBe(14);
+    expect(finding.totalRelevantFiles).toBe(16);
+    expect(finding.consistencyScore).toBe(88);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles).toHaveLength(2); // both routes in the stripped file
+    expect(finding.deviatingFiles.every((d) => d.path === strippedPath)).toBe(true);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Rust calibration: S2 primary dominance vote, Axum from_fn_with_state", () => {
+  it("flags exactly the one stripped file among 5 state-scoped route files (dominantCount 4, consistencyScore 80)", async () => {
+    const strippedPath = sortedStateRoutePaths(axumStateAuthedGroup())[0];
+    const ctx = await ctxFor(stripStateAuth(axumStateAuthedGroup(), 1));
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.severity).toBe("warning");
+    expect(finding.confidence).toBe(0.75);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Rust calibration: S3 uniform-auth-gap fallback", () => {
+  it("flags all 16 mutating Axum routes when the primary vote goes silent but the repo uses auth elsewhere", async () => {
+    const plantedPaths = sortedAxumRoutePaths(axumAuthedGroup());
+    // rustsrv/auth_tokens.rs retained (carries the repoHasAuthMachinery
+    // evidence via the literal `login_required` token); the gap must fire
+    // from that token alone, with every in-file require_auth layer stripped.
+    const files = [...stripAxumAuth(axumAuthedGroup(), 8), rustAuthTokensFile];
+    const ctx = await ctxFor(files);
+
+    const findings = securityConsistency.detect(ctx as any);
+    const auth = authFindings(findings);
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.finding).toContain(
+      "16 mutating route(s) lack auth while the codebase uses auth elsewhere",
+    );
+    expect(finding.severity).toBe("error");
+    expect(finding.confidence).toBe(0.6);
+    expect(finding.dominantCount).toBe(0);
+    expect(finding.totalRelevantFiles).toBe(16);
+    expect(finding.consistencyScore).toBe(0);
+    expect(finding.deviatingFiles).toHaveLength(16); // 8 files x 2 routes
+    expect([...new Set(finding.deviatingFiles.map((d) => d.path))].sort()).toEqual(plantedPaths);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set(plantedPaths);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Rust calibration: S4 negative control (uniformly public by design)", () => {
+  it("negative control contains no repo auth-machinery token, no limit/validate token, no CLAUDE.md/AGENTS.md file (self-check)", () => {
+    for (const f of publicByDesignControl()) {
+      expect(MACHINERY.test(f.content), f.path).toBe(false);
+      expect(/limit|validate/i.test(f.content), f.path).toBe(false);
+      expect(f.path.toLowerCase()).not.toMatch(/claude\.md|agents\.md/);
+    }
+  });
+
+  it("non-vacuity FIRST: extracts exactly 5 mutating, unauthed routes before silence can mean anything", async () => {
+    let total = 0;
+    for (const f of publicByDesignControl()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+      expect(routes[0].method, f.path).toBe("POST");
+      total += routes.length;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("THEN: produces zero security_posture findings", async () => {
+    const ctx = await ctxFor(publicByDesignControl());
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+});
+
+describe("Rust calibration: S5 uniformly-authed control", () => {
+  it("non-vacuity FIRST: extracts 21 routes across the corpus, every one authed, before silence can mean anything", async () => {
+    let total = 0;
+    for (const f of uniformlyAuthed()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      for (const r of routes) {
+        expect(r.hasAuth, `${f.path} ${r.method} ${r.path}`).toBe(true);
+        total += 1;
+      }
+    }
+    expect(total).toBe(21); // 8 files x 2 routes (axum) + 5 routes (state)
+  });
+
+  it("produces zero security_posture findings across the whole corpus, incl. validation and rate-limit", async () => {
+    const ctx = await ctxFor(uniformlyAuthed());
+    const findings = securityConsistency.detect(ctx as any);
+
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+    expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.validation)).toEqual([]);
+    expect(findings.filter((f) => f.subCategory === SECURITY_SUBCATEGORIES.rateLimit)).toEqual([]);
+  });
+});
+
+// ─── S6-S8: body-signature scenarios ──────────────────────────────────────────
+
+describe("Rust calibration: S6 name-auth-but-body-isnt collision (negative)", () => {
+  it("non-vacuity FIRST: 5 routes; the collision route hasAuth false, the unsure key ABSENT", async () => {
+    let total = 0;
+    for (const f of bodyCollisionGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      if (f.path === bodyCollisionDeviatorPath) {
+        expect(routes[0].hasAuth).toBe(false);
+        expect("authUnsureHook" in routes[0]).toBe(false); // visible non-auth body: flat, not hedged
+      } else {
+        expect(routes[0].hasAuth, f.path).toBe(true);
+      }
+      total += 1;
+    }
+    expect(total).toBe(5);
+  });
+
+  it("flags exactly the collision file (dominantCount 4, score 80), precision 1 recall 1, no-auth copy that is NOT hedged", async () => {
+    const ctx = await ctxFor(bodyCollisionGroup());
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([bodyCollisionDeviatorPath]);
+
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp.toLowerCase()).toContain("no auth");
+    expect(dp.toLowerCase()).not.toContain("double check");
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([bodyCollisionDeviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Rust calibration: S7 body-is-real-auth positive (boring gate() hook)", () => {
+  it("self-check: the S7 corpus contains no auth-lexicon identifier (only the BODY blesses)", () => {
+    for (const f of bodyGateGroup()) {
+      expect(MACHINERY.test(f.content), f.path).toBe(false);
+    }
+  });
+
+  it("scenario A (uniform): all 5 routes hasAuth true via the body signature, THEN zero security_posture findings", async () => {
+    let total = 0;
+    for (const f of bodyGateGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(true);
+      total += 1;
+    }
+    expect(total).toBe(5);
+
+    const ctx = await ctxFor(bodyGateGroup());
+    const findings = securityConsistency.detect(ctx as any);
+    expect(findings.filter((f) => f.driftCategory === "security_posture")).toEqual([]);
+  });
+
+  it("scenario B: stripping the guard hook from the first sorted file flags exactly it, precision 1 recall 1", async () => {
+    const strippedPath = sortedBodyGateRoutePaths(bodyGateGroup())[0];
+    const ctx = await ctxFor(stripBodyGate(bodyGateGroup(), 1));
+    const auth = authFindings(securityConsistency.detect(ctx as any));
+    expect(auth).toHaveLength(1);
+    expect(auth[0].dominantCount).toBe(4);
+    expect(auth[0].totalRelevantFiles).toBe(5);
+    expect(auth[0].consistencyScore).toBe(80);
+    expect(auth[0].deviatingFiles.map((d) => d.path)).toEqual([strippedPath]);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([strippedPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+  });
+});
+
+describe("Rust calibration: S8 unresolvable-body UNSURE (imported require_auth)", () => {
+  it("non-vacuity FIRST: the unsure route is POST/hasAuth false with authUnsureHook 'require_auth'; the 4 peers omit the key", async () => {
+    for (const f of bodyUnsureGroup()) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      if (f.path === bodyUnsureDeviatorPath) {
+        expect(routes[0].method).toBe("POST");
+        expect(routes[0].hasAuth).toBe(false);
+        expect(routes[0].authUnsureHook).toBe("require_auth");
+      } else {
+        expect(routes[0].hasAuth, f.path).toBe(true);
+        expect("authUnsureHook" in routes[0], f.path).toBe(false);
+      }
+    }
+  });
+
+  it("flags the unsure file with HEDGED copy; counts match the S6 control; the S1 deviator stays FLAT in the same run", async () => {
+    const auth = authFindings(securityConsistency.detect((await ctxFor(bodyUnsureGroup())) as any));
+    expect(auth).toHaveLength(1);
+    const finding = auth[0];
+
+    expect(finding.deviatingFiles.map((d) => d.path)).toEqual([bodyUnsureDeviatorPath]);
+    const dp = finding.deviatingFiles[0].detectedPattern;
+    expect(dp).toContain("require_auth");
+    expect(dp.toLowerCase()).toContain("double check");
+    expect(dp).not.toMatch(/—|--/); // hedged deviator copy carries no em-dash / double hyphen
+
+    expect(finding.recommendation).toContain("Double check");
+    expect(finding.recommendation).toContain("require_auth");
+
+    // Vote-arithmetic invariance: S8's counts equal the S6 control (5 files, 1 deviator).
+    expect(finding.dominantCount).toBe(4);
+    expect(finding.totalRelevantFiles).toBe(5);
+    expect(finding.consistencyScore).toBe(80);
+
+    const flagged = new Set(auth.flatMap((f) => f.deviatingFiles.map((d) => d.path)));
+    const planted = new Set([bodyUnsureDeviatorPath]);
+    const tp = [...flagged].filter((p) => planted.has(p)).length;
+    expect(tp / flagged.size).toBe(1); // precision
+    expect(tp / planted.size).toBe(1); // recall
+
+    // No hedge leakage: a plain stripped-auth deviator (S1 shape) stays flat.
+    const s1Path = sortedAxumRoutePaths(axumAuthedGroup())[0];
+    const s1Files = [...stripAxumAuth(axumAuthedGroup(), 1), rustAuthTokensFile];
+    const s1Auth = authFindings(securityConsistency.detect((await ctxFor(s1Files)) as any));
+    expect(s1Auth).toHaveLength(1);
+    expect(s1Auth[0].deviatingFiles.every((d) => d.path === s1Path)).toBe(true);
+    expect(
+      s1Auth[0].deviatingFiles.every((d) => !d.detectedPattern.toLowerCase().includes("double check")),
+    ).toBe(true);
+  });
+});
+
+// ─── Actix addendum: method+path recognition without ever blessing ──────────
+
+describe("Rust calibration: Actix recognition addendum (v1 boundary)", () => {
+  it("recognizes method+path via attribute macros; an auth-flavored extractor type hedges, never blesses", async () => {
+    const f = actixRecognitionGroup().find((x) => x.path.endsWith("orders.rs"))!;
+    const driftFile = await fileWithTree(f.path, f.content, "rust");
+    const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toMatchObject({ method: "POST", path: "/orders", hasAuth: false, authUnsureHook: "Identity" });
+  });
+
+  it("recognizes method+path with a path param; a non-auth extractor type resolves flat not-auth, never blesses", async () => {
+    const f = actixRecognitionGroup().find((x) => x.path.endsWith("products.rs"))!;
+    const driftFile = await fileWithTree(f.path, f.content, "rust");
+    const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("GET");
+    expect(routes[0].path).toBe("/products/{id}");
+    expect(routes[0].hasAuth).toBe(false);
+    expect("authUnsureHook" in routes[0]).toBe(false);
+  });
+
+  it("a scope-level .wrap(HttpAuthentication::bearer(...)) never covers an attribute-macro route (structurally invisible), never blesses", async () => {
+    const f = actixRecognitionGroup().find((x) => x.path.endsWith("reviews.rs"))!;
+    const driftFile = await fileWithTree(f.path, f.content, "rust");
+    const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe("DELETE");
+    expect(routes[0].path).toBe("/reviews/{id}");
+    expect(routes[0].hasAuth).toBe(false);
+    expect("authUnsureHook" in routes[0]).toBe(false);
+  });
+});
+
+// ─── Fixture self-check ───────────────────────────────────────────────────────
+// Every strip*() helper is exercised at its maximal count (every eligible
+// file in the group stripped at once), proving the deterministic string
+// surgery never corrupts the surrounding Rust source: each output still
+// parses error-free and still yields exactly the planted, now-unauthed
+// route(s). A broken strip would otherwise show up ONLY as an unexplained
+// vote-count drop in S1/S2/S3/S7, several layers away from the actual bug.
+
+describe("Rust calibration: fixture self-check (every strip*() output stays parseable and correctly unauthed)", () => {
+  it("stripAxumAuth(axumAuthedGroup(), 8): every file parses error-free, 2 unauthed routes, no leftover route_layer call", async () => {
+    for (const f of stripAxumAuth(axumAuthedGroup(), 8)) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("route_layer");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(2);
+      expect(routes.every((r) => !r.hasAuth), f.path).toBe(true);
+    }
+  });
+
+  it("stripStateAuth(axumStateAuthedGroup(), 5): every file parses error-free, 1 unauthed route, no leftover from_fn_with_state call", async () => {
+    for (const f of stripStateAuth(axumStateAuthedGroup(), 5)) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("from_fn_with_state");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+    }
+  });
+
+  it("stripBodyGate(bodyGateGroup(), 5): every file parses error-free, 1 unauthed route, no leftover gate hook call", async () => {
+    for (const f of stripBodyGate(bodyGateGroup(), 5)) {
+      const driftFile = await fileWithTree(f.path, f.content, "rust");
+      expect(driftFile.tree?.rootNode.hasError, f.path).toBe(false);
+      expect(f.content, f.path).not.toContain("from_fn(gate)");
+      const routes = extractRustRoutesAst(driftFile.tree!, driftFile.relativePath);
+      expect(routes, f.path).toHaveLength(1);
+      expect(routes[0].hasAuth, f.path).toBe(false);
+    }
+  });
+});

--- a/test/calibration/security-rust.test.ts
+++ b/test/calibration/security-rust.test.ts
@@ -452,6 +452,109 @@ describe("Rust calibration: S8 unresolvable-body UNSURE (imported require_auth)"
   });
 });
 
+// ─── S9: guarded-403 produce-gate (T3 fix #3) ─────────────────────────────────
+// A credential-guarded 403 blesses ONLY when the 403 is PRODUCED inside the
+// consequence (a `return`/`?`/block-tail reject) — the same produce-position
+// gate the 401 path uses. A 403 that merely APPEARS in the guarded branch as a
+// call argument, a comparison operand, a struct field, or a discarded `let`
+// binding is a MENTION: the middleware reads the header, does NOT reject, and
+// falls through to `next.run(...)`, so it must NEVER bless (NEVER-FALSE-BLESS).
+// Each negative uses a credential-read guard (so the guarded-403 lane is truly
+// exercised) and the auth-flavored name `require_auth`, so a regressed
+// (position-agnostic) 403 scan would return "auth"; the correct gate returns
+// "unsure" (opaque body + flavored name), which hedges and never blesses.
+
+describe("Rust calibration: S9 guarded-403 produce-gate (never-false-bless)", () => {
+  async function classifyFromFn(name: string, src: string) {
+    const driftFile = await fileWithTree("mw.rs", src, "rust");
+    const defs = collectRustFunctionDefs(driftFile.tree!.rootNode);
+    const def = defs.get(name)!;
+    const body = def.childForFieldName("body")!;
+    return classifyRustAuth(name, body, defs);
+  }
+
+  const guard = 'req.headers().get("Authorization").is_none()';
+
+  it("I1: 403 as a call/log argument in the guarded branch does NOT bless (falls through)", async () => {
+    const outcome = await classifyFromFn(
+      "require_auth",
+      `async fn require_auth(req: Request, next: Next) -> Response {\n` +
+        `    if ${guard} {\n` +
+        `        audit_log(StatusCode::FORBIDDEN, &req);\n` +
+        `    }\n` +
+        `    next.run(req).await\n}\n`,
+    );
+    expect(outcome).not.toBe("auth"); // invariant pin
+    expect(outcome).toBe("unsure"); // opaque body + flavored name -> hedge, never bless
+  });
+
+  it("I2: 403 as a comparison operand in the guarded branch does NOT bless", async () => {
+    const outcome = await classifyFromFn(
+      "require_auth",
+      `async fn require_auth(req: Request, next: Next) -> Response {\n` +
+        `    if ${guard} {\n` +
+        `        let denied = latest == StatusCode::FORBIDDEN;\n` +
+        `        note(denied);\n` +
+        `    }\n` +
+        `    next.run(req).await\n}\n`,
+    );
+    expect(outcome).not.toBe("auth");
+    expect(outcome).toBe("unsure");
+  });
+
+  it("I3: 403 as a struct-literal field in the guarded branch does NOT bless", async () => {
+    const outcome = await classifyFromFn(
+      "require_auth",
+      `async fn require_auth(req: Request, next: Next) -> Response {\n` +
+        `    if ${guard} {\n` +
+        `        let e = ErrInfo { code: StatusCode::FORBIDDEN, msg: "x" };\n` +
+        `        log_err(e);\n` +
+        `    }\n` +
+        `    next.run(req).await\n}\n`,
+    );
+    expect(outcome).not.toBe("auth");
+    expect(outcome).toBe("unsure");
+  });
+
+  it("H: 403 in a discarded `let` binding in the guarded branch does NOT bless", async () => {
+    const outcome = await classifyFromFn(
+      "require_auth",
+      `async fn require_auth(req: Request, next: Next) -> Response {\n` +
+        `    if ${guard} {\n` +
+        `        let _resp = StatusCode::FORBIDDEN;\n` +
+        `    }\n` +
+        `    next.run(req).await\n}\n`,
+    );
+    expect(outcome).not.toBe("auth");
+    expect(outcome).toBe("unsure");
+  });
+
+  it("PC1 (positive): a guarded `return Err(StatusCode::FORBIDDEN)` produce position DOES bless", async () => {
+    const outcome = await classifyFromFn(
+      "gate",
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+        `    if ${guard} {\n` +
+        `        return Err(StatusCode::FORBIDDEN);\n` +
+        `    }\n` +
+        `    Ok(next.run(req).await)\n}\n`,
+    );
+    expect(outcome).toBe("auth"); // body-only bless (name 'gate' is not auth-flavored)
+  });
+
+  it("PC2 (positive): a guarded block-TAIL `Err(StatusCode::FORBIDDEN)` (if/else value) DOES bless", async () => {
+    const outcome = await classifyFromFn(
+      "gate",
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+        `    if ${guard} {\n` +
+        `        Err(StatusCode::FORBIDDEN)\n` +
+        `    } else {\n` +
+        `        Ok(next.run(req).await)\n` +
+        `    }\n}\n`,
+    );
+    expect(outcome).toBe("auth");
+  });
+});
+
 // ─── Actix addendum: method+path recognition without ever blessing ──────────
 
 describe("Rust calibration: Actix recognition addendum (v1 boundary)", () => {

--- a/test/helpers/drift-tree.ts
+++ b/test/helpers/drift-tree.ts
@@ -4,7 +4,7 @@ import type { DriftFile } from "../../src/drift/types.js";
 export async function fileWithTree(
   path: string,
   content: string,
-  language: "javascript" | "typescript" | "python" | "go" = "typescript",
+  language: "javascript" | "typescript" | "python" | "go" | "rust" = "typescript",
 ): Promise<DriftFile> {
   const tree = await parseFile({
     path, relativePath: path, language, content, lineCount: content.split("\n").length,

--- a/test/unit/drift/security-ast-rust.test.ts
+++ b/test/unit/drift/security-ast-rust.test.ts
@@ -887,3 +887,334 @@ describe("auth extractor-typed → UNSURE (LOCKED no-type-bless)", () => {
     ]);
   });
 });
+
+// ─── Task 5: adversarial hardening + never-false-bless sweep ─────────────────
+// GOVERNING INVARIANT: still NEVER-FALSE-BLESS. Most pins below are EXTRACTION
+// correctness (should this construct be recognized as a route at all) rather
+// than auth signal: a route the extractor never emits trivially never blesses,
+// so a recall gap here is safe by construction — each case still documents the
+// actual observed behavior rather than an assumed one (every fixture below was
+// run against the real module before being pinned).
+
+describe("malformed and adversarial input (G8)", () => {
+  it("extractRustRoutesAst on a hand-built errored tree skips only the broken construct, never a whole-file gate (defense-in-depth)", async () => {
+    // The whole-file clean-tree gate (file.tree && !file.tree.rootNode.hasError)
+    // lives at DISPATCH, in security-consistency.ts's extractRustRoutes wrapper —
+    // NOT inside extractRustRoutesAst itself (see the companion dispatch-level
+    // pin in security-consistency.test.ts, "Task 5 (Rust): malformed input at
+    // dispatch"). Calling extractRustRoutesAst DIRECTLY on a hand-built tree
+    // whose ONLY error is a syntactically broken TRAILING fn still finds the
+    // earlier, syntactically clean route: the broken construct's hasError does
+    // not propagate to an EARLIER sibling's own subtree, and inErroredContext's
+    // per-node ancestor walk stops at source_file (it never consults the root's
+    // own hasError). Non-vacuous: rootNode.hasError is true, yet a route IS
+    // still emitted — proving the skip is per-construct, not whole-file.
+    const f = await rs("errctx.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n` +
+      `fn broken( {{{ .route(\n`);
+    expect(f.tree!.rootNode.hasError).toBe(true);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("does not extract #[post(...)] written inside a // line comment or /* block */ comment", async () => {
+    const line = await rs("attrlinecomment.rs", `// #[post("/x")]\nfn h(){}\n`);
+    expect(line.tree!.rootNode.hasError).toBe(false);
+    expect(extractRustRoutesAst(line.tree!, line.relativePath)).toEqual([]);
+    const block = await rs("attrblockcomment.rs", `/* #[post("/x")] */\nfn h(){}\n`);
+    expect(block.tree!.rootNode.hasError).toBe(false);
+    expect(extractRustRoutesAst(block.tree!, block.relativePath)).toEqual([]);
+  });
+
+  it("does not extract #[post(...)] text embedded in a string literal", async () => {
+    const f = await rs("attrstringtext.rs", `fn f() {\n    let s = "#[post(\\"/x\\")]";\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("terminates without stack blowup on a 100-link chained .route fluent chain, in source order", async () => {
+    let chain = "Router::new()";
+    for (let i = 0; i < 100; i++) chain += `\n        .route("/r${i}", post(h${i}))`;
+    const f = await rs("deepchain.rs", `fn app() -> Router {\n    ${chain}\n}\n`);
+    const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+    expect(routes).toHaveLength(100);
+    expect(routes.map((r) => r.path)).toEqual(Array.from({ length: 100 }, (_, i) => `/r${i}`));
+    // Each link's own line, ascending in source order (grammar trap 5's re-sort
+    // holds over a 100-link chain, not just the 2-link case pinned earlier).
+    expect(routes.map((r) => r.line)).toEqual(Array.from({ length: 100 }, (_, i) => i + 3));
+  });
+
+  it("emits nothing for #[post(...)] with a malformed token tree (no string_literal, a bare const)", async () => {
+    const f = await rs("attrbadtoken.rs", `#[post(SOME_CONST)]\nfn h(){}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("accepts a non-ASCII handler identifier with no gate on its content (language-agnostic arg1-method-call gate)", async () => {
+    const f = await rs("unicodehandler.rs", `fn app() -> Router {\n    Router::new().route("/x", post(café))\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("recognizes a route whose handler is an unresolvable closure: hasAuth false, no extractor-type signal", async () => {
+    const f = await rs("closurehandler.rs", `fn app() -> Router {\n    Router::new().route("/x", post(|| async {}))\n}\n`);
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+});
+
+describe("v1 boundary (deferred scope)", () => {
+  it("Actix .wrap(HttpAuthentication::bearer(validator)) never blesses (library closure body unread)", async () => {
+    const f = await rs("v1bearer.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(HttpAuthentication::bearer(validator))\n}\n`);
+    // Not a from_fn callee, so its body is never read (rule 5). The callee NAME
+    // "bearer" is itself auth-flavored (in RUST_AUTH_SEGMENTS), so it hedges to
+    // UNSURE rather than resolving cleanly to not-auth — still never a bless.
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["GET /x auth=false hook=bearer"]);
+  });
+
+  it("a Rocket-style typed AuthUser param imported from another crate (no in-file FromRequest) resolves UNSURE, never bless", async () => {
+    const f = await rs("v1rocket.rs",
+      `use other_crate::AuthUser;\n` +
+      `async fn h(user: AuthUser) -> Response { todo!() }\n` +
+      `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`);
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /x auth=false hook=AuthUser",
+    ]);
+  });
+
+  it(".route_layer(from_fn(auth)) covers only earlier chain links, never a route added after it", async () => {
+    const chain =
+      `Router::new()\n` +
+      `        .route("/early", post(a))\n` +
+      `        .route_layer(middleware::from_fn(auth))\n` +
+      `        .route("/late", post(b))`;
+    const f = await rs("v1routelayer.rs", withMw(rejBody("auth"), chain));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /early auth=true hook=-", "POST /late auth=false hook=-",
+    ]);
+  });
+
+  it("multi-statement router assembly does not connect a separate-statement .layer to an earlier route (documented recall gap)", async () => {
+    const chain =
+      `let app = Router::new().route("/x", post(h));\n` +
+      `    let app = app.layer(middleware::from_fn(auth));\n` +
+      `    app`;
+    const f = await rs("v1multistatement.rs", withMw(rejBody("auth"), chain));
+    // The route IS recognized (non-vacuous); the .layer sits in a SEPARATE
+    // let-statement, so it never becomes an ancestor of the .route call node —
+    // coveringLayerArgs finds nothing, and hasAuth stays false. Safe over-flag,
+    // not a false-bless.
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it(".nest(prefix, subrouter()) sub-router routes are recognized un-prefixed in their own expression; the nest call itself emits zero routes", async () => {
+    const f = await rs("v1nest.rs",
+      `fn api_routes() -> Router {\n    Router::new().route("/users", get(list_users))\n}\n` +
+      `fn app() -> Router {\n    Router::new().nest("/api", api_routes())\n}\n`);
+    // Only /users is emitted (un-prefixed) — the outer nest() call and its "/api"
+    // prefix contribute NOTHING; there is no phantom "/api" route.
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /users"]);
+  });
+
+  it("on(MethodFilter::POST, h) resolves method ALL; the route still enters the mutating vote", async () => {
+    const f = await rs("v1on.rs", `fn app() -> Router {\n    Router::new().route("/x", on(MethodFilter::POST, h))\n}\n`);
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["ALL /x auth=false hook=-"]);
+  });
+});
+
+// ─── Never-false-bless sweep ──────────────────────────────────────────────────
+// Registers every AUTH-relevant Rust fixture exercised across Tasks 3-5 (the
+// axis this invariant governs — Task 1/2's pure method/path-resolution fixtures
+// carry no auth machinery at all, so they are not repeated here). New fixtures
+// that exercise the auth signal must be added as a new entry in this table, not
+// left as a standalone test only.
+
+// Module-scope twin of the handlerRoute() helper defined inside the
+// "extractor-typed" describe above (that one is block-scoped to its own
+// describe callback and not reachable here).
+const handlerRoute = (params: string) =>
+  `async fn h(${params}) -> Response { todo!() }\n` +
+  `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`;
+
+const NEVER_FALSE_BLESS_SWEEP: Array<{
+  name: string; source: string; groundTruth: Array<{ path: string; method: string; authed: boolean }>;
+}> = [
+  // ── reject catalogue: not a bless ──
+  { name: "logs_only", source: withMw(
+      `async fn auth_check(req: Request, next: Next) -> Response {\n    tracing::info!("saw a request");\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(auth_check))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "bare_403_unguarded", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n    if maintenance_mode() { return Err(StatusCode::FORBIDDEN); }\n    Ok(next.run(req).await)\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "reject_404", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n    if bad(&req) { return Err(StatusCode::NOT_FOUND); }\n    Ok(next.run(req).await)\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "reject_500", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n    if bad(&req) { return Err(StatusCode::INTERNAL_SERVER_ERROR); }\n    Ok(next.run(req).await)\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "bare_int_401", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n    if bad(&req) { return Err(401); }\n    Ok(next.run(req).await)\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "from_u16_401", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n    if bad(&req) { return Err(StatusCode::from_u16(401).unwrap()); }\n    Ok(next.run(req).await)\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "never_returned_let", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Response {\n    let _code = StatusCode::UNAUTHORIZED;\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "nested_closure_pruned", source: withMw(
+      `async fn mw(req: Request, next: Next) -> Response {\n    let _f = || -> Result<(), StatusCode> { return Err(StatusCode::UNAUTHORIZED); };\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "mention_comparison", source: withMw(
+      `async fn tap(req: Request, next: Next) -> Response {\n    let resp = next.run(req).await;\n    if resp.status() == StatusCode::UNAUTHORIZED {\n        tracing::warn!("downstream returned 401");\n    }\n    resp\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(tap))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "mention_header_insert", source: withMw(
+      `async fn add_header(req: Request, next: Next) -> Response {\n    let mut resp = next.run(req).await;\n    if resp.status() == StatusCode::UNAUTHORIZED {\n        resp.headers_mut().insert("WWW-Authenticate", HeaderValue::from_static("Bearer"));\n    }\n    resp\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(add_header))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "mention_match_pattern", source: withMw(
+      `async fn observe(req: Request, next: Next) -> Response {\n    let resp = next.run(req).await;\n    match resp.status() {\n        StatusCode::UNAUTHORIZED => metrics::incr("downstream_401"),\n        _ => {}\n    }\n    resp\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(observe))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  // ── REQUIRED T3 fix-#2 residual regression pins (non-produce 401 positions) ──
+  { name: "residual_comparison_err", source: withMw(
+      `async fn tap(req: Request, next: Next) -> Response {\n    let resp = next.run(req).await;\n    if resp == Err(StatusCode::UNAUTHORIZED) {\n        tracing::warn!("downstream 401");\n    }\n    resp\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(tap))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "residual_call_arg", source: withMw(
+      `async fn record(req: Request, next: Next) -> Response {\n    record_metric(Err(StatusCode::UNAUTHORIZED));\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(record))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "residual_never_returned_err", source: withMw(
+      `async fn build(req: Request, next: Next) -> Response {\n    let _e = Err(StatusCode::UNAUTHORIZED);\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "residual_struct_field", source: withMw(
+      `async fn build(req: Request, next: Next) -> Response {\n    let _cfg = Config { fallback: Err(StatusCode::UNAUTHORIZED) };\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "residual_builder_arg", source: withMw(
+      `async fn build(req: Request, next: Next) -> Response {\n    let _svc = Handler::new().default_error(Err(StatusCode::UNAUTHORIZED));\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "residual_ok_or_else_403", source: withMw(
+      `async fn build(req: Request, next: Next) -> Result<Response, StatusCode> {\n    let _t = maybe(&req).ok_or_else(|| {\n        if flag() == StatusCode::UNAUTHORIZED { log(); }\n        StatusCode::FORBIDDEN\n    })?;\n    Ok(next.run(req).await)\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  // ── non-from_fn layers: never auth ──
+  { name: "trace_layer", source: `fn app() -> Router {\n    Router::new().route("/x", get(h)).layer(TraceLayer::new_for_http())\n}\n`,
+    groundTruth: [{ path: "/x", method: "GET", authed: false }] },
+  { name: "actix_logger_wrap", source: `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(Logger::default())\n}\n`,
+    groundTruth: [{ path: "/x", method: "GET", authed: false }] },
+  // ── layer scoping (the crux) ──
+  { name: "layer_scoping_below_route", source: withMw(rejBody("auth"),
+      `Router::new().layer(middleware::from_fn(auth)).route("/late", post(h))`),
+    groundTruth: [{ path: "/late", method: "POST", authed: false }] },
+  { name: "route_layer_after", source: withMw(rejBody("auth"),
+      `Router::new()\n        .route("/early", post(a))\n        .route_layer(middleware::from_fn(auth))\n        .route("/late", post(b))`),
+    groundTruth: [{ path: "/early", method: "POST", authed: true }, { path: "/late", method: "POST", authed: false }] },
+  // ── imported / opaque from_fn -> unsure, never bless ──
+  { name: "imported_from_fn", source: `fn app() -> Router {\n    Router::new().route("/x", post(h)).layer(middleware::from_fn(require_auth))\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "opaque_external_validator", source: withMw(
+      `async fn require_auth(req: Request, next: Next) -> Response {\n    let _ = validate_session(&req);\n    next.run(req).await\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(require_auth))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "wrap_bearer", source: `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(HttpAuthentication::bearer(v))\n}\n`,
+    groundTruth: [{ path: "/x", method: "GET", authed: false }] },
+  { name: "wrap_bare_mw", source: `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(auth_mw)\n}\n`,
+    groundTruth: [{ path: "/x", method: "GET", authed: false }] },
+  // ── extractor-typed: UNSURE, no type-name bless ──
+  ...["AuthUser", "Claims", "RequireAuth", "Identity", "Bearer"].map((ty) => ({
+    name: `extractor_${ty}`, source: handlerRoute(`user: ${ty}`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  })),
+  ...([["Option<AuthUser>", "opt_option"], ["MaybeAuth", "opt_maybe"], ["OptionalUser", "opt_optional"]] as const).map(([params, nm]) => ({
+    name: nm, source: handlerRoute(`user: ${params}`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  })),
+  ...([["body: Json<Order>", "nonauth_json"], ["id: Path<u32>", "nonauth_path"], ["state: State<AppState>", "nonauth_state"],
+      ["q: Query<Params>", "nonauth_query"], ["form: Form<Data>", "nonauth_form"]] as const).map(([params, nm]) => ({
+    name: nm, source: handlerRoute(params),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }],
+  })),
+  { name: "v1_fromrequest_impl_not_read", source:
+      `struct AuthUser;\n` +
+      `impl FromRequest for AuthUser {\n    type Rejection = StatusCode;\n` +
+      `    async fn from_request(req: Request, s: &S) -> Result<Self, StatusCode> {\n        return Err(StatusCode::UNAUTHORIZED);\n    }\n}\n` +
+      `async fn h(user: AuthUser) -> Response { todo!() }\n` +
+      `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "extractor_imported_authuser", source:
+      `use other_crate::AuthUser;\nasync fn h(user: AuthUser) -> Response { todo!() }\nfn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  // ── veto beats even a real reject ──
+  { name: "veto_skip_auth", source: withMw(rejBody("skip_auth"),
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(skip_auth))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  // ── Task 5 new adversarial / v1-boundary fixtures ──
+  { name: "multistatement_separate_layer", source: withMw(rejBody("auth"),
+      `let app = Router::new().route("/x", post(h));\n    let app = app.layer(middleware::from_fn(auth));\n    app`),
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "nest_inner_unprefixed", source:
+      `fn api_routes() -> Router {\n    Router::new().route("/users", get(list_users))\n}\n` +
+      `fn app() -> Router {\n    Router::new().nest("/api", api_routes())\n}\n`,
+    groundTruth: [{ path: "/users", method: "GET", authed: false }] },
+  { name: "unicode_path", source: `fn app() -> Router {\n    Router::new().route("/café", post(h))\n}\n`,
+    groundTruth: [{ path: "/café", method: "POST", authed: false }] },
+  { name: "closure_handler", source: `fn app() -> Router {\n    Router::new().route("/x", post(|| async {}))\n}\n`,
+    groundTruth: [{ path: "/x", method: "POST", authed: false }] },
+  { name: "on_method_filter", source: `fn app() -> Router {\n    Router::new().route("/x", on(MethodFilter::POST, h))\n}\n`,
+    groundTruth: [{ path: "/x", method: "ALL", authed: false }] },
+  // ── positive blessing controls (proves the sweep can also see a real bless;
+  //    kept to exactly PC1 + PC2 per the brief) ──
+  { name: "pc1_match_arm_tail", source: withMw(
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n    match check(&req) {\n        None => Err(StatusCode::UNAUTHORIZED),\n        Some(_u) => Ok(next.run(req).await),\n    }\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(gate))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: true }] },
+  { name: "pc2_if_else_tail", source: withMw(
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n    if bad(&req) { Err(StatusCode::UNAUTHORIZED) } else { Ok(next.run(req).await) }\n}\n`,
+      `Router::new().route("/x", post(h)).layer(middleware::from_fn(gate))`),
+    groundTruth: [{ path: "/x", method: "POST", authed: true }] },
+];
+
+describe("never-false-bless sweep", () => {
+  it("every sweep entry is NON-VACUOUS: every ground-truth route is actually emitted", async () => {
+    // Guards against the exact trap the governing invariant warns about: the
+    // main sweep assertion below uses `emitted?.hasAuth ?? false`, which would
+    // PASS TRIVIALLY if route recognition silently failed (no route == "not
+    // blessed"). This companion test proves every ground-truth route really is
+    // extracted, so the main assertion is exercising the auth axis, not hiding
+    // a recognition regression.
+    for (const entry of NEVER_FALSE_BLESS_SWEEP) {
+      const f = await rs(`sweep/${entry.name}.rs`, entry.source);
+      expect(f.tree!.rootNode.hasError, `${entry.name}: unexpected parse error`).toBe(false);
+      const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+      for (const gt of entry.groundTruth) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        expect(emitted, `${entry.name}: ${gt.method} ${gt.path} was not emitted at all`).toBeDefined();
+      }
+    }
+  });
+
+  it("no route with ground truth authed:false is ever emitted hasAuth:true", async () => {
+    for (const entry of NEVER_FALSE_BLESS_SWEEP) {
+      const f = await rs(`sweep/${entry.name}.rs`, entry.source);
+      const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+      for (const gt of entry.groundTruth.filter((g) => !g.authed)) {
+        const emitted = routes.find((r) => r.path === gt.path && r.method === gt.method);
+        expect(emitted?.hasAuth ?? false, `${entry.name}: ${gt.method} ${gt.path}`).toBe(false);
+      }
+    }
+  });
+});

--- a/test/unit/drift/security-ast-rust.test.ts
+++ b/test/unit/drift/security-ast-rust.test.ts
@@ -622,6 +622,47 @@ describe("auth NEGATIVE: never-false-bless", () => {
     expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
   });
 
+  // PASS-THROUGH middlewares that merely MENTION a downstream 401 in a NON-produce
+  // position (a comparison operand, a header-insert argument, a match-arm pattern)
+  // and then return the response unchanged. None rejects; none may bless. Neutral
+  // names (tap / add_header / observe) so no name veto is in play — the body
+  // signature alone must resolve not-auth. Reproduces the produce-position bug.
+  it("MENTION-not-reject: a 401 in an `== StatusCode::UNAUTHORIZED` comparison never blesses", async () => {
+    const mw =
+      `async fn tap(req: Request, next: Next) -> Response {\n` +
+      `    let resp = next.run(req).await;\n` +
+      `    if resp.status() == StatusCode::UNAUTHORIZED {\n` +
+      `        tracing::warn!("downstream returned 401");\n` +
+      `    }\n    resp\n}\n`;
+    const f = await rs("n9.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(tap))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("MENTION-not-reject: a 401-gated header INSERT (WWW-Authenticate) never blesses", async () => {
+    const mw =
+      `async fn add_header(req: Request, next: Next) -> Response {\n` +
+      `    let mut resp = next.run(req).await;\n` +
+      `    if resp.status() == StatusCode::UNAUTHORIZED {\n` +
+      `        resp.headers_mut().insert("WWW-Authenticate", HeaderValue::from_static("Bearer"));\n` +
+      `    }\n    resp\n}\n`;
+    const f = await rs("n10.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(add_header))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("MENTION-not-reject: a 401 as a `match` arm PATTERN (metric observe) never blesses", async () => {
+    const mw =
+      `async fn observe(req: Request, next: Next) -> Response {\n` +
+      `    let resp = next.run(req).await;\n` +
+      `    match resp.status() {\n` +
+      `        StatusCode::UNAUTHORIZED => metrics::incr("downstream_401"),\n` +
+      `        _ => {}\n    }\n    resp\n}\n`;
+    const f = await rs("n11.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(observe))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
   it("a non-from_fn layer (TraceLayer / Logger) is not auth", async () => {
     const trace = await rs("n6a.rs",
       `fn app() -> Router {\n    Router::new().route("/x", get(h)).layer(TraceLayer::new_for_http())\n}\n`);

--- a/test/unit/drift/security-ast-rust.test.ts
+++ b/test/unit/drift/security-ast-rust.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest";
+import { extractRustRoutesAst } from "../../../src/drift/security-ast-rust.js";
+import { fileWithTree } from "../../helpers/drift-tree.js";
+
+const rs = (path: string, src: string) => fileWithTree(path, src, "rust");
+
+describe("security-ast-rust: grammar-fact pins", () => {
+  it("pins the load-bearing Rust grammar facts this module is built on", async () => {
+    // Probe-verified 2026-07-15 against the pinned tree-sitter-wasms rust
+    // grammar. A grammar bump that renames these fails HERE with a named
+    // fact, not as a silent recall collapse.
+
+    // Axum builder `.route` anchor shape.
+    const f = await rs("facts.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    const routeCall = f.tree!.rootNode.descendantsOfType("call_expression")
+      .find((c) => c?.childForFieldName("function")?.type === "field_expression"
+        && c.childForFieldName("function")?.childForFieldName("field")?.text === "route")!;
+    const fn = routeCall.childForFieldName("function")!;
+    expect(fn.type).toBe("field_expression");
+    const field = fn.childForFieldName("field")!;
+    expect(field.type).toBe("field_identifier");
+    expect(field.text).toBe("route");
+    const args = routeCall.childForFieldName("arguments")!.namedChildren
+      .filter((n) => n !== null);
+    expect(args[0]!.type).toBe("string_literal");
+    expect(args[1]!.type).toBe("call_expression");
+
+    // string_literal is a LEAF (no string_content child) for a plain path.
+    expect(args[0]!.namedChildCount).toBe(0);
+    // raw_string_literal is a leaf too; its .text carries the r-prefix.
+    const rawFile = await rs("raw.rs", `fn f() { let x = r"raw"; }\n`);
+    const raw = rawFile.tree!.rootNode.descendantsOfType("raw_string_literal")[0]!;
+    expect(raw.namedChildCount).toBe(0);
+    expect(raw.text.startsWith("r")).toBe(true);
+
+    // Method-router callee shapes.
+    const plainVerb = args[1]!.childForFieldName("function")!;
+    expect(plainVerb.type).toBe("identifier");
+    expect(plainVerb.text).toBe("post");
+
+    const scopedFile = await rs("scoped.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", axum::routing::post(h))\n}\n`);
+    const scopedCall = scopedFile.tree!.rootNode.descendantsOfType("call_expression")
+      .find((c) => c?.childForFieldName("function")?.type === "field_expression"
+        && c.childForFieldName("function")?.childForFieldName("field")?.text === "route")!;
+    const scopedArg1 = scopedCall.childForFieldName("arguments")!.namedChildren
+      .filter((n) => n !== null)[1]!;
+    const scopedFn = scopedArg1.childForFieldName("function")!;
+    expect(scopedFn.type).toBe("scoped_identifier");
+    expect(scopedFn.childForFieldName("name")?.text).toBe("post");
+
+    const chainedFile = await rs("chained.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", get(l).post(c))\n}\n`);
+    const chainedCall = chainedFile.tree!.rootNode.descendantsOfType("call_expression")
+      .find((c) => c?.childForFieldName("function")?.type === "field_expression"
+        && c.childForFieldName("function")?.childForFieldName("field")?.text === "route")!;
+    const chainedArg1 = chainedCall.childForFieldName("arguments")!.namedChildren
+      .filter((n) => n !== null)[1]!;
+    const chainedFn = chainedArg1.childForFieldName("function")!;
+    expect(chainedFn.type).toBe("field_expression");
+    expect(chainedFn.childForFieldName("field")?.text).toBe("post");
+
+    // StatusCode::UNAUTHORIZED shape (forward-looking, Task 3).
+    const statusFile = await rs("status.rs", `fn f() { let x = StatusCode::UNAUTHORIZED; }\n`);
+    const statusNode = statusFile.tree!.rootNode.descendantsOfType("scoped_identifier")[0]!;
+    expect(statusNode.childForFieldName("path")?.type).toBe("identifier");
+    expect(statusNode.childForFieldName("path")?.text).toBe("StatusCode");
+    expect(statusNode.childForFieldName("name")?.type).toBe("identifier");
+    expect(statusNode.childForFieldName("name")?.text).toBe("UNAUTHORIZED");
+
+    // Attribute-macro association: a PRECEDING SIBLING, never a child.
+    const attrFile = await rs("attr.rs", `#[post("/x")]\nfn h(){}\n`);
+    const fnItem = attrFile.tree!.rootNode.descendantsOfType("function_item")[0]!;
+    expect(fnItem.previousNamedSibling?.type).toBe("attribute_item");
+    expect(fnItem.descendantsOfType("attribute_item").length).toBe(0);
+    const attrItem = attrFile.tree!.rootNode.descendantsOfType("attribute_item")[0]!;
+    const attr = attrItem.namedChildren.filter((n) => n !== null)
+      .find((n) => n.type === "attribute")!;
+    expect(attr.childForFieldName("path")).toBeNull();
+    const tokenTree = attr.childForFieldName("arguments")!;
+    expect(tokenTree.type).toBe("token_tree");
+    const firstString = tokenTree.namedChildren.filter((n) => n !== null)
+      .find((n) => n.type === "string_literal")!;
+    expect(firstString.text).toBe('"/x"');
+
+    // middleware::from_fn / from_fn_with_state shapes (forward-looking, Task 3).
+    const mwFile = await rs("mw.rs", `fn app() { let x = middleware::from_fn(auth); }\n`);
+    const mwCall = mwFile.tree!.rootNode.descendantsOfType("call_expression")[0]!;
+    const mwFn = mwCall.childForFieldName("function")!;
+    expect(mwFn.type).toBe("scoped_identifier");
+    expect(mwFn.childForFieldName("name")?.text).toBe("from_fn");
+    const mwArgs = mwCall.childForFieldName("arguments")!.namedChildren.filter((n) => n !== null);
+    expect(mwArgs.length).toBe(1);
+    expect(mwArgs[0]!.type).toBe("identifier");
+
+    const mwStateFile = await rs("mwstate.rs",
+      `fn app() { let x = middleware::from_fn_with_state(st, auth); }\n`);
+    const mwStateCall = mwStateFile.tree!.rootNode.descendantsOfType("call_expression")[0]!;
+    const mwStateArgs = mwStateCall.childForFieldName("arguments")!.namedChildren
+      .filter((n) => n !== null);
+    expect(mwStateArgs[mwStateArgs.length - 1]!.text).toBe("auth");
+
+    // impl Trait for Type shape (forward-looking, Task 3).
+    const implFile = await rs("impl.rs", `impl FromRequest for AuthUser {}\n`);
+    const implItem = implFile.tree!.rootNode.descendantsOfType("impl_item")[0]!;
+    expect(implItem.childForFieldName("trait")?.text).toBe("FromRequest");
+    expect(implItem.childForFieldName("type")?.text).toBe("AuthUser");
+
+    const inherentFile = await rs("inherent.rs", `impl AuthUser {}\n`);
+    const inherentItem = inherentFile.tree!.rootNode.descendantsOfType("impl_item")[0]!;
+    expect(inherentItem.childForFieldName("trait")).toBeNull();
+
+    // Broken source still returns a tree (never null), flagged via hasError.
+    const broken = await rs("broken.rs", `fn f( {{{ .route(`);
+    expect(broken.tree).toBeDefined();
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+  });
+});
+
+describe("extractRustRoutesAst: Axum builder routes", () => {
+  it("extracts a POST builder route with method, path, and anchor line", async () => {
+    const f = await rs("routes.rs",
+      `fn app() -> Router {\n` +
+      `    Router::new().route("/orders", post(create_order))\n` +
+      `}\n`);
+    const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual([
+      "POST /orders auth=false",
+    ]);
+    expect(routes[0].line).toBe(2);
+    expect(routes[0].file).toBe("routes.rs");
+  });
+
+  it("emits one route per .route link in a fluent chain, each with its own line", async () => {
+    const f = await rs("chain.rs",
+      `fn app() -> Router {\n` +
+      `    Router::new()\n` +
+      `        .route("/orders", post(create))\n` +
+      `        .route("/orders/:id", delete(remove))\n` +
+      `}\n`);
+    const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+    expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual(["POST /orders", "DELETE /orders/:id"]);
+    // Each link reports ITS OWN source line (the chain's outer node spans back
+    // to Router::new()'s line, which would be wrong for both if reused).
+    expect(routes.map((r) => r.line)).toEqual([3, 4]);
+  });
+
+  it("does NOT emit a route for a non-web .route call whose arg1 is not a verb", async () => {
+    const f = await rs("n.rs", `fn f(cfg: Cfg) { cfg.route("/x", handler_service); }\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("recognizes a turbofish-based Router::<AppState>::new() base", async () => {
+    const f = await rs("turbofish.rs",
+      `fn app() -> Router<AppState> {\n    Router::<AppState>::new().route("/x", post(h))\n}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("emits a GET-only builder route for completeness", async () => {
+    const f = await rs("health.rs",
+      `fn app() -> Router {\n    Router::new().route("/health", get(health))\n}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /health"]);
+  });
+
+  it("does not let passthrough links (.layer/.with_state/.fallback/.merge) stop the walk", async () => {
+    const f = await rs("passthrough.rs",
+      `fn app() -> Router {\n` +
+      `    Router::new()\n` +
+      `        .route("/a", get(x))\n` +
+      `        .layer(auth_layer())\n` +
+      `        .with_state(state())\n` +
+      `        .fallback(not_found)\n` +
+      `        .route("/b", post(y))\n` +
+      `        .merge(other())\n` +
+      `}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /a", "POST /b"]);
+  });
+
+  it("recognizes sibling .route links around a .nest(...) without applying its prefix", async () => {
+    // .nest("/api", api_routes()) itself emits zero routes; the /api prefix is
+    // NOT applied to sibling routes (documented cross-expression recall gap).
+    const f = await rs("nest.rs",
+      `fn app() -> Router {\n` +
+      `    Router::new()\n` +
+      `        .route("/a", get(x))\n` +
+      `        .nest("/api", api_routes())\n` +
+      `        .route("/b", post(y))\n` +
+      `}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["GET /a", "POST /b"]);
+  });
+
+  it("recognizes .route on a variable receiver (single-fluent-chain only)", async () => {
+    const f = await rs("var.rs",
+      `fn f() {\n    let app = Router::new();\n    app.route("/x", post(h));\n}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("does not resolve a .layer applied in a separate statement onto the route", async () => {
+    // Documents current scope: middleware scope tracing is Task 4. A .layer
+    // call on the same receiver in an earlier, separate statement never
+    // touches this route's recognition (still recognized; hasAuth stays false
+    // regardless either way in Task 1).
+    const f = await rs("varlayer.rs",
+      `fn f() {\n` +
+      `    let app = Router::new();\n` +
+      `    app.layer(auth());\n` +
+      `    app.route("/x", post(h));\n` +
+      `}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path} auth=${r.hasAuth}`)).toEqual(["POST /x auth=false"]);
+  });
+});
+
+describe("extractRustRoutesAst: Actix/Rocket attribute macros", () => {
+  it('extracts #[post("/users")] on the following fn', async () => {
+    const f = await rs("actix.rs", `#[post("/users")]\nasync fn create_user() -> HttpResponse { todo!() }\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /users"]);
+  });
+
+  it("ignores non-route attributes", async () => {
+    const f = await rs("d.rs", `#[derive(Debug)]\n#[tokio::main]\nasync fn main() {}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("recognizes an Actix scoped attribute #[actix_web::post(\"/x\")]", async () => {
+    const f = await rs("actix_scoped.rs", `#[actix_web::post("/x")]\nasync fn h() {}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it('reads the first string_literal as the path for a Rocket data arg', async () => {
+    const f = await rs("rocket.rs", `#[post("/users", data = "<user>")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /users"]);
+  });
+
+  it("skips intervening attribute_item and comment siblings to find the fn", async () => {
+    const f = await rs("intervening.rs",
+      `#[post("/x")]\n` +
+      `// a comment\n` +
+      `#[allow(dead_code)]\n` +
+      `async fn h() -> &'static str { "" }\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it("emits nothing for a route macro with no following function_item", async () => {
+    const f = await rs("nofn.rs", `#[post("/x")]\n#[derive(Debug)]\nstruct Foo {}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it.each([
+    ["#[derive(Debug)]\nstruct Foo {}\n"],
+    ["#[cfg(test)]\nmod tests {}\n"],
+    ["#[doc(\"hidden\")]\nfn h(){}\n"],
+    ["#[tokio::main]\nasync fn main() {}\n"],
+    ["#[get]\nfn h(){}\n"],
+  ])("recognizes no route for negative attribute %#", async (src) => {
+    const f = await rs("neg.rs", src);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});
+
+describe("extractRustRoutesAst: comments and strings never extracted (G8)", () => {
+  it("does not extract a .route call written inside a line comment", async () => {
+    const f = await rs("linecomment.rs",
+      `fn f() {\n    // Router::new().route("/x", post(h));\n}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not extract a .route call written inside a block comment", async () => {
+    const f = await rs("blockcomment.rs",
+      `fn f() {\n    /* Router::new().route("/x", post(h)); */\n}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("does not extract .route text embedded in a string literal", async () => {
+    const f = await rs("stringtext.rs",
+      `fn f() {\n    let s = ".route(\\"/fake\\", post(h))";\n}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+});

--- a/test/unit/drift/security-ast-rust.test.ts
+++ b/test/unit/drift/security-ast-rust.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { extractRustRoutesAst } from "../../../src/drift/security-ast-rust.js";
+import {
+  extractRustRoutesAst,
+  classifyRustAuth,
+  collectRustFunctionDefs,
+} from "../../../src/drift/security-ast-rust.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
+import type { SyntaxNode } from "../../../src/core/types.js";
 
 const rs = (path: string, src: string) => fileWithTree(path, src, "rust");
 
@@ -432,5 +437,316 @@ describe("extractRustRoutesAst: path forms and string handling (G4)", () => {
     expect(extractRustRoutesAst(fmt.tree!, fmt.relativePath)).toEqual([]);
     const concat = await rs("pconcat.rs", axum(`"/x" + "/y"`));
     expect(extractRustRoutesAst(concat.tree!, concat.relativePath)).toEqual([]);
+  });
+});
+
+// ─── Task 3: body-first auth classification ──────────────────────────────────
+// GOVERNING INVARIANT: NEVER-FALSE-BLESS. A route blesses ONLY when a covering
+// (ANCESTOR) .layer/.route_layer wraps a from_fn whose in-file body verifiably
+// rejects. No type-name bless; no name-only bless. Every extractor type and
+// every unreadable/opaque layer resolves UNSURE (authUnsureHook), never bless.
+
+// Fold a middleware fn + a router chain into one source file.
+const withMw = (mw: string, chain: string) =>
+  `${mw}\nfn app() -> Router {\n    ${chain}\n}\n`;
+// A rejecting from_fn body under a given name (401-family return).
+const rejBody = (name: string) =>
+  `async fn ${name}(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+  `    let t = req.headers().get("Authorization");\n` +
+  `    if t.is_none() { return Err(StatusCode::UNAUTHORIZED); }\n` +
+  `    Ok(next.run(req).await)\n}\n`;
+const authOf = (rts: ReturnType<typeof extractRustRoutesAst>) =>
+  rts.map((r) => `${r.method} ${r.path} auth=${r.hasAuth} hook=${r.authUnsureHook ?? "-"}`);
+
+describe("auth POSITIVE: covering from_fn body reject blesses", () => {
+  it("a covering from_fn whose body 401s blesses even a boring 'auth' name (rule 2)", async () => {
+    const f = await rs("p1.rs",
+      withMw(rejBody("auth"), `Router::new().route("/x", post(h)).layer(middleware::from_fn(auth))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("a body-only reject blesses under a boring name with no auth lexicon (mirror Go S7)", async () => {
+    const gate =
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    if req.uri().path().is_empty() { return Err(StatusCode::UNAUTHORIZED); }\n` +
+      `    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("p2.rs",
+      withMw(gate, `Router::new().route("/x", post(h)).layer(middleware::from_fn(gate))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("reject via (StatusCode::UNAUTHORIZED, msg).into_response() in an if guard blesses", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Response {\n` +
+      `    if req.headers().get("Authorization").is_none() {\n` +
+      `        return (StatusCode::UNAUTHORIZED, "no").into_response();\n` +
+      `    }\n    next.run(req).await\n}\n`;
+    const f = await rs("p3.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("reject via .ok_or(StatusCode::UNAUTHORIZED)? blesses", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    let _t = req.headers().get("Authorization").ok_or(StatusCode::UNAUTHORIZED)?;\n` +
+      `    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("p4.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("reject via .ok_or_else(|| StatusCode::UNAUTHORIZED) reads the closure body and blesses", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    let _t = req.headers().get("x").ok_or_else(|| StatusCode::UNAUTHORIZED)?;\n` +
+      `    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("p5.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("return Err((StatusCode::UNAUTHORIZED, body).into_response()) tuple form blesses", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Result<Response, Response> {\n` +
+      `    if bad(&req) { return Err((StatusCode::UNAUTHORIZED, "b").into_response()); }\n` +
+      `    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("p6.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("a bare tail StatusCode::UNAUTHORIZED (last block expr) blesses", async () => {
+    const mw = `async fn mw(req: Request, next: Next) -> StatusCode {\n    StatusCode::UNAUTHORIZED\n}\n`;
+    const f = await rs("p7.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("from_fn_with_state(state, auth) resolves the LAST arg to its body and blesses", async () => {
+    const f = await rs("p8.rs",
+      withMw(rejBody("auth"),
+        `Router::new().route("/x", post(h)).layer(middleware::from_fn_with_state(app_state, auth))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("a guarded 403 that structurally reads a credential surface blesses (reject403Guarded)", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    let t = req.headers().get("Authorization");\n` +
+      `    if t.is_none() { return Err(StatusCode::FORBIDDEN); }\n` +
+      `    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("p9.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("one covering .layer blesses EVERY route that is a DESCENDANT of it (whole-chain scope)", async () => {
+    const chain =
+      `Router::new()\n` +
+      `        .route("/a", post(x))\n` +
+      `        .route("/b", put(y))\n` +
+      `        .route("/c", delete(z))\n` +
+      `        .layer(middleware::from_fn(auth))`;
+    const f = await rs("p10.rs", withMw(rejBody("auth"), chain));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /a auth=true hook=-", "PUT /b auth=true hook=-", "DELETE /c auth=true hook=-",
+    ]);
+  });
+});
+
+describe("auth NEGATIVE: never-false-bless", () => {
+  it("a from_fn body that only logs and calls next.run never blesses (rule 3, name flavored)", async () => {
+    // Auth-flavored name, but a visible non-enforcing body -> not-auth. Name never rescues.
+    const mw =
+      `async fn auth_check(req: Request, next: Next) -> Response {\n` +
+      `    tracing::info!("saw a request");\n    next.run(req).await\n}\n`;
+    const f = await rs("n1.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(auth_check))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("a from_fn body returning 404 or 500 is NOT a bless", async () => {
+    for (const [nm, status] of [["nf.rs", "NOT_FOUND"], ["se.rs", "INTERNAL_SERVER_ERROR"]]) {
+      const mw =
+        `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+        `    if bad(&req) { return Err(StatusCode::${status}); }\n` +
+        `    Ok(next.run(req).await)\n}\n`;
+      const f = await rs(nm, withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+      expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+    }
+  });
+
+  it("a bare 403 with NO credential-reading guard is NOT a bless (403 asymmetry)", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    if maintenance_mode() { return Err(StatusCode::FORBIDDEN); }\n` +
+      `    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("n3.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("a bare integer status (Err(401) / from_u16(401)) is NOT a bless in v1", async () => {
+    for (const [nm, expr] of [
+      ["bi1.rs", "return Err(401);"],
+      ["bi2.rs", "return Err(StatusCode::from_u16(401).unwrap());"],
+    ]) {
+      const mw =
+        `async fn mw(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+        `    if bad(&req) { ${expr} }\n    Ok(next.run(req).await)\n}\n`;
+      const f = await rs(nm, withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+      expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+    }
+  });
+
+  it("a 401 that is only a let-binding reference (never returned) is NOT a bless", async () => {
+    // The invariant requires a verifiable rejection, not a mention. A bare
+    // `let code = StatusCode::UNAUTHORIZED;` binding that is never returned/produced
+    // must not bless the middleware.
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Response {\n` +
+      `    let _code = StatusCode::UNAUTHORIZED;\n    next.run(req).await\n}\n`;
+    const f = await rs("n4b.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("a reject inside a NESTED, non-inline closure is pruned and never counted", async () => {
+    const mw =
+      `async fn mw(req: Request, next: Next) -> Response {\n` +
+      `    let _f = || -> Result<(), StatusCode> { return Err(StatusCode::UNAUTHORIZED); };\n` +
+      `    next.run(req).await\n}\n`;
+    const f = await rs("n5.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(mw))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("a non-from_fn layer (TraceLayer / Logger) is not auth", async () => {
+    const trace = await rs("n6a.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", get(h)).layer(TraceLayer::new_for_http())\n}\n`);
+    expect(authOf(extractRustRoutesAst(trace.tree!, trace.relativePath))).toEqual(["GET /x auth=false hook=-"]);
+    const logger = await rs("n6b.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(Logger::default())\n}\n`);
+    expect(authOf(extractRustRoutesAst(logger.tree!, logger.relativePath))).toEqual(["GET /x auth=false hook=-"]);
+  });
+
+  it("LAYER SCOPING crux: .layer(auth).route(A) puts A OUTSIDE the layer subtree -> A false", async () => {
+    const chain = `Router::new().layer(middleware::from_fn(auth)).route("/late", post(h))`;
+    const f = await rs("n7.rs", withMw(rejBody("auth"), chain));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /late auth=false hook=-"]);
+  });
+
+  it(".route_layer covers the preceding route link but NOT a route added after it", async () => {
+    const chain =
+      `Router::new()\n` +
+      `        .route("/early", post(a))\n` +
+      `        .route_layer(middleware::from_fn(auth))\n` +
+      `        .route("/late", post(b))`;
+    const f = await rs("n8.rs", withMw(rejBody("auth"), chain));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /early auth=true hook=-", "POST /late auth=false hook=-",
+    ]);
+  });
+});
+
+describe("auth UNSURE: unreadable layer / imported / opaque", () => {
+  it("an imported from_fn with no in-file def resolves UNSURE, naming the hook", async () => {
+    const f = await rs("u1.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", post(h)).layer(middleware::from_fn(require_auth))\n}\n`);
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /x auth=false hook=require_auth",
+    ]);
+  });
+
+  it("an in-file from_fn body that only calls an external validator (no reject) is UNSURE", async () => {
+    const mw =
+      `async fn require_auth(req: Request, next: Next) -> Response {\n` +
+      `    let _ = validate_session(&req);\n    next.run(req).await\n}\n`;
+    const f = await rs("u2.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(require_auth))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /x auth=false hook=require_auth",
+    ]);
+  });
+
+  it("a .wrap of a library closure / bare mw resolves UNSURE or not-auth (never bless)", async () => {
+    const bearer = await rs("u3a.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(HttpAuthentication::bearer(v))\n}\n`);
+    const br = extractRustRoutesAst(bearer.tree!, bearer.relativePath);
+    expect(br[0].hasAuth).toBe(false);
+    const mw = await rs("u3b.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", get(h)).wrap(auth_mw)\n}\n`);
+    const mr = extractRustRoutesAst(mw.tree!, mw.relativePath);
+    expect(mr[0].hasAuth).toBe(false);
+  });
+
+  it("direct classifier pins: a NAME alone never returns 'auth'", async () => {
+    const empty = new Map<string, SyntaxNode | null>();
+    expect(classifyRustAuth("require_auth", null, empty)).toBe("unsure");
+    expect(classifyRustAuth("logger", null, empty)).toBe("not-auth");
+
+    // A veto segment beats even a real body reject (rule 1).
+    const f = await rs("pin.rs", rejBody("skip_auth"));
+    const defs = collectRustFunctionDefs(f.tree!.rootNode);
+    const body = f.tree!.rootNode.descendantsOfType("function_item")[0]!.childForFieldName("body")!;
+    expect(classifyRustAuth("skip_auth", body, defs)).toBe("not-auth");
+  });
+});
+
+describe("auth extractor-typed → UNSURE (LOCKED no-type-bless)", () => {
+  const handlerRoute = (params: string) =>
+    `async fn h(${params}) -> Response { todo!() }\n` +
+    `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`;
+
+  it("an auth-extractor-typed param resolves UNSURE naming the type (never a type-name bless)", async () => {
+    for (const ty of ["AuthUser", "Claims", "RequireAuth", "Identity", "Bearer"]) {
+      const f = await rs(`e_${ty}.rs`, handlerRoute(`user: ${ty}`));
+      expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+        `POST /x auth=false hook=${ty}`,
+      ]);
+    }
+  });
+
+  it("an Option/Maybe/Optional wrapper NEVER even hedges (optionality veto, hook absent)", async () => {
+    for (const [nm, params] of [
+      ["o1.rs", "user: Option<AuthUser>"],
+      ["o2.rs", "user: MaybeAuth"],
+      ["o3.rs", "user: OptionalUser"],
+    ]) {
+      const f = await rs(nm, handlerRoute(params));
+      expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+    }
+  });
+
+  it("a non-auth extractor type contributes nothing (hook absent)", async () => {
+    for (const [nm, params] of [
+      ["j.rs", "body: Json<Order>"],
+      ["p.rs", "id: Path<u32>"],
+      ["s.rs", "state: State<AppState>"],
+      ["q.rs", "q: Query<Params>"],
+      ["fm.rs", "form: Form<Data>"],
+    ]) {
+      const f = await rs(nm, handlerRoute(params));
+      expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+    }
+  });
+
+  it("v1 boundary pin: an in-file impl FromRequest for AuthUser is NOT read (still UNSURE)", async () => {
+    const src =
+      `struct AuthUser;\n` +
+      `impl FromRequest for AuthUser {\n` +
+      `    type Rejection = StatusCode;\n` +
+      `    async fn from_request(req: Request, s: &S) -> Result<Self, StatusCode> {\n` +
+      `        return Err(StatusCode::UNAUTHORIZED);\n` +
+      `    }\n}\n` +
+      `async fn h(user: AuthUser) -> Response { todo!() }\n` +
+      `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n`;
+    const f = await rs("v1boundary.rs", src);
+    // The rejecting FromRequest body is deliberately ignored in v1; the type name
+    // hedges but never blesses (the biggest documented recall cost).
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual([
+      "POST /x auth=false hook=AuthUser",
+    ]);
   });
 });

--- a/test/unit/drift/security-ast-rust.test.ts
+++ b/test/unit/drift/security-ast-rust.test.ts
@@ -288,3 +288,149 @@ describe("extractRustRoutesAst: comments and strings never extracted (G8)", () =
     expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
   });
 });
+
+describe("extractRustRoutesAst: method resolution (G3)", () => {
+  const axum = (arg1: string) =>
+    `fn app() -> Router {\n    Router::new().route("/x", ${arg1})\n}\n`;
+  const method = async (name: string, arg1: string): Promise<string[]> => {
+    const f = await rs(name, axum(arg1));
+    return extractRustRoutesAst(f.tree!, f.relativePath).map((r) => r.method);
+  };
+
+  it("resolves each single method-router verb callee to its HTTP verb", async () => {
+    expect(await method("mpost.rs", "post(h)")).toEqual(["POST"]);
+    expect(await method("mput.rs", "put(h)")).toEqual(["PUT"]);
+    expect(await method("mpatch.rs", "patch(h)")).toEqual(["PATCH"]);
+    expect(await method("mdelete.rs", "delete(h)")).toEqual(["DELETE"]);
+    expect(await method("mget.rs", "get(h)")).toEqual(["GET"]);
+  });
+
+  it("resolves any(h) to the ALL sentinel (stays in the mutating vote)", async () => {
+    expect(await method("many.rs", "any(h)")).toEqual(["ALL"]);
+  });
+
+  it("resolves a scoped verb callee axum::routing::post(h) to POST", async () => {
+    expect(await method("mscoped.rs", "axum::routing::post(h)")).toEqual(["POST"]);
+  });
+
+  it("collects both verbs of a chain and resolves the first mutating one", async () => {
+    // get(list).post(create): GET + POST present -> POST wins the mutating vote.
+    expect(await method("mchain1.rs", "get(list).post(create)")).toEqual(["POST"]);
+    // get(a).put(b): the sole mutating verb PUT wins.
+    expect(await method("mchain2.rs", "get(a).put(b)")).toEqual(["PUT"]);
+  });
+
+  it("resolves an unresolvable but verb-shaped on() combinator to ALL, never a GET-drop", async () => {
+    // v1 DEFERRED: the precise MethodFilter verb is not parsed; the route stays
+    // in the mutating vote as ALL rather than silently dropping to GET.
+    expect(await method("mon.rs", "on(MethodFilter::POST, h)")).toEqual(["ALL"]);
+  });
+
+  it("skips a HEAD-only method-router (never mutating)", async () => {
+    const f = await rs("mhead.rs", axum("head(h)"));
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a chain whose only verbs are head/options", async () => {
+    const f = await rs("mheadopt.rs", axum("head(h).options(o)"));
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a bare MethodRouter-variable arg1 (not a method-router shape)", async () => {
+    // route("/x", mr) is structurally indistinguishable from a non-Axum
+    // .route(path, someVar) call; recognizing it would over-capture. Documented
+    // recall gap: a let-bound `let mr = post(h)` route is not resolved here.
+    const f = await rs("mbarevar.rs", axum("mr"));
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips an unrecognized non-verb callee my_router()", async () => {
+    const f = await rs("munrec.rs", axum("my_router()"));
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a plain method call receiver.post(h) whose base is not a router callee", async () => {
+    // Guards the chain walk: an outer field verb alone must not synthesize a
+    // spurious mutating route; only a recognized base call asserts the shape.
+    const f = await rs("mfieldbase.rs", axum("receiver.post(h)"));
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("resolves attribute-macro verbs from the macro name", async () => {
+    const g = await rs("aget.rs", `#[get("/g")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(g.tree!, g.relativePath).map((r) => r.method)).toEqual(["GET"]);
+    const p = await rs("apost.rs", `#[post("/p")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(p.tree!, p.relativePath).map((r) => r.method)).toEqual(["POST"]);
+    const d = await rs("adelete.rs", `#[delete("/d")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(d.tree!, d.relativePath).map((r) => r.method)).toEqual(["DELETE"]);
+  });
+
+  it('resolves a generic #[route("/x", method = "POST")] macro to POST', async () => {
+    const f = await rs("aroute.rs", `#[route("/x", method = "POST")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["POST /x"]);
+  });
+
+  it('resolves a generic #[route("/x")] with no method= to ALL', async () => {
+    const f = await rs("aroutenone.rs", `#[route("/x")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)
+      .map((r) => `${r.method} ${r.path}`)).toEqual(["ALL /x"]);
+  });
+
+  it('resolves a fully-literal unrecognized verb in #[route] to GET', async () => {
+    // A statically-known-but-unrecognized verb resolves GET (DRF/Go precedent),
+    // distinct from an UNRESOLVABLE dynamic verb which resolves ALL.
+    const f = await rs("aroutetrace.rs", `#[route("/x", method = "TRACE")]\nfn h(){}\n`);
+    expect(extractRustRoutesAst(f.tree!, f.relativePath).map((r) => r.method)).toEqual(["GET"]);
+  });
+});
+
+describe("extractRustRoutesAst: path forms and string handling (G4)", () => {
+  const axum = (path: string, arg1 = "post(h)") =>
+    `fn app() -> Router {\n    Router::new().route(${path}, ${arg1})\n}\n`;
+  const paths = async (name: string, path: string): Promise<string[]> => {
+    const f = await rs(name, axum(path));
+    return extractRustRoutesAst(f.tree!, f.relativePath).map((r) => r.path);
+  };
+
+  it("requires a leading slash (skips a slash-less or empty path)", async () => {
+    const noslash = await rs("pnoslash.rs", axum(`"users"`));
+    expect(extractRustRoutesAst(noslash.tree!, noslash.relativePath)).toEqual([]);
+    const empty = await rs("pempty.rs", axum(`""`));
+    expect(extractRustRoutesAst(empty.tree!, empty.relativePath)).toEqual([]);
+  });
+
+  it("accepts axum :id and brace {id} path params verbatim", async () => {
+    expect(await paths("pcolon.rs", `"/users/:id"`)).toEqual(["/users/:id"]);
+    expect(await paths("pbrace.rs", `"/users/{id}"`)).toEqual(["/users/{id}"]);
+  });
+
+  it("accepts the root path /", async () => {
+    expect(await paths("proot.rs", `"/"`)).toEqual(["/"]);
+  });
+
+  it("accepts a unicode path verbatim", async () => {
+    expect(await paths("punicode.rs", `"/café"`)).toEqual(["/café"]);
+  });
+
+  it("reads a raw-string-literal path, stripping the r-prefix and hashes", async () => {
+    expect(await paths("praw.rs", `r"/raw"`)).toEqual(["/raw"]);
+    expect(await paths("prawhash.rs", `r#"/hash"#`)).toEqual(["/hash"]);
+  });
+
+  it("skips a mis-form raw path that fails the strip regex (deliberate safe miss)", async () => {
+    // A byte-raw string br"/x" is a raw_string_literal whose text starts with
+    // `b`, not `r`; the strip regex returns null -> path unresolved -> skip.
+    const f = await rs("prawbyte.rs", axum(`br"/x"`));
+    expect(extractRustRoutesAst(f.tree!, f.relativePath)).toEqual([]);
+  });
+
+  it("skips a non-literal path (const, format!, or binary concat)", async () => {
+    const konst = await rs("pconst.rs", axum(`PATH`));
+    expect(extractRustRoutesAst(konst.tree!, konst.relativePath)).toEqual([]);
+    const fmt = await rs("pfmt.rs", axum(`&format!("/x/{}", id)`));
+    expect(extractRustRoutesAst(fmt.tree!, fmt.relativePath)).toEqual([]);
+    const concat = await rs("pconcat.rs", axum(`"/x" + "/y"`));
+    expect(extractRustRoutesAst(concat.tree!, concat.relativePath)).toEqual([]);
+  });
+});

--- a/test/unit/drift/security-ast-rust.test.ts
+++ b/test/unit/drift/security-ast-rust.test.ts
@@ -553,6 +553,33 @@ describe("auth POSITIVE: covering from_fn body reject blesses", () => {
       "POST /a auth=true hook=-", "PUT /b auth=true hook=-", "DELETE /c auth=true hook=-",
     ]);
   });
+
+  // LOAD-BEARING (produce-position gating must NOT delete the branch-tail walk):
+  // a 401 that is the TAIL of a match arm / if branch (an implicit-return produce
+  // position) blesses even under a boring name. These bless ONLY through the
+  // produce-position recursion into branch tails — a naive "returns/tail only"
+  // scan of the block's own tail node would miss them (tree-sitter wraps a
+  // trailing match/if in an expression_statement).
+  it("PC1: a from_fn whose body tail is a match arm `None => Err(401)` blesses", async () => {
+    const mw =
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    match check(&req) {\n` +
+      `        None => Err(StatusCode::UNAUTHORIZED),\n` +
+      `        Some(_u) => Ok(next.run(req).await),\n` +
+      `    }\n}\n`;
+    const f = await rs("pc1.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(gate))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
+
+  it("PC2: a from_fn whose body tail is `if bad { Err(401) } else { Ok(next) }` blesses", async () => {
+    const mw =
+      `async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    if bad(&req) { Err(StatusCode::UNAUTHORIZED) } else { Ok(next.run(req).await) }\n}\n`;
+    const f = await rs("pc2.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(gate))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=true hook=-"]);
+  });
 });
 
 describe("auth NEGATIVE: never-false-bless", () => {
@@ -660,6 +687,75 @@ describe("auth NEGATIVE: never-false-bless", () => {
       `        _ => {}\n    }\n    resp\n}\n`;
     const f = await rs("n11.rs",
       withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(observe))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  // RESIDUAL produce-position pins: an `Err(401)` / `ErrorUnauthorized(..)` that
+  // sits in a NON-produce position (a comparison operand, a plain call argument,
+  // a never-returned let RHS, a struct-literal field, a builder argument) is a
+  // MENTION, never a reject. Neutral names (tap / record / build) so no name veto
+  // or hedge is in play — the produce-position gate alone must resolve not-auth.
+  it("R1: an `Err(401)` as a `== Err(..)` comparison operand never blesses", async () => {
+    const mw =
+      `async fn tap(req: Request, next: Next) -> Response {\n` +
+      `    let resp = next.run(req).await;\n` +
+      `    if resp == Err(StatusCode::UNAUTHORIZED) {\n` +
+      `        tracing::warn!("downstream 401");\n` +
+      `    }\n    resp\n}\n`;
+    const f = await rs("r1.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(tap))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("R2b: an `Err(401)` as a plain call argument never blesses", async () => {
+    const mw =
+      `async fn record(req: Request, next: Next) -> Response {\n` +
+      `    record_metric(Err(StatusCode::UNAUTHORIZED));\n` +
+      `    next.run(req).await\n}\n`;
+    const f = await rs("r2b.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(record))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("R3b: an `Err(401)` in a never-returned let RHS never blesses", async () => {
+    const mw =
+      `async fn build(req: Request, next: Next) -> Response {\n` +
+      `    let _e = Err(StatusCode::UNAUTHORIZED);\n` +
+      `    next.run(req).await\n}\n`;
+    const f = await rs("r3b.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("R6: an `Err(401)` as a struct-literal field value never blesses", async () => {
+    const mw =
+      `async fn build(req: Request, next: Next) -> Response {\n` +
+      `    let _cfg = Config { fallback: Err(StatusCode::UNAUTHORIZED) };\n` +
+      `    next.run(req).await\n}\n`;
+    const f = await rs("r6.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("R10: an `Err(401)` as a builder-method argument never blesses", async () => {
+    const mw =
+      `async fn build(req: Request, next: Next) -> Response {\n` +
+      `    let _svc = Handler::new().default_error(Err(StatusCode::UNAUTHORIZED));\n` +
+      `    next.run(req).await\n}\n`;
+    const f = await rs("r10.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`));
+    expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
+  });
+
+  it("R8: an `.ok_or_else` closure that MENTIONS 401 but PRODUCES 403 never blesses", async () => {
+    const mw =
+      `async fn build(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+      `    let _t = maybe(&req).ok_or_else(|| {\n` +
+      `        if flag() == StatusCode::UNAUTHORIZED { log(); }\n` +
+      `        StatusCode::FORBIDDEN\n` +
+      `    })?;\n    Ok(next.run(req).await)\n}\n`;
+    const f = await rs("r8.rs",
+      withMw(mw, `Router::new().route("/x", post(h)).layer(middleware::from_fn(build))`));
     expect(authOf(extractRustRoutesAst(f.tree!, f.relativePath))).toEqual(["POST /x auth=false hook=-"]);
   });
 

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -7,9 +7,11 @@ import { fileWithTree } from "../../helpers/drift-tree.js";
 import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
 import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
 import { extractGoFileMiddlewareAst, extractGoRoutesAst } from "../../../src/drift/security-ast-go.js";
+import { extractRustRoutesAst } from "../../../src/drift/security-ast-rust.js";
 import {
   SECURITY_SUPPRESSION_SUBCATEGORY,
   SECURITY_SUPPRESSION_ANALYZER_ID,
+  applyRouteSuppressions,
 } from "../../../src/drift/security-suppression.js";
 import { renderTerminalOutput } from "../../../src/output/terminal.js";
 import type { ScanResult, Finding } from "../../../src/core/types.js";
@@ -1998,5 +2000,157 @@ describe("Rust AST wiring (Task 4)", () => {
     // Meaningful: the non-rust findings actually present (the JS deviator fires),
     // so this is a real byte-for-byte comparison, not two empty arrays.
     expect(withoutRust.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Task 5 (Rust): malformed input at dispatch (G9) ───────────────────────────
+//
+// The whole-file clean-tree gate (`file.tree && !file.tree.rootNode.hasError`)
+// lives in security-consistency.ts's `extractRustRoutes` DISPATCH wrapper, not
+// inside `extractRustRoutesAst` itself (see the companion per-construct pin in
+// security-ast-rust.test.ts, "malformed and adversarial input (G8)"). These
+// pins prove the dispatch gate is unconditional on rootNode.hasError, covering
+// several distinct kinds of syntax error, and is STRICTER than the raw
+// extractor (which can still find an isolated clean construct).
+describe("Task 5 (Rust): malformed input at dispatch (G9)", () => {
+  const rsTree = (p: string, c: string) => fileWithTree(p, c, "rust");
+  const requireAuthFn =
+    `async fn require_auth(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+    `    let t = req.headers().get("Authorization");\n` +
+    `    if t.is_none() { return Err(StatusCode::UNAUTHORIZED); }\n` +
+    `    Ok(next.run(req).await)\n}\n`;
+  const sevenAuthedThen = (lastPath: string) =>
+    requireAuthFn +
+    `fn app() -> Router {\n    Router::new()\n` +
+    ["/a", "/b", "/c", "/d", "/e", "/f", "/g"].map((p) => `        .route("${p}", post(h))\n`).join("") +
+    `        .layer(middleware::from_fn(require_auth))\n` +
+    `        .route("${lastPath}", post(h))\n}\n`;
+
+  it("a hand-built errored tree contributes ZERO routes through the dispatch gate, even though extractRustRoutesAst alone would find one", async () => {
+    // Non-vacuous companion to the G8 per-construct pin: the SAME source (an
+    // earlier clean route followed by a syntactically broken trailing fn) is
+    // proven elsewhere to yield a route when extractRustRoutesAst is called
+    // directly. Through the full dispatch + vote pipeline, with 7 authed peers
+    // that WOULD flag a deviator if /x's route were counted unauthed, nothing
+    // fires: the dispatch gate discards the whole broken file outright.
+    const peers = await rsTree("src/g9peers/api.rs", sevenAuthedThen("/stripped"));
+    const broken = await rsTree("src/g9broken/api.rs",
+      `fn app() -> Router {\n    Router::new().route("/x", post(h))\n}\n` +
+      `fn broken( {{{ .route(\n`);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    const findings = securityConsistency.detect(mkCtx([peers, broken]));
+    const auths = findings.filter((x) => x.subCategory === SECURITY_SUBCATEGORIES.auth);
+    // Only /stripped (from the clean peers file) deviates; /x from the broken
+    // file never enters the vote at all.
+    expect(auths).toHaveLength(1);
+    expect(auths[0].deviatingFiles.map((d: any) => d.evidence[0].code)).toEqual(["POST /stripped"]);
+  });
+
+  it.each([
+    ["unbalanced brace", `fn oops() { let x = 1;\n`],
+    ["unterminated string literal", `fn oops() { let x = "never closes;\n}\n`],
+    ["garbage token stream", `fn oops() { @@@ ### $$$ }\n`],
+  ])("ANY syntax error (%s) yields zero routes through detect, vs a clean control that fires", async (_label, brokenSuffix) => {
+    const cleanSrc = sevenAuthedThen("/stripped");
+    const clean = await rsTree("src/g9m/clean.rs", cleanSrc);
+    expect(clean.tree!.rootNode.hasError).toBe(false);
+    const cleanFindings = securityConsistency.detect(mkCtx([clean]));
+    // Non-vacuous control: the clean version of this exact source DOES fire.
+    expect(cleanFindings.some((x) => x.subCategory === SECURITY_SUBCATEGORIES.auth)).toBe(true);
+
+    const broken = await rsTree("src/g9m/broken.rs", cleanSrc + brokenSuffix);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    expect(securityConsistency.detect(mkCtx([broken]))).toHaveLength(0);
+  });
+});
+
+// ── Task 5 (Rust): suppression pins ────────────────────────────────────────────
+//
+// DISCOVERED GAP (documented, not fixed here — out of this task's scope, which
+// is test-only plus security-ast-rust.ts). `applyRouteSuppressions`'s AST path
+// (`annotationCommentRows`) recognizes an annotation only inside a node of type
+// "comment" (security-suppression.ts). Go, Python, and JS/TS tree-sitter
+// grammars all name their comment nodes "comment" — verified directly against
+// the pinned grammars, both here and by the passing Task 6 (Go) suppression
+// pins above. Rust's grammar does NOT: a Rust line comment is a "line_comment"
+// node and a block comment is a "block_comment" node (probe-verified against
+// the pinned tree-sitter-wasms rust grammar), neither of which is type
+// "comment". Since a Rust route only ever reaches `applyRouteSuppressions` with
+// a real (non-error) tree attached (there is no regex fallback for Rust — see
+// `extractRustRoutes` in security-consistency.ts), the AST resolver is always
+// used and NEVER finds a match, so `// @vibedrift-public` currently has NO
+// effect on a Rust route, in any position (its own line or the line above),
+// for either a builder or an attribute-macro route.
+//
+// This is the "under-matching" failure direction, which the suppression
+// module's own header names as the deliberately safe one: the annotated route
+// simply stays in the vote instead of being silently hidden from it — a false
+// "not suppressed" reads as a normal deviator, never as a false "authed" or a
+// disappeared route. These two tests PIN the actual current behavior (an
+// annotation is a no-op for Rust) so a future grammar or suppression-module
+// change that silently alters it is caught here, not discovered in the field.
+describe("Task 5 (Rust): suppression pins (documented gap: annotation is a no-op for Rust)", () => {
+  const rsTree = (p: string, c: string) => fileWithTree(p, c, "rust");
+  const auth = (fs: any[]) => fs.find((f: any) => f.subCategory === SECURITY_SUBCATEGORIES.auth);
+  const audit = (fs: any[]) => fs.find((f: any) => f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY);
+  const requireAuthFn =
+    `async fn require_auth(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+    `    let t = req.headers().get("Authorization");\n` +
+    `    if t.is_none() { return Err(StatusCode::UNAUTHORIZED); }\n` +
+    `    Ok(next.run(req).await)\n}\n`;
+  const sevenAuthed =
+    requireAuthFn +
+    `fn app() -> Router {\n    Router::new()\n` +
+    ["/a", "/b", "/c", "/d", "/e", "/f", "/g"].map((p) => `        .route("${p}", post(h))\n`).join("") +
+    `        .layer(middleware::from_fn(require_auth))\n`;
+
+  it("// @vibedrift-public directly ABOVE a builder route's .route call does not suppress it (actual behavior, not the naively-expected one)", async () => {
+    const src = sevenAuthed +
+      `        // @vibedrift-public\n` +
+      `        .route("/public", post(h))\n}\n`;
+    const f = await rsTree("src/rustsuppress1/api.rs", src);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+
+    // Unit-level: applyRouteSuppressions itself keeps the route and suppresses
+    // nothing, even though the annotation sits on the line directly above it.
+    const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+    const { kept, suppressed } = applyRouteSuppressions(routes, [f]);
+    expect(suppressed).toEqual([]);
+    expect(kept.map((r) => `${r.method} ${r.path}`)).toContain("POST /public");
+
+    // End-to-end: /public (added after the layer, so genuinely unauthed) stays
+    // in the vote and is flagged as the deviator; no suppression-audit finding.
+    const findings = securityConsistency.detect(mkCtx([f]));
+    expect(audit(findings)).toBeUndefined();
+    const a = auth(findings);
+    expect(a).toBeDefined();
+    expect(a!.deviatingFiles.map((d: any) => d.evidence[0].code)).toEqual(["POST /public"]);
+  });
+
+  it("// @vibedrift-public directly ABOVE an attribute-macro route's attribute_item does not suppress it (actual behavior)", async () => {
+    const fullSrc =
+      requireAuthFn +
+      `fn app() -> Router {\n    Router::new()\n` +
+      ["/a", "/b", "/c", "/d", "/e", "/f", "/g"].map((p) => `        .route("${p}", post(h))\n`).join("") +
+      `        .layer(middleware::from_fn(require_auth))\n}\n` +
+      `// @vibedrift-public\n` +
+      `#[post("/public")]\n` +
+      `fn public_h(){}\n`;
+    const f = await rsTree("src/rustsuppress2/api.rs", fullSrc);
+    expect(f.tree!.rootNode.hasError).toBe(false);
+
+    const routes = extractRustRoutesAst(f.tree!, f.relativePath);
+    const { kept, suppressed } = applyRouteSuppressions(routes, [f]);
+    expect(suppressed).toEqual([]);
+    expect(kept.map((r) => `${r.method} ${r.path}`)).toContain("POST /public");
+
+    // Attribute-macro routes never carry a covering-layer auth signal at all
+    // (no builder chain), so /public is unauthed regardless; it stays in the
+    // vote and is cited as the deviator, with no suppression-audit finding.
+    const findings = securityConsistency.detect(mkCtx([f]));
+    expect(audit(findings)).toBeUndefined();
+    const a = auth(findings);
+    expect(a).toBeDefined();
+    expect(a!.deviatingFiles.map((d: any) => d.evidence[0].code)).toEqual(["POST /public"]);
   });
 });

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { securityConsistency } from "../../../src/drift/security-consistency.js";
 import { runDriftDetection, driftFindingToFinding } from "../../../src/drift/index.js";
 import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
+import { SECURITY_SUBCATEGORIES } from "../../../src/drift/types.js";
 import { fileWithTree } from "../../helpers/drift-tree.js";
 import { extractPythonRoutesAst } from "../../../src/drift/security-ast-python.js";
 import { extractJsRoutesAst } from "../../../src/drift/security-ast.js";
@@ -1855,5 +1856,147 @@ describe("Task 6 (Go): suppression pins", () => {
     expect(a).toBeDefined();
     const dangerLine = src.split("\n").findIndex((l) => l.includes(`/danger`)) + 1;
     expect(a!.deviatingFiles.some((d: any) => d.evidence[0].line === dangerLine)).toBe(true);
+  });
+});
+
+// ── Task 4 (Rust): AST extractor wired into both seams ───────────────────────
+//
+// Seam 1 (extractRoutes) and seam 2 (buildFileMiddlewareIndex) dispatch to the
+// Rust AST extractor for CLEAN-parsed rust files. Unlike Go/Python there is NO
+// regex fallback: an absent or errored tree yields zero Rust routes (unchanged
+// from before this module was wired in). Byte-identical for every non-rust file.
+describe("Rust AST wiring (Task 4)", () => {
+  const rsTree = (p: string, c: string) => fileWithTree(p, c, "rust");
+  const authFinding = (fs: any[]) => fs.find((f: any) => f.subCategory === SECURITY_SUBCATEGORIES.auth);
+  const devPaths = (f: any): string[] =>
+    f ? f.deviatingFiles.map((d: any) => d.evidence[0].code.split(" ")[1]) : [];
+
+  // A from_fn body that verifiably 401-rejects (rule 2 bless, NOT a name bless).
+  const requireAuthFn =
+    `async fn require_auth(req: Request, next: Next) -> Result<Response, StatusCode> {\n` +
+    `    let t = req.headers().get("Authorization");\n` +
+    `    if t.is_none() { return Err(StatusCode::UNAUTHORIZED); }\n` +
+    `    Ok(next.run(req).await)\n}\n`;
+
+  // 7 routes covered by a trailing from_fn(require_auth) .layer (all DESCENDANTS
+  // of it -> blessed), then ONE route added AFTER the layer. That last link is the
+  // OUTERMOST node with the layer as its DESCENDANT, so the covering-layer walk
+  // finds no ancestor layer -> it stays unauthed (the "stripped" deviator).
+  const sevenAuthedThen = (lastPath: string) =>
+    requireAuthFn +
+    `fn app() -> Router {\n    Router::new()\n` +
+    ["/a", "/b", "/c", "/d", "/e", "/f", "/g"].map((p) => `        .route("${p}", post(h))\n`).join("") +
+    `        .layer(middleware::from_fn(require_auth))\n` +
+    `        .route("${lastPath}", post(h))\n}\n`;
+
+  // N authed routes in one file, all covered by a trailing from_fn(require_auth) layer.
+  const authedPeersFile = (dir: string, name: string, paths: string[]) =>
+    rsTree(`${dir}/${name}`,
+      requireAuthFn +
+      `fn app() -> Router {\n    Router::new()\n` +
+      paths.map((p) => `        .route("${p}", post(h))\n`).join("") +
+      `        .layer(middleware::from_fn(require_auth))\n}\n`);
+  const sevenPeerPaths = ["/p1", "/p2", "/p3", "/p4", "/p5", "/p6", "/p7"];
+
+  // ── Seam 1: dispatch selects the Rust AST branch ──
+  it("dispatch: 7 layer-authed routes + 1 stripped route -> exactly one auth finding on the stripped route", async () => {
+    const f = await rsTree("src/rapi/api.rs", sevenAuthedThen("/stripped"));
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    const findings = securityConsistency.detect(mkCtx([f]));
+    const auths = findings.filter((x) => x.subCategory === SECURITY_SUBCATEGORIES.auth);
+    // Before this branch, Rust contributed zero routes and nothing fired.
+    expect(auths).toHaveLength(1);
+    expect(auths[0].deviatingFiles).toHaveLength(1);
+    expect(devPaths(auths[0])).toEqual(["/stripped"]);
+  });
+
+  it("no regex fallback: a tree-less OR broken-tree rust file emits zero routes through detect", async () => {
+    const src = sevenAuthedThen("/stripped");
+    // Control: a CLEAN tree extracts the routes and fires (the branch is live).
+    const clean = await rsTree("src/rnofb/api.rs", src);
+    expect(clean.tree!.rootNode.hasError).toBe(false);
+    expect(authFinding(securityConsistency.detect(mkCtx([clean])))).toBeDefined();
+    // Tree-less: no tree at all -> the Rust arm is gated off -> zero routes, so
+    // detect stays silent (routes.length < 2). There is NO regex fallback.
+    const treeless = file("src/rnofb/api.rs", src, "rust");
+    expect(treeless.tree).toBeUndefined();
+    expect(securityConsistency.detect(mkCtx([treeless]))).toHaveLength(0);
+    // Broken tree: rootNode.hasError -> the Rust arm is gated off -> zero routes.
+    // Unlike Go/Python, no regex fallback recovers the parse-error file's routes.
+    const broken = await rsTree("src/rnofb/api.rs", src + `fn broke() { let x = = 1; }\n`);
+    expect(broken.tree!.rootNode.hasError).toBe(true);
+    expect(securityConsistency.detect(mkCtx([broken]))).toHaveLength(0);
+  });
+
+  // ── Seam 2: cross-language regex noise can no longer bless a clean rust file ──
+  it("cross-language noise (seam 2): a rust doc-comment app.use never blesses a clean rust route", async () => {
+    const orders = await rsTree("src/rnoise/orders.rs",
+      `/// Mirrors the Node service: app.use(authMiddleware) runs first.\n` +
+      `fn app() -> Router {\n    Router::new().route("/orders", post(create))\n}\n`);
+    expect(orders.tree!.rootNode.hasError).toBe(false);
+    const peers = await authedPeersFile("src/rnoise", "peers.rs", sevenPeerPaths);
+    const f = authFinding(securityConsistency.detect(mkCtx([orders, peers])));
+    expect(f).toBeDefined();
+    // The case-insensitive jsAuth regex matches `app.use(authMiddleware` in the
+    // doc comment, but a clean rust tree forces the js/go/py index arms false, so
+    // /orders stays unauthed and is the flagged deviator.
+    expect(devPaths(f)).toContain("/orders");
+  });
+
+  it("unsure survives the dispatch: an extractor-typed route's deviator is the hedged shape", async () => {
+    const peers = await authedPeersFile("src/rhedge", "peers.rs", sevenPeerPaths);
+    // The handler carries an auth-extractor param (AuthUser) and the route is NOT
+    // covered by any layer -> the route resolves UNSURE naming the type (never a
+    // type-name bless: hasAuth stays false, authUnsureHook = "AuthUser").
+    const unsure = await rsTree("src/rhedge/unsure.rs",
+      `async fn h(user: AuthUser) -> Response { todo!() }\n` +
+      `fn app() -> Router {\n    Router::new().route("/unsure", post(h))\n}\n`);
+    const findings = securityConsistency.detect(mkCtx([peers, unsure]));
+    const auths = findings.filter((x) => x.subCategory === SECURITY_SUBCATEGORIES.auth);
+    expect(auths).toHaveLength(1);
+    expect(auths[0].deviatingFiles).toHaveLength(1);
+    const dev = auths[0].deviatingFiles[0].detectedPattern;
+    expect(dev).toContain("double check"); // the shipped hedged copy, reused verbatim
+    expect(dev).toContain("AuthUser");
+  });
+
+  it("healthPaths end-to-end: 7 layer-authed routes + 1 unauthed POST /healthz -> zero auth findings", async () => {
+    const f = await rsTree("src/rhealth/api.rs", sevenAuthedThen("/healthz"));
+    expect(f.tree!.rootNode.hasError).toBe(false);
+    // /healthz is excluded, leaving 7/7 authed -> no deviation.
+    expect(authFinding(securityConsistency.detect(mkCtx([f])))).toBeUndefined();
+  });
+
+  // ── Byte-identical guard: a clean rust file cannot perturb non-rust findings ──
+  it("byte-identity: adding a clean rust route file does not change the JS/Python/Go findings", async () => {
+    const js = await fileWithTree("src/js/api.ts",
+      `router.post("/items", requireAuth, createItem);\n` +
+      `router.put("/items/:id", requireAuth, updateItem);\n` +
+      `router.patch("/items/:id", requireAuth, patchItem);\n` +
+      `router.delete("/items/:id", requireAuth, deleteItem);\n` +
+      `router.post("/danger", wipeEverything);\n`);
+    const py = await fileWithTree("src/py/orders.py",
+      `@app.post("/a")\n@requires_auth\ndef a(): return {}\n` +
+      `@app.post("/b")\n@requires_auth\ndef b(): return {}\n` +
+      `@app.post("/c")\n@requires_auth\ndef c(): return {}\n` +
+      `@app.post("/d")\n@requires_auth\ndef d(): return {}\n` +
+      `@app.post("/pydanger")\ndef pydanger(): return {}\n`, "python");
+    const go = await fileWithTree("src/go/orders.go",
+      `func AuthMiddleware() gin.HandlerFunc { return func(c *gin.Context) { if c.GetHeader("Authorization") == "" { c.AbortWithStatus(http.StatusUnauthorized); return }; c.Next() } }\n` +
+      `func routes(r *gin.Engine) {\n\tr.Use(AuthMiddleware())\n\tr.POST("/o1", createX)\n\tr.POST("/o2", createY)\n}\n`, "go");
+    // A single unauthed GET route in its own directory: GET is not mutating, so it
+    // is in no auth/validation vote and (alone) triggers no rate-limit vote -> it
+    // contributes zero findings and carries no auth-machinery symbols.
+    const rust = await fileWithTree("src/rust/thing.rs",
+      `fn app() -> Router {\n    Router::new().route("/rust-thing", get(handler))\n}\n`, "rust");
+    expect(rust.tree!.rootNode.hasError).toBe(false);
+
+    const nonRust = [js, py, go];
+    const withoutRust = securityConsistency.detect(mkCtx(nonRust));
+    const withRust = securityConsistency.detect(mkCtx([...nonRust, rust]));
+    expect(withRust).toEqual(withoutRust);
+    // Meaningful: the non-rust findings actually present (the JS deviator fires),
+    // so this is a real byte-for-byte comparison, not two empty arrays.
+    expect(withoutRust.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Rust AST auth extractor for Security Consistency

Extends the multi-language Security Consistency auth detector (Python + Go already shipped) to **Rust**, governed by the same **NEVER-FALSE-BLESS** invariant: a route is only marked authenticated when a readable middleware body *verifiably rejects*; anything ambiguous, unreadable, or non-rejecting resolves to `not-auth` or a hedged `unsure` ("double check"), never a bless.

### What it does
- **Route recognition:** Axum builder routes (`.route(path, method(handler))`) and Actix/Rocket attribute macros (`#[post("/x")]`), with method + path resolution.
- **Body-first auth classification:** a `middleware::from_fn` / `from_fn_with_state` blesses a route only when its **in-file** body produces a rejection (401-family, or a credential-guarded 403) in a **produce position** — a `return` value, a `?` try operand, or a block/branch tail. A status merely *mentioned* in a comparison, a call argument, a struct field, or a discarded `let` is never a reject.
- **Layer scoping:** a middleware blesses a route only when its `.layer`/`.route_layer` is an **ancestor** of the route call in the fluent chain — a layer registered after the route does not cover it.
- **Three-way state:** protected / not-auth / **unsure**. Extractor-typed auth (`FromRequestParts`) and imported/opaque middleware resolve to `unsure` with hedged copy naming the hook — never a name-only or type-name bless (conservative v1).

### Verification
- Calibration scenarios S0–S9 assert explicit precision/recall against planted ground truth (bless via rejecting bodies, not names). Full suite **1820/1820**.
- Real-repo spot check: **0 false-bless across 568 routes / 5 Rust repos** (axum, realworld-axum, actix-examples, a JWT auth app, apollo-router); all `unsure` hedges hand-traced to real extractors/layers.
- Adversarial never-false-bless sweep + a dedicated produce-gate regression set (401 and 403), each proven to fail against pre-gate code.

### Boundary (v1)
Conservative by design: reads single-statement in-file middleware bodies. Deferred to follow-ups (all fail-safe — a miss, never a false-bless): reading `FromRequest` impls, multi-statement bodies, cross-function group wiring, `route_layer` nested inside `arg1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
