### PR TITLE
refactor(security): per-language route-extractor modules behind Route…

### DIFF
--- a/src/drift/route-extractors/go.ts
+++ b/src/drift/route-extractors/go.ts
@@ -15,44 +15,49 @@ import {
   inheritedRateLimit,
   findHandlerContent,
 } from "./shared.js";
+import {
+  GO_ROUTE_ECHO,
+  GO_ROUTE_GORILLA,
+  GO_AUTH,
+  GO_VALIDATION,
+  GO_RATE_LIMIT,
+  GO_ERROR_HANDLER,
+} from "./patterns.js";
 
 function extractGoRoutesRegex(file: DriftFile, fileMiddleware: FileMiddleware | undefined): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const lines = file.content.split("\n");
-  const echoPattern = /\.\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/;
-  const gorillaPattern = /HandleFunc\s*\(\s*"([^"]+)".*\.Methods\s*\(\s*"(\w+)"/;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     // Skip comment lines — prevents phantom routes from commented-out code.
     if (isCommentLine(line, C_STYLE_COMMENT_MARKERS)) continue;
     let method = "", path = "";
-    const echoMatch = line.match(echoPattern);
+    const echoMatch = line.match(GO_ROUTE_ECHO);
     if (echoMatch) { method = echoMatch[1]; path = echoMatch[2]; }
-    const gorillaMatch = line.match(gorillaPattern);
+    const gorillaMatch = line.match(GO_ROUTE_GORILLA);
     if (gorillaMatch) { path = gorillaMatch[1]; method = gorillaMatch[2]; }
     if (!method || !path) continue;
 
     const context = lines.slice(Math.max(0, i - 10), i + 10).join("\n");
     const handlerContent = findHandlerContent(file.content, path);
 
-    const perAuth = /[Aa]uth|[Tt]oken|require[A-Z]|middleware\.\w*[Aa]uth/.test(context);
-    const perVal = /[Bb]ind|[Vv]alidat|[Pp]arse/.test(handlerContent);
-    const perRate = /[Rr]ate[Ll]imit|[Tt]hrottle/.test(context + handlerContent);
+    const perAuth = GO_AUTH.test(context);
+    const perVal = GO_VALIDATION.test(handlerContent);
+    const perRate = GO_RATE_LIMIT.test(context + handlerContent);
 
     routes.push({
       method, path, file: file.relativePath, line: i + 1,
       hasAuth: inheritedAuth(perAuth, fileMiddleware),
       hasValidation: inheritedValidation(perVal, fileMiddleware),
       hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
-      hasErrorHandler: /catch|err\s*!=\s*nil|try|except|\.catch/.test(handlerContent),
+      hasErrorHandler: GO_ERROR_HANDLER.test(handlerContent),
     });
   }
   return routes;
 }
 
 export const goRouteExtractor: RouteExtractor = {
-  language: "go",
   extract(file, deps) {
     // AST only on a CLEAN parse: tree-sitter always returns a tree for broken Go
     // (with ERROR nodes), and error recovery SWALLOWS later valid registrations

--- a/src/drift/route-extractors/go.ts
+++ b/src/drift/route-extractors/go.ts
@@ -1,0 +1,71 @@
+/**
+ * Go route extractor — Echo / Gin / Gorilla mux.
+ *
+ * AST on a CLEAN parse (delegated to security-ast-go), regex fallback otherwise.
+ */
+
+import type { DriftFile } from "../types.js";
+import { extractGoRoutesAst } from "../security-ast-go.js";
+import type { RouteInfo, FileMiddleware, RouteExtractor } from "./types.js";
+import {
+  C_STYLE_COMMENT_MARKERS,
+  isCommentLine,
+  inheritedAuth,
+  inheritedValidation,
+  inheritedRateLimit,
+  findHandlerContent,
+} from "./shared.js";
+
+function extractGoRoutesRegex(file: DriftFile, fileMiddleware: FileMiddleware | undefined): RouteInfo[] {
+  const routes: RouteInfo[] = [];
+  const lines = file.content.split("\n");
+  const echoPattern = /\.\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/;
+  const gorillaPattern = /HandleFunc\s*\(\s*"([^"]+)".*\.Methods\s*\(\s*"(\w+)"/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip comment lines — prevents phantom routes from commented-out code.
+    if (isCommentLine(line, C_STYLE_COMMENT_MARKERS)) continue;
+    let method = "", path = "";
+    const echoMatch = line.match(echoPattern);
+    if (echoMatch) { method = echoMatch[1]; path = echoMatch[2]; }
+    const gorillaMatch = line.match(gorillaPattern);
+    if (gorillaMatch) { path = gorillaMatch[1]; method = gorillaMatch[2]; }
+    if (!method || !path) continue;
+
+    const context = lines.slice(Math.max(0, i - 10), i + 10).join("\n");
+    const handlerContent = findHandlerContent(file.content, path);
+
+    const perAuth = /[Aa]uth|[Tt]oken|require[A-Z]|middleware\.\w*[Aa]uth/.test(context);
+    const perVal = /[Bb]ind|[Vv]alidat|[Pp]arse/.test(handlerContent);
+    const perRate = /[Rr]ate[Ll]imit|[Tt]hrottle/.test(context + handlerContent);
+
+    routes.push({
+      method, path, file: file.relativePath, line: i + 1,
+      hasAuth: inheritedAuth(perAuth, fileMiddleware),
+      hasValidation: inheritedValidation(perVal, fileMiddleware),
+      hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
+      hasErrorHandler: /catch|err\s*!=\s*nil|try|except|\.catch/.test(handlerContent),
+    });
+  }
+  return routes;
+}
+
+export const goRouteExtractor: RouteExtractor = {
+  language: "go",
+  extract(file, deps) {
+    // AST only on a CLEAN parse: tree-sitter always returns a tree for broken Go
+    // (with ERROR nodes), and error recovery SWALLOWS later valid registrations
+    // into a broken call's argument_list as clean-looking nested calls (a
+    // cross-bless hazard). Any parse error routes the whole file to the regex,
+    // byte-identical to today's behavior INCLUDING the regex path's known
+    // over-blesses (see the pinned-legacy tests).
+    if (file.tree && !file.tree.rootNode.hasError) {
+      // The cross-file index lets an imported package middleware selector resolve
+      // to its in-repo defining body; an unresolved / external / index-disabled
+      // selector stays UNSURE, byte-identical to the in-file-only path.
+      return extractGoRoutesAst(file.tree, file.relativePath, deps.xfile);
+    }
+    return extractGoRoutesRegex(file, deps.fileMw.get(file.relativePath));
+  },
+};

--- a/src/drift/route-extractors/js.ts
+++ b/src/drift/route-extractors/js.ts
@@ -16,38 +16,44 @@ import {
   inheritedValidation,
   inheritedRateLimit,
 } from "./shared.js";
+import {
+  JS_ROUTE,
+  JS_METHOD,
+  JS_AUTH,
+  JS_VALIDATION,
+  JS_RATE_LIMIT,
+  JS_ERROR_HANDLER,
+} from "./patterns.js";
 
 function extractJsRoutesRegex(file: DriftFile, fileMiddleware: FileMiddleware | undefined): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const lines = file.content.split("\n");
