### PR TITLE
release: 0.16.0 (multi-language security, AST imports, scoring v11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ explicitly under **Breaking** so CI users can recalibrate.
 
 ## [Unreleased]
 
+## 0.16.0 — 2026-07-16
+
+### Added
+
+- **Security Consistency now checks Python, Go, and Rust**, not just
+  JavaScript/TypeScript. The auth check reads the body of the middleware or hook
+  that guards a route and classifies each route as protected, unprotected, or
+  **unsure**. It never marks a route authenticated on a name or type alone — only
+  when a readable guard verifiably rejects (a 401, or a credential-guarded 403).
+  When the guard's body can't be read (imported, opaque, or an extractor type),
+  the route is flagged "unsure, double check" and named, rather than guessed
+  either way. This holds across Flask/FastAPI/Django (Python), Gin/Echo/stdlib
+  (Go), and Axum/Actix/Rocket (Rust).
+- **Cross-file auth resolution.** When a route's guard is a hook imported from
+  another file, the scanner follows the import to that file and reads the real
+  body before deciding, instead of hedging on the name.
+
+### Changed
+
+- **Import graph is now AST-based.** Import and dependency analysis moved from
+  regex to a real tree-sitter AST with module resolution, so imports mentioned
+  in comments or strings no longer produce false-positive dependency drift.
+
+### Breaking
+
+- **Scoring recalibrated (internal scoring version bumped).** Because the auth
+  check now understands Python, Go, and Rust routes, a web repo in those
+  languages that carries real auth inconsistency may see its Security Consistency
+  (and composite) score move to reflect drift that was always present — a Flask
+  app in our testing dropped about 5 points. Repos whose auth is uniform or
+  expressed only through extractor types, and repos without those route shapes,
+  are unchanged. Saved scores are kept as-is, the new method applies to new
+  scans, cross-version score deltas are suppressed, and the CLI shows a one-time
+  notice linking to the release notes. CI users gating on `--fail-on-score` for
+  an affected repo should re-check their threshold.
+
 ## 0.15.0 — 2026-07-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibedrift/cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Ship agentic. Stay coherent. Self-checking code integrity for AI coding agents, in the loop via MCP.",
   "type": "module",
   "bin": {

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -55,12 +55,23 @@ import {
  *        mutating routes reflects the security_posture drift it always had.
  *        Only repos with those route shapes move; every other repo is byte
  *        identical, and the bundled calibration corpus is unchanged.
+ *   v11: multi-language security auth + AST import graph. The security auth vote
+ *        now runs body-first route + auth extraction for Python, Go, and Rust
+ *        (was JS/TS + regex-Flask only), with cross-file hook resolution and a
+ *        conservative "unsure" state that never false-blesses. A Python/Go/Rust
+ *        web repo with real auth inconsistency now reflects the security_posture
+ *        drift it always had (e.g. a Flask app's composite ~ -5); repos with
+ *        uniform or extractor-typed auth are unchanged. Separately, the import
+ *        graph moved from regex to AST with real module resolution, dropping
+ *        false-positive import/dependency drift. Repos without Python/Go/Rust
+ *        routes or import-drift false positives are byte identical; the bundled
+ *        calibration corpus is unchanged.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v10";
+export const SCORING_VERSION = "v11";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;


### PR DESCRIPTION
Prepares the 0.16.0 release.

- Bumps `package.json` to 0.16.0 and `SCORING_VERSION` to v11.
- CHANGELOG 0.16.0: Security Consistency now checks Python/Go/Rust auth (was JS/TS only) with cross-file resolution and a conservative "unsure, double check" state; import graph moved from regex to AST; scoring recalibrated (cross-version deltas suppressed + one-time notice).

Measured impact (v0.15.0 vs this build, real repos): a Flask app's composite dropped ~5 pts as improved auth detection surfaced real gaps; uniform / extractor-typed-auth repos unchanged. Suite 1822/1822.

Publish (`npm publish`) is gated on explicit approval and happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)