### PR TITLE
fix(security): skip comment lines in regex route fallback (#64 item 4)

### DIFF
--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -340,6 +340,21 @@ function inheritedRateLimit(perRoute: boolean, fileMw: FileMiddleware | undefine
   return perRoute || (fileMw?.hasRateLimit ?? false);
 }
 
+// ─── Regex-fallback comment skipping ─────────────────────────────────
+// The regex route extractors (used when tree-sitter has no clean parse) match
+// route-shaped text line by line. A commented-out registration must NOT become
+// a phantom route — it would steal a @vibedrift-public annotation from the real
+// route below it (see #64 item 4). JS/TS and Go share C-style comments, so their
+// markers live in one place; Python differs (# line comments, """/''' docstrings).
+const C_STYLE_COMMENT_MARKERS = ["//", "/*"] as const; // JS, TS, Go
+const PYTHON_COMMENT_MARKERS = ["#"] as const;
+
+/** True when a source line is a line comment for the given markers. */
+function isCommentLine(line: string, markers: readonly string[]): boolean {
+  const trimmed = line.trimStart();
+  return markers.some((m) => trimmed.startsWith(m));
+}
+
 function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>, xfile: CrossFileIndex) {
   // AST only on a CLEAN parse: tree-sitter always returns a tree for broken Go
   // (with ERROR nodes), and error recovery SWALLOWS later valid registrations
@@ -368,9 +383,8 @@ function extractGoRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddlewa
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const trimmed = line.trimStart();
-    // Skip comment lines — prevents phantom routes from commented-out code
-    if (trimmed.startsWith("//") || trimmed.startsWith("/*")) continue;
+    // Skip comment lines — prevents phantom routes from commented-out code.
+    if (isCommentLine(line, C_STYLE_COMMENT_MARKERS)) continue;
     let method = "", path = "";
     const echoMatch = line.match(echoPattern);
     if (echoMatch) { method = echoMatch[1]; path = echoMatch[2]; }
@@ -409,9 +423,8 @@ function extractJsRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddlewa
   const expressPattern = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trimStart();
-    // Skip comment lines — prevents phantom routes from commented-out code
-    if (trimmed.startsWith("//") || trimmed.startsWith("/*")) continue;
+    // Skip comment lines — prevents phantom routes from commented-out code.
+    if (isCommentLine(lines[i], C_STYLE_COMMENT_MARKERS)) continue;
     const match = lines[i].match(expressPattern);
     if (!match) continue;
     const path = match[1];
@@ -506,10 +519,20 @@ function extractPythonRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMidd
   const lines = file.content.split("\n");
   const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
 
+  let inDocstring = false;
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trimStart();
-    // Skip comment lines — prevents phantom routes from commented-out code
-    if (trimmed.startsWith("#") || trimmed.startsWith("//")) continue;
+    // Track triple-quoted docstring blocks: a route-shaped line inside a
+    // docstring is documentation, not a real registration. An odd count of
+    // triple-quotes on a line toggles the block state.
+    const tripleQuotes = (lines[i].match(/"""|'''/g) ?? []).length;
+    if (inDocstring) {
+      if (tripleQuotes % 2 === 1) inDocstring = false;
+      continue;
+    }
+    if (tripleQuotes % 2 === 1) { inDocstring = true; continue; }
+    // Skip comment lines — Python uses '#'. Prevents phantom routes from
+    // commented-out code.
+    if (isCommentLine(lines[i], PYTHON_COMMENT_MARKERS)) continue;
     const match = lines[i].match(routePattern);
     if (!match) continue;
     const path = match[1];

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -368,6 +368,9 @@ function extractGoRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddlewa
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    const trimmed = line.trimStart();
+    // Skip comment lines — prevents phantom routes from commented-out code
+    if (trimmed.startsWith("//") || trimmed.startsWith("/*")) continue;
     let method = "", path = "";
     const echoMatch = line.match(echoPattern);
     if (echoMatch) { method = echoMatch[1]; path = echoMatch[2]; }
@@ -406,6 +409,9 @@ function extractJsRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddlewa
   const expressPattern = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
 
   for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    // Skip comment lines — prevents phantom routes from commented-out code
+    if (trimmed.startsWith("//") || trimmed.startsWith("/*")) continue;
     const match = lines[i].match(expressPattern);
     if (!match) continue;
     const path = match[1];
@@ -501,6 +507,9 @@ function extractPythonRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMidd
   const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
 
   for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    // Skip comment lines — prevents phantom routes from commented-out code
+    if (trimmed.startsWith("#") || trimmed.startsWith("//")) continue;
     const match = lines[i].match(routePattern);
     if (!match) continue;
     const path = match[1];

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -781,7 +781,7 @@ describe("Python AST wiring (Task 4)", () => {
   const authFinding = (findings: any[]) => findings.find((f) => f.subCategory === "Auth middleware");
 
   // ── Seam 1: dispatch selects AST vs regex ──
-  it("dispatch: a route-shaped COMMENT yields a route via the regex path but NOT via the AST path", async () => {
+  it("dispatch: a route-shaped COMMENT is skipped by both the regex and AST paths (no phantom routes)", async () => {
     // 4 authed POST routes (per-route @requires_auth, which does NOT trip the
     // file-level pyAuth regex) plus a route-shaped COMMENT for /danger. The
     // regex extractor matches the comment (a live over-capture); the AST
@@ -793,12 +793,12 @@ describe("Python AST wiring (Task 4)", () => {
       `@app.post("/d")\n@requires_auth\ndef d(): return {}\n\n` +
       `# @app.post("/danger")\n`;
 
-    // Tree-less (regex): the comment extracts an unauthed POST /danger, so the
-    // 4/5 auth vote fires and cites it.
+    // Tree-less (regex): with the comment-skip fix, the commented-out route
+    // is no longer extracted as a phantom. Only 4 real authed routes exist,
+    // so no auth finding fires (same as the AST path).
     const regexCtx = mkCtx([file("src/routes/orders.py", src, "python")]);
     const regexFinding = authFinding(securityConsistency.detect(regexCtx));
-    expect(regexFinding).toBeDefined();
-    expect(regexFinding!.deviatingFiles.some((d: any) => d.detectedPattern.includes("/danger"))).toBe(true);
+    expect(regexFinding).toBeUndefined();
 
     // With a clean tree (AST): the comment is not a route, so all 4 real routes
     // are authed and no auth finding fires.

--- a/test/unit/drift/security-consistency.test.ts
+++ b/test/unit/drift/security-consistency.test.ts
@@ -806,6 +806,22 @@ describe("Python AST wiring (Task 4)", () => {
     expect(authFinding(securityConsistency.detect(astCtx))).toBeUndefined();
   });
 
+  it("dispatch: a route-shaped line inside a Python docstring is not a phantom route (regex fallback)", () => {
+    // 4 authed POST routes plus a route-shaped line INSIDE a triple-quoted
+    // docstring. Python has no `//` comments, so the fallback tracks `"""`
+    // blocks: the /danger line is documentation, not a registration.
+    const src =
+      `@app.post("/a")\n@requires_auth\ndef a(): return {}\n\n` +
+      `@app.post("/b")\n@requires_auth\ndef b(): return {}\n\n` +
+      `@app.post("/c")\n@requires_auth\ndef c(): return {}\n\n` +
+      `@app.post("/d")\n@requires_auth\ndef d(): return {}\n\n` +
+      `"""\nExample usage:\n    @app.post("/danger")\n"""\n`;
+    // No tree -> regex fallback. The docstring-enclosed route must NOT become a
+    // phantom unauthed deviator, so no auth finding fires.
+    const regexFinding = authFinding(securityConsistency.detect(mkCtx([file("src/routes/orders.py", src, "python")])));
+    expect(regexFinding).toBeUndefined();
+  });
+
   it("tree-less parity: a plain @app.route(methods=['POST']) file still yields its route via the regex fallback", () => {
     const src =
       `@app.post("/a")\n@requires_auth\ndef a(): return {}\n` +


### PR DESCRIPTION
## Summary

Addresses item 4 of #64 ("The suppression fallback can silently hide a route on a malformed line"). 

**Note:** The issue description was light on specifics for this item. Based on some investigation, I believe the scenario is: the regex fallback route extractors match route-like patterns inside comment lines, creating phantom `RouteInfo` entries that can steal `@vibedrift-public` annotations from adjacent real routes. If this isn't the intended scenario, happy to close this and adjust.

**The bug:**
```go
// @vibedrift-public                         ← annotation (line 6)
// r.POST("/admin/nuke", nukeHandler)        ← regex matches this comment (line 7)
r.POST("/admin/nuke", nukeHandler)           ← real route (line 8)
```

The regex creates a phantom route at line 7. The annotation on line 6 binds to the phantom (preceding-line match). The phantom gets suppressed and silently disappears from the vote. The real route on line 8 loses its intended suppression — it stays in the vote and gets flagged as "lacking auth" despite the user's `@vibedrift-public` intent.

**Fix:** Added comment-line skipping in all three regex fallback extractors (Go, JS/TS, Python) before matching route patterns:
- Go/JS: skip lines starting with `//` or `/*`
- Python: skip lines starting with `#` or `//`

The AST path was already immune (comment nodes never produce route registrations).

**Verified:** Existing test "route-shaped COMMENT" updated from asserting the old (buggy) behavior to the new behavior — both regex and AST paths now agree (no phantom routes from comments).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Partially closes #64 (item 4)
