### PR TITLE
fix(output): three honesty fixes in scan output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ explicitly under **Breaking** so CI users can recalibrate.
   the dashboard) omits it instead of showing a full-score bar next to the N/A.
 - Removed a crash risk on extremely large finding sets (whole-array argument spreads
   replaced with loops).
+- **Signed-in users no longer see the sign-in nudge.** `vibedrift watch` and any signed-in
+  `--format terminal` scan previously ended with "Sign in with `vibedrift login`" even
+  though the session was already authenticated. Signed-in state is now resolved locally
+  (zero egress — `--local-only` and `watch` are unaffected) and the closing line reads
+  "Run `vibedrift . --deep` to reveal them. Your first deep scan each month is free."
+- **The "Since last scan" diff no longer calls advisory findings drift.** The diff digest
+  and the persisted scan are both built from the scored drift view, so a below-floor
+  security finding (or a `@vibedrift-public` suppression) that the report renders as
+  advisory can no longer appear as a "new drift finding" in the banner or in
+  `.vibedrift/context.md`. Note: the first scan after this upgrade on a repo whose history
+  already persisted such findings reports them as "resolved" once, then self-heals.
 
 ## 0.16.2 — 2026-07-16
 

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -389,6 +389,7 @@ async function buildScanResult(
   startTime: number,
   timings: Record<string, number>,
   bearerToken: string | null,
+  signedIn: boolean,
   apiUrl: string | undefined,
   spinner: ReturnType<typeof ora> | null,
 ): Promise<ScanResult> {
@@ -468,7 +469,7 @@ async function buildScanResult(
   // Tease — show "run --deep" upsell only when user is *not* using deep mode.
   // Pass codeDnaResult so the tease can name specific near-duplicate files
   // and opaque-named functions deep scan would confirm, not generic copy.
-  const teaseMessages = generateTeaseMessages(ctx, allFindings, options.deep === true, codeDnaResult, bearerToken !== null);
+  const teaseMessages = generateTeaseMessages(ctx, allFindings, options.deep === true, codeDnaResult, signedIn);
   // Free Tier-1 reimplementation teaser (count only). Skipped on deep scans —
   // there the real panel-confirmed ml-reimplementation findings render instead.
   const reimplementationCandidates = options.deep
@@ -1135,6 +1136,15 @@ export async function runScan(
     ? await resolveAuthAndBanner(options)
     : { bearerToken: null, apiUrl: undefined };
 
+  // Signed-in state is independent of network mode. bearerToken is hard-set to
+  // null under --local-only (and `vibedrift watch` always scans local-only), so
+  // it cannot answer "is this user signed in?". resolveToken() is purely local
+  // (flag → env → config file, zero egress), so we can detect a signed-in
+  // session without breaking the --local-only zero-egress promise. This drives
+  // the tease copy only; every network path stays gated on the real bearerToken.
+  // (#64 item 1: a signed-in watch session must not print the sign-in nudge.)
+  const signedIn = bearerToken !== null || (await resolveToken()) !== null;
+
   // Kick off the passive update check as soon as we know the network
   // is allowed. Runs in parallel with the scan so it adds zero latency
   // in the common case (cache hit) and ~200ms worst-case (uncached
@@ -1170,7 +1180,7 @@ export async function runScan(
 
   const timings = { ...pipeline.timings, ...deepTimings.timings };
 
-  const result = await buildScanResult(pipeline, options, startTime, timings, bearerToken, apiUrl, spinner);
+  const result = await buildScanResult(pipeline, options, startTime, timings, bearerToken, signedIn, apiUrl, spinner);
 
   // Persist the RepoDriftBaseline as a scan side-effect so the MCP server's
   // cold start is a fast load rather than a 3–8s rebuild. Reuses the ctx +
@@ -1294,14 +1304,11 @@ export async function runScan(
   // Persisting `scoringVersion` lets future scans detect that this scan was
   // computed under a different formula and skip cross-version deltas.
   //
-  // Use the RAW driftResult.driftFindings (not the rendered/filtered
-  // result.driftFindings) so the persisted drift digests match the ones the
-  // scan-over-scan diff computes from the same raw array (see buildScanResult).
-  // If these two sources diverged, a below-floor security finding present in
-  // one but not the other would show as a spurious "new/resolved drift finding"
   // Save using the scored (rendered) drift view so the persisted scan matches
-  // the diff digest. A below-floor advisory never produces a spurious diff.
-  // The baseline (assembleBaseline) still reads the raw representation.
+  // the diff digest the scan-over-scan comparison computes from the same view.
+  // A below-floor advisory finding therefore never shows as a spurious
+  // "new/resolved drift finding". The baseline (assembleBaseline) still reads
+  // the raw representation.
   await saveScanResult(
     rootDir,
     result.scores,

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -468,7 +468,7 @@ async function buildScanResult(
   // Tease — show "run --deep" upsell only when user is *not* using deep mode.
   // Pass codeDnaResult so the tease can name specific near-duplicate files
   // and opaque-named functions deep scan would confirm, not generic copy.
-  const teaseMessages = generateTeaseMessages(ctx, allFindings, options.deep === true, codeDnaResult);
+  const teaseMessages = generateTeaseMessages(ctx, allFindings, options.deep === true, codeDnaResult, bearerToken !== null);
   // Free Tier-1 reimplementation teaser (count only). Skipped on deep scans —
   // there the real panel-confirmed ml-reimplementation findings render instead.
   const reimplementationCandidates = options.deep

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -486,6 +486,15 @@ async function buildScanResult(
   parts.push(`Total: ${(scanTimeMs / 1000).toFixed(1)}s`);
   console.error(chalk.dim(`  ${parts.join(" · ")}`));
 
+  // The DRIFT representation that rendering reads excludes below-floor
+  // route-consistency security findings (demoted to advisory; still present in
+  // `allFindings`/`result.findings` as hygiene-kind so we are never silent).
+  // Applied before the diff so saved scans and the diff digest agree with the
+  // rendered output — a below-floor advisory never appears as "new drift" in
+  // the comparison banner. driftResult.driftFindings itself is untouched so
+  // the baseline (assembleBaseline) still reads the raw representation.
+  const rendered = scoredDriftView(driftResult.driftFindings ?? [], ctx.totalLines);
+
   // Scan-over-scan diff. Defaults to enabled; `--no-compare` opts out.
   // `--since` overrides the default "latest prior scan" target.
   let diff: ScanResult["diff"];
@@ -499,7 +508,7 @@ async function buildScanResult(
         compositeScore,
         hygieneScore,
         findingDigests: allFindings.slice(0, 200).map(computeFindingDigest),
-        driftFindingDigests: (driftResult.driftFindings ?? []).slice(0, 100).map(computeDriftFindingDigest),
+        driftFindingDigests: (rendered.driftFindings ?? []).slice(0, 100).map(computeDriftFindingDigest),
         // Lets diffScans refuse cross-version comparisons for THIS pair —
         // `previousScoresMismatch` only covers the latest scan, but `--since`
         // can target any older scan, including one from a prior engine.
@@ -507,18 +516,6 @@ async function buildScanResult(
       });
     }
   }
-
-  // The DRIFT representation that rendering reads excludes below-floor
-  // route-consistency security findings (demoted to advisory; still present in
-  // `allFindings`/`result.findings` as hygiene-kind so we are never silent).
-  // Applying it here, at the single point where result.driftFindings /
-  // result.driftScores are produced, keeps every raw-driftFindings consumer
-  // (findings library, codebase intent, coherence heatmap, pattern consensus,
-  // CSV/DOCX, context.md) and the per-category breakdown consistent with the
-  // category's N/A WITHOUT a gate in each widget. driftResult.driftFindings
-  // itself is untouched, so the baseline (assembleBaseline) and the diff
-  // digests below keep reading the raw drift representation unchanged.
-  const rendered = scoredDriftView(driftResult.driftFindings ?? [], ctx.totalLines);
 
   const result: ScanResult = {
     context: ctx,
@@ -1302,7 +1299,9 @@ export async function runScan(
   // scan-over-scan diff computes from the same raw array (see buildScanResult).
   // If these two sources diverged, a below-floor security finding present in
   // one but not the other would show as a spurious "new/resolved drift finding"
-  // on every scan. Baseline + diff track the raw representation for continuity.
+  // Save using the scored (rendered) drift view so the persisted scan matches
+  // the diff digest. A below-floor advisory never produces a spurious diff.
+  // The baseline (assembleBaseline) still reads the raw representation.
   await saveScanResult(
     rootDir,
     result.scores,
@@ -1310,7 +1309,7 @@ export async function runScan(
     result.hygieneScores,
     result.hygieneScore,
     result.findings,
-    pipeline.driftResult.driftFindings,
+    result.driftFindings,
     result.scoringVersion,
   );
 

--- a/src/output/tease.ts
+++ b/src/output/tease.ts
@@ -64,6 +64,7 @@ export function generateTeaseMessages(
   findings: Finding[],
   deepUsed: boolean,
   codeDnaResult?: CodeDnaResult,
+  isSignedIn?: boolean,
 ): string[] {
   if (deepUsed) return [];
   const messages: string[] = [];
@@ -152,7 +153,11 @@ export function generateTeaseMessages(
   }
 
   if (messages.length > 0) {
-    messages.push(`Sign in with \`vibedrift login\` (free, 10s) and run \`vibedrift --deep\`. 1 free deep scan/month.`);
+    if (isSignedIn) {
+      messages.push(`Run \`vibedrift . --deep\` to reveal them. Your first deep scan each month is free.`);
+    } else {
+      messages.push(`Sign in with \`vibedrift login\` (free, 10s) and run \`vibedrift --deep\`. 1 free deep scan/month.`);
+    }
   }
 
   return messages;

--- a/test/calibration/README.md
+++ b/test/calibration/README.md
@@ -84,7 +84,7 @@ Injection  Composite  Drift   Δ composite  Δ drift
      90%       42.2    35.8        -12.8   -12.8
 
 monotonicity: ✓  (composite + drift both strictly decrease)
-responsiveness: ✓  (each +25% drift yields ≥5pt score drop)
+responsiveness: ✓  (each +25% drift yields ≥3pt score drop)
 ```
 
 ## Python security fixture (the multilang calibration gate)
@@ -371,11 +371,11 @@ row at >= 0.95, unaffected by this row).
 
 ## Adding a new injection type
 
-Drop a generator in `generators/`. Signature:
+Add an injector function to `test/calibration/injectors.ts`. Signature:
 
 ```ts
-export function injectFoo(baseline: Baseline, rate: number): Baseline
+export function injectFoo(baseline: BaselineFile[], rate: number): BaselineFile[]
 ```
 
 Where `rate` is 0-1 (fraction of files to deviate). Add it to
-`run.ts`'s list of generators and it'll sweep alongside the others.
+`run.ts`'s list of injectors and it'll sweep alongside the others.

--- a/test/unit/output/scan-diff-advisory.test.ts
+++ b/test/unit/output/scan-diff-advisory.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { scoredDriftView } from "../../../src/drift/index.js";
+import { buildSuppressionAuditFinding } from "../../../src/drift/security-suppression.js";
+import { diffScans } from "../../../src/output/history-diff.js";
+import { computeDriftFindingDigest, type SavedScan } from "../../../src/core/history.js";
+import type { DriftFinding } from "../../../src/drift/types.js";
+import type { CategoryScores } from "../../../src/core/types.js";
+
+/**
+ * Regression suite for #64 item 2: the "Since last scan" diff must not call
+ * something drift that the report itself renders as advisory.
+ *
+ * buildScanResult now derives the scored drift view (scoredDriftView) ONCE and
+ * feeds BOTH the persisted scan (result.driftFindings → saveScanResult) and the
+ * scan-over-scan diff digest from it. scoredDriftView drops below-floor security
+ * findings and the suppression-audit finding, so neither can surface as a
+ * spurious "new/resolved drift finding" in the diff banner. These tests exercise
+ * the real functions (scoredDriftView, diffScans, computeDriftFindingDigest).
+ */
+
+const TOTAL_LINES = 500;
+
+// Above MIN_SECURITY_PEERS and a real dominance vote — belongs in the drift view.
+function normalDrift(): DriftFinding {
+  return {
+    detector: "convention-oscillation",
+    subCategory: "case_style",
+    driftCategory: "naming_conventions",
+    severity: "warning",
+    confidence: 0.8,
+    finding: "3 files use snake_case while peers use camelCase",
+    dominantPattern: "camelCase",
+    dominantCount: 8,
+    totalRelevantFiles: 11,
+    consistencyScore: 73,
+    deviatingFiles: [{ path: "src/a.ts", detectedPattern: "snake_case", evidence: [{ line: 1, code: "x" }] }],
+    dominantFiles: [],
+    recommendation: "Use camelCase.",
+  };
+}
+
+// Peer sample of 3 < MIN_SECURITY_PEERS (4): the "small repo, 2-3 mutating
+// routes, one auth gap". Demoted to advisory; excluded from the drift view.
+function belowFloorSecurity(): DriftFinding {
+  return {
+    detector: "security_posture",
+    subCategory: "Auth middleware",
+    driftCategory: "security_posture",
+    severity: "warning",
+    confidence: 0.6,
+    finding: "1 mutating route(s) lack auth while the codebase uses auth elsewhere",
+    dominantPattern: "auth on mutating routes",
+    dominantCount: 2,
+    totalRelevantFiles: 3,
+    consistencyScore: 67,
+    deviatingFiles: [
+      { path: "src/routes/admin.ts", detectedPattern: "POST /admin no auth", evidence: [{ line: 12, code: "POST /admin" }] },
+    ],
+    dominantFiles: [],
+    recommendation: "Add auth middleware, or confirm it is intentionally public.",
+  };
+}
+
+const EMPTY_SCORES: CategoryScores = {
+  architecturalConsistency: { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: true },
+  redundancy: { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: true },
+  dependencyHealth: { score: 0, maxScore: 20, locked: false, findingCount: 0, applicable: false },
+  securityPosture: { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: true },
+  intentClarity: { score: 20, maxScore: 20, locked: false, findingCount: 0, applicable: true },
+};
+
+function savedScan(driftFindingDigests: string[]): SavedScan {
+  return {
+    timestamp: "2026-04-19T10:00:00Z",
+    rootDir: "/x",
+    schemaVersion: 3,
+    scores: EMPTY_SCORES,
+    compositeScore: 80,
+    hygieneScore: 100,
+    findingDigests: [],
+    driftFindingDigests,
+  };
+}
+
+function currentScan(driftFindingDigests: string[]) {
+  return {
+    timestamp: new Date().toISOString(),
+    compositeScore: 80,
+    hygieneScore: 100,
+    findingDigests: [] as string[],
+    driftFindingDigests,
+  };
+}
+
+describe("scan diff / advisory consistency (#64 item 2)", () => {
+  it("scoredDriftView drops below-floor security and suppression findings — the single source both saveScanResult and the diff digest read", () => {
+    const suppression = buildSuppressionAuditFinding([
+      { path: "src/routes/public.ts", line: 3, reason: "annotation", source: "@vibedrift-public" },
+    ]);
+    const raw = [normalDrift(), belowFloorSecurity(), suppression];
+    const { driftFindings } = scoredDriftView(raw, TOTAL_LINES);
+    expect(driftFindings).toHaveLength(1);
+    expect(driftFindings[0].driftCategory).toBe("naming_conventions");
+  });
+
+  it("a below-floor advisory finding introduced between two scans does not appear as new drift", () => {
+    // Previous scan: only the normal drift finding.
+    const previous = savedScan([normalDrift()].map(computeDriftFindingDigest));
+    // Current RAW set gained a below-floor advisory; the diff digest is built
+    // from the scored view (as buildScanResult does), which excludes it.
+    const scored = scoredDriftView([normalDrift(), belowFloorSecurity()], TOTAL_LINES).driftFindings;
+    const diff = diffScans(previous, currentScan(scored.map(computeDriftFindingDigest)));
+    expect(diff.driftFindingsDiff.new).toHaveLength(0);
+    expect(diff.driftFindingsDiff.persistent).toHaveLength(1); // the normal finding carries over
+  });
+
+  it("adding or removing a @vibedrift-public suppression between two scans is neither new nor resolved drift", () => {
+    const suppression = buildSuppressionAuditFinding([
+      { path: "src/routes/public.ts", line: 3, reason: "annotation", source: "@vibedrift-public" },
+    ]);
+
+    // Adding a suppression: previous had none, current gains one → not "new".
+    const prevNoSuppression = savedScan(
+      scoredDriftView([normalDrift()], TOTAL_LINES).driftFindings.map(computeDriftFindingDigest),
+    );
+    const withSuppression = scoredDriftView([normalDrift(), suppression], TOTAL_LINES).driftFindings;
+    const added = diffScans(prevNoSuppression, currentScan(withSuppression.map(computeDriftFindingDigest)));
+    expect(added.driftFindingsDiff.new).toHaveLength(0);
+
+    // Removing a suppression: previous had one, current drops it → not "resolved".
+    const prevWithSuppression = savedScan(
+      scoredDriftView([normalDrift(), suppression], TOTAL_LINES).driftFindings.map(computeDriftFindingDigest),
+    );
+    const withoutSuppression = scoredDriftView([normalDrift()], TOTAL_LINES).driftFindings;
+    const removed = diffScans(prevWithSuppression, currentScan(withoutSuppression.map(computeDriftFindingDigest)));
+    expect(removed.driftFindingsDiff.resolved).toHaveLength(0);
+  });
+
+  it("the saved scan and the diff digest are built from the same scored source", () => {
+    const raw = [normalDrift(), belowFloorSecurity()];
+    const scored = scoredDriftView(raw, TOTAL_LINES).driftFindings;
+    // buildScanResult sets result.driftFindings = scored (what saveScanResult
+    // persists) AND builds the diff digest from that same scored array.
+    const savedDigests = scored.map(computeDriftFindingDigest);
+    const diffDigests = scored.map(computeDriftFindingDigest);
+    expect(savedDigests).toEqual(diffDigests);
+    // The below-floor advisory's digest is in neither.
+    expect(savedDigests).not.toContain(computeDriftFindingDigest(belowFloorSecurity()));
+  });
+});

--- a/test/unit/output/tease.test.ts
+++ b/test/unit/output/tease.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { countReimplementationCandidates } from "../../../src/output/tease.js";
+import { generateTeaseMessages, countReimplementationCandidates } from "../../../src/output/tease.js";
 import type { ExtractedFunction } from "../../../src/codedna/types.js";
+import type { AnalysisContext } from "../../../src/core/types.js";
+import type { CodeDnaResult } from "../../../src/codedna/types.js";
 
 function mkFn(p: Partial<ExtractedFunction>): ExtractedFunction {
   return {
@@ -61,5 +63,41 @@ describe("countReimplementationCandidates", () => {
       mkFn({ name: "formatDate", relativePath: "src/a.ts" }),
       mkFn({ name: "formatDate", relativePath: "src/c.ts" }),
     ])).toBe(2);
+  });
+});
+
+describe("generateTeaseMessages — auth-aware sign-in nudge (#64 item 1)", () => {
+  const SIGN_IN_ASK = "Sign in with `vibedrift login`";
+  const SIGNED_IN_LINE = "Your first deep scan each month is free";
+
+  // Minimal context; the generic-name signal (below) is what makes the tease
+  // fire, so ctx.files only matters for the fallback path we don't exercise.
+  const ctx = { files: [] } as unknown as AnalysisContext;
+  // A generic-named function with a non-trivial body → Signal 2 fires, so the
+  // tease produces messages and therefore appends a closing line.
+  const dna = {
+    functions: [{ name: "handle", relativePath: "src/a.ts", line: 5, bodyTokenCount: 25 }],
+  } as unknown as CodeDnaResult;
+
+  it("signed-in: closing line never asks the user to sign in", () => {
+    const msgs = generateTeaseMessages(ctx, [], false, dna, true);
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs.join("\n")).not.toContain(SIGN_IN_ASK);
+    expect(msgs.some((m) => m.includes(SIGNED_IN_LINE))).toBe(true);
+  });
+
+  it("signed-out: keeps the existing sign-in copy unchanged", () => {
+    const msgs = generateTeaseMessages(ctx, [], false, dna, false);
+    expect(msgs.some((m) => m.includes(SIGN_IN_ASK))).toBe(true);
+    expect(msgs.join("\n")).not.toContain(SIGNED_IN_LINE);
+  });
+
+  it("defaults to the signed-out copy when isSignedIn is omitted", () => {
+    const msgs = generateTeaseMessages(ctx, [], false, dna);
+    expect(msgs.some((m) => m.includes(SIGN_IN_ASK))).toBe(true);
+  });
+
+  it("emits no tease (and so no nudge) on a deep scan", () => {
+    expect(generateTeaseMessages(ctx, [], true, dna, false)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Three honesty fixes in scan output, addressing items 1–3 of #64.

**1. Watch mode tells signed-in users to sign in**
The sign-in nudge is now gated on whether the session is actually authenticated. The catch the first pass missed: `bearerToken` is hard-set to `null` under `--local-only`, and `vibedrift watch` always scans local-only — so a signed-in watch session still printed the nudge. Fixed by resolving signed-in state independently of the network in `runScan`:

```ts
const signedIn = bearerToken !== null || (await resolveToken()) !== null;
```

`resolveToken()` is purely local (flag → env → config file, zero egress), so this doesn't break the `--local-only` promise. `signedIn` is threaded through `buildScanResult` into `generateTeaseMessages`; every network path still gates on the real `bearerToken`. Signed-in users now see "Run `vibedrift . --deep` to reveal them. Your first deep scan each month is free." with no sign-in ask; signed-out copy is unchanged.

**2. "Since last scan" diff calls advisory findings "drift"**
The diff digest was built from `driftResult.driftFindings` (raw, before advisory demotion), so a below-floor security finding could appear as "new drift" in the diff banner while the report rendered it as advisory/N/A. `scoredDriftView(...)` now runs above the diff, and both the diff digest and `saveScanResult` are fed from the scored view. The baseline (`assembleBaseline`) still reads the raw representation unchanged.

**3. Calibration README describes a harness that no longer exists**
- Sample output claimed `≥5pt` drop per 25% injection; actual gate is `REQUIRED_DROP_PER_25PCT = 3.0`
- "Adding a new injection type" referenced a `generators/` directory that doesn't exist; injectors live in `test/calibration/injectors.ts` with a `BaselineFile[]` signature

## Changes since review

Addressing @skhan75's review:

- **Watch path now actually fixed (blocking 1).** Switched from `bearerToken !== null` to the local `resolveToken()`-based `signedIn` above, so a signed-in `vibedrift watch` session no longer prints the nudge — the first acceptance criterion. Confirmed the path: `watch` → `runScan(localOnly: true)` → `buildScanResult` → `generateTeaseMessages(signedIn)`.
- **Regression tests added (blocking 2).**
  - `test/unit/output/tease.test.ts` — both copy branches (signed-in never contains "Sign in with"; signed-out unchanged; defaults to signed-out; deep scan emits no tease).
  - `test/unit/output/scan-diff-advisory.test.ts` — `scoredDriftView` drops below-floor security + suppression findings; a below-floor advisory introduced between scans is not "new" drift; a `@vibedrift-public` suppression is neither "new" nor "resolved"; the saved scan and diff digest come from the same scored source.
- **Stale comment removed (blocking 3).** The old RAW-`driftFindings` comment above `saveScanResult` contradicted the new code; removed the outdated half so it tells one story.
- **CHANGELOG.** Added Unreleased notes for the sign-in and diff/advisory fixes, including the one-time "resolved" self-heal on the first scan after upgrade.

One deliberate choice on your non-blocking note: I kept the signed-in closing line (it carries the "first deep scan free" CTA) rather than dropping it in favor of the banner — happy to switch to the no-line approach if you'd prefer.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Closes #64 (items 1, 2, 3 — item 4 shipped in #66)
