### PR TITLE
Release 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ explicitly under **Breaking** so CI users can recalibrate.
 
 ## [Unreleased]
 
+## 0.16.2 — 2026-07-16
+
 ### Fixed
 
 - **Cross-version score deltas are now fully suppressed.** The scan-over-scan diff refuses
@@ -13,7 +15,9 @@ explicitly under **Breaking** so CI users can recalibrate.
   resolved/new claims, in the terminal banner and in the committed `.vibedrift/context.md`
   trajectory alike, including when `--since` targets a scan from an older engine.
   Previously the suppression covered the score header, but a cross-version delta could
-  still reach the diff surfaces and be committed into `context.md`.
+  still reach the diff surfaces and be committed into `context.md`. The first scan after
+  a scoring upgrade simply shows no "since last scan" section; normal diffs resume from
+  the very next scan.
 
 ## 0.16.1 — 2026-07-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibedrift/cli",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Ship agentic. Stay coherent. Self-checking code integrity for AI coding agents, in the loop via MCP.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release: ships #61 (cross-version scan comparisons refused across every diff surface, `--since` included). No scoring-version change — verdicts and scores are byte-identical; this only stops an engine upgrade from being presented as a code change in the diff banner and the committed `context.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)