### PR TITLE
Release 0.16.1, scoring v12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,35 @@ explicitly under **Breaking** so CI users can recalibrate.
 
 ## [Unreleased]
 
+## 0.16.1 — 2026-07-16
+
 ### Changed
 
 - **Deep-scan results now show in the default output.** The default terminal summary
   surfaces the AI results a deep scan produced — the coherence grade (paid plans), the
   AI summary, the top AI finding, and the AI-validated finding count — instead of only
   under `--format terminal` or in the report. Non-deep scans are unchanged.
+- **Scoring refined (recalibration).** Three precision fixes move the score only for
+  repos they touch: the Go security auth check now reads routes registered on Fiber and
+  Gorilla mux routers, dependency drift no longer counts import-like text sitting inside
+  comments or strings, and files with regex special characters in their names classify
+  correctly. Affected repos may see their Vibe Drift Score move to reflect drift that was
+  always there (or shed false positives); every other repo is unchanged. Saved scores are
+  kept as-is, the new method applies to new scans, and the CLI shows a one-time notice.
+  CI users gating on `--fail-on-score` for such repos should re-check their threshold.
+
+### Added
+
+- **Go: Fiber and Gorilla mux route coverage.** Routes registered through Fiber and
+  Gorilla mux router constructors now enter the security auth-consistency check, so an
+  unauthed mutating route in those frameworks is flagged like its Gin and Echo peers.
+
+### Fixed
+
+- **Dependency drift ignores imports in comments and strings.** An import statement
+  quoted in a doc comment or a string literal no longer shows up as dependency drift.
+- **Filenames with special characters classify correctly.** Code-DNA patterns derived
+  from file names now escape regex metacharacters instead of misreading them.
 
 ## 0.16.0 — 2026-07-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibedrift/cli",
-  "version": "0.15.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibedrift/cli",
-      "version": "0.15.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibedrift/cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Ship agentic. Stay coherent. Self-checking code integrity for AI coding agents, in the loop via MCP.",
   "type": "module",
   "bin": {

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -66,12 +66,21 @@ import {
  *        false-positive import/dependency drift. Repos without Python/Go/Rust
  *        routes or import-drift false positives are byte identical; the bundled
  *        calibration corpus is unchanged.
+ *   v12: detection-precision batch. (1) The Go security auth vote now extracts
+ *        routes registered on Fiber and Gorilla mux router constructors, so a
+ *        Go repo using those frameworks reflects the security_posture drift it
+ *        always had. (2) The dependency scan ignores import-like text inside
+ *        comments and strings, dropping false dependency-drift findings.
+ *        (3) Code-DNA filename-derived patterns escape regex metacharacters,
+ *        fixing misclassification for files with special characters in their
+ *        names. Only repos in those three slices move; every other repo is
+ *        byte identical, and the bundled calibration corpus is unchanged.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v11";
+export const SCORING_VERSION = "v12";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;

--- a/todo.md
+++ b/todo.md
@@ -1,11 +1,5 @@
 # CLI backlog
 
-- **Next publish: consider a `SCORING_VERSION` v12 bump + release-notes entry.** Three
-  unpublished commits on main change scan verdicts (Fiber/Gorilla router constructors in the
-  Go security lane, dependency scan ignoring import-like text in comments/strings, codedna
-  regex-metacharacter escape). If they ship, bump the version so stored scores backfill
-  silently, and describe the change on vibedrift.ai/releases before/at publish.
-
 - **Import-style drift is JS/TS only ([#56](https://github.com/VibeDrift/VibeDrift/issues/56)).** No import
   convention check for Python, Go, or Rust (`imports` analyzer and the `import-consistency` detector are both
   JS/TS-gated). Other languages get import parsing only for dependency/dead-code, not a style signal. Candidate


### PR DESCRIPTION
## What

Patch release. Ships the inline deep-scan AI summary (#57) plus three detection-precision fixes that were already on main, and bumps `SCORING_VERSION` v11 → v12 so affected repos get the standard silent migration (baselines rebuild, cross-version deltas suppressed, one-time notice).

## Why v12

Three commits change scan verdicts for narrow slices:
- Go security auth vote now sees Fiber and Gorilla mux router constructors
- Dependency drift ignores import-like text inside comments and strings
- Code-DNA filename-derived patterns escape regex metacharacters

Same policy as the v10 and v11 bumps: only repos in those slices move, everyone else is byte identical, calibration corpus unchanged.

See CHANGELOG 0.16.1 for the user-facing notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)