### PR TITLE
Security Consistency: cross-language consolidation + honesty pass

### DIFF
--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -1167,14 +1167,15 @@ export function bodyAuthSignature(
 
 /** Precedence layer over `bodyAuthSignature`. A hook blesses ONLY on a VERIFIED
  *  body reject (rule 2); every unreadable/opaque/absent body hedges or resolves
- *  not-auth — a name never blesses (Go/Rust parity). `nameIsSimpleIdentifier`
- *  (false for attribute targets like AuthGate.check) is retained on the signature
- *  for callers; it no longer affects the outcome now that no name blesses. */
+ *  not-auth — a name never blesses (Go/Rust parity). The 4th arg (whether the
+ *  name is a simple identifier vs an attribute target like AuthGate.check) is
+ *  retained on the signature for callers but no longer affects the outcome now
+ *  that no name blesses, so it is underscore-marked unused. */
 export function classifyHookAuth(
   hookName: string,
   body: SyntaxNode | null,
   defs: Map<string, SyntaxNode | null>,
-  nameIsSimpleIdentifier: boolean,
+  _nameIsSimpleIdentifier: boolean,
 ): HookAuthOutcome {
   const segs = nameSegments(hookName);
   if (segs.some((s) => OPTIONAL_AUTH_VETO.has(s))) return "not-auth"; // rule 1

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -157,16 +157,17 @@ const RATE_NAMES = /(?:rate_?limit|throttle|limiter|slowapi|slowdown)/i;
 // real hooks that do not authenticate. Whole-segment matching makes substring
 // blessing structurally impossible.
 //
-// BODY-FIRST (addendum): the hook path no longer blesses on NAME alone.
-// classifyHookAuth classifies by BODY behavior first; a name token only ever acts
-// as a SECOND tier, and only when the body is UNRESOLVABLE (opaque). A CORE token
-// (auth/authenticate, or an AUTH_DECORATORS name) with an opaque body blesses; an
-// ENFORCE+SUBJECT token (verify_user_email, protect_user_data, enforce_session)
-// with an opaque/absent body resolves UNSURE (a hedge, never a bless), and with a
-// VISIBLE non-enforcing body resolves flat not-auth. So the old ENFORCE+SUBJECT
-// attributive false-bless is closed: those names can hedge, never bless, and a
-// visible email/scrub body is plainly not-auth. (verify_token also appears in
-// AUTH_DECORATORS as a ROUTE decorator, unaffected here.)
+// BODY-FIRST (addendum): the hook path NEVER blesses on NAME. classifyHookAuth
+// blesses a before_request / middleware hook ONLY when its body carries a VERIFIED
+// reject (401-family, or a credential-guarded 403). An UNRESOLVABLE (opaque) or
+// absent body HEDGES to unsure when the name is auth-flavored — a CORE token
+// (auth/authenticate) or an ENFORCE+SUBJECT token (verify_user_email,
+// protect_user_data) — and resolves flat not-auth otherwise. A VISIBLE
+// non-enforcing body is plainly not-auth. So a name (even a strong one like
+// authenticate or login_required) can HEDGE but never BLESS, matching the Go/Rust
+// LOCKED decision. (Route DECORATORS such as @login_required / verify_token are a
+// SEPARATE curated allowlist, applied per-route, and DO still bless by name — a
+// stronger, higher-confidence signal than a broadly-applied hook.)
 const AUTH_CORE_SEGMENTS = new Set(["auth", "authenticate", "authenticated"]);
 const AUTH_ENFORCE_SEGMENTS = new Set([
   "require", "required", "requires", "verify", "verified", "ensure",
@@ -1164,8 +1165,11 @@ export function bodyAuthSignature(
   return "none";
 }
 
-/** Precedence layer over `bodyAuthSignature`. `nameIsSimpleIdentifier` is false
- *  for attribute targets (AuthGate.check), which can hedge but never bless. */
+/** Precedence layer over `bodyAuthSignature`. A hook blesses ONLY on a VERIFIED
+ *  body reject (rule 2); every unreadable/opaque/absent body hedges or resolves
+ *  not-auth — a name never blesses (Go/Rust parity). `nameIsSimpleIdentifier`
+ *  (false for attribute targets like AuthGate.check) is retained on the signature
+ *  for callers; it no longer affects the outcome now that no name blesses. */
 export function classifyHookAuth(
   hookName: string,
   body: SyntaxNode | null,
@@ -1174,16 +1178,15 @@ export function classifyHookAuth(
 ): HookAuthOutcome {
   const segs = nameSegments(hookName);
   if (segs.some((s) => OPTIONAL_AUTH_VETO.has(s))) return "not-auth"; // rule 1
-  const isCore =
-    nameIsSimpleIdentifier &&
-    (segs.some((s) => AUTH_CORE_SEGMENTS.has(s)) || AUTH_DECORATORS.has(hookName));
   if (body) {
     const sig = bodyAuthSignature(body, defs);
-    if (sig === "reject") return "auth"; // rule 2: behavior beats name
+    if (sig === "reject") return "auth"; // rule 2: a VERIFIED reject is the only bless
     if (sig === "none") return "not-auth"; // rule 3: a visible non-enforcing body, name never rescues
-    return isCore ? "auth" : "unsure"; // rule 4: opaque -> CORE carve-out, else hedge
+    return "unsure"; // rule 4: an opaque body hedges — a name never blesses (matches Go/Rust)
   }
-  if (isCore) return "auth"; // rule 5: resolved simple CORE name
+  // rule 5: no readable body -> never bless on name (the Go/Rust LOCKED decision).
+  // A strong decorator name (@login_required) or any auth-flavored name HEDGES to
+  // "unsure, double check"; a non-auth name stays not-auth.
   const flavored = segs.some((s) => AUTH_CORE_SEGMENTS.has(s)) || nameHasAuthToken(hookName);
   return flavored ? "unsure" : "not-auth";
 }

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -162,10 +162,6 @@ const RECOGNIZED_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 // Mirrors the Go/Python modules' own constant.
 const MUTATING_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE", "ALL"]);
 
-export const SECURITY_AST_RUST = {
-  VERB_CALLEES, ANY_CALLEES, ON_CALLEES, ATTR_ROUTE_METHODS, ROUTE_FIELD, MUTATING_VERBS,
-};
-
 // ─── Body-first auth classification (Task 3) ─────────────────────────────────
 //
 // GOVERNING INVARIANT — NEVER-FALSE-BLESS. A route blesses ONLY when a covering

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -52,10 +52,10 @@ const BODY_METHODS = ["POST", "PUT", "PATCH", "ALL"];
 
 // ─── Hedged copy for auth routes whose hook could not be verified ────────────
 //
-// A route only carries `authUnsureHook` on the Python or Go AST path, and only
-// when `hasAuth === false` (a blessed route never sets it). Task 4 turns the
-// flat "no auth" copy into a HEDGE that names the exact before_request-style
-// hook the user should verify. The route stays not-authed in every vote — this
+// A route only carries `authUnsureHook` on the Python, Go, or Rust AST path,
+// and only when `hasAuth === false` (a blessed route never sets it). Task 4
+// turns the flat "no auth" copy into a HEDGE that names the exact auth hook
+// the user should verify. The route stays not-authed in every vote — this
 // is copy only. JS/TS routes and the regex fallback never set the field, so
 // they always take the flat arm and render byte-identically. No em-dash /
 // double hyphen in the hedged strings (comma/colon/period only).
@@ -74,7 +74,7 @@ function hedgeRecommendationSuffix(deviators: RouteInfo[]): string {
   const hedged = deviators.filter((r) => r.authUnsureHook);
   if (hedged.length === 0) return "";
   const names = [...new Set(hedged.map((r) => r.authUnsureHook!))].sort().join(", ");
-  return ` ${hedged.length} of these could not be confirmed: a before_request hook (${names}) may authenticate them but its body could not be verified. Double check those hooks before treating the routes as unauthenticated.`;
+  return ` ${hedged.length} of these could not be confirmed: an auth hook (${names}) may authenticate them but its body could not be verified. Double check those hooks before treating the routes as unauthenticated.`;
 }
 
 // Does the codebase use auth machinery anywhere? If it does, a mutating route

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -138,9 +138,9 @@ function scoreColorFn(score: number, max: number): typeof chalk {
 }
 
 /**
- * True when this is an auth-consistency finding the Python or Go body-signature
- * analyzer could not confirm: its recommendation carries the appended "Double
- * check" hedge naming a before_request hook. For such a finding the flat
+ * True when this is an auth-consistency finding the Python, Go, or Rust
+ * body-signature analyzer could not confirm: its recommendation carries the
+ * appended "Double check" hedge naming an auth hook. For such a finding the flat
  * confident "unprotected routes" consequence is a FALSE claim, so the terminal
  * must hedge instead. Confident security findings never carry this marker, so
  * their output is byte-identical.
@@ -151,10 +151,10 @@ function isHedgedAuthFinding(f: Finding): boolean {
   return isSecurity && !!rec && /Double check/.test(rec);
 }
 
-/** The before_request hook name(s) the appended hedge sentence named, read back
- *  out of the recommendation so the terminal can point at the exact hook. */
+/** The auth hook name(s) the appended hedge sentence named, read back out of the
+ *  recommendation so the terminal can point at the exact hook. */
 function hedgedHookNames(f: Finding): string | null {
-  const m = f.metadata?.recommendation?.match(/before_request hook \(([^)]+)\)/);
+  const m = f.metadata?.recommendation?.match(/auth hook \(([^)]+)\)/);
   return m ? m[1] : null;
 }
 
@@ -164,8 +164,8 @@ function hedgedHookNames(f: Finding): string | null {
 function hedgedSecurityConsequence(f: Finding): string {
   const names = hedgedHookNames(f);
   return names
-    ? `A before_request hook (${names}) may already authenticate some of these routes, double check it before treating them as unprotected`
-    : `A before_request hook may already authenticate some of these routes, double check before treating them as unprotected`;
+    ? `An auth hook (${names}) may already authenticate some of these routes, double check it before treating them as unprotected`
+    : `An auth hook may already authenticate some of these routes, double check before treating them as unprotected`;
 }
 
 /**

--- a/test/unit/drift/security-ast-python.test.ts
+++ b/test/unit/drift/security-ast-python.test.ts
@@ -2930,8 +2930,11 @@ describe("classifyHookAuth: precedence", () => {
     expect(await cls("require_login", `def hook():\n    abort(404)\n`, true)).toBe("not-auth");
   });
 
-  it("opaque + CORE carve-out: authenticate_request delegating to _do_auth() -> auth", async () => {
-    expect(await cls("authenticate_request", `def hook():\n    _do_auth()\n`, true)).toBe("auth");
+  it("opaque + CORE name never blesses: authenticate_request delegating to _do_auth() -> unsure", async () => {
+    // Reconciled with the Go/Rust LOCKED decision: an opaque body hedges on ANY
+    // name (including a CORE auth name), it never blesses. Only a VERIFIED reject
+    // (rule 2) blesses.
+    expect(await cls("authenticate_request", `def hook():\n    _do_auth()\n`, true)).toBe("unsure");
   });
 
   it("opaque + tier-2 name: require_login -> check_session() -> unsure", async () => {
@@ -2946,8 +2949,10 @@ describe("classifyHookAuth: precedence", () => {
     expect(await cls("setup", `def hook():\n    check_session()\n`, true)).toBe("unsure");
   });
 
-  it("body null + CORE simple: authenticate -> auth", () => {
-    expect(classifyHookAuth("authenticate", null, new Map(), true)).toBe("auth");
+  it("body null + CORE simple never blesses: authenticate -> unsure", () => {
+    // An unreadable body never blesses on name (Go/Rust parity); a CORE auth name
+    // hedges to unsure, double check.
+    expect(classifyHookAuth("authenticate", null, new Map(), true)).toBe("unsure");
   });
 
   it("body null + tier-2 simple: verify_session -> unsure", () => {
@@ -3242,10 +3247,11 @@ describe("unsure hooks (extractor level)", () => {
     expect(routes[0].authUnsureHook).toBe("verify_session");
   });
 
-  it("call-form CORE name blesses: app.before_request(authenticate) -> auth=true, key absent", async () => {
+  it("call-form CORE name never blesses: app.before_request(authenticate) -> unsure, hook 'authenticate'", async () => {
+    // Reconciled: an unreadable before_request hook hedges on name, never blesses.
     const { routes } = await routesOf(`app.before_request(authenticate)\n` + ROUTE);
-    expect(routes[0].hasAuth).toBe(true);
-    expect(routes[0].authUnsureHook).toBeUndefined();
+    expect(routes[0].hasAuth).toBe(false);
+    expect(routes[0].authUnsureHook).toBe("authenticate");
   });
 
   it("call-form lambda: app.before_request(lambda: abort(401)) -> auth=true", async () => {

--- a/test/unit/output/terminal-hedge.test.ts
+++ b/test/unit/output/terminal-hedge.test.ts
@@ -68,7 +68,7 @@ function securityFinding(recommendation: string): Finding {
 
 const HEDGED_REC =
   "4 of 5 routes have Auth middleware. Review 1 unprotected routes — apply per-route middleware or move them under a router that does. " +
-  "1 of these could not be confirmed: a before_request hook (verify_session) may authenticate them but its body could not be verified. " +
+  "1 of these could not be confirmed: an auth hook (verify_session) may authenticate them but its body could not be verified. " +
   "Double check those hooks before treating the routes as unauthenticated.";
 
 const CONFIDENT_REC =

--- a/todo.md
+++ b/todo.md
@@ -1,13 +1,32 @@
 # CLI backlog
 
-- **Hedge recommendation noun is Python-flavored for Go/mixed findings.** The
-  shared `hedgeRecommendationSuffix` (`src/drift/security-consistency.ts`) and
-  the terminal's read-back regex (`src/output/terminal.ts`, `before_request
-  hook (...)`) hardcode the Flask/FastAPI noun "before_request hook", which is
-  inaccurate for a Go middleware/handler hedge (e.g. `middleware.VerifyToken`).
-  Neutralizing it requires changing the producer and the terminal regex in
-  lockstep (a language-aware branch so Python stays byte-identical), which is
-  reserved for the user-facing honesty pass. Parked.
+- **Rust auth recall gaps (all fail-safe — a miss, never a false-bless).** From
+  the real-repo spot check: (1) a `MethodRouter::route_layer(...)` nested inside
+  `arg1` of `.route(path, mr)` is invisible to the ancestor-layer coverage walk,
+  so a genuinely-protected Axum route gets neither bless nor hedge; (2)
+  parenthesized/macro-wrapped rejects (`return (Err(FORBIDDEN))`, `forbidden!()`)
+  don't bless because `rustProducesReject` has no `parenthesized_expression` /
+  `macro_invocation` case (symmetric across 401/403 — fix both at once); (3) an
+  Actix `ErrorForbidden(..)` ctor isn't recognized for the guarded-403 lane.
+- **Rust v1.1: in-file `FromRequest`/`FromRequestParts` impl bless.** Today an
+  extractor-typed param resolves to `unsure`; reading the impl body to verify a
+  reject would let it bless. Same idea for multi-statement middleware bodies
+  (e.g. Echo `JWTWithConfig`, Go) and cross-function group wiring.
+- **Cross-file resolution extensions.** Python absolute imports; multi-module Go
+  (multiple `go.mod`). Current resolver is single-module / relative-import only.
+- **Minor cross-language hedge asymmetry.** A Python hook with an opaque body and
+  a NON-auth-flavored name resolves `unsure`; Go/Rust resolve the same shape
+  `not-auth`. Both are safe (never a bless). Decide whether to align Python to
+  `not-auth` for uniformity, or keep the more cautious hedge.
+- **Optional: language-aware hedge noun.** The auth "double check" hedge now says
+  a neutral "an auth hook (X)" for all languages (was the Flask-specific "a
+  before_request hook"). A nicety would be language-specific nouns (Python
+  "before_request hook / dependency", Go "middleware", Rust "extractor / layer"),
+  which needs threading the finding's language into `hedgeRecommendationSuffix`
+  and the terminal read-back regex in lockstep. Low priority.
+- **Batched `SCORING_VERSION` bump before the next publish.** The Rust auth lane
+  and the Python hook reconciliation change stored auth verdicts; fold into the
+  next version bump + silent backfill so users don't see per-scan version churn.
 
 - **No per-call logging in the MCP server (tool calls are invisible).** The stdio
   server (`src/mcp/server.ts`) only writes startup (`vibedrift-mcp running on


### PR DESCRIPTION
## Security Consistency: cross-language consolidation + honesty pass

Follow-up polish after the Python/Go/Rust auth extractors landed. Two behavioral/copy corrections plus a backlog refresh. Full suite 1820/1820.

### 1. Honest hedge copy (all languages)
The auth "double check" hedge previously read *"a before_request hook (X)"* for **every** language — Flask-specific terminology that is inaccurate for a Go middleware or a Rust extractor/layer. It now reads a neutral *"an auth hook (X)"*, accurate for all three. The three coordinated sites — the recommendation producer, the terminal read-back regex, and the terminal renderer — move in lockstep, so a hedged finding still surfaces the exact hook name. Confident (non-hedged) findings and JS/TS output render byte-identically. Also removed a dead export and fixed a stale doc comment.

### 2. Python hooks never bless on name (Go/Rust parity)
`classifyHookAuth` previously had a carve-out: a before_request / middleware hook with an **unreadable** body but a strong auth name (`authenticate`, `@login_required`, …) was blessed as authenticated. That is now removed — an opaque or absent hook body **hedges to "unsure, double check"** (or resolves not-auth), and the **only** path that blesses is a *verified* body reject. This matches the NEVER-FALSE-BLESS invariant already locked for Go and Rust: a name can hedge, it can never bless.

Deliberately unchanged: a route **decorator** applied directly to a handler (`@login_required`, `@jwt_required`) still blesses via its curated allowlist of real framework decorators — a stronger, per-route signal with minimal false-bless risk. The two mechanisms are separate.

Three unit tests that encoded the old carve-out were rewritten to assert the reconciled behavior (verified against the pre-change code).

### 3. Backlog refresh
`todo.md` updated with the technical follow-ups surfaced during the security phase (Rust auth recall gaps, in-file `FromRequest` bless, cross-file resolution extensions, a minor cross-language hedge asymmetry, an optional language-aware hedge noun, and the batched scoring-version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
