### PR TITLE
Security Consistency: language-aware auth hedge noun

### DIFF
--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -66,15 +66,39 @@ function hedgedDeviatorPattern(r: RouteInfo): string {
   return `${r.method} ${r.path}: auth not confirmed, double check hook '${r.authUnsureHook}'`;
 }
 
+// Language-appropriate noun (with article) for the unverified auth mechanism the
+// hedge names — a hedge only arises on the Python/Go/Rust AST paths. A finding
+// whose hedged hooks span MORE than one language falls back to the neutral phrase.
+const HOOK_PHRASE: Record<string, string> = {
+  python: "a before_request hook",
+  go: "a middleware",
+  rust: "an extractor or layer",
+};
+const NEUTRAL_HOOK_PHRASE = "an auth hook";
+
+/** Source language of a route's file, by extension. Null when unknown. */
+function langOfFile(file: string): string | null {
+  if (file.endsWith(".py")) return "python";
+  if (file.endsWith(".go")) return "go";
+  if (file.endsWith(".rs")) return "rust";
+  return null;
+}
+
 /** Sentence appended to an auth finding's recommendation when some deviators are
  *  unsure (their hook body could not be verified). Empty string when none are
- *  hedged, so a confident finding's recommendation is byte-identical. `names` is
- *  the sorted distinct set of hook names. */
+ *  hedged, so a confident finding's recommendation is byte-identical. The noun is
+ *  language-aware (a before_request hook / a middleware / an extractor or layer),
+ *  falling back to the neutral "an auth hook" when the hedged hooks span multiple
+ *  languages. `names` is the sorted distinct set of hook names. The terminal reads
+ *  the noun + names back out of this sentence (noun-agnostic), so its shape —
+ *  "could not be confirmed: <a|an> <noun> (<names>)" — must stay stable. */
 function hedgeRecommendationSuffix(deviators: RouteInfo[]): string {
   const hedged = deviators.filter((r) => r.authUnsureHook);
   if (hedged.length === 0) return "";
   const names = [...new Set(hedged.map((r) => r.authUnsureHook!))].sort().join(", ");
-  return ` ${hedged.length} of these could not be confirmed: an auth hook (${names}) may authenticate them but its body could not be verified. Double check those hooks before treating the routes as unauthenticated.`;
+  const langs = [...new Set(hedged.map((r) => langOfFile(r.file)))];
+  const phrase = langs.length === 1 && langs[0] ? (HOOK_PHRASE[langs[0]] ?? NEUTRAL_HOOK_PHRASE) : NEUTRAL_HOOK_PHRASE;
+  return ` ${hedged.length} of these could not be confirmed: ${phrase} (${names}) may authenticate them but its body could not be verified. Double check those hooks before treating the routes as unauthenticated.`;
 }
 
 // Does the codebase use auth machinery anywhere? If it does, a mutating route

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -140,7 +140,8 @@ function scoreColorFn(score: number, max: number): typeof chalk {
 /**
  * True when this is an auth-consistency finding the Python, Go, or Rust
  * body-signature analyzer could not confirm: its recommendation carries the
- * appended "Double check" hedge naming an auth hook. For such a finding the flat
+ * appended "Double check" hedge naming the unverified auth mechanism (a
+ * before_request hook, a middleware, or an extractor/layer). For such a finding the flat
  * confident "unprotected routes" consequence is a FALSE claim, so the terminal
  * must hedge instead. Confident security findings never carry this marker, so
  * their output is byte-identical.
@@ -151,20 +152,24 @@ function isHedgedAuthFinding(f: Finding): boolean {
   return isSecurity && !!rec && /Double check/.test(rec);
 }
 
-/** The auth hook name(s) the appended hedge sentence named, read back out of the
- *  recommendation so the terminal can point at the exact hook. */
-function hedgedHookNames(f: Finding): string | null {
-  const m = f.metadata?.recommendation?.match(/auth hook \(([^)]+)\)/);
-  return m ? m[1] : null;
+/** The auth-mechanism NOUN and hook name(s) the appended hedge sentence named,
+ *  read back out of the recommendation so the terminal can render a language-aware
+ *  "double check" line. Noun-agnostic: anchored on the stable
+ *  "could not be confirmed: <a|an> <noun> (<names>)" shape the producer emits, so
+ *  it matches "a before_request hook", "a middleware", "an extractor or layer",
+ *  and the neutral "an auth hook" alike. */
+function hedgedHook(f: Finding): { noun: string; names: string } | null {
+  const m = f.metadata?.recommendation?.match(/could not be confirmed: (?:an? )([^(]+) \(([^)]+)\)/);
+  return m ? { noun: m[1].trim(), names: m[2] } : null;
 }
 
 /** Hedged replacement for the confident security consequence. Names the hook(s)
  *  to verify and says "double check" instead of asserting the routes are
  *  unprotected. No em-dash / double hyphen (commas/periods only). */
 function hedgedSecurityConsequence(f: Finding): string {
-  const names = hedgedHookNames(f);
-  return names
-    ? `An auth hook (${names}) may already authenticate some of these routes, double check it before treating them as unprotected`
+  const h = hedgedHook(f);
+  return h
+    ? `The ${h.noun} (${h.names}) may already authenticate some of these routes, double check it before treating them as unprotected`
     : `An auth hook may already authenticate some of these routes, double check before treating them as unprotected`;
 }
 

--- a/test/calibration/security-go.test.ts
+++ b/test/calibration/security-go.test.ts
@@ -451,6 +451,8 @@ describe("Go calibration: S8 unresolvable-body UNSURE (imported auth-flavored mi
 
     expect(finding.recommendation).toContain("Double check");
     expect(finding.recommendation).toContain("middleware.VerifyToken");
+    // Language-aware noun: a Go hook hedges as "a middleware".
+    expect(finding.recommendation).toContain("a middleware (middleware.VerifyToken)");
 
     // Vote-arithmetic invariance: S8's counts equal the S6 control (5 files, 1 deviator).
     expect(finding.dominantCount).toBe(4);

--- a/test/calibration/security-rust.test.ts
+++ b/test/calibration/security-rust.test.ts
@@ -428,6 +428,8 @@ describe("Rust calibration: S8 unresolvable-body UNSURE (imported require_auth)"
 
     expect(finding.recommendation).toContain("Double check");
     expect(finding.recommendation).toContain("require_auth");
+    // Language-aware noun: a Rust hook hedges as "an extractor or layer".
+    expect(finding.recommendation).toContain("an extractor or layer (require_auth)");
 
     // Vote-arithmetic invariance: S8's counts equal the S6 control (5 files, 1 deviator).
     expect(finding.dominantCount).toBe(4);

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -1139,6 +1139,8 @@ describe("Task 4: hedged unsure-auth finding copy", () => {
     expect(a.recommendation).toMatch(/\d+ of these could not be confirmed/);
     expect(a.recommendation.toLowerCase()).toContain("double check");
     expect(a.recommendation).toContain("verify_session");
+    // Language-aware noun: a Python hook hedges as a "before_request hook".
+    expect(a.recommendation).toContain("a before_request hook (verify_session)");
   });
 
   it("confident sibling: a plainly-unauthed route (no unsure hook) keeps today's exact flat deviator byte-for-byte", async () => {

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -1143,6 +1143,30 @@ describe("Task 4: hedged unsure-auth finding copy", () => {
     expect(a.recommendation).toContain("a before_request hook (verify_session)");
   });
 
+  it("mixed-language finding (Python + Go hedged deviators): the noun falls back to the neutral 'auth hook'", async () => {
+    const goTree = (p: string, c: string) => fileWithTree(p, c, "go");
+    // Enough confidently-authed Python peers that the dominance vote fires with
+    // the two unsure routes (8/10 = 0.8 > 0.75).
+    const peers = await Promise.all([1, 2, 3, 4, 5, 6, 7, 8].map((n) => peerAuth(n)));
+    const pyUnsure = await unsureRoute(); // authUnsureHook "verify_session" (.py)
+    const goUnsure = await goTree(
+      "src/routes/reports.go",
+      `package routes\n\nimport (\n\t"github.com/gin-gonic/gin"\n\n\t"example.com/x/middleware"\n)\n\n` +
+        `func RegisterReports(router *gin.Engine) {\n\trouter.Use(middleware.VerifyToken)\n\trouter.POST("/reports", createReport)\n}\n\n` +
+        `func createReport(c *gin.Context) {}\n`,
+    );
+    const a = auth(securityConsistency.detect(ctxOf([...peers, pyUnsure, goUnsure]) as any))!;
+
+    // Both hooks are named...
+    expect(a.recommendation).toContain("verify_session");
+    expect(a.recommendation).toContain("middleware.VerifyToken");
+    // ...but because the hedged deviators span two languages, the noun is the
+    // NEUTRAL "auth hook", never a per-language noun.
+    expect(a.recommendation).toContain("an auth hook (");
+    expect(a.recommendation).not.toContain("before_request hook");
+    expect(a.recommendation).not.toContain("a middleware (");
+  });
+
   it("confident sibling: a plainly-unauthed route (no unsure hook) keeps today's exact flat deviator byte-for-byte", async () => {
     const peers = await Promise.all([peerAuth(1), peerAuth(2), peerAuth(3), peerAuth(4)]);
     const bare = await pyTree("src/routes/x.py", `@app.post("/x")\ndef x():\n    return {}\n`);

--- a/test/unit/output/terminal-hedge.test.ts
+++ b/test/unit/output/terminal-hedge.test.ts
@@ -68,7 +68,13 @@ function securityFinding(recommendation: string): Finding {
 
 const HEDGED_REC =
   "4 of 5 routes have Auth middleware. Review 1 unprotected routes — apply per-route middleware or move them under a router that does. " +
-  "1 of these could not be confirmed: an auth hook (verify_session) may authenticate them but its body could not be verified. " +
+  "1 of these could not be confirmed: a middleware (verify_session) may authenticate them but its body could not be verified. " +
+  "Double check those hooks before treating the routes as unauthenticated.";
+
+// A finding spanning multiple languages falls back to the neutral noun.
+const HEDGED_REC_NEUTRAL =
+  "4 of 5 routes have Auth middleware. Review 1 unprotected routes — apply per-route middleware or move them under a router that does. " +
+  "1 of these could not be confirmed: an auth hook (guard) may authenticate them but its body could not be verified. " +
   "Double check those hooks before treating the routes as unauthenticated.";
 
 const CONFIDENT_REC =
@@ -81,6 +87,15 @@ describe("terminal hedge visibility", () => {
     expect(out).not.toContain("Unprotected routes may be exposed in production");
     // The hedge MUST reach the user: the exact hook and "double check".
     expect(out).toContain("verify_session");
+    expect(out.toLowerCase()).toContain("double check");
+    // Language-aware noun is read back from the recommendation, not hardcoded.
+    expect(out).toContain("The middleware (verify_session)");
+    expect(out).not.toContain("auth hook");
+  });
+
+  it("neutral noun (multi-language finding) still renders the hook name and 'double check'", () => {
+    const out = renderTerminalOutput(mkResult([securityFinding(HEDGED_REC_NEUTRAL)]));
+    expect(out).toContain("The auth hook (guard)");
     expect(out.toLowerCase()).toContain("double check");
   });
 


### PR DESCRIPTION
Makes the auth "double check" hedge name the mechanism accurately per language instead of the fixed Flask-flavored "an auth hook":

- **Python** → "a before_request hook"
- **Go** → "a middleware"
- **Rust** → "an extractor or layer"
- A finding whose hedged hooks span multiple languages falls back to the neutral "an auth hook".

The producer derives the noun from each hedged deviator's file extension; the terminal reads the noun + hook name(s) back out of the recommendation with a noun-agnostic regex anchored on the stable "could not be confirmed:" lead-in, so the producer and terminal stay in sync without enumerating nouns. Confident (non-hedged) findings render byte-identically. Per-language producer assertions + terminal-render assertions + a mixed-language fallback test; suite 1822/1822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)