-  const expressPattern = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
 
   for (let i = 0; i < lines.length; i++) {
     // Skip comment lines — prevents phantom routes from commented-out code.
     if (isCommentLine(lines[i], C_STYLE_COMMENT_MARKERS)) continue;
-    const match = lines[i].match(expressPattern);
+    const match = lines[i].match(JS_ROUTE);
     if (!match) continue;
     const path = match[1];
-    const method = match[0].match(/\.(get|post|put|patch|delete|all)/)?.[1]?.toUpperCase() ?? "ANY";
+    const method = match[0].match(JS_METHOD)?.[1]?.toUpperCase() ?? "ANY";
     const context = lines.slice(Math.max(0, i - 5), i + 20).join("\n");
 
-    const perAuth = /(?:requireAuth|isAuthenticated|passport\.authenticate|verifyToken|jwt|authMiddleware)/.test(context);
-    const perVal = /validate|joi|zod|yup|celebrate|body\(|query\(/.test(context);
-    const perRate = /rateLimit|throttle|limiter/.test(context);
+    const perAuth = JS_AUTH.test(context);
+    const perVal = JS_VALIDATION.test(context);
+    const perRate = JS_RATE_LIMIT.test(context);
 
     routes.push({
       method, path, file: file.relativePath, line: i + 1,
       hasAuth: inheritedAuth(perAuth, fileMiddleware),
       hasValidation: inheritedValidation(perVal, fileMiddleware),
       hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
-      hasErrorHandler: /catch|try|\.catch|next\(err/.test(context),
+      hasErrorHandler: JS_ERROR_HANDLER.test(context),
     });
   }
   return routes;
 }
 
 export const jsRouteExtractor: RouteExtractor = {
-  language: "javascript", // also serves the "typescript" dispatch key
   extract(file, deps) {
     const fileMiddleware = deps.fileMw.get(file.relativePath);
     if (file.tree) {

--- a/src/drift/route-extractors/js.ts
+++ b/src/drift/route-extractors/js.ts
@@ -1,0 +1,58 @@
+/**
+ * JavaScript / TypeScript route extractor — Express / Hono / Fastify / Koa.
+ * Registered under both the `javascript` and `typescript` dispatch keys.
+ *
+ * AST when a parsed tree is available (delegated to security-ast), regex
+ * fallback otherwise.
+ */
+
+import type { DriftFile } from "../types.js";
+import { extractJsRoutesAst } from "../security-ast.js";
+import type { RouteInfo, FileMiddleware, RouteExtractor } from "./types.js";
+import {
+  C_STYLE_COMMENT_MARKERS,
+  isCommentLine,
+  inheritedAuth,
+  inheritedValidation,
+  inheritedRateLimit,
+} from "./shared.js";
+
+function extractJsRoutesRegex(file: DriftFile, fileMiddleware: FileMiddleware | undefined): RouteInfo[] {
+  const routes: RouteInfo[] = [];
+  const lines = file.content.split("\n");
+  const expressPattern = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
+
+  for (let i = 0; i < lines.length; i++) {
+    // Skip comment lines — prevents phantom routes from commented-out code.
+    if (isCommentLine(lines[i], C_STYLE_COMMENT_MARKERS)) continue;
+    const match = lines[i].match(expressPattern);
+    if (!match) continue;
+    const path = match[1];
+    const method = match[0].match(/\.(get|post|put|patch|delete|all)/)?.[1]?.toUpperCase() ?? "ANY";
+    const context = lines.slice(Math.max(0, i - 5), i + 20).join("\n");
+
+    const perAuth = /(?:requireAuth|isAuthenticated|passport\.authenticate|verifyToken|jwt|authMiddleware)/.test(context);
+    const perVal = /validate|joi|zod|yup|celebrate|body\(|query\(/.test(context);
+    const perRate = /rateLimit|throttle|limiter/.test(context);
+
+    routes.push({
+      method, path, file: file.relativePath, line: i + 1,
+      hasAuth: inheritedAuth(perAuth, fileMiddleware),
+      hasValidation: inheritedValidation(perVal, fileMiddleware),
+      hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
+      hasErrorHandler: /catch|try|\.catch|next\(err/.test(context),
+    });
+  }
+  return routes;
+}
+
+export const jsRouteExtractor: RouteExtractor = {
+  language: "javascript", // also serves the "typescript" dispatch key
+  extract(file, deps) {
+    const fileMiddleware = deps.fileMw.get(file.relativePath);
+    if (file.tree) {
+      return extractJsRoutesAst(file.tree, file.relativePath, fileMiddleware);
+    }
+    return extractJsRoutesRegex(file, fileMiddleware);
+  },
+};

--- a/src/drift/route-extractors/patterns.ts
+++ b/src/drift/route-extractors/patterns.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-language regexes for the route-extractor regex fallbacks (used only when
+ * tree-sitter has no clean parse). Collected here so each pattern can be
+ * unit-tested individually: the route patterns' capture groups (method / path)
+ * and the boolean signal detectors (auth / validation / rate-limit / error
+ * handler). Moved verbatim from the per-language extractors — behavior is
+ * unchanged; this is purely so the patterns are named and testable.
+ */
+
+// ─── Go — Echo / Gin / Gorilla mux ───
+
+/** Echo/Gin `.POST("/x"` → capture [1] = METHOD, [2] = path. */
+export const GO_ROUTE_ECHO = /\.\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/;
+/** Gorilla `HandleFunc("/x")…Methods("POST")` → capture [1] = path, [2] = METHOD. */
+export const GO_ROUTE_GORILLA = /HandleFunc\s*\(\s*"([^"]+)".*\.Methods\s*\(\s*"(\w+)"/;
+export const GO_AUTH = /[Aa]uth|[Tt]oken|require[A-Z]|middleware\.\w*[Aa]uth/;
+export const GO_VALIDATION = /[Bb]ind|[Vv]alidat|[Pp]arse/;
+export const GO_RATE_LIMIT = /[Rr]ate[Ll]imit|[Tt]hrottle/;
+export const GO_ERROR_HANDLER = /catch|err\s*!=\s*nil|try|except|\.catch/;
+
+// ─── JS/TS — Express / Hono / Fastify / Koa ───
+
+/** `.post("/x"` → capture [1] = path. */
+export const JS_ROUTE = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
+/** Verb of a matched route call → capture [1] = method (lowercase). */
+export const JS_METHOD = /\.(get|post|put|patch|delete|all)/;
+export const JS_AUTH = /(?:requireAuth|isAuthenticated|passport\.authenticate|verifyToken|jwt|authMiddleware)/;
+export const JS_VALIDATION = /validate|joi|zod|yup|celebrate|body\(|query\(/;
+export const JS_RATE_LIMIT = /rateLimit|throttle|limiter/;
+export const JS_ERROR_HANDLER = /catch|try|\.catch|next\(err/;
+
+// ─── Python — Flask / FastAPI ───
+
+/** `@app.route("/x"` / `@app.post("/x"` → capture [1] = path. */
+export const PY_ROUTE = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
+/** Decorator verb `.post(` → capture [1] = verb (lowercase). */
+export const PY_DECORATOR_VERB = /\.(get|post|put|patch|delete)\s*\(/;
+/** `methods=[...]` kwarg → capture [1] = inner list text (case-insensitive). */
+export const PY_METHODS_KWARG = /methods\s*=\s*\[([^\]]*)\]/i;
+/** Individual quoted verbs inside a `methods=[...]` list (global; used with `.match`). */
+export const PY_METHODS_VERBS = /["'](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["']/gi;
+export const PY_AUTH = /login_required|jwt_required|@requires|permission|token/;
+export const PY_VALIDATION = /pydantic|validate|Schema|Serializer/;
+export const PY_RATE_LIMIT = /rate_limit|throttle|limiter/;
+export const PY_ERROR_HANDLER = /try|except|raise/;

--- a/src/drift/route-extractors/python.ts
+++ b/src/drift/route-extractors/python.ts
@@ -16,6 +16,16 @@ import {
   inheritedValidation,
   inheritedRateLimit,
 } from "./shared.js";
+import {
+  PY_ROUTE,
+  PY_DECORATOR_VERB,
+  PY_METHODS_KWARG,
+  PY_METHODS_VERBS,
+  PY_AUTH,
+  PY_VALIDATION,
+  PY_RATE_LIMIT,
+  PY_ERROR_HANDLER,
+} from "./patterns.js";
 
 /** Text inside a Python route decorator's parentheses: from the first "(" on
  *  line `start` to its matching ")", spanning continuation lines. Bounded by
@@ -67,7 +77,6 @@ function balancedDecoratorArgs(lines: string[], start: number): string {
 function extractPythonRoutesRegex(file: DriftFile, fileMiddleware: FileMiddleware | undefined): RouteInfo[] {
   const routes: RouteInfo[] = [];
   const lines = file.content.split("\n");
-  const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
 
   let inDocstring = false;
   for (let i = 0; i < lines.length; i++) {
@@ -83,7 +92,7 @@ function extractPythonRoutesRegex(file: DriftFile, fileMiddleware: FileMiddlewar
     // Skip comment lines — Python uses '#'. Prevents phantom routes from
     // commented-out code.
     if (isCommentLine(lines[i], PYTHON_COMMENT_MARKERS)) continue;
-    const match = lines[i].match(routePattern);
+    const match = lines[i].match(PY_ROUTE);
     if (!match) continue;
     const path = match[1];
     // Flask's @app.route defaults to GET when no methods= kwarg is present, NOT an
@@ -92,35 +101,34 @@ function extractPythonRoutesRegex(file: DriftFile, fileMiddleware: FileMiddlewar
     // the route as mutating. The kwarg is read from the route's own decorator
     // via balanced paren scanning, so it can never bleed into an adjacent
     // route's decorator even when routes sit right next to each other.
-    const decoratorVerb = lines[i].match(/\.(get|post|put|patch|delete)\s*\(/)?.[1]?.toUpperCase();
+    const decoratorVerb = lines[i].match(PY_DECORATOR_VERB)?.[1]?.toUpperCase();
     let method = decoratorVerb ?? "GET";
     const decoratorArgs = balancedDecoratorArgs(lines, i);
-    const methodsKw = decoratorArgs.match(/methods\s*=\s*\[([^\]]*)\]/i);
+    const methodsKw = decoratorArgs.match(PY_METHODS_KWARG);
     if (methodsKw) {
-      const verbs = (methodsKw[1].match(/["'](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["']/gi) ?? [])
+      const verbs = (methodsKw[1].match(PY_METHODS_VERBS) ?? [])
         .map((v) => v.replace(/["']/g, "").toUpperCase());
       const mutating = verbs.find((v) => MUTATION_METHODS.includes(v));
       method = mutating ?? verbs[0] ?? method;
     }
     const context = lines.slice(i, Math.min(lines.length, i + 30)).join("\n");
 
-    const perAuth = /login_required|jwt_required|@requires|permission|token/.test(context);
-    const perVal = /pydantic|validate|Schema|Serializer/.test(context);
-    const perRate = /rate_limit|throttle|limiter/.test(context);
+    const perAuth = PY_AUTH.test(context);
+    const perVal = PY_VALIDATION.test(context);
+    const perRate = PY_RATE_LIMIT.test(context);
 
     routes.push({
       method, path, file: file.relativePath, line: i + 1,
       hasAuth: inheritedAuth(perAuth, fileMiddleware),
       hasValidation: inheritedValidation(perVal, fileMiddleware),
       hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
-      hasErrorHandler: /try|except|raise/.test(context),
+      hasErrorHandler: PY_ERROR_HANDLER.test(context),
     });
   }
   return routes;
 }
 
 export const pythonRouteExtractor: RouteExtractor = {
-  language: "python",
   extract(file, deps) {
     // AST only on a CLEAN parse: tree-sitter always returns a tree for broken
     // Python (with ERROR nodes), and error recovery can erase the whole file's

--- a/src/drift/route-extractors/python.ts
+++ b/src/drift/route-extractors/python.ts
@@ -1,0 +1,136 @@
+/**
+ * Python route extractor — Flask / FastAPI.
+ *
+ * AST on a CLEAN parse (delegated to security-ast-python), regex fallback
+ * otherwise. `balancedDecoratorArgs` is Python-specific and lives here.
+ */
+
+import type { DriftFile } from "../types.js";
+import { extractPythonRoutesAst } from "../security-ast-python.js";
+import type { RouteInfo, FileMiddleware, RouteExtractor } from "./types.js";
+import {
+  MUTATION_METHODS,
+  PYTHON_COMMENT_MARKERS,
+  isCommentLine,
+  inheritedAuth,
+  inheritedValidation,
+  inheritedRateLimit,
+} from "./shared.js";
+
+/** Text inside a Python route decorator's parentheses: from the first "(" on
+ *  line `start` to its matching ")", spanning continuation lines. Bounded by
+ *  paren depth so `methods=` is read from THIS decorator only and can never
+ *  bleed into an adjacent route's decorator. Parens inside string literals
+ *  (e.g. a route path like "/weird(path") are skipped, so an unbalanced literal
+ *  paren cannot throw off the depth count and leak into the next route. */
+function balancedDecoratorArgs(lines: string[], start: number): string {
+  let depth = 0;
+  let started = false;
+  let out = "";
+  let quote: string | null = null; // active string-literal quote char, or null
+  for (let j = start; j < lines.length; j++) {
+    const line = lines[j];
+    for (let k = 0; k < line.length; k++) {
+      const ch = line[k];
+      if (quote) {
+        // Inside a string literal: only a matching unescaped quote ends it;
+        // parens here are path/text, not structure.
+        if (ch === "\\") {
+          if (started) out += ch + (line[k + 1] ?? "");
+          k++; // skip the escaped char
+          continue;
+        }
+        if (ch === quote) quote = null;
+        if (started) out += ch;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        if (started) out += ch;
+        continue;
+      }
+      if (ch === "(") {
+        depth++;
+        started = true;
+      } else if (ch === ")") {
+        depth--;
+      }
+      if (started) out += ch;
+      if (started && depth === 0) return out;
+    }
+    out += " ";
+    if (j - start > 6) return out; // defensive cap for a malformed decorator
+  }
+  return out;
+}
+
+function extractPythonRoutesRegex(file: DriftFile, fileMiddleware: FileMiddleware | undefined): RouteInfo[] {
+  const routes: RouteInfo[] = [];
+  const lines = file.content.split("\n");
+  const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
+
+  let inDocstring = false;
+  for (let i = 0; i < lines.length; i++) {
+    // Track triple-quoted docstring blocks: a route-shaped line inside a
+    // docstring is documentation, not a real registration. An odd count of
+    // triple-quotes on a line toggles the block state.
+    const tripleQuotes = (lines[i].match(/"""|'''/g) ?? []).length;
+    if (inDocstring) {
+      if (tripleQuotes % 2 === 1) inDocstring = false;
+      continue;
+    }
+    if (tripleQuotes % 2 === 1) { inDocstring = true; continue; }
+    // Skip comment lines — Python uses '#'. Prevents phantom routes from
+    // commented-out code.
+    if (isCommentLine(lines[i], PYTHON_COMMENT_MARKERS)) continue;
+    const match = lines[i].match(routePattern);
+    if (!match) continue;
+    const path = match[1];
+    // Flask's @app.route defaults to GET when no methods= kwarg is present, NOT an
+    // unknown "ANY". Decorator-verb style (@app.post) resolves directly; the
+    // methods=[...] kwarg (Flask/others) is parsed so a mutating verb classifies
+    // the route as mutating. The kwarg is read from the route's own decorator
+    // via balanced paren scanning, so it can never bleed into an adjacent
+    // route's decorator even when routes sit right next to each other.
+    const decoratorVerb = lines[i].match(/\.(get|post|put|patch|delete)\s*\(/)?.[1]?.toUpperCase();
+    let method = decoratorVerb ?? "GET";
+    const decoratorArgs = balancedDecoratorArgs(lines, i);
+    const methodsKw = decoratorArgs.match(/methods\s*=\s*\[([^\]]*)\]/i);
+    if (methodsKw) {
+      const verbs = (methodsKw[1].match(/["'](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["']/gi) ?? [])
+        .map((v) => v.replace(/["']/g, "").toUpperCase());
+      const mutating = verbs.find((v) => MUTATION_METHODS.includes(v));
+      method = mutating ?? verbs[0] ?? method;
+    }
+    const context = lines.slice(i, Math.min(lines.length, i + 30)).join("\n");
+
+    const perAuth = /login_required|jwt_required|@requires|permission|token/.test(context);
+    const perVal = /pydantic|validate|Schema|Serializer/.test(context);
+    const perRate = /rate_limit|throttle|limiter/.test(context);
+
+    routes.push({
+      method, path, file: file.relativePath, line: i + 1,
+      hasAuth: inheritedAuth(perAuth, fileMiddleware),
+      hasValidation: inheritedValidation(perVal, fileMiddleware),
+      hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
+      hasErrorHandler: /try|except|raise/.test(context),
+    });
+  }
+  return routes;
+}
+
+export const pythonRouteExtractor: RouteExtractor = {
+  language: "python",
+  extract(file, deps) {
+    // AST only on a CLEAN parse: tree-sitter always returns a tree for broken
+    // Python (with ERROR nodes), and error recovery can erase the whole file's
+    // decorator structure or merge adjacent handlers' decorators into one
+    // decorated_definition (a cross-bless hazard). Any parse error routes the
+    // whole file to the regex, byte-identical to today's behavior INCLUDING the
+    // regex path's known over-blesses (see the pinned-legacy test).
+    if (file.tree && !file.tree.rootNode.hasError) {
+      return extractPythonRoutesAst(file.tree, file.relativePath, deps.xfile);
+    }
+    return extractPythonRoutesRegex(file, deps.fileMw.get(file.relativePath));
+  },
+};

--- a/src/drift/route-extractors/rust.ts
+++ b/src/drift/route-extractors/rust.ts
@@ -1,0 +1,23 @@
+/**
+ * Rust route extractor — Axum / Actix / Rocket.
+ *
+ * AST ONLY, and ONLY on a CLEAN parse. There is NO regex fallback for Rust
+ * anywhere in this codebase: an absent or errored tree yields zero Rust routes.
+ * A parse error can only shrink the recognized route set for that file, never
+ * emit a wrong route, and Rust has no legacy regex path whose over-blesses we
+ * would need to preserve. Ignores `deps`: Axum `.layer` scope is CHAIN-scoped,
+ * so the AST path computes covering-layer auth from the tree itself.
+ */
+
+import { extractRustRoutesAst } from "../security-ast-rust.js";
+import type { RouteExtractor } from "./types.js";
+
+export const rustRouteExtractor: RouteExtractor = {
+  language: "rust",
+  extract(file) {
+    if (file.tree && !file.tree.rootNode.hasError) {
+      return extractRustRoutesAst(file.tree, file.relativePath);
+    }
+    return [];
+  },
+};

--- a/src/drift/route-extractors/rust.ts
+++ b/src/drift/route-extractors/rust.ts
@@ -13,7 +13,6 @@ import { extractRustRoutesAst } from "../security-ast-rust.js";
 import type { RouteExtractor } from "./types.js";
 
 export const rustRouteExtractor: RouteExtractor = {
-  language: "rust",
   extract(file) {
     if (file.tree && !file.tree.rootNode.hasError) {
       return extractRustRoutesAst(file.tree, file.relativePath);

--- a/src/drift/route-extractors/shared.ts
+++ b/src/drift/route-extractors/shared.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared helpers for the per-language route extractors: comment-line skipping
+ * for the regex fallbacks, file-level middleware inheritance, handler-body
+ * lookup, and the canonical mutating-method set. Extracted from
+ * `security-consistency.ts` so each per-language module reuses one definition.
+ */
+
+import { SECURITY_AST } from "../security-ast.js";
+import type { FileMiddleware } from "./types.js";
+
+// Canonical mutating set (upper-cased), shared with the in-loop classifier via
+// SECURITY_AST.MUTATING so batch and in-loop can never disagree. Includes ALL
+// (Express .all() handles every verb) so an unauthed .all() route is not
+// silently excluded from the auth vote.
+export const MUTATION_METHODS = [...SECURITY_AST.MUTATING].map((m) => m.toUpperCase());
+
+// ─── Regex-fallback comment skipping ─────────────────────────────────
+// The regex route extractors (used when tree-sitter has no clean parse) match
+// route-shaped text line by line. A commented-out registration must NOT become
+// a phantom route — it would steal a @vibedrift-public annotation from the real
+// route below it (see #64 item 4). JS/TS and Go share C-style comments, so their
+// markers live in one place; Python differs (# line comments, """/''' docstrings).
+export const C_STYLE_COMMENT_MARKERS = ["//", "/*"] as const; // JS, TS, Go
+export const PYTHON_COMMENT_MARKERS = ["#"] as const;
+
+/** True when a source line is a line comment for the given markers. */
+export function isCommentLine(line: string, markers: readonly string[]): boolean {
+  const trimmed = line.trimStart();
+  return markers.some((m) => trimmed.startsWith(m));
+}
+
+// ─── Phase 2: inheritance resolution ─────────────────────────────────
+// A route's effective protection is its per-route middleware UNION the
+// file-level middleware detected for its file.
+export function inheritedAuth(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {
+  return perRoute || (fileMw?.hasAuth ?? false);
+}
+export function inheritedValidation(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {
+  return perRoute || (fileMw?.hasValidation ?? false);
+}
+export function inheritedRateLimit(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {
+  return perRoute || (fileMw?.hasRateLimit ?? false);
+}
+
+/** A window of source around a route path, used by the regex fallbacks to sniff
+ *  the handler body for validation / error-handling signals. */
+export function findHandlerContent(fullContent: string, routePath: string): string {
+  const idx = fullContent.indexOf(routePath);
+  if (idx === -1) return "";
+  return fullContent.slice(Math.max(0, idx - 500), Math.min(fullContent.length, idx + 2000));
+}

--- a/src/drift/route-extractors/types.ts
+++ b/src/drift/route-extractors/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared types for the per-language route extractors.
+ *
+ * `RouteInfo` and `FileMiddleware` live here (rather than in
+ * `security-consistency.ts`) so the per-language extractor modules and the
+ * `security-ast-*` modules can depend on them without a circular import.
+ * `security-consistency.ts` re-exports both for back-compat, so existing
+ * `import type { RouteInfo } from "./security-consistency.js"` sites keep working.
+ */
+
+import type { DriftFile } from "../types.js";
+import type { SupportedLanguage } from "../../core/types.js";
+import type { CrossFileIndex } from "../security-xfile-index.js";
+
+export interface FileMiddleware {
+  hasAuth: boolean;
+  hasValidation: boolean;
+  hasRateLimit: boolean;
+}
+
+export interface RouteInfo {
+  method: string;
+  path: string;
+  file: string;
+  line: number;
+  hasAuth: boolean;
+  hasValidation: boolean;
+  hasRateLimit: boolean;
+  hasErrorHandler: boolean;
+  /** Python or Go AST path only: the name of a middleware/hook whose BODY is
+   *  auth-flavored but statically unverifiable (an opaque helper, an imported or
+   *  selector/attribute target, a duplicate def). Present ONLY when
+   *  `hasAuth === false`; `hasAuth === true` always omits it. An "unsure" route
+   *  still counts as not-authed in every vote (never blesses) — this field only
+   *  lets a renderer hedge the finding copy to name the exact middleware the user
+   *  should double-check. Never set on the JS/TS AST path or the regex fallback,
+   *  so those routes serialize byte-identically. */
+  authUnsureHook?: string;
+}
+
+/**
+ * Dependencies threaded into every route extractor. A uniform shape keeps the
+ * dispatch table simple; each language module reads only what it needs:
+ *   - Go / Python: `fileMw` (regex-fallback inheritance) + `xfile` (AST import resolution)
+ *   - JS/TS: `fileMw` only
+ *   - Rust: neither (Axum layer scope is computed from the tree)
+ */
+export interface ExtractDeps {
+  fileMw: Map<string, FileMiddleware>;
+  xfile: CrossFileIndex;
+}
+
+/**
+ * A per-language route extractor. `extract` runs the AST path on a clean parse
+ * and falls back to regex otherwise, returning the routes for a single file.
+ * Stateless — a plain object satisfies it (no class needed).
+ */
+export interface RouteExtractor {
+  language: SupportedLanguage;
+  extract(file: DriftFile, deps: ExtractDeps): RouteInfo[];
+}

--- a/src/drift/route-extractors/types.ts
+++ b/src/drift/route-extractors/types.ts
@@ -9,7 +9,6 @@
  */
 
 import type { DriftFile } from "../types.js";
-import type { SupportedLanguage } from "../../core/types.js";
 import type { CrossFileIndex } from "../security-xfile-index.js";
 
 export interface FileMiddleware {
@@ -53,9 +52,10 @@ export interface ExtractDeps {
 /**
  * A per-language route extractor. `extract` runs the AST path on a clean parse
  * and falls back to regex otherwise, returning the routes for a single file.
- * Stateless — a plain object satisfies it (no class needed).
+ * Stateless — a plain object satisfies it (no class needed). Dispatch is by the
+ * `ROUTE_EXTRACTORS` table key in security-consistency.ts; extractors carry no
+ * language tag of their own (one extractor can serve several keys, e.g. js+ts).
  */
 export interface RouteExtractor {
-  language: SupportedLanguage;
   extract(file: DriftFile, deps: ExtractDeps): RouteInfo[];
 }

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -32,21 +32,27 @@
  */
 
 import type { DriftDetector, DriftContext, DriftFinding, DriftFile } from "./types.js";
+import type { SupportedLanguage } from "../core/types.js";
 import { SECURITY_SUBCATEGORIES } from "./types.js";
 import { pickIntentHint } from "./utils.js";
-import { extractJsRoutesAst, extractFileMiddlewareAst, SECURITY_AST } from "./security-ast.js";
-import { extractPythonRoutesAst, extractPythonFileMiddlewareAst } from "./security-ast-python.js";
-import { extractGoRoutesAst, extractGoFileMiddlewareAst } from "./security-ast-go.js";
-import { extractRustRoutesAst, extractRustFileMiddlewareAst } from "./security-ast-rust.js";
+import { extractFileMiddlewareAst } from "./security-ast.js";
+import { extractPythonFileMiddlewareAst } from "./security-ast-python.js";
+import { extractGoFileMiddlewareAst } from "./security-ast-go.js";
+import { extractRustFileMiddlewareAst } from "./security-ast-rust.js";
 import { buildXFileIndex } from "./security-xfile-index.js";
 import type { CrossFileIndex } from "./security-xfile-index.js";
 import { applyRouteSuppressions, buildSuppressionAuditFinding } from "./security-suppression.js";
+import type { RouteInfo, FileMiddleware, ExtractDeps, RouteExtractor } from "./route-extractors/types.js";
+import { MUTATION_METHODS } from "./route-extractors/shared.js";
+import { goRouteExtractor } from "./route-extractors/go.js";
+import { jsRouteExtractor } from "./route-extractors/js.js";
+import { pythonRouteExtractor } from "./route-extractors/python.js";
+import { rustRouteExtractor } from "./route-extractors/rust.js";
 
-// Canonical mutating set (upper-cased), shared with the in-loop classifier via
-// SECURITY_AST.MUTATING so batch and in-loop can never disagree. Includes ALL
-// (Express .all() handles every verb) so an unauthed .all() route is not
-// silently excluded from the auth vote.
-const MUTATION_METHODS = [...SECURITY_AST.MUTATING].map((m) => m.toUpperCase());
+// Re-exported for back-compat: security-ast{,-go,-python,-rust}.ts and
+// security-suppression.ts import these types from "./security-consistency.js".
+export type { RouteInfo, FileMiddleware };
+
 // Body-bearing methods for the validation vote (DELETE usually has no body).
 const BODY_METHODS = ["POST", "PUT", "PATCH", "ALL"];
 
@@ -76,14 +82,6 @@ const HOOK_PHRASE: Record<string, string> = {
 };
 const NEUTRAL_HOOK_PHRASE = "an auth hook";
 
-/** Source language of a route's file, by extension. Null when unknown. */
-function langOfFile(file: string): string | null {
-  if (file.endsWith(".py")) return "python";
-  if (file.endsWith(".go")) return "go";
-  if (file.endsWith(".rs")) return "rust";
-  return null;
-}
-
 /** Sentence appended to an auth finding's recommendation when some deviators are
  *  unsure (their hook body could not be verified). Empty string when none are
  *  hedged, so a confident finding's recommendation is byte-identical. The noun is
@@ -91,12 +89,14 @@ function langOfFile(file: string): string | null {
  *  falling back to the neutral "an auth hook" when the hedged hooks span multiple
  *  languages. `names` is the sorted distinct set of hook names. The terminal reads
  *  the noun + names back out of this sentence (noun-agnostic), so its shape —
- *  "could not be confirmed: <a|an> <noun> (<names>)" — must stay stable. */
-function hedgeRecommendationSuffix(deviators: RouteInfo[]): string {
+ *  "could not be confirmed: <a|an> <noun> (<names>)" — must stay stable.
+ *  `langByFile` maps a route's file to the pipeline-computed `file.language`, so
+ *  the noun reuses that property instead of re-deriving language from the path. */
+function hedgeRecommendationSuffix(deviators: RouteInfo[], langByFile: Map<string, string | null>): string {
   const hedged = deviators.filter((r) => r.authUnsureHook);
   if (hedged.length === 0) return "";
   const names = [...new Set(hedged.map((r) => r.authUnsureHook!))].sort().join(", ");
-  const langs = [...new Set(hedged.map((r) => langOfFile(r.file)))];
+  const langs = [...new Set(hedged.map((r) => langByFile.get(r.file) ?? null))];
   const phrase = langs.length === 1 && langs[0] ? (HOOK_PHRASE[langs[0]] ?? NEUTRAL_HOOK_PHRASE) : NEUTRAL_HOOK_PHRASE;
   return ` ${hedged.length} of these could not be confirmed: ${phrase} (${names}) may authenticate them but its body could not be verified. Double check those hooks before treating the routes as unauthenticated.`;
 }
@@ -121,6 +121,7 @@ function repoHasAuthMachinery(files: DriftFile[]): boolean {
 function analyzeUniformAuthGap(
   routes: RouteInfo[],
   opts: { hasMachinery: boolean; hint: ReturnType<typeof pickIntentHint>; healthPaths: RegExp },
+  langByFile: Map<string, string | null>,
 ): DriftFinding | null {
   const mutating = routes.filter((r) => MUTATION_METHODS.includes(r.method) && !opts.healthPaths.test(r.path));
   const unauthed = mutating.filter((r) => !r.hasAuth);
@@ -156,34 +157,8 @@ function analyzeUniformAuthGap(
       (declared
         ? `${opts.hint!.source}:${opts.hint!.line} declares auth is required. Add auth middleware to these ${unauthed.length} mutating route(s), or mark them explicitly public.`
         : `These ${unauthed.length} mutating route(s) have no auth while the codebase authenticates elsewhere. Add auth middleware, or confirm they are intentionally public.`) +
-      hedgeRecommendationSuffix(unauthed),
+      hedgeRecommendationSuffix(unauthed, langByFile),
   };
-}
-
-export interface FileMiddleware {
-  hasAuth: boolean;
-  hasValidation: boolean;
-  hasRateLimit: boolean;
-}
-
-export interface RouteInfo {
-  method: string;
-  path: string;
-  file: string;
-  line: number;
-  hasAuth: boolean;
-  hasValidation: boolean;
-  hasRateLimit: boolean;
-  hasErrorHandler: boolean;
-  /** Python or Go AST path only: the name of a middleware/hook whose BODY is
-   *  auth-flavored but statically unverifiable (an opaque helper, an imported or
-   *  selector/attribute target, a duplicate def). Present ONLY when
-   *  `hasAuth === false`; `hasAuth === true` always omits it. An "unsure" route
-   *  still counts as not-authed in every vote (never blesses) — this field only
-   *  lets a renderer hedge the finding copy to name the exact middleware the user
-   *  should double-check. Never set on the JS/TS AST path or the regex fallback,
-   *  so those routes serialize byte-identically. */
-  authUnsureHook?: string;
 }
 
 // ─── Phase 1: file-level middleware index ────────────────────────────
@@ -299,280 +274,34 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
 
 // ─── Route extraction (per-route middleware via proximity) ──────────
 
+// Route extraction dispatched by language. Each per-language module is a
+// self-contained functional RouteExtractor (AST on a clean parse, regex
+// fallback otherwise). JS and TS share one extractor.
+const ROUTE_EXTRACTORS: Partial<Record<SupportedLanguage, RouteExtractor>> = {
+  go: goRouteExtractor,
+  javascript: jsRouteExtractor,
+  typescript: jsRouteExtractor,
+  python: pythonRouteExtractor,
+  rust: rustRouteExtractor,
+};
+
 function extractRoutes(
   files: DriftFile[],
   fileMw: Map<string, FileMiddleware>,
   xfile: CrossFileIndex,
 ): RouteInfo[] {
   const routes: RouteInfo[] = [];
+  const deps: ExtractDeps = { fileMw, xfile };
   for (const file of files) {
-    if (!file.language) continue;
-    if (file.language === "go") extractGoRoutes(file, routes, fileMw, xfile);
-    else if (file.language === "javascript" || file.language === "typescript") extractJsRoutes(file, routes, fileMw);
-    else if (file.language === "python") extractPythonRoutes(file, routes, fileMw, xfile);
-    else if (file.language === "rust") extractRustRoutes(file, routes);
+    const extractor = file.language ? ROUTE_EXTRACTORS[file.language as SupportedLanguage] : undefined;
+    if (extractor) routes.push(...extractor.extract(file, deps));
   }
   return routes;
 }
 
-function extractRustRoutes(file: DriftFile, routes: RouteInfo[]) {
-  // AST ONLY, and ONLY on a CLEAN parse. There is NO regex fallback for Rust
-  // anywhere in this codebase: an absent or errored tree yields zero Rust routes
-  // (unchanged from before this module was wired in). A parse error can only
-  // shrink the recognized route set for that file, never emit a wrong route, and
-  // Rust has no legacy regex path whose over-blesses we would need to preserve.
-  // No FileMiddleware argument: Axum .layer scope is CHAIN-scoped, so the AST path
-  // computes covering-layer auth from the tree itself (a file-level OR would
-  // false-bless siblings a layer never wrapped, and the seam-2 index entry is
-  // all-false for rust anyway).
-  if (file.tree && !file.tree.rootNode.hasError) {
-    routes.push(...extractRustRoutesAst(file.tree, file.relativePath));
-  }
-}
+// Per-language route extractors now live in ./route-extractors/{go,js,python,rust}.ts
+// behind the RouteExtractor interface, dispatched via ROUTE_EXTRACTORS above.
 
-function inheritedAuth(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {
-  return perRoute || (fileMw?.hasAuth ?? false);
-}
-function inheritedValidation(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {
-  return perRoute || (fileMw?.hasValidation ?? false);
-}
-function inheritedRateLimit(perRoute: boolean, fileMw: FileMiddleware | undefined): boolean {
-  return perRoute || (fileMw?.hasRateLimit ?? false);
-}
-
-// ─── Regex-fallback comment skipping ─────────────────────────────────
-// The regex route extractors (used when tree-sitter has no clean parse) match
-// route-shaped text line by line. A commented-out registration must NOT become
-// a phantom route — it would steal a @vibedrift-public annotation from the real
-// route below it (see #64 item 4). JS/TS and Go share C-style comments, so their
-// markers live in one place; Python differs (# line comments, """/''' docstrings).
-const C_STYLE_COMMENT_MARKERS = ["//", "/*"] as const; // JS, TS, Go
-const PYTHON_COMMENT_MARKERS = ["#"] as const;
-
-/** True when a source line is a line comment for the given markers. */
-function isCommentLine(line: string, markers: readonly string[]): boolean {
-  const trimmed = line.trimStart();
-  return markers.some((m) => trimmed.startsWith(m));
-}
-
-function extractGoRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>, xfile: CrossFileIndex) {
-  // AST only on a CLEAN parse: tree-sitter always returns a tree for broken Go
-  // (with ERROR nodes), and error recovery SWALLOWS later valid registrations
-  // into a broken call's argument_list as clean-looking nested calls (a
-  // cross-bless hazard). Any parse error routes the whole file to the regex,
-  // byte-identical to today's behavior INCLUDING the regex path's known
-  // over-blesses (see the pinned-legacy tests).
-  if (file.tree && !file.tree.rootNode.hasError) {
-    // No FileMiddleware argument: the AST path computes receiver-scoped
-    // inheritance from the tree itself (a file-level OR would false-bless
-    // mixed-receiver files, and the index entry may carry cross-language noise
-    // for non-go files). The cross-file index lets an imported package
-    // middleware selector resolve to its in-repo defining body (blessing still
-    // requires that body to verifiably reject); an unresolved / external / index-
-    // disabled selector stays UNSURE, byte-identical to the in-file-only path.
-    routes.push(...extractGoRoutesAst(file.tree, file.relativePath, xfile));
-    return;
-  }
-  extractGoRoutesRegex(file, routes, fileMw.get(file.relativePath));
-}
-
-function extractGoRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddleware: FileMiddleware | undefined) {
-  const lines = file.content.split("\n");
-  const echoPattern = /\.\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/;
-  const gorillaPattern = /HandleFunc\s*\(\s*"([^"]+)".*\.Methods\s*\(\s*"(\w+)"/;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Skip comment lines — prevents phantom routes from commented-out code.
-    if (isCommentLine(line, C_STYLE_COMMENT_MARKERS)) continue;
-    let method = "", path = "";
-    const echoMatch = line.match(echoPattern);
-    if (echoMatch) { method = echoMatch[1]; path = echoMatch[2]; }
-    const gorillaMatch = line.match(gorillaPattern);
-    if (gorillaMatch) { path = gorillaMatch[1]; method = gorillaMatch[2]; }
-    if (!method || !path) continue;
-
-    const context = lines.slice(Math.max(0, i - 10), i + 10).join("\n");
-    const handlerContent = findHandlerContent(file.content, path);
-
-    const perAuth = /[Aa]uth|[Tt]oken|require[A-Z]|middleware\.\w*[Aa]uth/.test(context);
-    const perVal = /[Bb]ind|[Vv]alidat|[Pp]arse/.test(handlerContent);
-    const perRate = /[Rr]ate[Ll]imit|[Tt]hrottle/.test(context + handlerContent);
-
-    routes.push({
-      method, path, file: file.relativePath, line: i + 1,
-      hasAuth: inheritedAuth(perAuth, fileMiddleware),
-      hasValidation: inheritedValidation(perVal, fileMiddleware),
-      hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
-      hasErrorHandler: /catch|err\s*!=\s*nil|try|except|\.catch/.test(handlerContent),
-    });
-  }
-}
-
-function extractJsRoutes(file: DriftFile, routes: RouteInfo[], fileMw: Map<string, FileMiddleware>) {
-  const fileMiddleware = fileMw.get(file.relativePath);
-  if (file.tree) {
-    routes.push(...extractJsRoutesAst(file.tree, file.relativePath, fileMiddleware));
-    return;
-  }
-  extractJsRoutesRegex(file, routes, fileMiddleware);
-}
-
-function extractJsRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddleware: FileMiddleware | undefined) {
-  const lines = file.content.split("\n");
-  const expressPattern = /\.(?:get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/;
-
-  for (let i = 0; i < lines.length; i++) {
-    // Skip comment lines — prevents phantom routes from commented-out code.
-    if (isCommentLine(lines[i], C_STYLE_COMMENT_MARKERS)) continue;
-    const match = lines[i].match(expressPattern);
-    if (!match) continue;
-    const path = match[1];
-    const method = match[0].match(/\.(get|post|put|patch|delete|all)/)?.[1]?.toUpperCase() ?? "ANY";
-    const context = lines.slice(Math.max(0, i - 5), i + 20).join("\n");
-
-    const perAuth = /(?:requireAuth|isAuthenticated|passport\.authenticate|verifyToken|jwt|authMiddleware)/.test(context);
-    const perVal = /validate|joi|zod|yup|celebrate|body\(|query\(/.test(context);
-    const perRate = /rateLimit|throttle|limiter/.test(context);
-
-    routes.push({
-      method, path, file: file.relativePath, line: i + 1,
-      hasAuth: inheritedAuth(perAuth, fileMiddleware),
-      hasValidation: inheritedValidation(perVal, fileMiddleware),
-      hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
-      hasErrorHandler: /catch|try|\.catch|next\(err/.test(context),
-    });
-  }
-}
-
-/** Text inside a Python route decorator's parentheses: from the first "(" on
- *  line `start` to its matching ")", spanning continuation lines. Bounded by
- *  paren depth so `methods=` is read from THIS decorator only and can never
- *  bleed into an adjacent route's decorator. Parens inside string literals
- *  (e.g. a route path like "/weird(path") are skipped, so an unbalanced literal
- *  paren cannot throw off the depth count and leak into the next route. */
-function balancedDecoratorArgs(lines: string[], start: number): string {
-  let depth = 0;
-  let started = false;
-  let out = "";
-  let quote: string | null = null; // active string-literal quote char, or null
-  for (let j = start; j < lines.length; j++) {
-    const line = lines[j];
-    for (let k = 0; k < line.length; k++) {
-      const ch = line[k];
-      if (quote) {
-        // Inside a string literal: only a matching unescaped quote ends it;
-        // parens here are path/text, not structure.
-        if (ch === "\\") {
-          if (started) out += ch + (line[k + 1] ?? "");
-          k++; // skip the escaped char
-          continue;
-        }
-        if (ch === quote) quote = null;
-        if (started) out += ch;
-        continue;
-      }
-      if (ch === '"' || ch === "'") {
-        quote = ch;
-        if (started) out += ch;
-        continue;
-      }
-      if (ch === "(") {
-        depth++;
-        started = true;
-      } else if (ch === ")") {
-        depth--;
-      }
-      if (started) out += ch;
-      if (started && depth === 0) return out;
-    }
-    out += " ";
-    if (j - start > 6) return out; // defensive cap for a malformed decorator
-  }
-  return out;
-}
-
-function extractPythonRoutes(
-  file: DriftFile,
-  routes: RouteInfo[],
-  fileMw: Map<string, FileMiddleware>,
-  xfile: CrossFileIndex,
-) {
-  // AST only on a CLEAN parse: tree-sitter always returns a tree for broken
-  // Python (with ERROR nodes), and error recovery can erase the whole file's
-  // decorator structure or merge adjacent handlers' decorators into one
-  // decorated_definition (a cross-bless hazard). Any parse error routes the
-  // whole file to the regex, byte-identical to today's behavior INCLUDING the
-  // regex path's known over-blesses (see the pinned-legacy test, Task 6).
-  if (file.tree && !file.tree.rootNode.hasError) {
-    // No FileMiddleware argument: the AST path computes receiver-scoped
-    // inheritance from the tree itself (a file-level OR would false-bless
-    // mixed-receiver files, and the index entry may carry cross-language noise
-    // for non-python files).
-    routes.push(...extractPythonRoutesAst(file.tree, file.relativePath, xfile));
-    return;
-  }
-  extractPythonRoutesRegex(file, routes, fileMw.get(file.relativePath));
-}
-
-function extractPythonRoutesRegex(file: DriftFile, routes: RouteInfo[], fileMiddleware: FileMiddleware | undefined) {
-  const lines = file.content.split("\n");
-  const routePattern = /@\w+\.(?:route|get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/;
-
-  let inDocstring = false;
-  for (let i = 0; i < lines.length; i++) {
-    // Track triple-quoted docstring blocks: a route-shaped line inside a
-    // docstring is documentation, not a real registration. An odd count of
-    // triple-quotes on a line toggles the block state.
-    const tripleQuotes = (lines[i].match(/"""|'''/g) ?? []).length;
-    if (inDocstring) {
-      if (tripleQuotes % 2 === 1) inDocstring = false;
-      continue;
-    }
-    if (tripleQuotes % 2 === 1) { inDocstring = true; continue; }
-    // Skip comment lines — Python uses '#'. Prevents phantom routes from
-    // commented-out code.
-    if (isCommentLine(lines[i], PYTHON_COMMENT_MARKERS)) continue;
-    const match = lines[i].match(routePattern);
-    if (!match) continue;
-    const path = match[1];
-    // Flask's @app.route defaults to GET when no methods= kwarg is present, NOT an
-    // unknown "ANY". Decorator-verb style (@app.post) resolves directly; the
-    // methods=[...] kwarg (Flask/others) is parsed so a mutating verb classifies
-    // the route as mutating. The kwarg is read from the route's own decorator
-    // via balanced paren scanning, so it can never bleed into an adjacent
-    // route's decorator even when routes sit right next to each other.
-    const decoratorVerb = lines[i].match(/\.(get|post|put|patch|delete)\s*\(/)?.[1]?.toUpperCase();
-    let method = decoratorVerb ?? "GET";
-    const decoratorArgs = balancedDecoratorArgs(lines, i);
-    const methodsKw = decoratorArgs.match(/methods\s*=\s*\[([^\]]*)\]/i);
-    if (methodsKw) {
-      const verbs = (methodsKw[1].match(/["'](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["']/gi) ?? [])
-        .map((v) => v.replace(/["']/g, "").toUpperCase());
-      const mutating = verbs.find((v) => MUTATION_METHODS.includes(v));
-      method = mutating ?? verbs[0] ?? method;
-    }
-    const context = lines.slice(i, Math.min(lines.length, i + 30)).join("\n");
-
-    const perAuth = /login_required|jwt_required|@requires|permission|token/.test(context);
-    const perVal = /pydantic|validate|Schema|Serializer/.test(context);
-    const perRate = /rate_limit|throttle|limiter/.test(context);
-
-    routes.push({
-      method, path, file: file.relativePath, line: i + 1,
-      hasAuth: inheritedAuth(perAuth, fileMiddleware),
-      hasValidation: inheritedValidation(perVal, fileMiddleware),
-      hasRateLimit: inheritedRateLimit(perRate, fileMiddleware),
-      hasErrorHandler: /try|except|raise/.test(context),
-    });
-  }
-}
-
-function findHandlerContent(fullContent: string, routePath: string): string {
-  const idx = fullContent.indexOf(routePath);
-  if (idx === -1) return "";
-  return fullContent.slice(Math.max(0, idx - 500), Math.min(fullContent.length, idx + 2000));
-}
 
 // ─── Phase 3: dominance vote per security property, scoped per directory ──
 
@@ -600,6 +329,7 @@ function analyzeSecurityProperty(
   propertyName: string,
   getter: (r: RouteInfo) => boolean,
   excludePaths: RegExp,
+  langByFile: Map<string, string | null>,
 ): DriftFinding | null {
   const applicableRoutes = routes.filter((r) => !excludePaths.test(r.path));
   if (applicableRoutes.length < 2) return null;
@@ -635,7 +365,7 @@ function analyzeSecurityProperty(
     dominantFiles: [...new Set(withProperty.map((r) => r.file))].sort().slice(0, 3),
     recommendation:
       `${withProperty.length} of ${applicableRoutes.length} routes have ${propertyName}. Review ${withoutProperty.length} unprotected routes — apply per-route middleware or move them under a router that does.` +
-      (propertyName === SECURITY_SUBCATEGORIES.auth ? hedgeRecommendationSuffix(withoutProperty) : ""),
+      (propertyName === SECURITY_SUBCATEGORIES.auth ? hedgeRecommendationSuffix(withoutProperty, langByFile) : ""),
   };
 }
 
@@ -647,6 +377,9 @@ export const securityConsistency: DriftDetector = {
   detect(ctx: DriftContext): DriftFinding[] {
     const findings: DriftFinding[] = [];
     const fileMw = buildFileMiddlewareIndex(ctx.files);
+    // path → pipeline-computed file.language, so recommendation copy reuses
+    // file.language instead of re-deriving language from the path extension.
+    const langByFile = new Map<string, string | null>(ctx.files.map((f) => [f.relativePath, f.language]));
     // Repo-wide cross-file symbol index: lets the Python AST route extractor
     // resolve an imported before_request hook / FastAPI dependency to its in-repo
     // defining body, but ONLY when resolution is exact and unambiguous (every
@@ -690,7 +423,7 @@ export const securityConsistency: DriftDetector = {
       // reads in the denominator and made the "X of Y mutating routes" line false.
       // Same set as analyzeUniformAuthGap so the primary vote and its fallback agree.
       const groupAuthRoutes = group.filter((r) => MUTATION_METHODS.includes(r.method));
-      const authFinding = analyzeSecurityProperty(groupAuthRoutes, SECURITY_SUBCATEGORIES.auth, (r) => r.hasAuth, healthPaths);
+      const authFinding = analyzeSecurityProperty(groupAuthRoutes, SECURITY_SUBCATEGORIES.auth, (r) => r.hasAuth, healthPaths, langByFile);
       if (authFinding) {
         findings.push(authFinding);
         continue;
@@ -709,18 +442,18 @@ export const securityConsistency: DriftDetector = {
         hasMachinery: repoHasAuthMachinery(ctx.files),
         hint: authHint,
         healthPaths,
-      });
+      }, langByFile);
       if (gap) findings.push(gap);
     }
 
     for (const group of groups) {
       const groupMutationRoutes = group.filter((r) => BODY_METHODS.includes(r.method));
-      const valFinding = analyzeSecurityProperty(groupMutationRoutes, SECURITY_SUBCATEGORIES.validation, (r) => r.hasValidation, healthPaths);
+      const valFinding = analyzeSecurityProperty(groupMutationRoutes, SECURITY_SUBCATEGORIES.validation, (r) => r.hasValidation, healthPaths, langByFile);
       if (valFinding) findings.push(valFinding);
     }
 
     for (const group of groups) {
-      const rateLimitFinding = analyzeSecurityProperty(group, SECURITY_SUBCATEGORIES.rateLimit, (r) => r.hasRateLimit, healthPaths);
+      const rateLimitFinding = analyzeSecurityProperty(group, SECURITY_SUBCATEGORIES.rateLimit, (r) => r.hasRateLimit, healthPaths, langByFile);
       if (rateLimitFinding) findings.push(rateLimitFinding);
     }
 

--- a/src/drift/security-consistency.ts
+++ b/src/drift/security-consistency.ts
@@ -277,7 +277,10 @@ function buildFileMiddlewareIndex(files: DriftFile[]): Map<string, FileMiddlewar
 // Route extraction dispatched by language. Each per-language module is a
 // self-contained functional RouteExtractor (AST on a clean parse, regex
 // fallback otherwise). JS and TS share one extractor.
-const ROUTE_EXTRACTORS: Partial<Record<SupportedLanguage, RouteExtractor>> = {
+// Every SupportedLanguage must appear here: this is a total Record (not Partial),
+// so adding a language to the union without wiring an extractor is a compile
+// error at this literal rather than a silent "zero routes for that language".
+const ROUTE_EXTRACTORS: Record<SupportedLanguage, RouteExtractor> = {
   go: goRouteExtractor,
   javascript: jsRouteExtractor,
   typescript: jsRouteExtractor,
@@ -293,8 +296,10 @@ function extractRoutes(
   const routes: RouteInfo[] = [];
   const deps: ExtractDeps = { fileMw, xfile };
   for (const file of files) {
-    const extractor = file.language ? ROUTE_EXTRACTORS[file.language as SupportedLanguage] : undefined;
-    if (extractor) routes.push(...extractor.extract(file, deps));
+    // `in` guard keeps this runtime-safe for files whose language isn't a
+    // SupportedLanguage (or is null) — those are simply skipped.
+    if (!file.language || !(file.language in ROUTE_EXTRACTORS)) continue;
+    routes.push(...ROUTE_EXTRACTORS[file.language as SupportedLanguage].extract(file, deps));
   }
   return routes;
 }

--- a/test/unit/drift/patterns.test.ts
+++ b/test/unit/drift/patterns.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  GO_ROUTE_ECHO, GO_ROUTE_GORILLA, GO_AUTH, GO_VALIDATION, GO_RATE_LIMIT, GO_ERROR_HANDLER,
+  JS_ROUTE, JS_METHOD, JS_AUTH, JS_VALIDATION, JS_RATE_LIMIT, JS_ERROR_HANDLER,
+  PY_ROUTE, PY_DECORATOR_VERB, PY_METHODS_KWARG, PY_METHODS_VERBS, PY_AUTH, PY_VALIDATION, PY_RATE_LIMIT, PY_ERROR_HANDLER,
+} from "../../../src/drift/route-extractors/patterns.js";
+
+/**
+ * Unit tests for the per-language route-fallback regexes (PR #70 review ask:
+ * "put the regexes in a separate file and test them individually to make sure
+ * for every language the regex captures the correct match group").
+ *
+ * Route patterns are checked for their capture groups (method / path); the
+ * boolean signal detectors are checked for representative positives + negatives.
+ */
+
+describe("Go patterns", () => {
+  it("GO_ROUTE_ECHO captures [1]=method, [2]=path", () => {
+    const m = `r.POST("/users", h)`.match(GO_ROUTE_ECHO);
+    expect(m?.[1]).toBe("POST");
+    expect(m?.[2]).toBe("/users");
+  });
+  it("GO_ROUTE_GORILLA captures [1]=path, [2]=method", () => {
+    const m = `r.HandleFunc("/admin", h).Methods("PUT")`.match(GO_ROUTE_GORILLA);
+    expect(m?.[1]).toBe("/admin");
+    expect(m?.[2]).toBe("PUT");
+  });
+  it("GO_ROUTE_ECHO ignores a non-verb call", () => {
+    expect(`r.Group("/api")`.match(GO_ROUTE_ECHO)).toBeNull();
+  });
+  it("signal detectors match / reject", () => {
+    expect(GO_AUTH.test("requireAuth(c)")).toBe(true);
+    expect(GO_AUTH.test("return json(c)")).toBe(false);
+    expect(GO_VALIDATION.test("c.Bind(&o)")).toBe(true);
+    expect(GO_VALIDATION.test("c.JSON(200, o)")).toBe(false);
+    expect(GO_RATE_LIMIT.test("rateLimiter.Wait()")).toBe(true);
+    expect(GO_RATE_LIMIT.test("logger.Info()")).toBe(false);
+    expect(GO_ERROR_HANDLER.test("if err != nil {")).toBe(true);
+    expect(GO_ERROR_HANDLER.test("return nil")).toBe(false);
+  });
+});
+
+describe("JS/TS patterns", () => {
+  it("JS_ROUTE captures [1]=path and JS_METHOD captures [1]=verb", () => {
+    const m = `router.post('/secure', h)`.match(JS_ROUTE);
+    expect(m?.[1]).toBe("/secure");
+    expect(m?.[0].match(JS_METHOD)?.[1]).toBe("post");
+  });
+  it("JS_ROUTE supports template-literal and double-quote paths", () => {
+    expect("app.get(`/t`, h)".match(JS_ROUTE)?.[1]).toBe("/t");
+    expect('app.delete("/d", h)'.match(JS_ROUTE)?.[1]).toBe("/d");
+  });
+  it("JS_ROUTE ignores a non-route method call", () => {
+    expect(`router.use(mw)`.match(JS_ROUTE)).toBeNull();
+  });
+  it("signal detectors match / reject", () => {
+    expect(JS_AUTH.test("passport.authenticate('jwt')")).toBe(true);
+    expect(JS_AUTH.test("res.send(data)")).toBe(false);
+    expect(JS_VALIDATION.test("celebrate(schema)")).toBe(true);
+    expect(JS_VALIDATION.test("res.json(x)")).toBe(false);
+    expect(JS_RATE_LIMIT.test("rateLimit({})")).toBe(true);
+    expect(JS_RATE_LIMIT.test("next()")).toBe(false);
+    expect(JS_ERROR_HANDLER.test("next(err)")).toBe(true);
+    expect(JS_ERROR_HANDLER.test("res.end()")).toBe(false);
+  });
+});
+
+describe("Python patterns", () => {
+  it("PY_ROUTE captures [1]=path", () => {
+    expect(`@app.route("/x")`.match(PY_ROUTE)?.[1]).toBe("/x");
+    expect(`@app.post("/y")`.match(PY_ROUTE)?.[1]).toBe("/y");
+  });
+  it("PY_DECORATOR_VERB captures [1]=verb", () => {
+    expect(`@app.post(`.match(PY_DECORATOR_VERB)?.[1]).toBe("post");
+    expect(`@app.route(`.match(PY_DECORATOR_VERB)).toBeNull(); // route has no verb
+  });
+  it("PY_METHODS_KWARG + PY_METHODS_VERBS pull the verb list", () => {
+    const kw = `methods=["GET", "POST"]`.match(PY_METHODS_KWARG);
+    expect(kw?.[1]).toBe(`"GET", "POST"`);
+    const verbs = kw![1].match(PY_METHODS_VERBS)?.map((v) => v.replace(/["']/g, ""));
+    expect(verbs).toEqual(["GET", "POST"]);
+  });
+  it("signal detectors match / reject", () => {
+    expect(PY_AUTH.test("@login_required")).toBe(true);
+    expect(PY_AUTH.test("def index():")).toBe(false);
+    expect(PY_VALIDATION.test("class S(Schema):")).toBe(true);
+    expect(PY_VALIDATION.test("return jsonify(x)")).toBe(false);
+    expect(PY_RATE_LIMIT.test("@limiter.limit('1/s')")).toBe(true);
+    expect(PY_RATE_LIMIT.test("print(x)")).toBe(false);
+    expect(PY_ERROR_HANDLER.test("except ValueError:")).toBe(true);
+    expect(PY_ERROR_HANDLER.test("return data")).toBe(false);
+  });
+});

--- a/test/unit/drift/route-extractors.test.ts
+++ b/test/unit/drift/route-extractors.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { goRouteExtractor } from "../../../src/drift/route-extractors/go.js";
+import { jsRouteExtractor } from "../../../src/drift/route-extractors/js.js";
+import { pythonRouteExtractor } from "../../../src/drift/route-extractors/python.js";
+import { rustRouteExtractor } from "../../../src/drift/route-extractors/rust.js";
+import type { FileMiddleware, ExtractDeps } from "../../../src/drift/route-extractors/types.js";
+import type { CrossFileIndex } from "../../../src/drift/security-xfile-index.js";
+import type { DriftFile } from "../../../src/drift/types.js";
+
+/**
+ * Boundary tests for the per-language route extractors (PR #70 review).
+ *
+ * These call each extractor DIRECTLY on tree-less files (no `file.tree` → the
+ * regex fallback path) and assert the WHOLE `RouteInfo` via `toEqual`, not just
+ * one field. That closes the coverage gap the reviewer found: deleting the
+ * comment-skip lines or gutting `inheritedValidation`/`inheritedRateLimit`
+ * previously left the full suite green. Each case below turns red under exactly
+ * those breakages.
+ */
+
+// A tree-less DriftFile: omitting `tree` forces the regex fallback in every extractor.
+function file(relativePath: string, language: string, content: string): DriftFile {
+  return { relativePath, language, content, lineCount: content.split("\n").length };
+}
+
+// xfile is only touched on the AST path, which tree-less files never reach.
+function deps(fileMw?: Map<string, FileMiddleware>): ExtractDeps {
+  return { fileMw: fileMw ?? new Map(), xfile: {} as unknown as CrossFileIndex };
+}
+
+describe("route-extractors: Go (regex fallback)", () => {
+  it("extracts an Echo/Gin route with no signals", () => {
+    const f = file("routes.go", "go", `package main\nr.GET("/health", healthCheck)`);
+    expect(goRouteExtractor.extract(f, deps())).toEqual([
+      { method: "GET", path: "/health", file: "routes.go", line: 2, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("detects auth (context) + captures Gorilla method from .Methods()", () => {
+    const f = file("routes.go", "go", `authMiddleware(r)\nr.HandleFunc("/admin", h).Methods("PUT")`);
+    expect(goRouteExtractor.extract(f, deps())).toEqual([
+      { method: "PUT", path: "/admin", file: "routes.go", line: 2, hasAuth: true, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("detects validation + error handling from the handler body", () => {
+    const f = file("routes.go", "go", `r.POST("/orders", h)\nfunc h(c *gin.Context){ c.Bind(&o); if err != nil {} }`);
+    expect(goRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/orders", file: "routes.go", line: 1, hasAuth: false, hasValidation: true, hasRateLimit: false, hasErrorHandler: true },
+    ]);
+  });
+
+  it("skips a commented-out route (the #66 fix — C-style)", () => {
+    const f = file("routes.go", "go", `// r.POST("/admin", adminHandler)\nr.POST("/admin", adminHandler)`);
+    // Exactly one route (line 2). If the comment-skip regressed, this would be two.
+    expect(goRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/admin", file: "routes.go", line: 2, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+});
+
+describe("route-extractors: JS/TS (regex fallback)", () => {
+  it("extracts an Express route with no signals", () => {
+    const f = file("app.js", "javascript", `router.get('/x', handler)`);
+    expect(jsRouteExtractor.extract(f, deps())).toEqual([
+      { method: "GET", path: "/x", file: "app.js", line: 1, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("detects inline auth + validation", () => {
+    const f = file("app.js", "javascript", `router.use(requireAuth)\nrouter.post('/secure', validate(schema), handler)`);
+    expect(jsRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/secure", file: "app.js", line: 2, hasAuth: true, hasValidation: true, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("inherits validation + rate-limit from file-level middleware", () => {
+    // No inline val/rate signal on the route; both come from fileMw → exercises
+    // inheritedValidation / inheritedRateLimit specifically.
+    const mw = new Map<string, FileMiddleware>([["app.js", { hasAuth: false, hasValidation: true, hasRateLimit: true }]]);
+    const f = file("app.js", "javascript", `router.get('/x', handler)`);
+    expect(jsRouteExtractor.extract(f, deps(mw))).toEqual([
+      { method: "GET", path: "/x", file: "app.js", line: 1, hasAuth: false, hasValidation: true, hasRateLimit: true, hasErrorHandler: false },
+    ]);
+  });
+
+  it("skips a commented-out route (the #66 fix — C-style)", () => {
+    const f = file("app.js", "javascript", `// router.post('/admin/delete', h)\nrouter.post('/admin/delete', h)`);
+    expect(jsRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/admin/delete", file: "app.js", line: 2, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("maps .all() to method ALL", () => {
+    const f = file("app.js", "javascript", `router.all('/any', handler)`);
+    expect(jsRouteExtractor.extract(f, deps())[0].method).toBe("ALL");
+  });
+});
+
+describe("route-extractors: Python (regex fallback)", () => {
+  it("extracts a decorator-verb route (defaults handled), no signals", () => {
+    const f = file("api.py", "python", `@app.post("/x")\ndef x(): return {}`);
+    expect(pythonRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/x", file: "api.py", line: 1, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("reads the mutating verb from a methods=[...] kwarg", () => {
+    const f = file("api.py", "python", `@app.route("/y", methods=["PUT"])\ndef y(): return {}`);
+    expect(pythonRouteExtractor.extract(f, deps())[0]).toMatchObject({ method: "PUT", path: "/y" });
+  });
+
+  it("detects auth + error handling from surrounding context", () => {
+    const f = file("api.py", "python", `@app.post("/z")\n@login_required\ndef z():\n    try:\n        pass\n    except Exception:\n        raise`);
+    expect(pythonRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/z", file: "api.py", line: 1, hasAuth: true, hasValidation: false, hasRateLimit: false, hasErrorHandler: true },
+    ]);
+  });
+
+  it("skips a commented-out route (# comment)", () => {
+    const f = file("api.py", "python", `# @app.post("/danger")\n@app.post("/danger")\ndef danger(): return {}`);
+    expect(pythonRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/danger", file: "api.py", line: 2, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+
+  it("skips a route-shaped line inside a docstring", () => {
+    const f = file("api.py", "python", `"""\nExample:\n    @app.post("/doc")\n"""\n@app.post("/real")\ndef real(): return {}`);
+    expect(pythonRouteExtractor.extract(f, deps())).toEqual([
+      { method: "POST", path: "/real", file: "api.py", line: 5, hasAuth: false, hasValidation: false, hasRateLimit: false, hasErrorHandler: false },
+    ]);
+  });
+});
+
+describe("route-extractors: Rust (AST-only, no regex fallback)", () => {
+  it("returns no routes for a tree-less file (no regex fallback exists)", () => {
+    const f = file("main.rs", "rust", `async fn handler() {}\nRouter::new().route("/x", get(handler))`);
+    expect(rustRouteExtractor.extract(f, deps())).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Modularizes security route extraction out of `src/drift/security-consistency.ts`, addressing the refactor discussion from #66 (tracked in #69). The file previously branched on `file.language` inline and concentrated every language's regex fallback in one place.

- New `src/drift/route-extractors/`:
  - `types.ts` — `RouteInfo`, `FileMiddleware`, and the `ExtractDeps` / `RouteExtractor` interfaces.
  - `shared.ts` — comment-marker constants, `isCommentLine`, `inheritedAuth/Validation/RateLimit`, `findHandlerContent`, `MUTATION_METHODS`.
  - `patterns.ts` — every per-language regex as a named constant (route patterns with their capture groups, plus the auth/validation/rate-limit/error-handler detectors), so they're individually testable.
  - `go.ts`, `js.ts`, `python.ts`, `rust.ts` — each exports a functional `RouteExtractor` (AST on a clean parse, regex fallback otherwise). `js.ts` serves both the `javascript` and `typescript` keys; `rust.ts` is AST-only.
- `security-consistency.ts` is now thin dispatch over a total `Record<SupportedLanguage, RouteExtractor>` table instead of inline `if/else` — a missing language is a compile error at the literal, with a runtime `in` guard for unknown/unset `file.language`. It re-exports `RouteInfo`/`FileMiddleware` so `security-ast{,-go,-python,-rust}.ts` and `security-suppression.ts` are **untouched**.
- Reuses the pipeline's `file.language` and removes the `langOfFile` extension re-derivation.

**Design note:** per the plan approved on #69, the per-language units are **functional modules** behind a shared interface (not classes) — the extractors are stateless `(file) → RouteInfo[]` transforms, matching the existing `security-ast-*` style. `SupportedLanguage` is reused as the dispatch key (no new `FileType` enum), and `RouteExtractor` carries no `language` field — dispatch is by the table key, the single source of truth.

**Out of scope (deliberately):** the AST module internals, suppression, finding construction, and any change to the `RouteInfo` shape or its baseline serialization.

## Tests

Added in response to review — the refactor moved code into new files, so these pin the behavior in its new home:

- `test/unit/drift/route-extractors.test.ts` — calls each extractor directly on tree-less files and asserts the **full `RouteInfo` via `toEqual`**: comment-skip (JS/Go C-style, Python `#` + docstring), auth/validation/rate-limit detection, `inheritedValidation`/`inheritedRateLimit` via file-level middleware, error-handler, and method/path capture (Echo vs Gorilla `.Methods`, `methods=[...]`, `.all`).
- `test/unit/drift/patterns.test.ts` — per-language regex units: route patterns' capture groups + each detector's match/reject.

**Guardrail check:** I reproduced the reviewer's experiment — deleting a comment-skip line (or gutting `inheritedValidation`/`inheritedRateLimit`) now turns `route-extractors.test.ts` **red**, closing the gap where those breakages previously went unnoticed.

## Verification

- The refactor is **behavior-preserving**: regexes were relocated verbatim, and the `Record`/`language`-field changes are type-only / dead-code. AST modules, suppression, finding construction, and `RouteInfo` serialization are untouched. (Route output was independently confirmed byte-identical during review — 51 routes across all four languages + three real repos.)
- Full suite: **1906 passed (+27 new tests)**. The only failures are two pre-existing, environment-only tests unrelated to this diff — `git-metadata` (git-timing flakiness on Windows) and `concise-ai-summary` (an ANSI/`FORCE_COLOR` assertion); neither file is touched here and both are green on CI.
- `npm run typecheck` clean, `npm run build` success, `npm run lint` 0 errors (no issues in the new modules).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [x] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests — *added `route-extractors.test.ts` (full-`RouteInfo` boundary tests) and `patterns.test.ts` (regex units); verified they fail under a deliberate comment-skip deletion.*
- [x] `README.md` updated if a flag, command, or feature changed — *N/A: no user-facing change.*
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra) — *neutral infra: reduces the surface where per-language extraction bugs hide (cf. the #66 phantom-route bug), now with test coverage, and makes adding new languages (cf. #56) safer.*
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Closes #69
