### PR TITLE
Drift Sessions (preview): watch-session + hosted sync

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,6 +16,14 @@ paths = [
   '''test/unit/analyzers/security\.test\.ts''',
   '''test/unit/analyzers/security-floor\.test\.ts''',
   '''test/calibration/injectors\.ts''',
+  # Drift Sessions tests: synthetic credential fixtures for the secret masker /
+  # prompt normalizer / hook (verified: no real secrets — dummy api_key=, PEM,
+  # and provider-key shapes used only to prove the masker catches them).
+  '''test/unit/session/mask\.test\.ts''',
+  '''test/unit/session/normalize\.test\.ts''',
+  '''test/unit/session/decision\.test\.ts''',
+  '''test/unit/session/upload-schema\.test\.ts''',
+  '''test/integration/session-hook\.test\.ts''',
   '''\.env\.example$''',
   '''docs/handbook/.*\.md''',
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ explicitly under **Breaking** so CI users can recalibrate.
 
 ## [Unreleased]
 
+### Added
+
+- **Drift Sessions (preview): `vibedrift watch-session`.** Consent-gated Claude Code
+  hooks record the session to a local append-only ledger (`~/.vibedrift/sessions/`):
+  prompts (secrets masked), edit metadata, and drift flags, with one-line advisory
+  notes fed back into the agent when an edit diverges from the repo's own dominant
+  patterns. Local-only, fail-open. `--uninstall` restores your settings byte-for-byte
+  when they are unedited since install, otherwise removes only our entries.
+- **Drift Sessions: live event tape.** `vibedrift watch-session` now follows the
+  session in real time — prompts, edits, and drift flags stream in with a running
+  count and an end-of-session summary. When the VibeDrift MCP is enabled, the agent's
+  own tool calls join the same tape as ASKS/REPLIES rows. `--no-watch` installs
+  without following.
+- **Drift Sessions: intent tier + drift gauge.** The tape now captures the task
+  from your prompt (files and symbols named), locks it, and conservatively flags an
+  edit unrelated to any of them (experimental). A smoothed noisy-OR drift gauge with
+  hysteresis rides the footer, and the summary reports how many of the task's target
+  files were touched.
+- **Drift Sessions: real outcomes.** A finding resolves only when the same finding
+  re-runs over the re-edited file and passes (never because an unrelated file changed),
+  so resolved/open counts are honest. Repeat flags on an already-open finding are
+  deduped, byte-exact reverts are noted, and `watch-session` hints when a repo has no
+  baseline yet.
+- **Drift Sessions are Pro, with a 5-session free trial.** A free account gets the
+  first five sessions full-featured; after that the tape locks behind a summary of what
+  the trial caught, with an upgrade CTA. The trial count is server-side (survives
+  reinstalls). A locked account captures nothing; the capture hook stays offline and
+  reads a local entitlement cache. Recorded local ledgers always remain yours.
+
 ## 0.16.3 — 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Detection tells you, in-loop prevention nudges you, language-level prevention ma
 ```
 vibedrift [path]            Scan a project (default command)
 vibedrift watch [path]      Re-scan on file changes (Pro)
+vibedrift watch-session     Drift Sessions (preview): record agent sessions to a local ledger
 vibedrift mcp               Run the MCP server (Claude Code / Cursor / any MCP client)
 vibedrift login / logout    Account auth
 vibedrift status            Account, plan, and token
@@ -107,6 +108,38 @@ Common scan options:
 ```
 
 Run `vibedrift --help` for the complete list.
+
+### Drift Sessions (preview)
+
+Drift Sessions are a **Pro** feature, with a one-time **5-session free trial** (a free
+account is all it takes to start). After the trial the live tape locks behind a summary
+of what it caught, and `vibedrift upgrade` unlocks unlimited sessions. Your locally
+recorded ledgers always remain yours.
+
+`vibedrift watch-session` registers Claude Code hooks for the current repo (with an
+explicit consent prompt) so your agent session is recorded to a local, append-only
+ledger under `~/.vibedrift/sessions/`: your prompts (secrets masked), edit metadata,
+and any drift flags VibeDrift raised, with one-line advisory notes delivered into the
+agent's own context when an edit diverges from the repo's dominant patterns. Your
+prompts and code never leave your machine: the capture hook is fully offline, never
+reads the agent's transcript file, and never stores full edit bodies. (The
+`watch-session` viewer itself checks your session entitlement with the server on
+start — that is the only network on this surface, and it is off the hook's path.)
+Hooks fail open — an error or timeout never interrupts your agent. `--status` reports
+the install state; `--uninstall` removes exactly what was added.
+
+Run `vibedrift watch-session` and it follows a **live event tape**: each prompt,
+edit, and drift flag streams in as it happens, with a running count, a smoothed
+drift gauge, and an end-of-session summary (including how many of the task's
+target files you actually touched). It captures the task from your prompt — the
+files and symbols you named — and, conservatively, flags an edit that looks
+unrelated to any of them (experimental, so verify before trusting it). When a
+later edit fixes a flagged file, the finding is marked **resolved** — the same
+finding re-run over the new code, never a guess — so the summary's resolved and
+open counts are real. If the VibeDrift MCP is also enabled, the agent's own
+questions (`validate_change`, `check_file_drift`, `find_similar_function`) join the
+same tape as ASKS/REPLIES rows, so the whole exchange reads as one dialogue. Use
+`--no-watch` to install without following.
 
 ## Deep scan
 

--- a/bin/vibedrift-hook.mjs
+++ b/bin/vibedrift-hook.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+/* global process */
+// Fail-open even if the build is missing/corrupt: a hook must never break the agent.
+import("../dist/session/hook-entry.js").catch(() => process.exit(0));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Ship agentic. Stay coherent. Self-checking code integrity for AI coding agents, in the loop via MCP.",
   "type": "module",
   "bin": {
-    "vibedrift": "bin/vibedrift.mjs"
+    "vibedrift": "bin/vibedrift.mjs",
+    "vibedrift-hook": "bin/vibedrift-hook.mjs"
   },
   "main": "./dist/cli/index.js",
   "exports": {

--- a/src/auth/api.ts
+++ b/src/auth/api.ts
@@ -1,4 +1,5 @@
 import { resolveApiUrl } from "./resolver.js";
+import type { UploadEvent } from "../session/upload-schema.js";
 
 /**
  * Typed HTTP client for the VibeDrift Auth + Account API.
@@ -180,6 +181,66 @@ export async function fetchUsage(token: string, opts?: { apiUrl?: string }): Pro
     method: "GET",
     headers: { Authorization: `Bearer ${token}` },
   });
+}
+
+export interface SessionEntitlementResponse {
+  entitled: boolean;
+  plan: "free" | "pro" | "enterprise";
+  trial_used: number;
+  trial_limit: number;
+}
+
+/** Drift Sessions entitlement for the account (Pro or trial-remaining). */
+export async function fetchSessionEntitlement(
+  token: string,
+  opts?: { apiUrl?: string },
+): Promise<SessionEntitlementResponse> {
+  const base = await resolveApiUrl(opts?.apiUrl);
+  return jsonFetch<SessionEntitlementResponse>(`${base}/v1/sessions/entitlement`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+/** Count a watched session against the trial. The server dedups by session_id,
+ *  so reinstalls / rapid restarts of the same session never double-count. */
+export async function consumeSessionTrial(
+  token: string,
+  sessionId: string,
+  opts?: { apiUrl?: string },
+): Promise<SessionEntitlementResponse> {
+  const base = await resolveApiUrl(opts?.apiUrl);
+  return jsonFetch<SessionEntitlementResponse>(`${base}/v1/sessions/consume`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+}
+
+export interface SessionIngestResponse {
+  accepted: number;
+}
+
+/** Upload a batch of DERIVED-ONLY session events (Phase 5). Only invoked by the
+ *  uploader when the user opted into hosted sync and is logged in. The wire
+ *  carries `UploadEvent`s (findings/scores/outcomes/metadata) — never prompts or
+ *  code; the server re-validates derived-only as defense in depth. Shorter
+ *  timeout: a stalled upload must not wedge the resident watcher. */
+export async function postSessionIngest(
+  token: string,
+  events: UploadEvent[],
+  opts?: { apiUrl?: string; timeoutMs?: number },
+): Promise<SessionIngestResponse> {
+  const base = await resolveApiUrl(opts?.apiUrl);
+  return jsonFetch<SessionIngestResponse>(
+    `${base}/v1/sessions/ingest`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ events }),
+    },
+    opts?.timeoutMs ?? 15_000,
+  );
 }
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -72,6 +72,25 @@ export interface VibeDriftConfig {
    * quiet for a day after firing. See src/mcp/nudge.ts.
    */
   lastNudgedAt?: string;
+
+  /**
+   * Drift Sessions hosted sync (Phase 5). Opt-in, OFF by default. When true and
+   * logged in, `watch-session` streams a DERIVED-ONLY projection of the session
+   * (findings, scores, outcomes, metadata) to the dashboard. Prompts and code
+   * never leave the machine — see src/session/upload-schema.ts. Toggle with
+   * `vibedrift watch-session --sync on|off`; `--local-only` forces it off per run.
+   */
+  sessionsSyncEnabled?: boolean;
+
+  /**
+   * Team opt-in to ALSO ship the two derived free-text fields — the agent's
+   * decision reasoning and the intent label (both secret-masked). OFF by default
+   * even when sync is on; this is the code-egress boundary for shared reasoning.
+   */
+  sessionsTeamIntentOptIn?: boolean;
+
+  /** Set true after the one-time hosted-sync consent notice has been shown. */
+  sessionsSyncNoticeShown?: boolean;
 }
 
 const DEFAULT_DIR = join(homedir(), ".vibedrift");

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -1,4 +1,5 @@
 import { resolve } from "path";
+import { canonicalizeRoot } from "../../core/baseline.js";
 import { writeFile } from "fs/promises";
 import { stat } from "fs/promises";
 import chalk from "chalk";
@@ -1091,7 +1092,7 @@ export async function runScan(
   targetPath: string,
   options: ScanOptions,
 ): Promise<void> {
-  const rootDir = resolve(targetPath);
+  const rootDir = canonicalizeRoot(targetPath);
 
   try {
     const info = await stat(rootDir);

--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -1,0 +1,415 @@
+/**
+ * `vibedrift watch-session` — Drift Sessions (preview): install / uninstall /
+ * status for the agent hooks that record a session ledger, and (the default
+ * action) follow the live event tape until Ctrl-C.
+ *
+ * The capture path (the hook + the ledger) stays local. This command itself,
+ * being the resident viewer, resolves session entitlement from the server on
+ * start and counts a trial session — that is the only network on this surface,
+ * and it is off the hook's hot path.
+ */
+
+import readline from "readline";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import chalk from "chalk";
+import { repoIdentity, defaultSessionsDir } from "../../session/repo.js";
+import { installHooks, uninstallHooks, hooksStatus } from "../../session/install.js";
+import { runLiveTape } from "../../session/live.js";
+import { runUploader, shouldSync } from "../../session/uploader.js";
+import { parseJsonlLines } from "../../session/ledger.js";
+import { summarize } from "../../session/summary.js";
+import { readConfig, patchConfig } from "../../auth/config.js";
+import { postSessionIngest } from "../../auth/api.js";
+import type { UploadEvent } from "../../session/upload-schema.js";
+
+interface UploadPlan {
+  post: (events: UploadEvent[]) => Promise<void>;
+  teamIntentOptIn: boolean;
+}
+import {
+  computeEntitlement,
+  writeEntitlementCache,
+  readEntitlementCache,
+  entitlementDir,
+  type SessionEntitlement,
+} from "../../session/entitlement.js";
+
+export interface WatchSessionOptions {
+  uninstall?: boolean;
+  status?: boolean;
+  yes?: boolean;
+  /** After ensuring hooks are installed, follow the live event tape until SIGINT.
+   *  The CLI sets this true by default; omit it (as tests do) to just install. */
+  watch?: boolean;
+  /** Toggle hosted sync (Phase 5): "on" opts into derived-only upload, "off"
+   *  disables it. A standalone control — sets config and returns. */
+  sync?: "on" | "off";
+  /** Force hosted sync off for THIS run regardless of the saved setting. */
+  localOnly?: boolean;
+  /** Test seam: inject config instead of reading ~/.vibedrift (bypasses network). */
+  loadConfig?: () => Promise<{ sessionsSyncEnabled?: boolean; sessionsTeamIntentOptIn?: boolean; token?: string; apiUrl?: string }>;
+  /** Test/advanced seams; default to the real locations. */
+  sessionsDir?: string;
+  hookCommand?: string;
+  homeDir?: string;
+  confirm?: (question: string) => Promise<boolean>;
+  /** Inject the resolved entitlement (bypasses the network); tests use this.
+   *  Return null to simulate "login required". */
+  resolveEntitlement?: () => Promise<SessionEntitlement | null>;
+  /** dir for the entitlement cache (default ~/.vibedrift). */
+  entitlementDir?: string;
+  /** called (fire-and-forget) to count a trial session server-side. */
+  onConsumeTrial?: (sessionId: string) => void;
+}
+
+export type WatchSessionStatus =
+  | "installed"
+  | "already"
+  | "uninstalled"
+  | "not_installed"
+  | "status"
+  | "no_agent"
+  | "declined"
+  | "locked"
+  | "login_required"
+  | "sync_updated"
+  | "aborted_unparseable";
+
+function detectClaudeCode(repoRoot: string, homeDir: string): boolean {
+  return (
+    existsSync(join(repoRoot, ".claude")) || existsSync(join(homeDir, ".claude", "settings.json"))
+  );
+}
+
+/** Absolute `node <dist>/session/hook-entry.js` so hooks never depend on PATH.
+ *  At runtime this module lives in dist/cli/, so the entry is a sibling tree.
+ *  Both paths are double-quoted so a node install or repo checkout under a
+ *  directory containing spaces still runs (the shell would otherwise split it);
+ *  the trailing ` #vibedrift-hook` marker stays a shell comment. */
+function resolveHookCommand(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const entry = resolve(here, "..", "session", "hook-entry.js");
+  return `"${process.execPath}" "${entry}"`;
+}
+
+async function askConsent(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((res) => rl.question(question, res));
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+export async function runWatchSession(
+  targetPath: string,
+  options: WatchSessionOptions,
+): Promise<WatchSessionStatus> {
+  const { rootDir, projectHash } = repoIdentity(resolve(targetPath));
+  const sessionsDir = options.sessionsDir ?? defaultSessionsDir();
+  const home = options.homeDir ?? homedir();
+  const installOpts = {
+    hookCommand: options.hookCommand ?? resolveHookCommand(),
+    sessionsDir,
+    projectHash,
+  };
+  const ledgerDir = join(sessionsDir, projectHash);
+
+  if (options.status) {
+    const s = await hooksStatus(rootDir);
+    console.log(
+      s.installed
+        ? `${chalk.green("●")} Drift Sessions hooks installed (${s.file})`
+        : `${chalk.dim("○")} Drift Sessions hooks not installed`,
+    );
+    console.log(chalk.dim(`  session ledger: ${ledgerDir}`));
+    return "status";
+  }
+
+  if (options.uninstall) {
+    const res = await uninstallHooks(rootDir, installOpts);
+    if (res.status === "not_installed") {
+      console.log("Drift Sessions hooks were not installed; nothing to remove.");
+      return "not_installed";
+    }
+    if (res.status === "aborted_unparseable") {
+      console.error(`Could not parse ${res.file}; left untouched. Remove the ${chalk.bold("#vibedrift-hook")} entries manually.`);
+      process.exitCode = 1;
+      return "aborted_unparseable";
+    }
+    console.log(`${chalk.green("✓")} Drift Sessions hooks removed (${res.status === "restored" ? "settings restored exactly" : res.status === "removed" ? "settings file removed" : "our entries removed, your edits kept"}).`);
+    console.log(chalk.dim(`  recorded ledgers remain yours at ${ledgerDir}`));
+    return "uninstalled";
+  }
+
+  // Hosted sync toggle (Phase 5): a standalone control — set the flag and return.
+  if (options.sync) {
+    const on = options.sync === "on";
+    await patchConfig({ sessionsSyncEnabled: on, ...(on ? { sessionsSyncNoticeShown: true } : {}) });
+    if (on) {
+      console.log(`${chalk.green("✓")} Drift Sessions hosted sync is ON.`);
+      console.log(
+        chalk.dim(
+          [
+            "  Only a DERIVED projection leaves this machine — findings, scores, outcomes,",
+            "  and metadata. Your prompts and code never do. File paths ship only as",
+            "  per-repo grouping hashes, never the paths themselves. The agent's decision",
+            "  reasoning + intent label stay local unless a team explicitly opts in.",
+            "  Turn off anytime: vibedrift watch-session --sync off",
+          ].join("\n"),
+        ),
+      );
+    } else {
+      console.log(`${chalk.green("✓")} Drift Sessions hosted sync is OFF — sessions stay entirely on this machine.`);
+    }
+    return "sync_updated";
+  }
+
+  // Entitlement gate (decision 8): sessions are Pro-only with a one-time
+  // 5-session trial. Only gate the WATCH path (delivering the live tape); a
+  // bare install (--no-watch) just wires hooks, and the hook self-gates via the
+  // cache (a LOCKED account — which by definition has already watched to spend
+  // the trial — always has a cache that says locked). Pro unlock later takes
+  // effect via the cache alone, no reinstall.
+  const entDir = options.entitlementDir ?? entitlementDir();
+  let consumeCb: ((sessionId: string) => void) | undefined;
+  let uploadPlan: UploadPlan | undefined;
+  if (options.watch) {
+    const entitlement = options.resolveEntitlement
+      ? await options.resolveEntitlement()
+      : await resolveEntitlementViaNetwork(entDir);
+    if (entitlement === null) {
+      console.error("Drift Sessions need a free account. Run: vibedrift login");
+      process.exitCode = 1;
+      return "login_required";
+    }
+    writeEntitlementCache(entDir, entitlement);
+    if (!entitlement.entitled) {
+      printLockScreen(entitlement, sessionsDir, projectHash);
+      return "locked";
+    }
+    // On trial, count each watched session (with activity) against the trial.
+    consumeCb = options.onConsumeTrial
+      ? options.onConsumeTrial
+      : entitlement.reason === "trial"
+        ? (sessionId) => void consumeTrialOnFirstEdit(sessionId, entDir)
+        : undefined;
+    uploadPlan = await resolveUploadPlan(options);
+    if (uploadPlan) console.log(chalk.dim("  hosted sync: on (derived-only — findings/scores/outcomes, never code or prompts)"));
+  }
+
+  // Already installed: consent was given at install time, so skip straight to
+  // watching (consent gates INSTALLING hooks, not following an existing session).
+  const already = await hooksStatus(rootDir);
+  if (already.installed) {
+    console.log(`${chalk.green("●")} Drift Sessions hooks already installed (${already.file}).`);
+    console.log(chalk.dim(`  session ledger: ${ledgerDir}`));
+    if (options.watch) {
+      await followLiveTape(projectHash, sessionsDir, rootDir, entDir, consumeCb, uploadPlan);
+    }
+    return "already";
+  }
+
+  if (!detectClaudeCode(rootDir, home)) {
+    console.error("No supported agent detected (looked for .claude/ in the repo or ~/.claude/settings.json). Claude Code is the first supported agent.");
+    process.exitCode = 1;
+    return "no_agent";
+  }
+
+  if (!options.yes) {
+    const confirm = options.confirm ?? askConsent;
+    const ok = await confirm(
+      [
+        "Drift Sessions (preview) will register Claude Code hooks for THIS repo that:",
+        "  - record your prompts (secrets masked) and edit metadata to a local ledger",
+        `    under ${ledgerDir} (never uploaded by this feature; no network calls),`,
+        "  - send one-line advisory notes into the agent when an edit diverges",
+        "    from this repo's own dominant patterns,",
+        "  - never read the agent's transcript file, and fail open: a hook error",
+        "    or timeout never interrupts your agent.",
+        `Uninstall anytime: vibedrift watch-session --uninstall`,
+        "Install the hooks? [y/N] ",
+      ].join("\n"),
+    );
+    if (!ok) {
+      console.log("Nothing installed.");
+      return "declined";
+    }
+  }
+
+  const res = await installHooks(rootDir, installOpts);
+  if (res.status === "aborted_unparseable") {
+    console.error(`Could not parse ${res.file}; refusing to modify it. Fix the JSON and re-run.`);
+    process.exitCode = 1;
+    return "aborted_unparseable";
+  }
+  const installed = res.status === "already" ? "already" : "installed";
+  if (installed === "already") {
+    console.log(`${chalk.green("●")} Drift Sessions hooks already installed (${res.file}).`);
+  } else {
+    console.log(`${chalk.green("✓")} Drift Sessions hooks installed for this repo (${res.file}).`);
+    console.log(chalk.dim("  fail-open: a hook failure or timeout never interrupts your agent."));
+  }
+  console.log(chalk.dim(`  session ledger: ${ledgerDir}`));
+
+  if (options.watch) {
+    await followLiveTape(projectHash, sessionsDir, rootDir, entDir, consumeCb, uploadPlan);
+  } else {
+    console.log(chalk.dim("  next Claude Code session in this repo will be recorded; run with --status to check."));
+  }
+  return installed;
+}
+
+/** Resolve entitlement from the server, tolerating offline via the local cache.
+ *  Returns null only when there is no account AND no prior cache (login needed). */
+async function resolveEntitlementViaNetwork(entDir: string): Promise<SessionEntitlement | null> {
+  const { resolveToken } = await import("../../auth/resolver.js");
+  const resolved = await resolveToken();
+  const cached = readEntitlementCache(entDir);
+  if (!resolved) return cached ?? null; // no account: use a prior cache, else require login
+  try {
+    const { fetchSessionEntitlement } = await import("../../auth/api.js");
+    const r = await fetchSessionEntitlement(resolved.token);
+    return computeEntitlement(r.plan, r.trial_used, r.trial_limit);
+  } catch {
+    // offline: last known entitlement, or a provisional trial so a logged-in
+    // user is not locked out by a network blip (the server reconciles the count).
+    return cached ?? computeEntitlement("free", 0);
+  }
+}
+
+/** Count a watched session against the trial (fire-and-forget). The server
+ *  dedups by session id; we refresh the local cache with the returned count so
+ *  the lock lands on the next run once the trial is spent. */
+async function consumeTrialOnFirstEdit(sessionId: string, entDir: string): Promise<void> {
+  try {
+    const { resolveToken } = await import("../../auth/resolver.js");
+    const resolved = await resolveToken();
+    if (!resolved) return;
+    const { consumeSessionTrial } = await import("../../auth/api.js");
+    const r = await consumeSessionTrial(resolved.token, sessionId);
+    // Grandfather the in-flight session: keep capture ON even when this consume
+    // spends the last trial, so the 5th session runs full-featured to the end.
+    // The authoritative (possibly locked) entitlement is written when this watch
+    // exits (see refreshEntitlementOnExit); the next run then locks.
+    const e = computeEntitlement(r.plan, r.trial_used, r.trial_limit);
+    writeEntitlementCache(entDir, { ...e, entitled: true, reason: e.reason });
+  } catch {
+    // best-effort; the server remains authoritative for the count
+  }
+}
+
+/** After a watch ends, write the authoritative entitlement so a spent trial
+ *  re-locks promptly (a grandfathered in-flight session may have left the cache
+ *  entitled). Best-effort. */
+async function refreshEntitlementOnExit(entDir: string): Promise<void> {
+  try {
+    const e = await resolveEntitlementViaNetwork(entDir);
+    if (e) writeEntitlementCache(entDir, e);
+  } catch {
+    // best-effort
+  }
+}
+
+/** The honest lock screen: what the trial actually caught (from this repo's real
+ *  local ledgers) plus the upgrade CTA. No prevention claims. */
+function printLockScreen(e: SessionEntitlement, sessionsDir: string, projectHash: string): void {
+  let sessions = 0;
+  let flagged = 0;
+  try {
+    const dir = join(sessionsDir, projectHash);
+    const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+    for (const f of files) {
+      const events = parseJsonlLines(readFileSync(join(dir, f), "utf8"));
+      const s = summarize(events);
+      if (s.edits > 0) sessions++;
+      flagged += s.flagged; // confirmed findings only; experimental scope signals excluded
+    }
+  } catch {
+    // no local history to summarize; the CTA still stands
+  }
+  console.log(`\n${chalk.bold("Drift Sessions — trial complete.")}`);
+  console.log(
+    chalk.dim(
+      `  Your ${e.trialLimit}-session trial is used up${sessions ? ` (${sessions} watched, ${flagged} finding${flagged === 1 ? "" : "s"} surfaced on this repo)` : ""}.`,
+    ),
+  );
+  console.log("  Upgrade to Pro to keep the navigator watching every session:");
+  console.log(`    ${chalk.bold("vibedrift upgrade")}   ${chalk.dim("($15/mo — unlimited sessions, history, dashboard)")}`);
+  console.log(chalk.dim("  Your recorded local ledgers remain yours; nothing was uploaded.\n"));
+}
+
+/** Build the hosted-sync upload plan for this run, or undefined when sync is off
+ *  (not opted in, logged out, or --local-only). Fail-open: a config read error
+ *  just means no sync. Kept off the hook path — this runs in the resident viewer. */
+async function resolveUploadPlan(options: WatchSessionOptions): Promise<UploadPlan | undefined> {
+  try {
+    const cfg = options.loadConfig ? await options.loadConfig() : await readConfig();
+    if (!shouldSync(cfg, options.localOnly) || !cfg.token) return undefined;
+    const token = cfg.token;
+    const apiUrl = cfg.apiUrl;
+    return {
+      teamIntentOptIn: cfg.sessionsTeamIntentOptIn === true,
+      post: async (events) => {
+        await postSessionIngest(token, events, { apiUrl });
+      },
+    };
+  } catch {
+    return undefined; // config unreadable → no sync, local unaffected
+  }
+}
+
+/** Print the tape header and follow the live session until Ctrl-C. */
+async function followLiveTape(
+  projectHash: string,
+  sessionsDir: string,
+  rootDir: string,
+  entDir: string,
+  onFirstEdit?: (sessionId: string) => void,
+  upload?: UploadPlan,
+): Promise<void> {
+  // Staleness honesty: convention/redundancy checks need a baseline. Scope drift
+  // still works without one, so this is a hint, not a blocker.
+  try {
+    const { loadBaselineUnchecked } = await import("../../core/baseline.js");
+    if (!(await loadBaselineUnchecked(rootDir))) {
+      console.log(
+        chalk.dim("  note: no baseline yet — run `vibedrift scan` for convention + duplicate checks (scope drift works without one)."),
+      );
+    }
+  } catch {
+    // hint only; never block watching
+  }
+  console.log(chalk.dim("\n◆ EVENT TAPE · agent ↔ vibedrift · watching for your next session\n"));
+  const controller = new AbortController();
+  const onSigint = () => controller.abort();
+  process.once("SIGINT", onSigint);
+  try {
+    const tasks: Promise<void>[] = [
+      // If the tape ends (Ctrl-C) or crashes, abort so the uploader stops too.
+      runLiveTape({ sessionsDir, projectHash, out: process.stdout, signal: controller.signal, onFirstEdit }).finally(
+        () => controller.abort(),
+      ),
+    ];
+    if (upload) {
+      // Runs alongside the tape, own follower/offsets, fail-open, shares the
+      // Ctrl-C signal. Never on the hook path. Guarded so an uploader fault can
+      // never take the tape down.
+      tasks.push(
+        runUploader({
+          sessionsDir,
+          projectHash,
+          teamIntentOptIn: upload.teamIntentOptIn,
+          post: upload.post,
+          signal: controller.signal,
+        }).catch(() => {}),
+      );
+    }
+    await Promise.all(tasks);
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+    if (onFirstEdit) await refreshEntitlementOnExit(entDir);
+    process.stdout.write("\n");
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import { runBilling } from "./commands/billing.js";
 import { runDoctor } from "./commands/doctor.js";
 import { runFeedback } from "./commands/feedback.js";
 import { runWatch } from "./commands/watch.js";
+import { runWatchSession } from "./commands/watch-session.js";
 import { runHook } from "./commands/hook.js";
 import { getVersion } from "../core/version.js";
 
@@ -248,6 +249,31 @@ program
       verbose: options.verbose,
       include: options.include,
       exclude: options.exclude,
+    });
+  });
+
+// ──── Drift Sessions (preview) subcommand ────
+program
+  .command("watch-session")
+  .description(
+    "Drift Sessions (preview): record an agent session's prompts and edits to a local ledger via Claude Code hooks (local-only, consent-gated)",
+  )
+  .argument("[path]", "path to project directory", ".")
+  .option("--uninstall", "remove the hooks this command installed")
+  .option("--status", "report whether hooks are installed")
+  .option("--yes", "skip the consent prompt (you have read what it records)")
+  .option("--no-watch", "install only; do not follow the live event tape")
+  .option("--sync <state>", "hosted sync (Pro): 'on' opts into derived-only upload, 'off' disables it")
+  .option("--local-only", "force hosted sync off for this run")
+  .action(async (path: string, options) => {
+    const sync = options.sync === "on" ? "on" : options.sync === "off" ? "off" : undefined;
+    await runWatchSession(path, {
+      uninstall: options.uninstall,
+      status: options.status,
+      yes: options.yes,
+      sync,
+      localOnly: options.localOnly === true,
+      watch: options.watch !== false && !options.uninstall && !options.status && !sync,
     });
   });
 

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -14,7 +14,8 @@
  */
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { realpathSync } from "node:fs";
 import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 
 import { buildAnalysisContext } from "./discovery.js";
@@ -80,6 +81,23 @@ export interface RepoDriftBaseline {
 /** On-disk shape: signatures degrade to number[] (JSON has no typed arrays). */
 interface SerializedBaseline extends Omit<RepoDriftBaseline, "minhashIndex"> {
   minhashIndex: Array<Omit<MinhashEntry, "signature"> & { signature: number[] }>;
+}
+
+/**
+ * Canonicalize a repo root (resolve symlinks) so every entry point that keys a
+ * baseline or session ledger on it agrees. `vibedrift scan`, the MCP baseline
+ * provider, the agent hook, and the live tape must all derive the SAME
+ * projectHash from the SAME repo, or the hook loads no baseline and the tape
+ * follows the wrong ledger. macOS `/tmp -> /private/tmp` and symlinked
+ * project/home dirs are the common traps. Falls back to a plain resolve when
+ * the path does not exist yet.
+ */
+export function canonicalizeRoot(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
 }
 
 export function projectHash(rootDir: string): string {

--- a/src/mcp/baseline-provider.ts
+++ b/src/mcp/baseline-provider.ts
@@ -20,6 +20,7 @@ import {
   writeBaseline,
   computeBaselineKey,
   loadBaselineUnchecked,
+  canonicalizeRoot,
   BASELINE_VERSION,
   type RepoDriftBaseline,
 } from "../core/baseline.js";
@@ -104,8 +105,11 @@ async function liveKey(rootDir: string, baseline: RepoDriftBaseline): Promise<st
 }
 
 export async function getBaseline(
-  rootDir: string,
+  rawRootDir: string,
 ): Promise<{ baseline: RepoDriftBaseline | null; status: "ok" | "stale" | "no_baseline" }> {
+  // Canonicalize so the MCP tools key the same baseline the scan wrote and the
+  // hook loads (symlinked paths otherwise miss it).
+  const rootDir = canonicalizeRoot(rawRootDir);
   let baseline = memCache.get(rootDir) ?? null;
   if (!baseline) {
     baseline = await loadBaselineUnchecked(rootDir);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,9 +4,10 @@
  *
  * Exposes VibeDrift's drift / Code-DNA / intent engines as in-loop agent tools
  * so a coding agent can consult the repo's own conventions WHILE it writes,
- * turning drift detection into drift prevention. Local-only and FREE for
- * everyone: the tools run on the user's machine and send zero bytes. (Opt-in
- * `deep: true` checks are metered server-side inside the individual tools.)
+ * surfacing drift in the loop, while it is cheap to fix, instead of at review
+ * time. Local-only and FREE for everyone: the tools run on the user's machine
+ * and send zero bytes. (Opt-in `deep: true` checks are metered server-side
+ * inside the individual tools.)
  *
  * stdout is the JSON-RPC channel — all logging MUST go to stderr or it
  * corrupts the protocol framing.
@@ -18,6 +19,7 @@ import { registerGetDominantPattern } from "./tools/get-dominant-pattern.js";
 import { registerCheckFileDrift } from "./tools/check-file-drift.js";
 import { registerFindSimilarFunction } from "./tools/find-similar-function.js";
 import { registerValidateChange } from "./tools/validate-change.js";
+import { registerRespondToFlag } from "./tools/respond-to-flag.js";
 import { registerInit } from "./tools/init.js";
 
 const SERVER_INSTRUCTIONS = `VibeDrift detects drift in AI-generated code — where new code diverges from the patterns the rest of the codebase already follows.
@@ -29,6 +31,7 @@ These in-loop tools are LOCAL and FREE — call them while writing code:
 - check_file_drift: whether a file diverges from the dominant patterns.
 - find_similar_function: existing near-duplicates of a function you're about to write (avoid re-implementing).
 - validate_change: pre-commit drift check on an edit.
+- respond_to_flag: when a VibeDrift hook advisory flags your change (it carries a DF-<n> id), record your call on it — accept (you'll fix it), park (defer to a human reviewer), or decline (you judge the flag wrong/unneeded) — with a one-line reason.
 
 For a deeper, AI-validated pass on a CHANGE SET (before committing or opening a PR), have the user run the CLI:
 - \`vibedrift --deep --diff\`        deep-scan ONLY the files changed vs HEAD (fast, scoped).
@@ -37,7 +40,7 @@ For a deeper, AI-validated pass on a CHANGE SET (before committing or opening a 
 The --deep workflows (semantic-duplicate confirmation, intent lie-detection, the coherence audit) are a paid Pro feature; the local tools above stay free.`;
 
 /**
- * Build the server with the six local tools registered. The local tools are
+ * Build the server with the seven local tools registered. The local tools are
  * free for everyone; deep checks are metered server-side inside the tools.
  */
 export function createServer(): McpServer {
@@ -51,11 +54,14 @@ export function createServer(): McpServer {
   registerCheckFileDrift.register(server);
   registerFindSimilarFunction.register(server);
   registerValidateChange.register(server);
+  registerRespondToFlag.register(server);
   return server;
 }
 
 /** Start the server on stdio. Called by the `vibedrift mcp` subcommand and by
- *  direct `node dist/mcp/server.js` execution (the integration test spawns that). */
+ *  direct `node dist/mcp/server.js` execution (the integration test spawns that).
+ *  Note: respond_to_flag WRITES to the local session ledger; every other tool is
+ *  read-only. Still zero network — "local + free" holds. */
 export async function runServer(): Promise<void> {
   const server = createServer();
   const transport = new StdioServerTransport();

--- a/src/mcp/session-tee.ts
+++ b/src/mcp/session-tee.ts
@@ -1,0 +1,75 @@
+/**
+ * MCP-side adapter for the session tee: derive a one-line ask + verdict from a
+ * verdict tool's args and result, and record them into the active session
+ * ledger (if any). Fail-open — teeing never affects the tool's own result.
+ */
+
+import { defaultSessionsDir } from "../session/repo.js";
+import { teeMcpVerdict } from "../session/mcp-tee.js";
+
+interface ValidateOut {
+  ok?: boolean;
+  conflicts?: unknown[];
+  duplicateOf?: unknown[];
+}
+interface DriftOut {
+  fits?: boolean | null;
+  deviations?: unknown[];
+}
+interface SimilarOut {
+  found?: boolean;
+  matches?: unknown[];
+}
+
+function short(p: string): string {
+  const parts = p.split(/[\\/]/);
+  return parts.slice(-2).join("/");
+}
+
+export async function teeValidateChange(
+  args: { rootDir: string; targetPath: string },
+  out: ValidateOut,
+): Promise<void> {
+  const drift = out.conflicts?.length ?? 0;
+  const dup = out.duplicateOf?.length ?? 0;
+  const verdict =
+    out.ok || (drift === 0 && dup === 0)
+      ? "in line"
+      : [drift ? `${drift} drift` : "", dup ? `${dup} duplicate` : ""].filter(Boolean).join(", ");
+  await teeMcpVerdict({
+    sessionsDir: defaultSessionsDir(),
+    rootDir: args.rootDir,
+    tool: "validate_change",
+    ask: `validate ${short(args.targetPath)}`,
+    verdict,
+  });
+}
+
+export async function teeCheckFileDrift(
+  args: { rootDir: string; filePath: string },
+  out: DriftOut,
+): Promise<void> {
+  const dev = out.deviations?.length ?? 0;
+  const verdict = out.fits ? "fits" : dev ? `${dev} deviation${dev === 1 ? "" : "s"}` : "fits";
+  await teeMcpVerdict({
+    sessionsDir: defaultSessionsDir(),
+    rootDir: args.rootDir,
+    tool: "check_file_drift",
+    ask: `check ${short(args.filePath)}`,
+    verdict,
+  });
+}
+
+export async function teeFindSimilar(
+  args: { rootDir: string },
+  out: SimilarOut,
+): Promise<void> {
+  const n = out.matches?.length ?? 0;
+  await teeMcpVerdict({
+    sessionsDir: defaultSessionsDir(),
+    rootDir: args.rootDir,
+    tool: "find_similar_function",
+    ask: "find a similar existing function",
+    verdict: out.found ? `${n} similar found` : "no match",
+  });
+}

--- a/src/mcp/tools/check-file-drift.ts
+++ b/src/mcp/tools/check-file-drift.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, inputSchema } from "../../tools-core/tools/check-file-drift.js";
 import { finalizeMcpResult } from "../nudge.js";
+import { teeCheckFileDrift } from "../session-tee.js";
 
 export * from "../../tools-core/tools/check-file-drift.js";
 
@@ -23,7 +24,11 @@ export const registerCheckFileDrift = {
         inputSchema,
       },
       // Write-time tool: may carry the deep-scan nudge.
-      async (args) => finalizeMcpResult(await run(args), { nudge: true }),
+      async (args) => {
+        const out = await run(args);
+        void teeCheckFileDrift(args, out); // fire-and-forget; never slows the tool
+        return finalizeMcpResult(out, { nudge: true });
+      },
     );
   },
 };

--- a/src/mcp/tools/find-similar-function.ts
+++ b/src/mcp/tools/find-similar-function.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, inputSchema } from "../../tools-core/tools/find-similar-function.js";
 import { finalizeMcpResult } from "../nudge.js";
+import { teeFindSimilar } from "../session-tee.js";
 
 export * from "../../tools-core/tools/find-similar-function.js";
 
@@ -24,7 +25,11 @@ export const registerFindSimilarFunction = {
       },
       // A successful deep pass resets the nudge clock; the nudge itself rides on
       // the write-time tools (validate_change / check_file_drift).
-      async (args) => finalizeMcpResult(await run(args), { nudge: false }),
+      async (args) => {
+        const out = await run(args);
+        void teeFindSimilar(args, out); // fire-and-forget; never slows the tool
+        return finalizeMcpResult(out, { nudge: false });
+      },
     );
   },
 };

--- a/src/mcp/tools/respond-to-flag.ts
+++ b/src/mcp/tools/respond-to-flag.ts
@@ -1,0 +1,117 @@
+/**
+ * respond_to_flag — MCP adapter.
+ *
+ * Lets the agent record its own call on a VibeDrift flag (accept / park /
+ * decline) with a one-line reason. Local + free: it writes only to the local
+ * session ledger and sends zero bytes. Advisory — it never blocks the edit, and
+ * recording is best-effort (fail-open). The decision is a stated intent, not a
+ * verified resolution: accepting a flag does NOT mark it resolved; only a later
+ * re-edit that clears the signal does.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toToolResult, type ToolResult } from "../envelope.js";
+import type { StructuredBase } from "../../tools-core/result.js";
+import { defaultSessionsDir } from "../../session/repo.js";
+import { recordFlagDecision, DECISIONS, type Decision } from "../../session/decision.js";
+
+export const inputSchema = {
+  rootDir: z.string().describe("Absolute path to the repository root"),
+  findingId: z
+    .string()
+    .describe("The flag's id from the VibeDrift hook advisory, e.g. \"DF-3\"."),
+  decision: z
+    .enum(DECISIONS)
+    .describe(
+      "accept = you agree and will fix it; park = defer it to a human reviewer; decline = you judge the flag wrong or not needed for this codebase.",
+    ),
+  reason: z
+    .string()
+    .describe("One line on why you made this call. Recorded secret-masked and capped (~2000 chars)."),
+};
+
+export interface RespondToFlagOut extends StructuredBase {
+  recorded: boolean;
+  findingId?: string;
+  decision?: Decision;
+  knownFindings?: string[];
+}
+
+export async function run(args: {
+  rootDir: string;
+  findingId: string;
+  decision: Decision;
+  reason: string;
+}): Promise<RespondToFlagOut> {
+  // Whole body guarded: even resolving the sessions dir (homedir) must never
+  // surface as an MCP tool error — recording a decision is strictly advisory.
+  try {
+    const res = await recordFlagDecision({
+      sessionsDir: defaultSessionsDir(),
+      rootDir: args.rootDir,
+      findingId: args.findingId,
+      decision: args.decision,
+      reason: args.reason,
+    });
+
+    if (res.ok) {
+      return {
+        status: "ok",
+        recorded: true,
+        findingId: res.findingId,
+        decision: res.decision,
+        message: `Recorded ${res.decision} on ${res.findingId}.`,
+      };
+    }
+    if (res.code === "unknown_finding") {
+      const known = res.knownFindings.length ? res.knownFindings.join(", ") : "none";
+      return {
+        status: "ok",
+        recorded: false,
+        knownFindings: res.knownFindings,
+        message: `No flag ${args.findingId} in an active session for this repo. Open flags: ${known}.`,
+      };
+    }
+    if (res.code === "no_active_session") {
+      return {
+        status: "ok",
+        recorded: false,
+        message: "No active VibeDrift session for this repo, so nothing was recorded.",
+      };
+    }
+    if (res.code === "record_failed") {
+      return {
+        status: "ok",
+        recorded: false,
+        message: "Couldn't record the decision (an internal error). Nothing was saved.",
+      };
+    }
+    return {
+      status: "ok",
+      recorded: false,
+      message: `Not a valid decision. Use one of: ${DECISIONS.join(", ")}.`,
+    };
+  } catch {
+    return {
+      status: "ok",
+      recorded: false,
+      message: "Couldn't record the decision. Nothing was saved.",
+    };
+  }
+}
+
+export const registerRespondToFlag = {
+  run,
+  register(server: McpServer): void {
+    server.registerTool(
+      "respond_to_flag",
+      {
+        title: "Respond to a VibeDrift flag",
+        description:
+          "When a VibeDrift hook advisory flags one of your changes (the message carries a DF-<n> id), record your call on it: accept (you'll fix it), park (defer to a human reviewer), or decline (you judge the flag wrong or unnecessary here), with a one-line reason. Local, free, advisory — it records your decision to the session log and never blocks your edit. Accepting does not by itself resolve the flag; a later edit that clears the signal does.",
+        inputSchema,
+      },
+      async (args): Promise<ToolResult> => toToolResult(await run(args)),
+    );
+  },
+};

--- a/src/mcp/tools/validate-change.ts
+++ b/src/mcp/tools/validate-change.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, inputSchema } from "../../tools-core/tools/validate-change.js";
 import { finalizeMcpResult } from "../nudge.js";
+import { teeValidateChange } from "../session-tee.js";
 
 export * from "../../tools-core/tools/validate-change.js";
 
@@ -24,7 +25,13 @@ export const registerValidateChange = {
       },
       // Write-time tool: may carry the deep-scan nudge; a successful deep pass
       // resets the nudge clock.
-      async (args) => finalizeMcpResult(await run(args), { nudge: true }),
+      async (args) => {
+        const out = await run(args);
+        // Fire-and-forget: the tee is best-effort and self-contained fail-open,
+        // so it never blocks or slows the tool's own response.
+        void teeValidateChange(args, out);
+        return finalizeMcpResult(out, { nudge: true });
+      },
     );
   },
 };

--- a/src/session/anchors.ts
+++ b/src/session/anchors.ts
@@ -1,0 +1,132 @@
+/**
+ * Deterministic task anchors extracted from a prompt (Phase 3, free tier). No
+ * ML: file paths, backticked symbols, and identifier tokens the user named
+ * become the task's targets; follow-up prompts extend them. Used only for the
+ * conservative scope-drift signal, which ships labeled experimental.
+ */
+
+export interface Anchors {
+  files: string[];
+  symbols: string[];
+  tokens: string[];
+}
+
+// Prose stopwords + ubiquitous programming words. The token signal only works
+// if anchor tokens are DISTINCTIVE (stripe, webhook, billing) — generic code
+// words (return, error, export, value, response) appear in almost every file
+// and would make every edit look "related", neutering the scope signal.
+const STOPWORDS = new Set([
+  // prose
+  "the", "and", "for", "with", "that", "this", "from", "into", "your", "add",
+  "use", "using", "follow", "make", "also", "then", "when", "should", "would",
+  "like", "have", "will", "some", "them", "they", "want", "need", "please",
+  "here", "there", "where", "which", "while", "about", "over", "onto", "each",
+  // generic programming words
+  "code", "file", "files", "function", "functions", "route", "routes", "handler",
+  "handlers", "return", "returns", "export", "exports", "import", "imports",
+  "const", "async", "await", "throw", "catch", "class", "type", "types", "void",
+  "null", "true", "false", "undefined", "value", "values", "result", "results",
+  "response", "request", "params", "config", "data", "index", "name", "names",
+  "props", "state", "event", "events", "callback", "promise", "string", "number",
+  "boolean", "object", "array", "console", "message", "error", "errors", "update",
+  "create", "delete", "user", "users", "test", "tests", "mock", "util", "utils",
+  "helper", "helpers", "common", "shared", "base", "core", "main", "page", "pages",
+]);
+
+const uniq = (xs: string[]): string[] => [...new Set(xs)];
+
+export function extractAnchors(prompt: string): Anchors {
+  const pathFiles: string[] = [];
+  // a slash-separated path that ends in a file extension (routes/billing.ts).
+  // The extension requirement stops prose like "async/await" or "and/or" from
+  // being captured as a file.
+  for (const m of prompt.matchAll(/\b[\w.-]*\/[\w./-]*\.[a-z][a-z0-9]{0,4}\b/gi)) pathFiles.push(m[0]);
+  const pathBases = new Set(pathFiles.map((f) => baseName(f).toLowerCase()));
+  const files: string[] = [...pathFiles];
+  for (const m of prompt.matchAll(/\b[\w-]+\.[A-Za-z][\w]*\b/g)) {
+    // a bare dotted filename like package.json; skip when a path anchor already
+    // covers the same basename (routes/billing.ts vs billing.ts) so coverage
+    // does not double-count one file.
+    if (
+      /\.(ts|tsx|js|jsx|py|go|rs|json|md|yml|yaml|toml|css|html|sql)$/i.test(m[0]) &&
+      !pathBases.has(m[0].toLowerCase())
+    ) {
+      files.push(m[0]);
+    }
+  }
+
+  const symbols: string[] = [];
+  // backticked code spans: `handleStripeWebhook`, `apiClient.get`
+  for (const m of prompt.matchAll(/`([^`]+)`/g)) {
+    const inner = m[1].trim();
+    if (/^[A-Za-z_$][\w$.]*$/.test(inner)) symbols.push(inner.split(".")[0]);
+  }
+  // lowerCamelCase identifiers (a lowercase start with an internal capital) —
+  // these are unambiguously code symbols. Bare Capitalized words are NOT
+  // captured: they swallow ordinary prose (Update, User, Error) and made
+  // relatedness match nearly every file.
+  for (const m of prompt.matchAll(/\b([a-z][a-z0-9]*[A-Z]\w*)\b/g)) symbols.push(m[1]);
+  // explicit call sites: word(  or  word.word
+  for (const m of prompt.matchAll(/\b([a-zA-Z_$][\w$]{2,})\s*\(/g)) symbols.push(m[1]);
+
+  const tokens: string[] = [];
+  for (const m of prompt.toLowerCase().matchAll(/\b[a-z][a-z0-9]{3,}\b/g)) {
+    const w = m[0];
+    if (!STOPWORDS.has(w)) tokens.push(w);
+  }
+
+  return { files: uniq(files), symbols: uniq(symbols), tokens: uniq(tokens) };
+}
+
+export function mergeAnchors(a: Anchors, b: Anchors): Anchors {
+  return {
+    files: uniq([...a.files, ...b.files]),
+    symbols: uniq([...a.symbols, ...b.symbols]),
+    tokens: uniq([...a.tokens, ...b.tokens]),
+  };
+}
+
+const baseName = (p: string): string => p.split(/[\\/]/).pop() ?? p;
+
+/** True when the edited file is (or is within) an anchor file. Path anchors
+ *  match by exact path or a separator-bounded suffix; bare filenames match by
+ *  basename. Bounded so "a.ts" never matches "banana.ts". */
+export function fileMatchesAnchors(relFile: string, files: string[]): boolean {
+  const rf = relFile.toLowerCase().replace(/\\/g, "/");
+  const rfBase = baseName(rf);
+  for (const raw of files) {
+    const f = raw.toLowerCase().replace(/\\/g, "/");
+    if (f.includes("/")) {
+      if (rf === f || rf.endsWith(`/${f}`)) return true;
+    } else if (rfBase === f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function editRelatesToAnchors(relFile: string, body: string, anchors: Anchors): boolean {
+  if (fileMatchesAnchors(relFile, anchors.files)) return true;
+
+  // Tokenize the body ONCE (no per-anchor regex): identifier set (case-kept for
+  // symbols) + lowercased set for token matching.
+  const idents = body.match(/[A-Za-z_$][\w$]*/g) ?? [];
+  const identSet = new Set(idents);
+  const lowerJoined = `${relFile} ${idents.join(" ")}`.toLowerCase();
+
+  // body uses an anchor symbol verbatim
+  for (const s of anchors.symbols) {
+    if (s.length >= 3 && identSet.has(s)) return true;
+  }
+  // shares a DISTINCTIVE task token (anchor tokens are already stopword-filtered,
+  // so a substring hit like "webhook" in "webhookRouter" is meaningful, not noise)
+  for (const t of anchors.tokens) {
+    if (t.length >= 4 && lowerJoined.includes(t)) return true;
+  }
+  return false;
+}
+
+export function taskSummary(prompt: string): string {
+  const firstLine = prompt.split("\n")[0].trim().replace(/\s+/g, " ");
+  return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine;
+}

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -1,0 +1,171 @@
+/**
+ * Inline drift checks for a single edit event, sharing the exact classifiers
+ * the detectors use (via the tools-core pure projection), plus the FYI
+ * throttle. Everything here is fail-open: state I/O errors are swallowed and
+ * the caller gets an empty outcome rather than an exception.
+ *
+ * Phase 0 measurement: the check scales ~0.1ms per indexed function, so the
+ * inline path is gated to baselines at or under INLINE_CHECK_MAX_ENTRIES;
+ * larger repos record the edit and stay quiet (deferred checking is a later
+ * phase).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { loadBaselineUnchecked, type RepoDriftBaseline } from "../core/baseline.js";
+import { detectDrift } from "./detect.js";
+import { newActivityId, safeSegment } from "./ledger.js";
+import { SESSIONS_SCHEMA_VERSION } from "./types.js";
+import type { SessionEvent } from "./types.js";
+
+export const INLINE_CHECK_MAX_ENTRIES = 2000;
+export const COOLDOWN_MS = 5 * 60_000;
+
+interface CooldownState {
+  nextFindingSeq: number;
+  lastFyi: Record<string, number>;
+}
+
+export interface EditCheckOptions {
+  rootDir: string;
+  projectHash: string;
+  sessionId: string;
+  sessionsDir: string;
+  file: string;
+  body: string;
+  loadBaselineFor?: (rootDir: string) => Promise<RepoDriftBaseline | null>;
+  now?: () => number;
+}
+
+export interface EditCheckOutcome {
+  flags: SessionEvent[];
+  fyi: string | null;
+  /** the baseline that was loaded (if any), so callers can reuse it for the
+   *  finding-scoped outcome re-check without loading it twice */
+  baseline: RepoDriftBaseline | null;
+}
+
+function statePath(opts: EditCheckOptions): string {
+  return join(
+    opts.sessionsDir,
+    safeSegment(opts.projectHash),
+    `${safeSegment(opts.sessionId)}.cooldown.json`,
+  );
+}
+
+async function readState(opts: EditCheckOptions): Promise<CooldownState> {
+  try {
+    const raw = await readFile(statePath(opts), "utf8");
+    const parsed = JSON.parse(raw) as Partial<CooldownState>;
+    return {
+      nextFindingSeq: typeof parsed.nextFindingSeq === "number" ? parsed.nextFindingSeq : 1,
+      lastFyi: parsed.lastFyi && typeof parsed.lastFyi === "object" ? parsed.lastFyi : {},
+    };
+  } catch {
+    return { nextFindingSeq: 1, lastFyi: {} };
+  }
+}
+
+async function writeState(opts: EditCheckOptions, state: CooldownState): Promise<void> {
+  try {
+    await mkdir(join(opts.sessionsDir, safeSegment(opts.projectHash)), {
+      recursive: true,
+      mode: 0o700,
+    });
+    await writeFile(statePath(opts), JSON.stringify(state), { mode: 0o600 });
+  } catch {
+    // cooldown is best-effort; losing it degrades to an extra FYI, never a failure
+  }
+}
+
+export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOutcome> {
+  const load = opts.loadBaselineFor ?? loadBaselineUnchecked;
+  const now = opts.now ?? Date.now;
+
+  let baseline: RepoDriftBaseline | null;
+  try {
+    baseline = await load(opts.rootDir);
+  } catch {
+    return { flags: [], fyi: null, baseline: null };
+  }
+  if (!baseline || baseline.minhashIndex.length > INLINE_CHECK_MAX_ENTRIES) {
+    return { flags: [], fyi: null, baseline: null };
+  }
+
+  const relPath = relative(opts.rootDir, opts.file) || opts.file;
+
+  let conflictsByDim: Map<string, { dominantPattern: string; yourPattern: string; fixHint: string }>;
+  let dupsByLoc: Map<string, { relativePath: string; name: string; line: number; similarity: number }>;
+  try {
+    const detected = detectDrift(baseline, relPath, opts.body);
+    conflictsByDim = detected.conflicts;
+    dupsByLoc = detected.dups;
+  } catch {
+    return { flags: [], fyi: null, baseline };
+  }
+
+  const state = await readState(opts);
+  const flags: SessionEvent[] = [];
+  const candidates: Array<{ key: string; message: string; event: SessionEvent }> = [];
+
+  const mkFlag = (detail: SessionEvent["detail"]): SessionEvent => ({
+    v: SESSIONS_SCHEMA_VERSION,
+    sid: opts.sessionId,
+    aid: newActivityId(),
+    ts: new Date().toISOString(),
+    agent: "claude-code",
+    projectHash: opts.projectHash,
+    channel: "hook",
+    type: "flag",
+    mode: "passive",
+    findingId: `DF-${state.nextFindingSeq++}`,
+    detail,
+    outcome: null,
+  });
+
+  for (const [dimension, c] of conflictsByDim) {
+    const event = mkFlag({
+      file: relPath,
+      category: dimension,
+      dominant: c.dominantPattern,
+      observed: c.yourPattern,
+    });
+    flags.push(event);
+    candidates.push({
+      key: `${relPath}|${dimension}`,
+      message: `[vibedrift] flagged ${relPath} (${event.findingId}): ${c.fixHint}`,
+      event,
+    });
+  }
+
+  const topDup = [...dupsByLoc.values()].sort((a, b) => b.similarity - a.similarity)[0];
+  if (topDup) {
+    const where = `${topDup.relativePath}:${topDup.line}`;
+    const event = mkFlag({
+      file: relPath,
+      category: "redundancy",
+      similarTo: where,
+      similarity: topDup.similarity,
+    });
+    flags.push(event);
+    candidates.push({
+      key: `${relPath}|redundancy`,
+      message: `[vibedrift] flagged ${relPath} (${event.findingId}): new function duplicates ${topDup.name} at ${where} (${topDup.similarity.toFixed(2)} similar); prefer importing it.`,
+      event,
+    });
+  }
+
+  let fyi: string | null = null;
+  const t = now();
+  for (const cand of candidates) {
+    const last = state.lastFyi[cand.key];
+    if (last !== undefined && t - last < COOLDOWN_MS) continue;
+    state.lastFyi[cand.key] = t;
+    cand.event.msgToAgent = cand.message;
+    fyi = cand.message;
+    break;
+  }
+
+  if (flags.length > 0) await writeState(opts, state);
+  return { flags, fyi, baseline };
+}

--- a/src/session/decision.ts
+++ b/src/session/decision.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-flag decision capture (respond_to_flag): record the agent's own call on a
+ * VibeDrift flag — accept / park / decline — with a one-line reason, appended to
+ * the session ledger as a `decision` event.
+ *
+ * A decision is ORTHOGONAL to an outcome: "the agent accepted DF-3" is a stated
+ * intent, not a verified resolution. Accepting a flag does NOT mark it resolved;
+ * only the finding-scoped re-check (src/session/outcomes.ts) does. We record both
+ * and never conflate them.
+ *
+ * Correlation mirrors the MCP tee: no session id is available, so we find the
+ * repo's recently-active ledgers and record against one that raised the finding.
+ * Per-session `DF-<n>` ids are not globally unique, so when two concurrent
+ * same-repo sessions both minted the id, we prefer the ledger where it is still
+ * open + undecided; a truly ambiguous collision (both open) falls back to the
+ * newest and is an accepted best-effort limit. Fail-open — never throws; the
+ * worst case is a soft "not recorded" the agent can act on.
+ */
+
+import { join } from "node:path";
+import { projectHash, canonicalizeRoot } from "../core/baseline.js";
+import { appendEvent, newActivityId, readSessionEvents, safeSegment, sessionFilePath } from "./ledger.js";
+import { listActiveSessions } from "./mcp-tee.js";
+import { maskSecrets } from "./mask.js";
+import { SESSIONS_SCHEMA_VERSION } from "./types.js";
+import type { SessionEvent } from "./types.js";
+
+export const MAX_REASON_LEN = 2000;
+export const DECISIONS = ["accept", "park", "decline"] as const;
+export type Decision = (typeof DECISIONS)[number];
+
+export interface RecordDecisionOptions {
+  sessionsDir: string;
+  rootDir: string;
+  findingId: string;
+  decision: Decision;
+  reason: string;
+  now?: () => number;
+}
+
+export type RecordDecisionResult =
+  | { ok: true; sid: string; findingId: string; decision: Decision }
+  | { ok: false; code: "no_active_session" }
+  | { ok: false; code: "unknown_finding"; knownFindings: string[] }
+  | { ok: false; code: "bad_decision" }
+  | { ok: false; code: "record_failed" };
+
+/** Non-experimental raised flag ids in a ledger's events (the ids an agent could
+ *  legitimately respond to). */
+function raisedFindingIds(events: SessionEvent[]): string[] {
+  const ids: string[] = [];
+  for (const e of events) {
+    if (e.type === "flag" && e.findingId && !e.detail.experimental && !ids.includes(e.findingId)) {
+      ids.push(e.findingId);
+    }
+  }
+  return ids;
+}
+
+/** Is `id` still awaiting a response in this ledger — raised, not yet
+ *  resolved/held, and no decision recorded? Used to prefer the right ledger when
+ *  two concurrent same-repo sessions each minted the same per-session `DF-<n>`. */
+function isOpenUndecided(events: SessionEvent[], id: string): boolean {
+  let state: "open" | "resolved" | "held" = "open";
+  let decided = false;
+  for (const e of events) {
+    if (e.findingId !== id) continue;
+    if (e.type === "flag") {
+      if (e.outcome === "resolved") state = "resolved";
+      else if (e.outcome === "held" || e.mode === "blocking") state = "held";
+    } else if (e.type === "resolve") state = "resolved";
+    else if (e.type === "hold") state = "held";
+    else if (e.type === "decision") decided = true;
+  }
+  return state === "open" && !decided;
+}
+
+export async function recordFlagDecision(opts: RecordDecisionOptions): Promise<RecordDecisionResult> {
+  if (!(DECISIONS as readonly string[]).includes(opts.decision)) {
+    return { ok: false, code: "bad_decision" };
+  }
+
+  try {
+    const now = (opts.now ?? Date.now)();
+    const hash = projectHash(canonicalizeRoot(opts.rootDir));
+    const dir = join(opts.sessionsDir, safeSegment(hash));
+    const sessions = await listActiveSessions(dir, now);
+    if (sessions.length === 0) return { ok: false, code: "no_active_session" };
+
+    // Per-session `DF-<n>` ids are NOT globally unique, so two concurrent same-repo
+    // sessions can each mint a `DF-1`. Scan all active ledgers (newest-first),
+    // collect every one that raised this id, and prefer the ledger where the
+    // finding is still open + undecided (the one genuinely awaiting a response);
+    // fall back to the newest match. The union of raised ids across ledgers is the
+    // hint returned when nothing matches.
+    const knownUnion = new Set<string>();
+    const matches: Array<{ sid: string; open: boolean }> = [];
+    for (const s of sessions) {
+      const events = await readSessionEvents(sessionFilePath(opts.sessionsDir, hash, s.sid));
+      const ids = raisedFindingIds(events);
+      for (const id of ids) knownUnion.add(id);
+      if (ids.includes(opts.findingId)) {
+        matches.push({ sid: s.sid, open: isOpenUndecided(events, opts.findingId) });
+      }
+    }
+    if (matches.length === 0) {
+      return { ok: false, code: "unknown_finding", knownFindings: [...knownUnion] };
+    }
+    // `matches` preserves the newest-first order, so the first open match is the
+    // newest open one, and matches[0] is the newest overall.
+    const target = (matches.find((m) => m.open) ?? matches[0]).sid;
+
+    const reason = maskSecrets(opts.reason ?? "").slice(0, MAX_REASON_LEN);
+    const event: SessionEvent = {
+      v: SESSIONS_SCHEMA_VERSION,
+      sid: target,
+      aid: newActivityId(),
+      ts: new Date().toISOString(),
+      agent: "claude-code",
+      projectHash: hash,
+      channel: "mcp",
+      type: "decision",
+      mode: "passive",
+      findingId: opts.findingId,
+      detail: { decision: opts.decision, reason },
+    };
+    await appendEvent(opts.sessionsDir, hash, target, event);
+    return { ok: true, sid: target, findingId: opts.findingId, decision: opts.decision };
+  } catch {
+    // fail-open: a decision we couldn't record is a soft miss, never a thrown
+    // error. `record_failed` (not `no_active_session`) so the agent-facing copy
+    // doesn't falsely claim there was no session when a write actually failed.
+    return { ok: false, code: "record_failed" };
+  }
+}

--- a/src/session/detect.ts
+++ b/src/session/detect.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared drift detection for a file's content: the SAME multi-query
+ * decomposition the flag path and the outcome re-check both need. A single
+ * whole-body query dilutes redundancy below the 0.8 threshold (a 3-function
+ * body vs a 1-function index entry scores ~0.33) and can classify a
+ * mixed-async body as null, so both the raise AND the resolve must query the
+ * whole body PLUS each extracted function body — otherwise a still-present
+ * finding falsely reads "resolved".
+ */
+
+import { validateChangeAgainstBaseline } from "../tools-core/index.js";
+import { extractAllFunctions } from "../codedna/function-extractor.js";
+import { detectLanguage } from "../core/language.js";
+import type { RepoDriftBaseline } from "../core/baseline.js";
+
+const MAX_FUNCTIONS = 5;
+
+export interface DetectedConflict {
+  dominantPattern: string;
+  yourPattern: string;
+  fixHint: string;
+}
+export interface DetectedDup {
+  relativePath: string;
+  name: string;
+  line: number;
+  similarity: number;
+}
+export interface Detected {
+  conflicts: Map<string, DetectedConflict>;
+  dups: Map<string, DetectedDup>;
+}
+
+/** Throws only if validateChangeAgainstBaseline throws; callers wrap. */
+export function detectDrift(
+  baseline: RepoDriftBaseline,
+  relFile: string,
+  content: string,
+): Detected {
+  const queries: string[] = [content];
+  try {
+    const language = detectLanguage(relFile);
+    if (language) {
+      const fns = extractAllFunctions([
+        { path: relFile, relativePath: relFile, language, content, lineCount: content.split("\n").length },
+      ]);
+      for (const fn of fns.slice(0, MAX_FUNCTIONS)) queries.push(fn.rawBody);
+    }
+  } catch {
+    // extraction is an accuracy booster, never a requirement
+  }
+
+  const conflicts = new Map<string, DetectedConflict>();
+  const dups = new Map<string, DetectedDup>();
+  for (const q of queries) {
+    const result = validateChangeAgainstBaseline(baseline, relFile, q);
+    for (const c of result.conflicts) {
+      if (!conflicts.has(c.dimension)) conflicts.set(c.dimension, c);
+    }
+    for (const d of result.duplicateOf) {
+      const key = `${d.relativePath}:${d.line}`;
+      const prev = dups.get(key);
+      if (!prev || d.similarity > prev.similarity) dups.set(key, d);
+    }
+  }
+  return { conflicts, dups };
+}

--- a/src/session/entitlement.ts
+++ b/src/session/entitlement.ts
@@ -1,0 +1,80 @@
+/**
+ * Drift Sessions entitlement (decision 8): sessions are Pro-only with a one-time
+ * 5-session trial. The count lives server-side (survives reinstall / machine
+ * hops); this module holds the pure policy plus a LOCAL cache the offline hook
+ * reads to decide whether to capture at all. `watch-session` (online) refreshes
+ * the cache from the server; the hook never makes a network call.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { isPaidPlan, type Plan } from "../auth/plan.js";
+
+export const SESSION_TRIAL_LIMIT = 5;
+
+export type EntitlementReason = "pro" | "trial" | "locked";
+
+export interface SessionEntitlement {
+  entitled: boolean;
+  reason: EntitlementReason;
+  plan: Plan;
+  trialUsed: number;
+  trialLimit: number;
+}
+
+/** Pure policy: Pro/Enterprise always entitled; free entitled while trial remains. */
+export function computeEntitlement(
+  plan: Plan,
+  trialUsed: number,
+  trialLimit: number = SESSION_TRIAL_LIMIT,
+): SessionEntitlement {
+  if (isPaidPlan(plan)) {
+    return { entitled: true, reason: "pro", plan, trialUsed, trialLimit };
+  }
+  const entitled = trialUsed < trialLimit;
+  return { entitled, reason: entitled ? "trial" : "locked", plan, trialUsed, trialLimit };
+}
+
+function cachePath(baseDir: string): string {
+  return join(baseDir, "sessions-entitlement.json");
+}
+
+/** Default cache dir is ~/.vibedrift; tests pass an explicit dir. */
+export function entitlementDir(): string {
+  return join(homedir(), ".vibedrift");
+}
+
+export function readEntitlementCache(baseDir: string = entitlementDir()): SessionEntitlement | null {
+  try {
+    const raw = readFileSync(cachePath(baseDir), "utf8");
+    const parsed = JSON.parse(raw) as Partial<SessionEntitlement>;
+    if (typeof parsed.entitled !== "boolean") return null;
+    return {
+      entitled: parsed.entitled,
+      reason: (parsed.reason as EntitlementReason) ?? (parsed.entitled ? "trial" : "locked"),
+      plan: (parsed.plan as Plan) ?? "free",
+      trialUsed: typeof parsed.trialUsed === "number" ? parsed.trialUsed : 0,
+      trialLimit: typeof parsed.trialLimit === "number" ? parsed.trialLimit : SESSION_TRIAL_LIMIT,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeEntitlementCache(baseDir: string, e: SessionEntitlement): void {
+  try {
+    mkdirSync(baseDir, { recursive: true, mode: 0o700 });
+    writeFileSync(cachePath(baseDir), JSON.stringify(e), { mode: 0o600 });
+  } catch {
+    // best-effort; a missing cache fails OPEN (capture), never closed
+  }
+}
+
+/** The hook's gate: capture unless the cache explicitly says locked. A missing
+ *  cache permits capture — watch-session writes the cache before hooks are
+ *  useful, and failing open avoids silently dropping a paying user's session. */
+export function isCapturePermitted(baseDir: string = entitlementDir()): boolean {
+  const cached = readEntitlementCache(baseDir);
+  return cached ? cached.entitled : true;
+}

--- a/src/session/follow.ts
+++ b/src/session/follow.ts
@@ -1,0 +1,81 @@
+/**
+ * Poll-based tail of the active session ledger. No daemon, no fs.watch: each
+ * poll reads bytes appended to the current session file since the last read and
+ * returns the whole lines that arrived. Follows rotation to a newer session
+ * file (a new agent session in the same repo). Fail-open: any I/O error yields
+ * an empty batch rather than throwing into the render loop.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { safeSegment, parseJsonlLines } from "./ledger.js";
+import type { SessionEvent } from "./types.js";
+
+export class SessionFollower {
+  private readonly dir: string;
+  private activeFile: string | null = null;
+  /** Per-file read offset, so switching back to an earlier file (leapfrogging
+   *  mtimes across concurrent sessions) never replays events already emitted. */
+  private readonly offsets = new Map<string, number>();
+
+  constructor(sessionsDir: string, projectHash: string) {
+    this.dir = join(sessionsDir, safeSegment(projectHash));
+  }
+
+  private async newestSessionFile(): Promise<string | null> {
+    let names: string[];
+    try {
+      names = await readdir(this.dir);
+    } catch {
+      return null;
+    }
+    let newest: { file: string; mtime: number } | null = null;
+    for (const name of names) {
+      if (!name.endsWith(".jsonl")) continue;
+      const file = join(this.dir, name);
+      try {
+        const s = await stat(file);
+        // Tie-break equal mtimes by name so selection is deterministic.
+        if (
+          !newest ||
+          s.mtimeMs > newest.mtime ||
+          (s.mtimeMs === newest.mtime && file > newest.file)
+        ) {
+          newest = { file, mtime: s.mtimeMs };
+        }
+      } catch {
+        // file vanished between readdir and stat; skip
+      }
+    }
+    return newest?.file ?? null;
+  }
+
+  async poll(): Promise<SessionEvent[]> {
+    const active = await this.newestSessionFile();
+    if (!active) return [];
+    this.activeFile = active;
+    const offset = this.offsets.get(active) ?? 0;
+
+    let raw: string;
+    try {
+      raw = await readFile(active, "utf8");
+    } catch {
+      return [];
+    }
+    // If the file shrank (truncated/replaced), reset to read it fresh.
+    const start = raw.length < offset ? 0 : offset;
+    if (raw.length <= start) {
+      this.offsets.set(active, raw.length);
+      return [];
+    }
+
+    const slice = raw.slice(start);
+    // advance the offset only past the last COMPLETE line, so a half-written
+    // trailing line is re-read whole on the next poll.
+    const lastNl = slice.lastIndexOf("\n");
+    if (lastNl < 0) return [];
+    this.offsets.set(active, start + lastNl + 1);
+
+    return parseJsonlLines(slice.slice(0, lastNl));
+  }
+}

--- a/src/session/gauge.ts
+++ b/src/session/gauge.ts
@@ -1,0 +1,77 @@
+/**
+ * The drift gauge: a smoothed, honest aggregate of the three per-edit signals
+ * over a sliding window. Combined with the scoring-v11 noisy-OR family so no
+ * single signal dominates, and shown with zone hysteresis so it never flaps.
+ * Weights ship labeled "initial calibration" (see the plan).
+ */
+
+import type { SessionEvent } from "./types.js";
+
+export type Zone = "green" | "yellow" | "red";
+
+// Initial calibration (labeled as such per the plan): the noisy-OR weights, the
+// zone boundaries, the hysteresis margin, and the default window. These move
+// once we calibrate on real opt-in ledgers; kept together so that is one edit.
+export const GAUGE_WEIGHTS = { scope: 0.5, convention: 0.35, redundancy: 0.4 } as const;
+export const GAUGE_DEFAULT_WINDOW = 5;
+const GREEN_MAX = 0.25;
+const YELLOW_MAX = 0.5;
+const HYSTERESIS_MARGIN = 0.05;
+
+/** a = scope drift, b = convention drift, c = redundancy — each in [0,1]. */
+export function computeDrift(a: number, b: number, c: number): number {
+  const clamp = (x: number) => Math.min(1, Math.max(0, x));
+  const w = GAUGE_WEIGHTS;
+  const d = 1 - (1 - w.scope * clamp(a)) * (1 - w.convention * clamp(b)) * (1 - w.redundancy * clamp(c));
+  return Math.round(d * 1000) / 1000;
+}
+
+export function classifyZone(d: number): Zone {
+  if (d < GREEN_MAX) return "green";
+  if (d < YELLOW_MAX) return "yellow";
+  return "red";
+}
+
+/** Require the value to move a margin PAST a boundary before changing zone, so a
+ *  value hovering on a threshold does not oscillate. */
+export function applyHysteresis(prev: Zone, d: number, margin = HYSTERESIS_MARGIN): Zone {
+  const raw = classifyZone(d);
+  if (raw === prev) return prev;
+  // moving up: only switch if clearly past the upper edge of the current zone
+  if (raw === "yellow" && prev === "green" && d < GREEN_MAX + margin) return "green";
+  if (raw === "red" && prev === "yellow" && d < YELLOW_MAX + margin) return "yellow";
+  // moving down: only switch if clearly below the lower edge of the current zone
+  if (raw === "green" && prev === "yellow" && d > GREEN_MAX - margin) return "yellow";
+  if (raw === "yellow" && prev === "red" && d > YELLOW_MAX - margin) return "red";
+  return raw;
+}
+
+/** Fractions over the last `window` edits: scope / convention / redundancy flags
+ *  attributed to the edits they followed. Simple and honest: count flag events
+ *  by category among the events since the window's first edit. */
+export function gaugeSignals(
+  events: SessionEvent[],
+  window: number,
+): { a: number; b: number; c: number } {
+  const editIdx: number[] = [];
+  events.forEach((e, i) => {
+    if (e.type === "edit") editIdx.push(i);
+  });
+  if (editIdx.length === 0) return { a: 0, b: 0, c: 0 };
+  const windowEdits = editIdx.slice(-window);
+  const from = windowEdits[0];
+  const n = windowEdits.length;
+
+  let scope = 0;
+  let convention = 0;
+  let redundancy = 0;
+  for (let i = from; i < events.length; i++) {
+    const e = events[i];
+    if (e.type !== "flag") continue;
+    const cat = e.detail.category;
+    if (cat === "scope") scope++;
+    else if (cat === "redundancy") redundancy++;
+    else convention++;
+  }
+  return { a: scope / n, b: convention / n, c: redundancy / n };
+}

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -1,0 +1,210 @@
+/**
+ * vibedrift-hook: the thin session-event entrypoint that agent hooks invoke.
+ *
+ * Contract (Phase 1, passive only):
+ * - reads ONE hook JSON payload from stdin;
+ * - normalizes it, masks secrets, appends it to the session ledger;
+ * - on edit events, runs the inline drift checks and, when there is an
+ *   un-cooled advisory, prints it to stderr and exits 2 (PostToolUse feeds
+ *   stderr into the agent's context without blocking the tool);
+ * - exits 0 in EVERY other circumstance: malformed input, unknown events,
+ *   missing baseline, internal errors, timeout. A hook failure must never
+ *   interrupt the user's agent.
+ *
+ * Only Node built-ins are imported statically, so the self-timeout arms before
+ * any heavy module is evaluated; the workhorse modules (ledger, checks, and the
+ * baseline loader they pull) are dynamically imported inside the guarded run.
+ * This entry deliberately avoids Commander (measured ~1.1s CLI entry vs ~0.2s
+ * here). It does transitively pull the baseline loader and the AST function
+ * extractor, but the tree-sitter WASM parser is never initialized on this path
+ * (no file is parsed), so the cold cost stays ~60-80ms.
+ */
+
+import { relative, resolve, isAbsolute, basename } from "node:path";
+import { readFile } from "node:fs/promises";
+
+const SELF_TIMEOUT_MS = 2000;
+
+// Arm the fail-open guard first, before the dynamic imports below run.
+const timer = setTimeout(() => {
+  if (process.env.VIBEDRIFT_HOOK_DEBUG === "1") process.stderr.write("[vibedrift-hook] self-timeout\n");
+  process.exit(0);
+}, SELF_TIMEOUT_MS);
+
+function debug(msg: string): void {
+  if (process.env.VIBEDRIFT_HOOK_DEBUG === "1") process.stderr.write(`[vibedrift-hook] ${msg}\n`);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main(): Promise<number> {
+  const raw = await readStdin();
+  if (!raw.trim()) return 0;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return 0;
+  }
+
+  const [
+    { appendEvent, newActivityId },
+    { normalizeHookPayload },
+    { repoIdentity, defaultSessionsDir },
+    { runEditChecks },
+    { processPrompt, checkScope },
+    { recheckFile, detectRevert, readOutcomeState, writeOutcomeState },
+  ] = await Promise.all([
+    import("./ledger.js"),
+    import("./normalize.js"),
+    import("./repo.js"),
+    import("./check.js"),
+    import("./scope.js"),
+    import("./outcomes.js"),
+  ]);
+
+  const cwd =
+    typeof (payload as Record<string, unknown>)?.cwd === "string"
+      ? ((payload as Record<string, unknown>).cwd as string)
+      : process.cwd();
+  const { rootDir, projectHash } = repoIdentity(cwd);
+
+  const normalized = normalizeHookPayload(payload, { projectHash });
+  if (!normalized) return 0;
+
+  // Entitlement gate (decision 8): a LOCKED account captures nothing. The check
+  // reads a local cache written by `watch-session` — no network on this path.
+  // Fail-open: a missing/unreadable cache permits capture.
+  const { isCapturePermitted } = await import("./entitlement.js");
+  if (!isCapturePermitted()) return 0;
+
+  // The in-memory body hand-off must never reach the ledger.
+  const { body, ...event } = normalized;
+
+  // Resolve the edited file to a repo-relative path. A relative file_path from
+  // the hook is resolved against the repo root; an edit OUTSIDE the repo is not
+  // in this repo's baseline, so we record only its basename (never a machine
+  // path) and skip the inline check.
+  let checkAbsFile: string | null = null;
+  if (event.detail.file) {
+    const abs = isAbsolute(event.detail.file)
+      ? event.detail.file
+      : resolve(rootDir, event.detail.file);
+    const rel = relative(rootDir, abs);
+    if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+      event.detail.file = rel;
+      checkAbsFile = abs;
+    } else {
+      event.detail.file = basename(abs);
+    }
+  }
+
+  const sessionsDir = defaultSessionsDir();
+  await appendEvent(sessionsDir, projectHash, event.sid, event);
+
+  // Capture the task intent from prompts; lock it on the first one.
+  if (event.type === "user_prompt" && event.detail.promptText) {
+    const lock = await processPrompt(sessionsDir, projectHash, event.sid, event.detail.promptText);
+    if (lock) await appendEvent(sessionsDir, projectHash, event.sid, lock);
+  }
+
+  if (event.type === "edit" && body && event.detail.file) {
+    const relFile = event.detail.file;
+    let fyi: string | null = null;
+    const outcomes = await readOutcomeState(sessionsDir, projectHash, event.sid);
+
+    if (checkAbsFile) {
+      const res = await runEditChecks({
+        rootDir,
+        projectHash,
+        sessionId: event.sid,
+        sessionsDir,
+        file: checkAbsFile,
+        body,
+      });
+
+      // Finding-scoped resolution: re-run the detection over the file's CURRENT
+      // full content (read from disk — the post-edit state), not the edit hunk,
+      // so a finding resolves only when its own signal is genuinely gone.
+      if (res.baseline) {
+        let currentContent = body;
+        try {
+          currentContent = await readFile(checkAbsFile, "utf8");
+        } catch {
+          // fall back to the edit body (correct for Write, best-effort for Edit)
+        }
+        const { resolved } = recheckFile(res.baseline, relFile, currentContent, outcomes.open);
+        const resolvedIds = new Set(resolved.map((f) => f.findingId));
+        for (const f of resolved) {
+          await appendEvent(sessionsDir, projectHash, event.sid, {
+            v: event.v, sid: event.sid, aid: newActivityId(), ts: new Date().toISOString(),
+            agent: "claude-code", projectHash, channel: "hook", type: "resolve", mode: "passive",
+            findingId: f.findingId, detail: { file: f.file, category: f.category }, outcome: "resolved",
+          });
+        }
+        outcomes.open = outcomes.open.filter((f) => !resolvedIds.has(f.findingId));
+      }
+
+      // Dedupe: do not re-append a flag whose file|category is already open, and
+      // suppress its re-message too (the messaged flag carries res.fyi verbatim).
+      let suppressFyi = false;
+      for (const flag of res.flags) {
+        const key = `${flag.detail.file}|${flag.detail.category}`;
+        const already = outcomes.open.some((o) => `${o.file}|${o.category}` === key);
+        if (already) {
+          if (flag.msgToAgent && flag.msgToAgent === res.fyi) suppressFyi = true;
+          continue;
+        }
+        await appendEvent(sessionsDir, projectHash, event.sid, flag);
+        if (flag.findingId && flag.detail.file && flag.detail.category) {
+          outcomes.open.push({ findingId: flag.findingId, file: flag.detail.file, category: flag.detail.category });
+        }
+      }
+      if (!fyi && !suppressFyi) fyi = res.fyi;
+    }
+
+    // Best-effort byte-exact revert: the file restored to an earlier state this
+    // session (a formatter changes bytes, so it never false-positives). Out of
+    // the resolution rate; recorded as a subtle note.
+    if (detectRevert(relFile, body, outcomes.hashes).reverted) {
+      await appendEvent(sessionsDir, projectHash, event.sid, {
+        v: event.v, sid: event.sid, aid: newActivityId(), ts: new Date().toISOString(),
+        agent: "claude-code", projectHash, channel: "hook", type: "recheck", mode: "passive",
+        detail: { file: relFile, observed: "reverted to an earlier state" },
+      });
+    }
+
+    await writeOutcomeState(sessionsDir, projectHash, event.sid, outcomes);
+
+    // Scope drift is independent of the baseline check (fires even on edits
+    // outside the size gate or the repo's peer groups).
+    const scope = await checkScope(sessionsDir, projectHash, event.sid, relFile, body);
+    if (scope.flag) await appendEvent(sessionsDir, projectHash, event.sid, scope.flag);
+    if (!fyi && scope.fyi) fyi = scope.fyi;
+
+    if (fyi) {
+      process.stderr.write(`${fyi}\n`);
+      return 2;
+    }
+  }
+
+  return 0;
+}
+
+main()
+  .then((code) => {
+    clearTimeout(timer);
+    process.exit(code);
+  })
+  .catch((err: unknown) => {
+    clearTimeout(timer);
+    debug(`error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(0);
+  });

--- a/src/session/install.ts
+++ b/src/session/install.ts
@@ -1,0 +1,214 @@
+/**
+ * Agent-hook installer for Drift Sessions.
+ *
+ * Writes marker-tagged hook entries into the project's
+ * `.claude/settings.local.json` (project-local, conventionally uncommitted).
+ * Safety contract:
+ * - never touches a file it cannot parse (refuse-to-clobber);
+ * - snapshots the pre-install bytes so uninstall can restore them EXACTLY
+ *   when the user hasn't edited settings since (byte-identical restore);
+ * - falls back to surgical marker-entry removal when they have;
+ * - deletes the file on uninstall only when we created it and nothing else
+ *   was added to it.
+ */
+
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const HOOK_MARKER = "vibedrift-hook";
+
+/** The events Phase 1 listens to. PostToolUse is scoped to edit tools. */
+const HOOK_EVENTS: Array<{ event: string; matcher?: string }> = [
+  { event: "SessionStart" },
+  { event: "UserPromptSubmit" },
+  { event: "PostToolUse", matcher: "Edit|Write|MultiEdit" },
+  { event: "Stop" },
+];
+
+const HOOK_TIMEOUT_SECONDS = 10;
+
+export interface InstallOptions {
+  hookCommand: string;
+  sessionsDir: string;
+  projectHash: string;
+}
+
+export interface InstallResult {
+  status: "installed" | "already" | "aborted_unparseable";
+  file: string;
+}
+
+export interface UninstallResult {
+  status: "removed" | "restored" | "removed_surgical" | "not_installed" | "aborted_unparseable";
+  file: string;
+}
+
+type HookEntry = { type: string; command: string; timeout?: number };
+type HookGroup = { matcher?: string; hooks: HookEntry[] };
+type SettingsShape = Record<string, unknown> & { hooks?: Record<string, HookGroup[]> };
+
+function settingsPath(repoRoot: string): string {
+  return join(repoRoot, ".claude", "settings.local.json");
+}
+
+function backupPath(opts: InstallOptions): string {
+  return join(opts.sessionsDir, opts.projectHash, "settings-backup.json");
+}
+
+/** Sentinel meaning "the settings file did not exist before install". */
+const NO_FILE_SENTINEL = "::vibedrift:no-file::";
+
+function taggedCommand(opts: InstallOptions): string {
+  // Trailing shell comment doubles as the removal/idempotency marker.
+  return `${opts.hookCommand} #${HOOK_MARKER}`;
+}
+
+function isOurs(entry: HookEntry): boolean {
+  return typeof entry.command === "string" && entry.command.includes(HOOK_MARKER);
+}
+
+function hasOurEntry(groups: HookGroup[] | undefined): boolean {
+  return !!groups?.some((g) => Array.isArray(g.hooks) && g.hooks.some(isOurs));
+}
+
+async function readSettings(
+  file: string,
+): Promise<{ raw: string | null; parsed: SettingsShape | null; unparseable: boolean }> {
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf8");
+  } catch {
+    return { raw: null, parsed: null, unparseable: false };
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { raw, parsed: null, unparseable: true };
+    }
+    return { raw, parsed: parsed as SettingsShape, unparseable: false };
+  } catch {
+    return { raw, parsed: null, unparseable: true };
+  }
+}
+
+export async function installHooks(repoRoot: string, opts: InstallOptions): Promise<InstallResult> {
+  const file = settingsPath(repoRoot);
+  const { raw, parsed, unparseable } = await readSettings(file);
+  if (unparseable) return { status: "aborted_unparseable", file };
+
+  const settings: SettingsShape = parsed ?? {};
+  const hooks: Record<string, HookGroup[]> = (settings.hooks as Record<string, HookGroup[]>) ?? {};
+
+  if (HOOK_EVENTS.every(({ event }) => hasOurEntry(hooks[event]))) {
+    return { status: "already", file };
+  }
+
+  // Snapshot the pre-install state ONCE. On a re-install over a partial state
+  // (some of our events present, some not), a pristine snapshot already exists
+  // and must not be clobbered with the now-partially-installed bytes.
+  const backup = backupPath(opts);
+  await mkdir(dirname(backup), { recursive: true, mode: 0o700 });
+  let backupExists = true;
+  try {
+    await access(backup);
+  } catch {
+    backupExists = false;
+  }
+  if (!backupExists) {
+    await writeFile(backup, raw ?? NO_FILE_SENTINEL, { mode: 0o600 });
+  }
+
+  const command = taggedCommand(opts);
+  for (const { event, matcher } of HOOK_EVENTS) {
+    const groups = hooks[event] ?? [];
+    if (!hasOurEntry(groups)) {
+      const entry: HookEntry = { type: "command", command, timeout: HOOK_TIMEOUT_SECONDS };
+      groups.push(matcher !== undefined ? { matcher, hooks: [entry] } : { hooks: [entry] });
+    }
+    hooks[event] = groups;
+  }
+  settings.hooks = hooks;
+
+  await mkdir(dirname(file), { recursive: true });
+  await writeFile(file, `${JSON.stringify(settings, null, 2)}\n`);
+  return { status: "installed", file };
+}
+
+function stripOurEntries(hooks: Record<string, HookGroup[]>): Record<string, HookGroup[]> {
+  const out: Record<string, HookGroup[]> = {};
+  for (const [event, groups] of Object.entries(hooks)) {
+    const kept = groups
+      .map((g) => ({ ...g, hooks: (g.hooks ?? []).filter((h) => !isOurs(h)) }))
+      .filter((g) => g.hooks.length > 0);
+    if (kept.length > 0) out[event] = kept;
+  }
+  return out;
+}
+
+/** Deep-equal check that ignores our own marker entries: true when the current
+ *  file is exactly "the snapshot plus our install". */
+function matchesSnapshotPlusOurs(currentRaw: string, snapshotRaw: string): boolean {
+  try {
+    const current = JSON.parse(currentRaw) as SettingsShape;
+    const strippedHooks = stripOurEntries((current.hooks as Record<string, HookGroup[]>) ?? {});
+    const stripped: SettingsShape = { ...current };
+    if (Object.keys(strippedHooks).length > 0) stripped.hooks = strippedHooks;
+    else delete stripped.hooks;
+
+    const snapshot =
+      snapshotRaw === NO_FILE_SENTINEL ? {} : (JSON.parse(snapshotRaw) as SettingsShape);
+    return JSON.stringify(stripped) === JSON.stringify(snapshot);
+  } catch {
+    return false;
+  }
+}
+
+export async function uninstallHooks(
+  repoRoot: string,
+  opts: InstallOptions,
+): Promise<UninstallResult> {
+  const file = settingsPath(repoRoot);
+  const { raw, parsed, unparseable } = await readSettings(file);
+  if (unparseable) return { status: "aborted_unparseable", file };
+  if (raw === null || !parsed) return { status: "not_installed", file };
+
+  const hooks = (parsed.hooks as Record<string, HookGroup[]>) ?? {};
+  if (!Object.values(hooks).some((groups) => hasOurEntry(groups))) {
+    return { status: "not_installed", file };
+  }
+
+  let snapshotRaw: string | null;
+  try {
+    snapshotRaw = await readFile(backupPath(opts), "utf8");
+  } catch {
+    snapshotRaw = null;
+  }
+
+  if (snapshotRaw !== null && matchesSnapshotPlusOurs(raw, snapshotRaw)) {
+    if (snapshotRaw === NO_FILE_SENTINEL) {
+      await rm(file, { force: true });
+      await rm(backupPath(opts), { force: true });
+      return { status: "removed", file };
+    }
+    await writeFile(file, snapshotRaw);
+    await rm(backupPath(opts), { force: true });
+    return { status: "restored", file };
+  }
+
+  const strippedHooks = stripOurEntries(hooks);
+  const next: SettingsShape = { ...parsed };
+  if (Object.keys(strippedHooks).length > 0) next.hooks = strippedHooks;
+  else delete next.hooks;
+  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`);
+  await rm(backupPath(opts), { force: true });
+  return { status: "removed_surgical", file };
+}
+
+export async function hooksStatus(
+  repoRoot: string,
+): Promise<{ installed: boolean; file: string }> {
+  const file = settingsPath(repoRoot);
+  const { parsed } = await readSettings(file);
+  const hooks = (parsed?.hooks as Record<string, HookGroup[]>) ?? {};
+  return { installed: Object.values(hooks).some((groups) => hasOurEntry(groups)), file };
+}

--- a/src/session/intent-state.ts
+++ b/src/session/intent-state.ts
@@ -1,0 +1,68 @@
+/**
+ * Per-session intent state: the task anchors captured from prompts plus the
+ * scope-drift bookkeeping, persisted next to the ledger so the stateless hook
+ * processes (prompt in one invocation, edits in later ones) share it. All I/O
+ * is fail-open — a lost or corrupt file degrades to "no intent captured", never
+ * an error.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { safeSegment } from "./ledger.js";
+import type { Anchors } from "./anchors.js";
+
+export interface IntentState {
+  anchors: Anchors;
+  locked: boolean;
+  task: string;
+  unrelatedEdits: number;
+  /** files already scope-flagged this session, so we do not re-flag them */
+  scopeFlagged: string[];
+}
+
+export function emptyIntentState(): IntentState {
+  return { anchors: { files: [], symbols: [], tokens: [] }, locked: false, task: "", unrelatedEdits: 0, scopeFlagged: [] };
+}
+
+function statePath(sessionsDir: string, projectHash: string, sessionId: string): string {
+  return join(sessionsDir, safeSegment(projectHash), `${safeSegment(sessionId)}.intent.json`);
+}
+
+export async function readIntentState(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+): Promise<IntentState> {
+  try {
+    const raw = await readFile(statePath(sessionsDir, projectHash, sessionId), "utf8");
+    const parsed = JSON.parse(raw) as Partial<IntentState>;
+    const base = emptyIntentState();
+    return {
+      anchors: {
+        files: parsed.anchors?.files ?? base.anchors.files,
+        symbols: parsed.anchors?.symbols ?? base.anchors.symbols,
+        tokens: parsed.anchors?.tokens ?? base.anchors.tokens,
+      },
+      locked: parsed.locked ?? base.locked,
+      task: parsed.task ?? base.task,
+      unrelatedEdits: typeof parsed.unrelatedEdits === "number" ? parsed.unrelatedEdits : base.unrelatedEdits,
+      scopeFlagged: Array.isArray(parsed.scopeFlagged) ? parsed.scopeFlagged : base.scopeFlagged,
+    };
+  } catch {
+    return emptyIntentState();
+  }
+}
+
+export async function writeIntentState(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+  state: IntentState,
+): Promise<void> {
+  try {
+    await mkdir(join(sessionsDir, safeSegment(projectHash)), { recursive: true, mode: 0o700 });
+    await writeFile(statePath(sessionsDir, projectHash, sessionId), JSON.stringify(state), { mode: 0o600 });
+  } catch {
+    // best-effort; losing intent state degrades scope detection, never fails the hook
+  }
+}

--- a/src/session/ledger.ts
+++ b/src/session/ledger.ts
@@ -1,0 +1,87 @@
+/**
+ * Append-only JSONL session ledger.
+ *
+ * Writes are one line per event via a single appendFile call; readers tolerate
+ * corrupt lines (an interrupted write must never take the tape down with it).
+ */
+
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import type { SessionEvent } from "./types.js";
+
+/** Hard cap per line so a pathological prompt cannot bloat the ledger. */
+const MAX_LINE_BYTES = 32 * 1024;
+
+export function newActivityId(): string {
+  return `evt-${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
+}
+
+/** Confine an untrusted id (session id comes from the hook payload) to a single
+ *  safe path segment: no separators, no `..`, so it can never escape the
+ *  per-project sessions dir or target a directory that was never created. */
+export function safeSegment(id: string): string {
+  const cleaned = id.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^\.+/, "_");
+  return cleaned.length > 0 ? cleaned.slice(0, 128) : "unknown";
+}
+
+export function sessionFilePath(baseDir: string, projectHash: string, sessionId: string): string {
+  return join(baseDir, safeSegment(projectHash), `${safeSegment(sessionId)}.jsonl`);
+}
+
+function byteLen(s: string): number {
+  return Buffer.byteLength(s, "utf8");
+}
+
+export async function appendEvent(
+  baseDir: string,
+  projectHash: string,
+  sessionId: string,
+  ev: SessionEvent,
+): Promise<void> {
+  const dir = join(baseDir, safeSegment(projectHash));
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  let line = JSON.stringify(ev);
+  // Cap by UTF-8 BYTES, not code units: a CJK/emoji prompt is 1 code unit but
+  // 3-4 bytes each, so a length check would pass lines ~3x over the cap.
+  if (byteLen(line) > MAX_LINE_BYTES && ev.detail.promptText) {
+    let kept = ev.detail.promptText;
+    // Shrink until the whole serialized line fits, halving the prompt each pass
+    // then trimming; cheap and convergent for any multibyte content.
+    while (kept.length > 0 && byteLen(line) > MAX_LINE_BYTES) {
+      const target = Math.max(0, Math.floor(kept.length * 0.75) - 16);
+      kept = kept.slice(0, target);
+      line = JSON.stringify({ ...ev, detail: { ...ev.detail, promptText: kept, truncated: true } });
+    }
+    if (byteLen(line) > MAX_LINE_BYTES) {
+      line = JSON.stringify({ ...ev, detail: { ...ev.detail, promptText: "", truncated: true } });
+    }
+  }
+  await appendFile(sessionFilePath(baseDir, projectHash, sessionId), `${line}\n`, { mode: 0o600 });
+}
+
+/** Parse a chunk of newline-delimited JSON events, skipping any corrupt line
+ *  (an interrupted write must never take the reader down). Shared by the
+ *  whole-file reader and the live follower. */
+export function parseJsonlLines(chunk: string): SessionEvent[] {
+  const out: SessionEvent[] = [];
+  for (const line of chunk.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line) as SessionEvent);
+    } catch {
+      // corrupt line: skip it, never throw
+    }
+  }
+  return out;
+}
+
+export async function readSessionEvents(filePath: string): Promise<SessionEvent[]> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch {
+    return [];
+  }
+  return parseJsonlLines(raw);
+}

--- a/src/session/live.ts
+++ b/src/session/live.ts
@@ -1,0 +1,102 @@
+/**
+ * The live event tape: follows the active session ledger and prints each new
+ * event as a tape line, with a repainted one-line status footer, and a summary
+ * block at session end. Append-only above, single repainting line below (no TUI
+ * framework — just `\r\x1b[2K` to clear the footer line).
+ */
+
+import chalk from "chalk";
+import { SessionFollower } from "./follow.js";
+import { formatEventLine } from "./tape.js";
+import { summarize, formatSummary, type SessionSummary } from "./summary.js";
+import { computeDrift, gaugeSignals, applyHysteresis, GAUGE_DEFAULT_WINDOW, type Zone } from "./gauge.js";
+import type { SessionEvent } from "./types.js";
+
+const CLEAR_LINE = "\r\x1b[2K";
+const GAUGE_WINDOW = GAUGE_DEFAULT_WINDOW;
+
+function gaugeLabel(zone: Zone, d: number): string {
+  const dot = zone === "red" ? chalk.red("●") : zone === "yellow" ? chalk.yellow("●") : chalk.green("●");
+  return `${dot} drift ${d.toFixed(2)}`;
+}
+
+export interface LiveTapeOptions {
+  sessionsDir: string;
+  projectHash: string;
+  out: NodeJS.WritableStream;
+  intervalMs?: number;
+  signal?: AbortSignal;
+  /** injectable sleeper for tests; defaults to real setTimeout */
+  sleep?: (ms: number) => Promise<void>;
+  /** fired once per session id the first time it shows a real edit — used to
+   *  count a trial session server-side (a session counts only with activity). */
+  onFirstEdit?: (sessionId: string) => void;
+}
+
+function footer(count: number, s: SessionSummary, gauge: string): string {
+  return chalk.dim(
+    `⟳ watching · ${count} events · ${s.flagged} flagged · ${s.open} open · ${gauge} · Ctrl-C to stop`,
+  );
+}
+
+export async function runLiveTape(opts: LiveTapeOptions): Promise<void> {
+  const interval = opts.intervalMs ?? 300;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const follower = new SessionFollower(opts.sessionsDir, opts.projectHash);
+  const all: SessionEvent[] = [];
+  let footerShown = false;
+  let zone: Zone = "green";
+  const editedSessions = new Set<string>();
+  // Only count sessions whose activity arrives AFTER we start watching — the
+  // first poll replays the existing ledger, and a pre-existing/old session must
+  // not be charged against the trial.
+  const startedAt = Date.now();
+
+  const write = (s: string) => opts.out.write(s);
+  const clearFooter = () => {
+    if (footerShown) {
+      write(CLEAR_LINE);
+      footerShown = false;
+    }
+  };
+  const showFooter = () => {
+    const { a, b, c } = gaugeSignals(all, GAUGE_WINDOW);
+    const d = computeDrift(a, b, c);
+    zone = applyHysteresis(zone, d);
+    write(footer(all.length, summarize(all), gaugeLabel(zone, d)));
+    footerShown = true;
+  };
+
+  while (!opts.signal?.aborted) {
+    const batch = await follower.poll();
+    if (batch.length) {
+      clearFooter();
+      for (const ev of batch) {
+        all.push(ev);
+        if (
+          ev.type === "edit" &&
+          ev.sid &&
+          !editedSessions.has(ev.sid) &&
+          (Date.parse(ev.ts) || 0) >= startedAt
+        ) {
+          editedSessions.add(ev.sid);
+          try {
+            opts.onFirstEdit?.(ev.sid);
+          } catch {
+            // trial counting is best-effort; never break the tape
+          }
+        }
+        const line = formatEventLine(ev);
+        if (line) write(`${line}\n`);
+        if (ev.type === "session_end") {
+          const s = summarize(all);
+          write(`\n${chalk.bold("session summary")}  ${formatSummary(s)}\n\n`);
+        }
+      }
+      showFooter();
+    }
+    if (opts.signal?.aborted) break;
+    await sleep(interval);
+  }
+  clearFooter();
+}

--- a/src/session/mask.ts
+++ b/src/session/mask.ts
@@ -1,0 +1,52 @@
+/**
+ * Conservative secret masking applied to prompt text before every ledger
+ * write. The ledger must never be the easiest place on the machine to steal a
+ * key from. Biased toward high-confidence shapes: over-masking prose would
+ * degrade the tape, so short/ambiguous values are deliberately left alone.
+ *
+ * (The analyzer's SECURITY_PATTERNS in src/analyzers/security.ts is
+ * file-context-shaped and module-private; this is a dedicated prompt-text set.)
+ */
+
+const BLOCK_RULES: RegExp[] = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  // Provider API keys: sk-…, sk-ant-api03-…, sk-proj-…, sk_live_…, pk-…, rk_…
+  // The key body legitimately contains internal hyphens/underscores (sk-ant-api03-),
+  // so the run must allow them, not stop at the first hyphen.
+  /\b(?:sk|pk|rk)[-_][A-Za-z0-9](?:[A-Za-z0-9_-]{14,})[A-Za-z0-9]/gi,
+  /\bBearer\s+[A-Za-z0-9._~+/-]{16,}=*/g,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g,
+  // High-entropy, near-zero-false-positive vendor shapes that carry no key= prefix,
+  // so KEYED_RULE never sees them: Slack (xoxb-/xoxp-/xoxa-/xoxr-/xoxs-), Google API
+  // keys (AIza…), and granular npm tokens (npm_…).
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}/g,
+  /\bAIza[0-9A-Za-z_-]{35}/g,
+  /\bnpm_[A-Za-z0-9]{36,}/g,
+];
+
+// Credentials embedded in a connection string / URL userinfo
+// (postgres://user:PASS@host, redis://:PASS@host, mongodb+srv://u:PASS@…). The
+// password is not key=value shaped, so KEYED_RULE misses it; mask only the
+// password, preserving the scheme + user for a still-useful, non-secret trace.
+const URL_CRED_RULE = /([a-z][a-z0-9+.-]*:\/\/[^\s/:@]*:)([^\s/@]+)@/gi;
+
+// key = value / key: value, where the value is >= 8 non-space chars.
+// Group 1 captures the FULL identifier including any SNAKE_CASE prefix
+// (OPENAI_API_KEY, DB_PASSWORD): `_` is a word character, so a `\b` before the
+// bare keyword never matches inside `DB_PASSWORD` — the prefix run fixes that
+// and is preserved in the replacement so only the value is masked.
+const KEYED_RULE =
+  /([A-Za-z0-9_-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key))(\s*[:=]\s*)["']?[^\s"']{8,}["']?/gi;
+
+export function maskSecrets(text: string): string {
+  let out = text;
+  for (const re of BLOCK_RULES) {
+    out = out.replace(re, "[masked]");
+  }
+  // Mask only the password in a connection-string userinfo, preserving scheme+user.
+  out = out.replace(URL_CRED_RULE, (_m, prefix: string) => `${prefix}[masked]@`);
+  out = out.replace(KEYED_RULE, (_m, key: string, sep: string) => `${key}${sep}[masked]`);
+  return out;
+}

--- a/src/session/mcp-tee.ts
+++ b/src/session/mcp-tee.ts
@@ -1,0 +1,88 @@
+/**
+ * Tee an MCP tool's verdict into the active session ledger, so the agent asking
+ * VibeDrift (via MCP) and VibeDrift flagging the agent (via hooks) read as one
+ * dialogue. Correlated by project hash: the verdict joins the most-recently
+ * active session for the repo. No active session -> no-op. Fail-open.
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { projectHash, canonicalizeRoot } from "../core/baseline.js";
+import { appendEvent, newActivityId, safeSegment } from "./ledger.js";
+import { SESSIONS_SCHEMA_VERSION } from "./types.js";
+import type { SessionEvent } from "./types.js";
+
+/** A session is "active" if its ledger was touched within this window. */
+export const ACTIVE_WINDOW_MS = 10 * 60_000;
+
+export interface TeeOptions {
+  sessionsDir: string;
+  rootDir: string;
+  tool: string;
+  ask: string;
+  verdict: string;
+  now?: () => number;
+}
+
+/** Every ledger in `dir` touched within `windowMs`, newest-first. Shared by the
+ *  MCP tee (which takes the newest) and decision capture (which scans them for
+ *  the one that raised a given finding). Fail-open: an unreadable dir is []. */
+export async function listActiveSessions(
+  dir: string,
+  now: number,
+  windowMs: number = ACTIVE_WINDOW_MS,
+): Promise<Array<{ sid: string; mtime: number }>> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: Array<{ sid: string; mtime: number }> = [];
+  for (const name of names) {
+    if (!name.endsWith(".jsonl")) continue;
+    try {
+      const s = await stat(join(dir, name));
+      if (now - s.mtimeMs > windowMs) continue;
+      out.push({ sid: name.slice(0, -".jsonl".length), mtime: s.mtimeMs });
+    } catch {
+      // vanished; skip
+    }
+  }
+  return out.sort((a, b) => b.mtime - a.mtime);
+}
+
+async function activeSession(
+  dir: string,
+  now: number,
+): Promise<{ sid: string; mtime: number } | null> {
+  return (await listActiveSessions(dir, now))[0] ?? null;
+}
+
+export async function teeMcpVerdict(opts: TeeOptions): Promise<void> {
+  try {
+    const now = (opts.now ?? Date.now)();
+    const hash = projectHash(canonicalizeRoot(opts.rootDir));
+    const dir = join(opts.sessionsDir, safeSegment(hash));
+    const session = await activeSession(dir, now);
+    if (!session) return;
+
+    const mk = (type: SessionEvent["type"], detail: SessionEvent["detail"], channel: "mcp"): SessionEvent => ({
+      v: SESSIONS_SCHEMA_VERSION,
+      sid: session.sid,
+      aid: newActivityId(),
+      ts: new Date().toISOString(),
+      agent: "claude-code",
+      projectHash: hash,
+      channel,
+      type,
+      mode: "passive",
+      detail,
+    });
+
+    await appendEvent(opts.sessionsDir, hash, session.sid, mk("mcp_ask", { toolName: opts.tool, promptText: opts.ask }, "mcp"));
+    await appendEvent(opts.sessionsDir, hash, session.sid, mk("mcp_verdict", { toolName: opts.tool, observed: opts.verdict }, "mcp"));
+  } catch {
+    // teeing is best-effort; never break the MCP tool
+  }
+}

--- a/src/session/normalize.ts
+++ b/src/session/normalize.ts
@@ -1,0 +1,111 @@
+/**
+ * Normalize a Claude Code hook stdin payload into a SessionEvent, or null for
+ * anything we do not record (fail-open: unknown means ignore, never error).
+ *
+ * Data-minimization invariants:
+ * - prompt text is secret-masked before it ever reaches a SessionEvent;
+ * - Bash commands are recorded as a bare `command` event with no command text;
+ * - the transcript_path in the payload is deliberately never read.
+ */
+
+import { maskSecrets } from "./mask.js";
+import { newActivityId } from "./ledger.js";
+import { SESSIONS_SCHEMA_VERSION } from "./types.js";
+import type { SessionEvent, SessionEventDetail } from "./types.js";
+
+export const EDIT_TOOLS = ["Edit", "Write", "MultiEdit"] as const;
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v !== null && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function countLines(body: string): number {
+  const s = body.endsWith("\n") ? body.slice(0, -1) : body;
+  return s.length === 0 ? 0 : s.split("\n").length;
+}
+
+export function extractEditedBody(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): { file?: string; body?: string; diffstat?: string } | null {
+  const file = asString(toolInput.file_path) ?? undefined;
+  if (toolName === "Edit") {
+    const body = asString(toolInput.new_string) ?? "";
+    return { file, body, diffstat: `+${countLines(body)}` };
+  }
+  if (toolName === "Write") {
+    const body = asString(toolInput.content) ?? asString(toolInput.file_text) ?? "";
+    return { file, body, diffstat: `+${countLines(body)}` };
+  }
+  if (toolName === "MultiEdit") {
+    const edits = Array.isArray(toolInput.edits) ? toolInput.edits : [];
+    const parts: string[] = [];
+    for (const e of edits) {
+      const rec = asRecord(e);
+      const s = rec ? asString(rec.new_string) : null;
+      if (s) parts.push(s);
+    }
+    const body = parts.join("\n");
+    return { file, body, diffstat: `+${countLines(body)}` };
+  }
+  return null;
+}
+
+export function normalizeHookPayload(
+  raw: unknown,
+  ctx: { projectHash: string },
+): (SessionEvent & { body?: string }) | null {
+  const p = asRecord(raw);
+  if (!p) return null;
+  const sid = asString(p.session_id);
+  const eventName = asString(p.hook_event_name);
+  if (!sid || !eventName) return null;
+
+  const mk = (
+    type: SessionEvent["type"],
+    detail: SessionEventDetail,
+    body?: string,
+  ): SessionEvent & { body?: string } => ({
+    v: SESSIONS_SCHEMA_VERSION,
+    sid,
+    aid: newActivityId(),
+    ts: new Date().toISOString(),
+    agent: "claude-code",
+    projectHash: ctx.projectHash,
+    channel: "hook",
+    type,
+    mode: "passive",
+    detail,
+    ...(body !== undefined ? { body } : {}),
+  });
+
+  if (eventName === "SessionStart") return mk("session_start", {});
+  if (eventName === "Stop" || eventName === "SessionEnd") return mk("session_end", {});
+
+  if (eventName === "UserPromptSubmit") {
+    const prompt = asString(p.prompt) ?? asString(p.user_prompt);
+    if (!prompt) return null;
+    return mk("user_prompt", { promptText: maskSecrets(prompt) });
+  }
+
+  if (eventName === "PostToolUse") {
+    const toolName = asString(p.tool_name);
+    const toolInput = asRecord(p.tool_input);
+    if (!toolName) return null;
+    if ((EDIT_TOOLS as readonly string[]).includes(toolName) && toolInput) {
+      const ext = extractEditedBody(toolName, toolInput);
+      if (!ext) return null;
+      return mk("edit", { file: ext.file, toolName, diffstat: ext.diffstat }, ext.body);
+    }
+    if (toolName === "Bash") return mk("command", { toolName });
+    return null;
+  }
+
+  return null;
+}

--- a/src/session/outcomes.ts
+++ b/src/session/outcomes.ts
@@ -1,0 +1,115 @@
+/**
+ * Finding-scoped outcomes (Phase 4): a finding resolves only when the SAME
+ * finding re-runs over its actual inputs and passes — never because some
+ * unrelated file was edited. Re-check is triggered by an edit to the finding's
+ * own file: the new body is re-validated, and an open convention/redundancy
+ * finding whose signal no longer fires is resolved. Scope findings are
+ * experimental and not auto-resolved here. Revert detection is byte-exact and
+ * best-effort (a formatter changes bytes, so it never false-positives) and
+ * stays out of the resolution rate.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { detectDrift } from "./detect.js";
+import { safeSegment } from "./ledger.js";
+import type { RepoDriftBaseline } from "../core/baseline.js";
+
+export interface OpenFinding {
+  findingId: string;
+  file: string;
+  category: string;
+}
+
+export interface OutcomeState {
+  open: OpenFinding[];
+  /** recent body hashes per file, for byte-exact revert detection */
+  hashes: Record<string, string[]>;
+}
+
+const MAX_HASHES_PER_FILE = 20;
+
+export function emptyOutcomeState(): OutcomeState {
+  return { open: [], hashes: {} };
+}
+
+/** Re-run the drift detection over the file's CURRENT full content (not the
+ *  edit hunk) using the SAME multi-query decomposition the flag path uses, and
+ *  return the open findings on that file whose signal is genuinely gone. Using
+ *  the same detection avoids the dilution trap where a whole-body query misses
+ *  a per-function duplicate; using the full file (not the hunk) avoids resolving
+ *  a finding on a function the current edit did not even touch. Fail-open: on
+ *  any error nothing resolves (a finding stays open rather than falsely clears). */
+export function recheckFile(
+  baseline: RepoDriftBaseline,
+  relFile: string,
+  content: string,
+  open: OpenFinding[],
+): { resolved: OpenFinding[] } {
+  const here = open.filter((f) => f.file === relFile && f.category !== "scope");
+  if (here.length === 0) return { resolved: [] };
+
+  let conflictDims: Set<string>;
+  let hasDup: boolean;
+  try {
+    const d = detectDrift(baseline, relFile, content);
+    conflictDims = new Set(d.conflicts.keys());
+    hasDup = d.dups.size > 0;
+  } catch {
+    return { resolved: [] };
+  }
+
+  const resolved = here.filter((f) =>
+    f.category === "redundancy" ? !hasDup : !conflictDims.has(f.category),
+  );
+  return { resolved };
+}
+
+export function detectRevert(
+  relFile: string,
+  body: string,
+  hashes: Record<string, string[]>,
+): { reverted: boolean } {
+  const h = createHash("sha256").update(body).digest("hex").slice(0, 16);
+  const seen = hashes[relFile] ?? [];
+  const reverted = seen.includes(h);
+  const next = [...seen, h].slice(-MAX_HASHES_PER_FILE);
+  hashes[relFile] = next;
+  return { reverted };
+}
+
+function statePath(sessionsDir: string, projectHash: string, sessionId: string): string {
+  return join(sessionsDir, safeSegment(projectHash), `${safeSegment(sessionId)}.outcomes.json`);
+}
+
+export async function readOutcomeState(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+): Promise<OutcomeState> {
+  try {
+    const raw = await readFile(statePath(sessionsDir, projectHash, sessionId), "utf8");
+    const parsed = JSON.parse(raw) as Partial<OutcomeState>;
+    return {
+      open: Array.isArray(parsed.open) ? parsed.open : [],
+      hashes: parsed.hashes && typeof parsed.hashes === "object" ? parsed.hashes : {},
+    };
+  } catch {
+    return emptyOutcomeState();
+  }
+}
+
+export async function writeOutcomeState(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+  state: OutcomeState,
+): Promise<void> {
+  try {
+    await mkdir(join(sessionsDir, safeSegment(projectHash)), { recursive: true, mode: 0o700 });
+    await writeFile(statePath(sessionsDir, projectHash, sessionId), JSON.stringify(state), { mode: 0o600 });
+  } catch {
+    // best-effort; losing outcome state degrades to "flags stay open", never a failure
+  }
+}

--- a/src/session/repo.ts
+++ b/src/session/repo.ts
@@ -1,0 +1,29 @@
+/**
+ * Repo identity for the session ledger: hooks hand us a cwd that may be a
+ * subdirectory; the ledger (and the baseline it is checked against) is keyed
+ * on the repo root, defined as the nearest ancestor containing `.git`.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { projectHash, canonicalizeRoot } from "../core/baseline.js";
+
+export function resolveRepoRoot(cwd: string): string {
+  let dir = resolve(cwd);
+  for (;;) {
+    if (existsSync(join(dir, ".git"))) return canonicalizeRoot(dir);
+    const parent = dirname(dir);
+    if (parent === dir) return canonicalizeRoot(cwd);
+    dir = parent;
+  }
+}
+
+export function defaultSessionsDir(): string {
+  return join(homedir(), ".vibedrift", "sessions");
+}
+
+export function repoIdentity(cwd: string): { rootDir: string; projectHash: string } {
+  const rootDir = resolveRepoRoot(cwd);
+  return { rootDir, projectHash: projectHash(rootDir) };
+}

--- a/src/session/scope.ts
+++ b/src/session/scope.ts
@@ -1,0 +1,93 @@
+/**
+ * Scope-drift signal (Phase 3, experimental, deterministic, free): does an edit
+ * relate to anything the task asked for? Conservative by design — flags only the
+ * SECOND-and-later unrelated edit, and each file at most once, so a genuinely
+ * new subtask (one file) never trips it. Labeled experimental until calibrated
+ * on real ledgers.
+ */
+
+import { extractAnchors, mergeAnchors, editRelatesToAnchors, taskSummary } from "./anchors.js";
+import { readIntentState, writeIntentState } from "./intent-state.js";
+import { newActivityId } from "./ledger.js";
+import { SESSIONS_SCHEMA_VERSION } from "./types.js";
+import type { SessionEvent } from "./types.js";
+
+/** Merge a prompt's anchors into session state; emit an intent_lock on the first. */
+export async function processPrompt(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+  promptText: string,
+): Promise<SessionEvent | null> {
+  const task = taskSummary(promptText);
+  const state = await readIntentState(sessionsDir, projectHash, sessionId);
+  const filesBefore = state.anchors.files.length;
+  state.anchors = mergeAnchors(state.anchors, extractAnchors(promptText));
+
+  // Lock on the first prompt that actually says something (an empty/whitespace
+  // prompt must not lock intent with a blank task label).
+  const firstLock = !state.locked && task.length > 0;
+  if (firstLock) {
+    state.locked = true;
+    state.task = task;
+  }
+  const filesGrew = state.locked && state.anchors.files.length > filesBefore;
+  await writeIntentState(sessionsDir, projectHash, sessionId, state);
+
+  if (!firstLock && !filesGrew) return null;
+  return {
+    v: SESSIONS_SCHEMA_VERSION,
+    sid: sessionId,
+    aid: newActivityId(),
+    ts: new Date().toISOString(),
+    agent: "claude-code",
+    projectHash,
+    channel: "hook",
+    type: "intent_lock",
+    mode: "passive",
+    // full current anchor files on every emit, so coverage sees the whole task
+    detail: { promptText: state.task, anchorFiles: state.anchors.files, observed: firstLock ? "" : "expanded" },
+  };
+}
+
+export interface ScopeResult {
+  flag: SessionEvent | null;
+  fyi: string | null;
+}
+
+export async function checkScope(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+  relFile: string,
+  body: string,
+): Promise<ScopeResult> {
+  const state = await readIntentState(sessionsDir, projectHash, sessionId);
+  if (!state.locked) return { flag: null, fyi: null };
+  if (editRelatesToAnchors(relFile, body, state.anchors)) return { flag: null, fyi: null };
+  if (state.scopeFlagged.includes(relFile)) return { flag: null, fyi: null };
+
+  state.unrelatedEdits += 1;
+  // Conservative: only the 2nd+ unrelated edit is flaggable.
+  const flaggable = state.unrelatedEdits >= 2;
+  if (flaggable) state.scopeFlagged.push(relFile);
+  await writeIntentState(sessionsDir, projectHash, sessionId, state);
+  if (!flaggable) return { flag: null, fyi: null };
+
+  const flag: SessionEvent = {
+    v: SESSIONS_SCHEMA_VERSION,
+    sid: sessionId,
+    aid: newActivityId(),
+    ts: new Date().toISOString(),
+    agent: "claude-code",
+    projectHash,
+    channel: "hook",
+    type: "flag",
+    mode: "passive",
+    findingId: `DF-scope-${state.unrelatedEdits}`,
+    detail: { file: relFile, category: "scope", observed: "edit unrelated to the task", experimental: true },
+    outcome: null,
+  };
+  const fyi = `[vibedrift] ${relFile} looks unrelated to this task (${state.task}) — experimental scope check, verify it belongs here.`;
+  return { flag, fyi };
+}

--- a/src/session/summary.ts
+++ b/src/session/summary.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure session summary: fold a ledger's events into counts.
+ *
+ * Resolution model: a flag is resolved if it carries outcome "resolved" or a
+ * later `resolve` event names its findingId; held if it is a blocking flag or a
+ * `hold` event names it; open otherwise.
+ *
+ * Decisions (accept/park/decline) are a SEPARATE axis from resolution: they
+ * record what the agent SAID it would do, not whether the drift signal actually
+ * cleared. A flag can be declined yet still open, or accepted and later resolved.
+ * The two are counted independently and never conflated.
+ */
+
+import { fileMatchesAnchors } from "./anchors.js";
+import type { SessionEvent } from "./types.js";
+
+export interface SessionSummary {
+  edits: number;
+  /** confirmed (non-experimental) flags in the headline */
+  flagged: number;
+  resolved: number;
+  held: number;
+  open: number;
+  /** experimental signals (scope drift) — tracked apart from the headline */
+  experimental: number;
+  /** the agent's own calls on flags (last decision per finding wins). Orthogonal
+   *  to resolved/held/open: a decision is a stated intent, not a verified outcome. */
+  decisions: { accepted: number; parked: number; declined: number };
+  findings: string[];
+  /** Phase 3 coverage: task target files that got an edit / total task files.
+   *  null when the task named no files. */
+  coverage: { touched: number; total: number } | null;
+}
+
+export function summarize(events: SessionEvent[]): SessionSummary {
+  const flags = new Map<string, "open" | "resolved" | "held">();
+  // last decision per finding wins (append-only ledger, iterated in order)
+  const decisionByFinding = new Map<string, "accept" | "park" | "decline">();
+  let anonFlagged = 0;
+  let experimental = 0;
+  let edits = 0;
+  let anchorFiles: string[] = [];
+  const editedFiles = new Set<string>();
+
+  for (const e of events) {
+    if (e.type === "decision" && e.findingId && e.detail.decision) {
+      decisionByFinding.set(e.findingId, e.detail.decision);
+      continue;
+    }
+    if (e.type === "edit") {
+      edits++;
+      if (e.detail.file) editedFiles.add(e.detail.file);
+    } else if (e.type === "intent_lock") {
+      // each intent_lock carries the full current anchor set, so the last one
+      // has all files (including those added by follow-up prompts).
+      if (e.detail.anchorFiles?.length) anchorFiles = e.detail.anchorFiles;
+    } else if (e.type === "flag") {
+      // experimental signals (scope drift) are tracked apart from the headline
+      if (e.detail.experimental) {
+        experimental++;
+        continue;
+      }
+      const id = e.findingId;
+      if (!id) {
+        anonFlagged++;
+        continue;
+      }
+      if (e.outcome === "resolved") flags.set(id, "resolved");
+      else if (e.outcome === "held" || e.mode === "blocking") flags.set(id, "held");
+      else if (!flags.has(id)) flags.set(id, "open");
+    } else if (e.type === "resolve" && e.findingId) {
+      flags.set(e.findingId, "resolved");
+    } else if (e.type === "hold" && e.findingId) {
+      flags.set(e.findingId, "held");
+    }
+  }
+
+  let resolved = 0;
+  let held = 0;
+  for (const state of flags.values()) {
+    if (state === "resolved") resolved++;
+    else if (state === "held") held++;
+  }
+  const flagged = flags.size + anonFlagged;
+  const open = flagged - resolved - held;
+
+  // Only count a decision that names a finding this ledger actually flagged, so a
+  // stray/mis-correlated decision event can never overstate agent engagement.
+  const decisions = { accepted: 0, parked: 0, declined: 0 };
+  for (const [id, d] of decisionByFinding) {
+    if (!flags.has(id)) continue;
+    if (d === "accept") decisions.accepted++;
+    else if (d === "park") decisions.parked++;
+    else decisions.declined++;
+  }
+
+  let coverage: SessionSummary["coverage"] = null;
+  if (anchorFiles.length) {
+    // bounded matching (a.ts must not match banana.ts); an anchor file is
+    // "touched" if some edited file is or is within it.
+    const edited = [...editedFiles];
+    const touched = anchorFiles.filter((f) =>
+      edited.some((e) => fileMatchesAnchors(e, [f])),
+    ).length;
+    coverage = { touched, total: anchorFiles.length };
+  }
+
+  return { edits, flagged, resolved, held, open, experimental, decisions, findings: [...flags.keys()], coverage };
+}
+
+export function formatSummary(s: SessionSummary): string {
+  // "edits" not "edits checked": an edit outside the repo or above the inline
+  // size gate is recorded but not drift-checked, so "checked" would overstate.
+  const parts = [`${s.edits} edits`, `${s.flagged} flagged`];
+  if (s.resolved) parts.push(`${s.resolved} resolved`);
+  if (s.held) parts.push(`${s.held} held`);
+  parts.push(`${s.open} open`);
+  if (s.experimental) parts.push(`${s.experimental} experimental`);
+  const { accepted, parked, declined } = s.decisions;
+  if (accepted || parked || declined) {
+    const dparts: string[] = [];
+    if (accepted) dparts.push(`${accepted} accepted`);
+    if (parked) dparts.push(`${parked} parked`);
+    if (declined) dparts.push(`${declined} declined`);
+    // "agent said:" marks these as stated intents, distinct from the verified
+    // resolved/held/open outcomes above — a reader must never read "accepted" as "fixed".
+    parts.push(`agent said: ${dparts.join(", ")}`);
+  }
+  if (s.coverage) parts.push(`${s.coverage.touched}/${s.coverage.total} task files touched`);
+  return parts.join(" · ");
+}

--- a/src/session/tape.ts
+++ b/src/session/tape.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure tape-line rendering for the live event tape and dashboard replay.
+ * One colored line per event; returns null for events not shown on the tape.
+ * Vocabulary is observational (flagged / diverges / duplicates / asks / replies).
+ */
+
+import chalk from "chalk";
+import type { SessionEvent } from "./types.js";
+
+/** Wall-clock time of an event as HH:MM:SS — human-readable and matching the
+ *  dashboard's decision-log timestamps. Falls back to --:--:-- on a bad ts. */
+function stamp(ev: SessionEvent): string {
+  const t = Date.parse(ev.ts);
+  if (!Number.isFinite(t)) return chalk.dim("--:--:--");
+  const d = new Date(t);
+  const p = (n: number): string => String(n).padStart(2, "0");
+  return chalk.dim(`${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`);
+}
+
+export function formatEventLine(ev: SessionEvent): string | null {
+  // A ledger line can be valid JSON but the wrong shape (a truncated/foreign
+  // write); never let a missing `detail` crash the live loop.
+  const d = ev.detail ?? {};
+  const s = stamp(ev);
+  switch (ev.type) {
+    case "session_start":
+      return `${s}  SESSION    ${chalk.dim("capture started")}`;
+    case "session_end":
+      return `${s}  SESSION    ${chalk.dim("session end")}`;
+    case "user_prompt":
+      return `${s}  USER       ${(d.promptText ?? "").slice(0, 64)}`;
+    case "edit":
+      return `${s}  AGENT      edits ${d.file ?? ""} ${chalk.dim(d.diffstat ?? "")}`;
+    case "intent_lock": {
+      const label = d.observed === "expanded" ? "intent expanded" : "contract locked";
+      return `${s}  ${chalk.cyan("INTENT")}     ${chalk.cyan(label)} ${chalk.dim(`· ${d.promptText ?? ""}`)}`;
+    }
+    case "flag": {
+      const badge = ev.mode === "blocking" ? chalk.red("[BLOCKING]") : chalk.yellow("[PASSIVE]");
+      const verb = ev.mode === "blocking" ? chalk.red("[HELD]") : chalk.yellow("[FLAGGED]");
+      const id = ev.findingId ? `${ev.findingId} ` : "";
+      const exp = d.experimental ? chalk.dim(" [EXPERIMENTAL]") : "";
+      let msg: string;
+      if (d.category === "redundancy") {
+        msg = `duplicates ${d.similarTo ?? ""}${d.similarity ? ` (${d.similarity} similar)` : ""}`;
+      } else if (d.category === "scope") {
+        msg = `scope: ${d.observed ?? "edit unrelated to the task"}`;
+      } else {
+        msg = `${d.category ?? "drift"}: repo uses ${d.dominant ?? "?"}, this uses ${d.observed ?? "?"}`;
+      }
+      return `${s}  ${chalk.yellow("VIBEDRIFT")}  ${verb} ${id}${badge}${exp} ${msg}`;
+    }
+    case "mcp_ask":
+      return `${s}  AGENT      ${chalk.cyan("[ASKS]")} ${chalk.dim((d.promptText ?? "").slice(0, 60))}`;
+    case "mcp_verdict":
+      return `${s}  ${chalk.yellow("VIBEDRIFT")}  ${chalk.cyan("[REPLIES]")} ${chalk.dim((d.observed ?? "").slice(0, 60))}`;
+    case "decision": {
+      // the agent's own call on a flag — a stated intent, distinct from the
+      // verified [RESOLVED]/[HELD] outcomes below (an ACCEPT is not a fix).
+      const badge =
+        d.decision === "accept"
+          ? chalk.green("[ACCEPT]")
+          : d.decision === "park"
+            ? chalk.yellow("[PARK]")
+            : d.decision === "decline"
+              ? chalk.red("[DECLINE]")
+              : null;
+      if (!badge) return null; // unknown/absent decision: not shown
+      const id = ev.findingId ? `${ev.findingId} ` : "";
+      const reason = d.reason ? chalk.dim((d.reason ?? "").slice(0, 60)) : "";
+      return `${s}  AGENT      ${badge} ${id}${reason}`;
+    }
+    case "resolve":
+      return `${s}  ${chalk.yellow("VIBEDRIFT")}  ${chalk.green("[RESOLVED]")} ${ev.findingId ?? ""} ${chalk.dim(d.file ?? "")}`;
+    case "hold":
+      return `${s}  ${chalk.yellow("VIBEDRIFT")}  ${chalk.red("[HELD]")} ${ev.findingId ?? ""}`;
+    case "recheck":
+      return `${s}  ${chalk.dim(`AGENT      ${d.file ?? ""} ${d.observed ?? ""}`)}`;
+    default:
+      return null; // command, and any event type not shown on the tape
+  }
+}

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Drift Sessions event schema v1.
+ *
+ * One SessionEvent per JSONL line in ~/.vibedrift/sessions/<project-hash>/<session-id>.jsonl.
+ * The ledger is append-only: outcomes are recorded by appending recheck/resolve
+ * events, never by rewriting earlier lines.
+ */
+
+export type SessionEventType =
+  | "session_start"
+  | "user_prompt"
+  | "intent_lock"
+  | "edit"
+  | "command"
+  | "flag"
+  | "mcp_ask"
+  | "mcp_verdict"
+  | "recheck"
+  | "resolve"
+  | "hold"
+  | "decision"
+  | "session_end";
+
+export interface SessionEventDetail {
+  file?: string;
+  promptText?: string;
+  toolName?: string;
+  diffstat?: string;
+  category?: string;
+  dominant?: string;
+  observed?: string;
+  similarTo?: string;
+  similarity?: number;
+  truncated?: boolean;
+  /** set on the experimental scope-drift signal (Phase 3) */
+  experimental?: boolean;
+  /** the task's target files, carried on the intent_lock event (Phase 3 coverage) */
+  anchorFiles?: string[];
+  /** the agent's own call on a flag, carried on a `decision` event. ACCEPT =
+   *  agree & will fix; PARK = defer to a human reviewer; DECLINE = judge the flag
+   *  wrong / not needed. Orthogonal to `outcome` (a stated intent, not a verified
+   *  resolution). */
+  decision?: "accept" | "park" | "decline";
+  /** the agent's one-line reasoning for `decision`, masked + capped before write. */
+  reason?: string;
+}
+
+export interface SessionEvent {
+  v: 1;
+  /** Agent session id, from the hook payload. */
+  sid: string;
+  /** Unique activity id for this event. */
+  aid: string;
+  /** ISO-8601 timestamp. */
+  ts: string;
+  agent: "claude-code";
+  projectHash: string;
+  /** Which side of the conversation produced the event. */
+  channel: "hook" | "mcp";
+  type: SessionEventType;
+  /** Advisory vs interception. Phase 1 is passive-only. */
+  mode: "passive" | "blocking";
+  /** Present on flag/recheck/resolve/hold events (DF-<n>). */
+  findingId?: string;
+  detail: SessionEventDetail;
+  /** The exact advisory message delivered into the agent's context, if any. */
+  msgToAgent?: string;
+  outcome?: "resolved" | "open" | "held" | null;
+}
+
+export const SESSIONS_SCHEMA_VERSION = 1 as const;

--- a/src/session/upload-schema.ts
+++ b/src/session/upload-schema.ts
@@ -1,0 +1,195 @@
+/**
+ * Drift Sessions derived-only upload schema (Phase 5). The ONE invariant: what
+ * leaves the machine is a derived PROJECTION — findings, scores, outcomes,
+ * metadata — never a prompt, a line of code, a free-text advisory, or a file
+ * path. That invariant is enforced BY CONSTRUCTION here: `toUploadEvent` builds a
+ * fresh `UploadEvent` from an explicit allow-list of fields; it never spreads the
+ * ledger event, so a field that isn't named below cannot leak. `upload-schema.test.ts`
+ * proves, per event kind, that no banned field survives the mapping.
+ *
+ * File paths are carried only as `sha256(projectHash + relPath)[:16]` — a
+ * per-repo grouping PSEUDONYM, not an irreversible hash. Salting by the repo hash
+ * keeps files group-able within a project while defeating a global relpath
+ * rainbow table (an unsalted 64-bit path hash is trivially reversed for a known
+ * repo layout). Label fields (category/dominant/observed) are a bounded detector
+ * vocabulary and are additionally secret-masked as defense in depth.
+ *
+ * The two free-text fields a team may find worth sharing — the decision REASON
+ * and the derived intent LABEL — ship only under explicit team opt-in (the
+ * code-egress boundary) and are secret-masked + capped even then. Note: opt-in
+ * relaxes the path guarantee for these two fields only — the agent's own reason
+ * text may reference a path, so the guarantee there is "secret-masked + capped,"
+ * not "no path." Default (opt-in off): conclusions leave, analysis stays local.
+ */
+
+import { createHash } from "node:crypto";
+import { extractAnchors } from "./anchors.js";
+import { maskSecrets } from "./mask.js";
+import { MAX_REASON_LEN } from "./decision.js";
+import type { SessionEvent, SessionEventType } from "./types.js";
+
+export const UPLOAD_SCHEMA_VERSION = 1 as const;
+const MAX_LABEL = 120;
+const MAX_TASK_LABEL = 200;
+
+export type UploadEventType =
+  | "session_start"
+  | "edit"
+  | "flag"
+  | "resolve"
+  | "hold"
+  | "mcp_ask"
+  | "mcp_verdict"
+  | "intent_lock"
+  | "decision"
+  | "session_end";
+
+/** The wire shape. Every optional field is a derived label, a number, an id, or
+ *  a hash — never raw text, code, or a path. `reason`/`taskLabel` are the only
+ *  free-text fields and are team-opt-in + masked. */
+export interface UploadEvent {
+  v: typeof UPLOAD_SCHEMA_VERSION;
+  sessionId: string;
+  activityId: string;
+  ts: string;
+  agent: "claude-code";
+  projectHash: string;
+  type: UploadEventType;
+  /** sha256(relPath)[:16] — group by file without revealing the path. */
+  fileHash?: string;
+  category?: string;
+  /** pattern LABELS only (e.g. "async/await" vs ".then() chains"), never code. */
+  dominant?: string;
+  observed?: string;
+  similarity?: number;
+  findingId?: string;
+  outcome?: "resolved" | "open" | "held";
+  mode?: "passive" | "blocking";
+  experimental?: boolean;
+  /** the +N line count only, never the diff. */
+  diffLines?: number;
+  decision?: "accept" | "park" | "decline";
+  /** count of task target files, never the paths. */
+  taskFileCount?: number;
+  // ---- team-opt-in free text (masked); absent by default ----
+  reason?: string;
+  taskLabel?: string;
+}
+
+export interface UploadMapOptions {
+  /** Explicit team opt-in to ship the two derived free-text fields (decision
+   *  reasoning + intent label). Off by default — the code-egress boundary. */
+  teamIntentOptIn?: boolean;
+}
+
+const UPLOADABLE = new Set<SessionEventType>([
+  "session_start",
+  "edit",
+  "flag",
+  "resolve",
+  "hold",
+  "mcp_ask",
+  "mcp_verdict",
+  "intent_lock",
+  "decision",
+  "session_end",
+]);
+
+/** A per-repo grouping pseudonym for a path: salted by the project hash so the
+ *  same file groups within a repo but a global path rainbow table can't reverse
+ *  it. NUL separator so `a`+`bc` and `ab`+`c` never collide. */
+function hashPath(projectHash: string, relPath: string): string {
+  return createHash("sha256").update(`${projectHash}\0${relPath}`).digest("hex").slice(0, 16);
+}
+
+/** Parse "+38" / "+5 -2" → 38; anything else → undefined. Never the diff text. */
+function parseDiffLines(diffstat: string | undefined): number | undefined {
+  if (!diffstat) return undefined;
+  const m = /\+(\d+)/.exec(diffstat);
+  return m ? Number(m[1]) : undefined;
+}
+
+/** A bounded detector-vocabulary label: secret-masked (defense in depth against a
+ *  future producer) and capped. Real labels ("async/await", ".then() chains")
+ *  are untouched by the masker. */
+function label(s: string | undefined, cap = MAX_LABEL): string | undefined {
+  if (!s) return undefined;
+  return maskSecrets(s).slice(0, cap);
+}
+
+/**
+ * Map a ledger event to its derived upload projection, or null if the event kind
+ * is not uploaded at all (command, recheck). Builds a fresh object from an
+ * allow-list — banned fields (promptText, body, msgToAgent, file/similarTo paths)
+ * have no landing spot and cannot leak.
+ */
+export function toUploadEvent(ev: SessionEvent, opts: UploadMapOptions = {}): UploadEvent | null {
+  if (!ev || !UPLOADABLE.has(ev.type)) return null;
+  const d = ev.detail ?? {};
+  const u: UploadEvent = {
+    v: UPLOAD_SCHEMA_VERSION,
+    sessionId: ev.sid,
+    activityId: ev.aid,
+    ts: ev.ts,
+    agent: ev.agent,
+    projectHash: ev.projectHash,
+    type: ev.type as UploadEventType,
+  };
+
+  switch (ev.type) {
+    case "edit": {
+      if (d.file) u.fileHash = hashPath(ev.projectHash, d.file);
+      const n = parseDiffLines(d.diffstat);
+      if (n !== undefined) u.diffLines = n;
+      break;
+    }
+    case "flag": {
+      if (d.file) u.fileHash = hashPath(ev.projectHash, d.file);
+      u.category = label(d.category);
+      u.dominant = label(d.dominant);
+      u.observed = label(d.observed);
+      if (typeof d.similarity === "number") u.similarity = d.similarity;
+      if (ev.findingId) u.findingId = ev.findingId;
+      if (ev.mode) u.mode = ev.mode;
+      if (d.experimental) u.experimental = true;
+      if (ev.outcome === "resolved" || ev.outcome === "held" || ev.outcome === "open") u.outcome = ev.outcome;
+      break;
+    }
+    case "resolve":
+    case "hold": {
+      if (ev.findingId) u.findingId = ev.findingId;
+      if (d.file) u.fileHash = hashPath(ev.projectHash, d.file);
+      u.outcome = ev.type === "resolve" ? "resolved" : "held";
+      break;
+    }
+    case "mcp_verdict": {
+      // a bounded derived verdict label ("in line", "1 drift", "no match"); the
+      // MCP ASK text carries a path, so mcp_ask ships ids+type only (below).
+      u.observed = label(d.observed);
+      break;
+    }
+    case "decision": {
+      if (ev.findingId) u.findingId = ev.findingId;
+      if (d.decision === "accept" || d.decision === "park" || d.decision === "decline") u.decision = d.decision;
+      if (opts.teamIntentOptIn && d.reason) u.reason = maskSecrets(d.reason).slice(0, MAX_REASON_LEN);
+      break;
+    }
+    case "intent_lock": {
+      // the COUNT of task files (never the paths); an intent LABEL derived from
+      // anchor tokens/symbols (never the prompt's sentence) only under team opt-in.
+      if (d.anchorFiles) u.taskFileCount = d.anchorFiles.length;
+      if (opts.teamIntentOptIn && d.promptText) {
+        // mask BEFORE tokenizing so a keyed secret is caught while its `key=`
+        // shape is still intact, then again after (belt and suspenders).
+        const a = extractAnchors(maskSecrets(d.promptText));
+        const derived = [...a.symbols, ...a.tokens].slice(0, 12).join(" ").trim();
+        if (derived) u.taskLabel = maskSecrets(derived).slice(0, MAX_TASK_LABEL);
+      }
+      break;
+    }
+    // session_start, session_end, mcp_ask: ids + type only.
+    default:
+      break;
+  }
+  return u;
+}

--- a/src/session/uploader.ts
+++ b/src/session/uploader.ts
@@ -1,0 +1,105 @@
+/**
+ * Drift Sessions derived-only uploader (Phase 5). A resident reader — the tape
+ * follower's sibling — that tails the active ledger, maps each new event to its
+ * derived `UploadEvent` (src/session/upload-schema.ts), batches them, and hands
+ * them to an injected `post`. It runs ONLY when the caller has confirmed opt-in +
+ * login (`watch-session` gates it); it is never on the hook's critical path.
+ *
+ * Fail-open in the strong sense: a failed flush never throws and never loses the
+ * batch — the events stay queued and are retried on the next tick, with a hard
+ * buffer cap so a long outage can't grow memory without bound. When sync is off
+ * (or `--local-only`, or logged out) the caller simply never starts this, so
+ * local behaviour is byte-identical.
+ */
+
+import { SessionFollower } from "./follow.js";
+import { toUploadEvent, type UploadEvent } from "./upload-schema.js";
+import type { SessionEvent } from "./types.js";
+
+const DEFAULT_BATCH = 50;
+const DEFAULT_INTERVAL_MS = 1000;
+const MAX_BUFFER = 2000;
+/** Cap the best-effort flush after Ctrl-C so a hanging network can't freeze the
+ *  terminal (the tape's cleanup awaits this). A refused connection rejects fast;
+ *  this only bounds a truly hanging socket. */
+const SHUTDOWN_FLUSH_MS = 2500;
+
+/** Whether hosted sync should run this session: opted in, logged in, and not
+ *  forced local for this run. Pure so the gate is unit-testable. Off by default
+ *  in every dimension — sync never starts by accident. */
+export function shouldSync(
+  cfg: { sessionsSyncEnabled?: boolean; token?: string },
+  localOnly?: boolean,
+): boolean {
+  return !localOnly && cfg.sessionsSyncEnabled === true && Boolean(cfg.token);
+}
+
+export interface UploaderOptions {
+  sessionsDir: string;
+  projectHash: string;
+  /** Ship the two derived free-text fields (decision reason + intent label).
+   *  Off unless the team explicitly opted in — the code-egress boundary. */
+  teamIntentOptIn?: boolean;
+  /** POST a batch of derived events. Injected so the loop is testable and so the
+   *  transport (auth, apiUrl) stays out of this module. Must reject on failure. */
+  post: (events: UploadEvent[]) => Promise<void>;
+  batchSize?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+  /** injectable sleeper for tests; defaults to real setTimeout */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Try to flush as many whole batches as possible; stop at the first failure so
+ *  the rest is retried next tick. Never throws. Returns the events still queued. */
+async function drain(
+  pending: UploadEvent[],
+  batchSize: number,
+  post: (e: UploadEvent[]) => Promise<void>,
+): Promise<UploadEvent[]> {
+  while (pending.length > 0) {
+    const chunk = pending.slice(0, batchSize);
+    try {
+      await post(chunk);
+    } catch {
+      break; // keep everything from here on; retry next tick
+    }
+    pending.splice(0, chunk.length);
+  }
+  return pending;
+}
+
+export async function runUploader(opts: UploaderOptions): Promise<void> {
+  const batchSize = opts.batchSize && opts.batchSize > 0 ? opts.batchSize : DEFAULT_BATCH;
+  const interval = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const follower = new SessionFollower(opts.sessionsDir, opts.projectHash);
+  let pending: UploadEvent[] = [];
+
+  while (!opts.signal?.aborted) {
+    let batch: SessionEvent[];
+    try {
+      batch = await follower.poll();
+    } catch {
+      batch = []; // fail-open: a read error is an empty tick, never a crash
+    }
+    for (const ev of batch) {
+      const u = toUploadEvent(ev, { teamIntentOptIn: opts.teamIntentOptIn });
+      if (u) pending.push(u);
+    }
+    // Cap the buffer: under a long outage, drop the OLDEST derived events rather
+    // than grow memory unbounded (they are advisory analytics, not the ledger).
+    if (pending.length > MAX_BUFFER) pending = pending.slice(pending.length - MAX_BUFFER);
+
+    pending = await drain(pending, batchSize, opts.post);
+
+    if (opts.signal?.aborted) break;
+    await sleep(interval);
+  }
+  // A final best-effort flush on shutdown, time-bounded so a hanging network
+  // can't wedge the terminal after Ctrl-C (the tape cleanup awaits this task).
+  await Promise.race([
+    drain(pending, batchSize, opts.post),
+    new Promise<void>((r) => setTimeout(r, SHUTDOWN_FLUSH_MS)),
+  ]);
+}

--- a/test/helpers/session-build-baseline.ts
+++ b/test/helpers/session-build-baseline.ts
@@ -1,0 +1,14 @@
+// Test helper: build and persist a baseline for the repo at argv[2], under the
+// HOME the child was spawned with (baseline cache is homedir-derived). Used by
+// the session-hook exit-2 integration test to stage a real baseline the hook
+// child can load. Relative imports so it runs under tsx without alias config.
+import { buildBaseline, writeBaseline } from "../../src/core/baseline.js";
+
+const repo = process.argv[2];
+buildBaseline(repo)
+  .then((b) => writeBaseline(b))
+  .then(() => process.exit(0))
+  .catch((err) => {
+    process.stderr.write(String(err) + "\n");
+    process.exit(1);
+  });

--- a/test/integration/mcp.test.ts
+++ b/test/integration/mcp.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_TOOLS = [
   "get_dominant_pattern",
   "get_intent_hints",
   "init",
+  "respond_to_flag",
   "validate_change",
 ];
 
@@ -68,7 +69,7 @@ describe("MCP integration — Pro plan (tools serve)", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("advertises exactly the six tools", async () => {
+  it("advertises exactly the seven tools", async () => {
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(EXPECTED_TOOLS);
   });
@@ -119,7 +120,7 @@ describe("MCP integration — signed-out user gets the local tools free", () => 
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("still advertises exactly the six tools", async () => {
+  it("still advertises exactly the seven tools", async () => {
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(EXPECTED_TOOLS);
   });

--- a/test/integration/session-hook.test.ts
+++ b/test/integration/session-hook.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ENTRY = join(process.cwd(), "src", "session", "hook-entry.ts");
+const BUILDER = join(process.cwd(), "test", "helpers", "session-build-baseline.ts");
+const TSX = join(process.cwd(), "node_modules", ".bin", "tsx");
+
+function runHook(home: string, payload: unknown, rawInput?: string) {
+  return spawnSync(TSX, [ENTRY], {
+    input: rawInput ?? JSON.stringify(payload),
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, USERPROFILE: home, VIBEDRIFT_HOOK_DEBUG: "" },
+    timeout: 30_000,
+  });
+}
+
+function tmp(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
+
+function ledgerLines(home: string, sessionId: string): string[] {
+  const sessions = join(home, ".vibedrift", "sessions");
+  const hashDir = readdirSync(sessions)[0];
+  return readFileSync(join(sessions, hashDir, `${sessionId}.jsonl`), "utf8").trim().split("\n");
+}
+
+describe("hook entry (integration)", () => {
+  it("appends a user_prompt event with masked secrets and exits 0", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    const r = runHook(home, {
+      session_id: "it-1",
+      cwd: repo,
+      hook_event_name: "UserPromptSubmit",
+      prompt: "wire up billing with api_key=abcd1234efgh5678 please",
+    });
+    expect(r.status).toBe(0);
+    const lines = ledgerLines(home, "it-1");
+    // first prompt also emits an intent_lock event
+    const types = lines.map((l) => JSON.parse(l).type);
+    expect(types).toEqual(["user_prompt", "intent_lock"]);
+    const ev = JSON.parse(lines[0]);
+    expect(ev.detail.promptText).toContain("[masked]");
+    expect(lines[0]).not.toContain("abcd1234efgh5678");
+  });
+
+  it("appends an edit event WITHOUT persisting the edit body", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    const secretishContent = "export const UNIQUE_BODY_SENTINEL_9f2 = 42;\n";
+    const r = runHook(home, {
+      session_id: "it-2",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: join(repo, "src", "a.ts"), content: secretishContent },
+    });
+    expect(r.status).toBe(0);
+    const lines = ledgerLines(home, "it-2");
+    const ev = JSON.parse(lines[0]);
+    expect(ev.type).toBe("edit");
+    expect(ev.detail.diffstat).toBe("+1");
+    expect(ev.detail.file).toBe(join("src", "a.ts"));
+    expect(lines[0]).not.toContain("UNIQUE_BODY_SENTINEL_9f2");
+    expect(ev.body).toBeUndefined();
+  });
+
+  it("captures NOTHING when the entitlement cache says locked", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    // write a locked entitlement cache under this HOME
+    mkdirSync(join(home, ".vibedrift"), { recursive: true });
+    writeFileSync(
+      join(home, ".vibedrift", "sessions-entitlement.json"),
+      JSON.stringify({ entitled: false, reason: "locked", plan: "free", trialUsed: 5, trialLimit: 5 }),
+    );
+    const r = runHook(home, {
+      session_id: "locked-1",
+      cwd: repo,
+      hook_event_name: "UserPromptSubmit",
+      prompt: "hello",
+    });
+    expect(r.status).toBe(0);
+    // no sessions dir / no ledger written
+    expect(existsSync(join(home, ".vibedrift", "sessions"))).toBe(false);
+  });
+
+  it("exits 0 on malformed stdin (fail-open)", () => {
+    const home = tmp("vd-home-");
+    const r = runHook(home, null, "{definitely not json");
+    expect(r.status).toBe(0);
+  });
+
+  it("exits 0 on empty stdin and unknown events", () => {
+    const home = tmp("vd-home-");
+    expect(runHook(home, null, "").status).toBe(0);
+    expect(
+      runHook(home, { session_id: "x", cwd: "/", hook_event_name: "Notification" }).status,
+    ).toBe(0);
+  });
+
+  it("delivers an advisory via exit 2 + stderr when an edit diverges from the baseline", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    mkdirSync(join(repo, "src"), { recursive: true });
+    // async/await is the declared + dominant rule
+    writeFileSync(join(repo, "CLAUDE.md"), "- Async: use async/await throughout. No .then() chains.\n");
+    for (const n of ["a", "b", "c"]) {
+      writeFileSync(join(repo, "src", `${n}.ts`), `export async function ${n}(){ return await fetch("/${n}"); }\n`);
+    }
+    // stage a real baseline under this HOME
+    const build = spawnSync(TSX, [BUILDER, repo], {
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      timeout: 60_000,
+    });
+    expect(build.status).toBe(0);
+
+    // an edit written in .then() style should trip the async-consistency flag
+    const thenBody = [
+      'export function loadReport(id: string) {',
+      '  return fetch("/api/report/" + id)',
+      "    .then((res) => res.json())",
+      "    .then((data) => data.rows);",
+      "}",
+    ].join("\n");
+    const r = runHook(home, {
+      session_id: "it-fyi",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: join(repo, "src", "reports.ts"), content: thenBody },
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("[vibedrift]");
+
+    // the edit event and at least one flag event are in the ledger
+    const types = ledgerLines(home, "it-fyi").map((l) => JSON.parse(l).type);
+    expect(types).toContain("edit");
+    expect(types).toContain("flag");
+  });
+
+  it("resolves a finding when the same file is re-edited to fix it", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "CLAUDE.md"), "- Async: use async/await throughout. No .then() chains.\n");
+    for (const n of ["a", "b", "c"]) {
+      writeFileSync(join(repo, "src", `${n}.ts`), `export async function ${n}(){ return await fetch("/${n}"); }\n`);
+    }
+    const build = spawnSync(TSX, [BUILDER, repo], {
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      timeout: 60_000,
+    });
+    expect(build.status).toBe(0);
+
+    const editPayload = (bodyText: string) => ({
+      session_id: "res-1",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: join(repo, "src", "report.ts"), content: bodyText },
+    });
+
+    // 1) a .then() body trips the async flag (multi-line: the classifier counts
+    // .then( per line and needs >= 2 async ops)
+    const thenBody = [
+      "export function r() {",
+      '  return fetch("/r")',
+      "    .then((x) => x.json())",
+      "    .then((j) => j.data);",
+      "}",
+    ].join("\n");
+    const flagged = runHook(home, editPayload(thenBody));
+    expect(flagged.status).toBe(2);
+
+    // 2) re-edit the SAME file to async/await -> the finding resolves
+    runHook(home, editPayload(
+      'export async function r(){ const x = await fetch("/r"); const j = await x.json(); return j.data; }',
+    ));
+
+    const types = ledgerLines(home, "res-1").map((l) => JSON.parse(l).type);
+    expect(types).toContain("flag");
+    expect(types).toContain("resolve");
+  });
+
+  it("does not re-message (or re-append) an already-open finding on a repeat edit", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "CLAUDE.md"), "- Async: use async/await throughout. No .then() chains.\n");
+    for (const n of ["a", "b", "c"]) {
+      writeFileSync(join(repo, "src", `${n}.ts`), `export async function ${n}(){ return await fetch("/${n}"); }\n`);
+    }
+    expect(
+      spawnSync(TSX, [BUILDER, repo], {
+        encoding: "utf8",
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        timeout: 60_000,
+      }).status,
+    ).toBe(0);
+
+    const thenBody = [
+      "export function r() {",
+      '  return fetch("/r")',
+      "    .then((x) => x.json())",
+      "    .then((j) => j.data);",
+      "}",
+    ].join("\n");
+    const p = (extra: string) => ({
+      session_id: "dedupe-1",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: join(repo, "src", "report.ts"), content: `${thenBody}\n// ${extra}` },
+    });
+
+    const first = runHook(home, p("v1"));
+    expect(first.status).toBe(2); // flagged + messaged
+    // still-.then, so the finding stays open; the repeat must NOT re-message
+    const second = runHook(home, p("v2"));
+    expect(second.status).toBe(0); // no re-message
+    // exactly one flag event for this file|category in the ledger
+    const flags = ledgerLines(home, "dedupe-1")
+      .map((l) => JSON.parse(l))
+      .filter((e) => e.type === "flag" && e.detail.category === "async_patterns");
+    expect(flags).toHaveLength(1);
+  });
+
+  it("never emits exit codes other than 0 or 2, even on a bad cwd", () => {
+    const home = tmp("vd-home-");
+    const r = runHook(home, {
+      session_id: "it-3",
+      cwd: "/nonexistent-dir-xyz",
+      hook_event_name: "PostToolUse",
+      tool_name: "Edit",
+      tool_input: { file_path: "/nonexistent-dir-xyz/a.ts", old_string: "a", new_string: "x" },
+    });
+    expect([0, 2]).toContain(r.status);
+  });
+});

--- a/test/integration/session-live.test.ts
+++ b/test/integration/session-live.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { runLiveTape } from "@/session/live";
+import { appendEvent } from "@/session/ledger";
+import type { SessionEvent } from "@/session/types";
+
+const HASH = "livehashlivehash";
+let seq = 0;
+const ev = (type: SessionEvent["type"], over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "live",
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: HASH,
+  channel: "hook",
+  type,
+  mode: "passive",
+  detail: {},
+  ...over,
+});
+
+function capture(): { stream: Writable; text: () => string } {
+  let buf = "";
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      buf += chunk.toString();
+      cb();
+    },
+  });
+  const ansi = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m|\\r`, "g");
+  return { stream, text: () => buf.replace(ansi, "") };
+}
+
+describe("runLiveTape", () => {
+  it("renders new events live and prints a summary at session end", async () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "vd-live-")));
+    const { stream, text } = capture();
+    const ctrl = new AbortController();
+
+    const loop = runLiveTape({
+      sessionsDir: dir,
+      projectHash: HASH,
+      out: stream,
+      intervalMs: 10,
+      signal: ctrl.signal,
+    });
+
+    const tick = () => new Promise((r) => setTimeout(r, 30));
+    await appendEvent(dir, HASH, "live", ev("session_start"));
+    await appendEvent(dir, HASH, "live", ev("edit", { detail: { file: "src/a.ts", diffstat: "+5" } }));
+    await appendEvent(dir, HASH, "live", ev("flag", { findingId: "DF-1", detail: { file: "src/a.ts", category: "async_patterns", dominant: "async/await", observed: ".then() chains" } }));
+    await tick();
+    await appendEvent(dir, HASH, "live", ev("session_end"));
+    await tick();
+
+    ctrl.abort();
+    await loop;
+
+    const out = text();
+    expect(out).toContain("edits src/a.ts");
+    expect(out).toContain("[FLAGGED]");
+    expect(out).toContain("DF-1");
+    expect(out).toContain("session summary");
+    expect(out).toContain("1 flagged");
+    expect(out.toLowerCase()).not.toContain("prevented");
+  });
+});

--- a/test/unit/cli/watch-session.test.ts
+++ b/test/unit/cli/watch-session.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runWatchSession } from "@/cli/commands/watch-session";
+import { readConfig } from "@/auth/config";
+
+function tmp(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
+
+function repoWithAgent(): string {
+  const repo = tmp("vd-ws-");
+  mkdirSync(join(repo, ".git"));
+  mkdirSync(join(repo, ".claude"));
+  return repo;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe("runWatchSession — hosted sync toggle", () => {
+  it("--sync on/off flips the config flag and never installs hooks", async () => {
+    const home = tmp("vd-ws-home-");
+    const prevHome = process.env.HOME;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const repo = repoWithAgent();
+      const on = await runWatchSession(repo, { sync: "on" });
+      expect(on).toBe("sync_updated");
+      expect((await readConfig()).sessionsSyncEnabled).toBe(true);
+      // a toggle is a control action — it must not install hooks
+      expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+
+      const off = await runWatchSession(repo, { sync: "off" });
+      expect(off).toBe("sync_updated");
+      expect((await readConfig()).sessionsSyncEnabled).toBe(false);
+    } finally {
+      process.env.HOME = prevHome;
+      process.env.USERPROFILE = prevProfile;
+    }
+  });
+});
+
+describe("runWatchSession", () => {
+  it("installs hooks with --yes and reports the ledger location", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runWatchSession(repo, { yes: true, sessionsDir });
+    expect(status).toBe("installed");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(true);
+    const printed = log.mock.calls.flat().join("\n");
+    expect(printed).toContain(sessionsDir);
+    expect(printed.toLowerCase()).toContain("fail-open");
+  });
+
+  it("reports already on a second run", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(repo, { yes: true, sessionsDir });
+    expect(await runWatchSession(repo, { yes: true, sessionsDir })).toBe("already");
+  });
+
+  it("uninstalls cleanly", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(repo, { yes: true, sessionsDir });
+    const status = await runWatchSession(repo, { uninstall: true, sessionsDir });
+    expect(status).toBe("uninstalled");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+  });
+
+  it("reports status without modifying anything", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(await runWatchSession(repo, { status: true, sessionsDir })).toBe("status");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+  });
+
+  it("exits nonzero when no supported agent is detected", async () => {
+    const repo = tmp("vd-ws-none-");
+    mkdirSync(join(repo, ".git"));
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const home = tmp("vd-ws-home-");
+    const status = await runWatchSession(repo, { yes: true, sessionsDir, homeDir: home });
+    expect(status).toBe("no_agent");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("writes nothing when consent is declined", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runWatchSession(repo, { sessionsDir, confirm: async () => false });
+    expect(status).toBe("declined");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+  });
+
+  it("locks (with the trial CTA) and does NOT install when the trial is spent", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    const entDir = tmp("vd-ws-ent-");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runWatchSession(repo, {
+      yes: true,
+      watch: true,
+      sessionsDir,
+      entitlementDir: entDir,
+      resolveEntitlement: async () => ({ entitled: false, reason: "locked", plan: "free", trialUsed: 5, trialLimit: 5 }),
+    });
+    expect(status).toBe("locked");
+    // did not install hooks
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+    // wrote a locked cache the hook will read
+    const cache = JSON.parse(readFileSync(join(entDir, "sessions-entitlement.json"), "utf8"));
+    expect(cache.entitled).toBe(false);
+    // honest CTA copy, no prevention claims
+    const printed = log.mock.calls.flat().join("\n");
+    expect(printed).toContain("vibedrift upgrade");
+    expect(printed.toLowerCase()).not.toContain("prevented");
+  });
+
+  it("requires a free account (login) when no entitlement can be resolved", async () => {
+    const repo = repoWithAgent();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const status = await runWatchSession(repo, {
+      watch: true,
+      sessionsDir: tmp("vd-ws-sess-"),
+      entitlementDir: tmp("vd-ws-ent-"),
+      resolveEntitlement: async () => null,
+    });
+    expect(status).toBe("login_required");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/test/unit/mcp/baseline-provider.test.ts
+++ b/test/unit/mcp/baseline-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -19,7 +19,7 @@ import { getBaseline, __clearBaselineCache, invalidateBaselineMem } from "../../
 describe("baseline provider", () => {
   let repo: string;
   beforeAll(async () => {
-    repo = mkdtempSync(join(tmpdir(), "vd-provider-"));
+    repo = realpathSync(mkdtempSync(join(tmpdir(), "vd-provider-")));
     writeFileSync(join(repo, "a.ts"), "export async function a(){ return await fetch('/x'); }\n");
     writeFileSync(join(repo, "b.ts"), "export async function b(){ return await fetch('/y'); }\n");
     writeFileSync(join(repo, "c.ts"), "export function c(){ return fetch('/z').then(r => r.json()); }\n");
@@ -36,7 +36,7 @@ describe("baseline provider", () => {
   });
 
   it("lazily BUILDS a baseline on first call for a repo with code but no prior scan", async () => {
-    const fresh = mkdtempSync(join(tmpdir(), "vd-lazy-"));
+    const fresh = realpathSync(mkdtempSync(join(tmpdir(), "vd-lazy-")));
     try {
       writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
       writeFileSync(join(fresh, "y.ts"), "export async function y(){ return await fetch('/b'); }\n");
@@ -52,7 +52,7 @@ describe("baseline provider", () => {
   });
 
   it("persists the lazily-built baseline so the next load comes from disk", async () => {
-    const fresh = mkdtempSync(join(tmpdir(), "vd-lazy2-"));
+    const fresh = realpathSync(mkdtempSync(join(tmpdir(), "vd-lazy2-")));
     try {
       writeFileSync(join(fresh, "x.ts"), "export function x(){ return fetch('/a').then(r => r.json()); }\n");
       __clearBaselineCache();
@@ -67,7 +67,7 @@ describe("baseline provider", () => {
   });
 
   it("returns 'no_baseline' (and null) for an empty dir with no code to analyze", async () => {
-    const empty = mkdtempSync(join(tmpdir(), "vd-empty-"));
+    const empty = realpathSync(mkdtempSync(join(tmpdir(), "vd-empty-")));
     try {
       const { baseline, status } = await getBaseline(empty);
       expect(status).toBe("no_baseline");
@@ -87,7 +87,7 @@ describe("baseline provider", () => {
   });
 
   it("rebuilds once when the on-disk baseline predates BASELINE_VERSION, then serves the rebuilt baseline without rebuilding again", async () => {
-    const fresh = mkdtempSync(join(tmpdir(), "vd-version-"));
+    const fresh = realpathSync(mkdtempSync(join(tmpdir(), "vd-version-")));
     try {
       writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
       writeFileSync(join(fresh, "y.ts"), "export async function y(){ return await fetch('/b'); }\n");
@@ -118,7 +118,7 @@ describe("baseline provider", () => {
   });
 
   it("a current-version baseline with content-only drift still returns 'stale' (cheap re-hash), not a rebuild", async () => {
-    const fresh = mkdtempSync(join(tmpdir(), "vd-version-content-"));
+    const fresh = realpathSync(mkdtempSync(join(tmpdir(), "vd-version-content-")));
     try {
       writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
       await writeBaseline(await buildBaseline(fresh));
@@ -142,7 +142,7 @@ describe("baseline provider", () => {
   });
 
   it("attempts a version-mismatch rebuild AT MOST ONCE when the rebuild persistently fails, then serves the old baseline until invalidateBaselineMem clears the failure memory", async () => {
-    const fresh = mkdtempSync(join(tmpdir(), "vd-version-failrebuild-"));
+    const fresh = realpathSync(mkdtempSync(join(tmpdir(), "vd-version-failrebuild-")));
     try {
       writeFileSync(join(fresh, "x.ts"), "export async function x(){ return await fetch('/a'); }\n");
       const built = await buildBaseline(fresh);

--- a/test/unit/session/anchors.test.ts
+++ b/test/unit/session/anchors.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { extractAnchors, mergeAnchors, editRelatesToAnchors, taskSummary } from "@/session/anchors";
+
+describe("extractAnchors", () => {
+  it("pulls file paths, backticked symbols, and identifier tokens", () => {
+    const a = extractAnchors(
+      "add Stripe webhook handling to routes/billing.ts, reuse `handleStripeWebhook`, follow requireAuth",
+    );
+    expect(a.files).toContain("routes/billing.ts");
+    expect(a.symbols).toContain("handleStripeWebhook");
+    expect(a.tokens).toContain("stripe");
+    expect(a.tokens).toContain("webhook");
+    // stopwords / short words dropped
+    expect(a.tokens).not.toContain("add");
+    expect(a.tokens).not.toContain("to");
+  });
+
+  it("captures dotted filenames without a slash", () => {
+    expect(extractAnchors("update package.json and tsconfig.json").files).toEqual(
+      expect.arrayContaining(["package.json", "tsconfig.json"]),
+    );
+  });
+
+  it("does not double-count a path and its bare basename", () => {
+    // "routes/billing.ts" must not also yield a separate "billing.ts"
+    expect(extractAnchors("edit routes/billing.ts now").files).toEqual(["routes/billing.ts"]);
+  });
+
+  it("does not treat prose slashes (async/await, and/or) as files", () => {
+    const a = extractAnchors("use async/await in src/api/reports.ts and/or fix it");
+    expect(a.files).toEqual(["src/api/reports.ts"]);
+  });
+});
+
+describe("mergeAnchors", () => {
+  it("unions and dedupes so follow-up prompts extend", () => {
+    const a = extractAnchors("work on routes/billing.ts with `formatMoney`");
+    const b = extractAnchors("also touch routes/orders.ts and `formatMoney`");
+    const m = mergeAnchors(a, b);
+    expect(m.files).toEqual(expect.arrayContaining(["routes/billing.ts", "routes/orders.ts"]));
+    expect(m.symbols.filter((s) => s === "formatMoney")).toHaveLength(1);
+  });
+});
+
+describe("editRelatesToAnchors", () => {
+  const anchors = extractAnchors("add webhook handling to routes/billing.ts using `handleStripeWebhook`");
+
+  it("relates when the file matches an anchor path", () => {
+    expect(editRelatesToAnchors("routes/billing.ts", "export function x(){}", anchors)).toBe(true);
+  });
+  it("relates when the body contains an anchor symbol", () => {
+    expect(editRelatesToAnchors("lib/other.ts", "handleStripeWebhook()", anchors)).toBe(true);
+  });
+  it("relates when it shares an identifier token", () => {
+    expect(editRelatesToAnchors("lib/hooks.ts", "function webhookRouter(){}", anchors)).toBe(true);
+  });
+  it("does NOT relate for an unrelated edit", () => {
+    expect(editRelatesToAnchors("ui/theme.ts", "const palette = { red: 1 };", anchors)).toBe(false);
+  });
+
+  it("does NOT relate a REAL code body that only shares generic keywords", () => {
+    // the review's example: a logger with return/error/export must be UNRELATED
+    const a = extractAnchors("Update the User profile page to return an Error on failure");
+    const logger = "export function log(msg: string) { return console.error(msg); }";
+    expect(editRelatesToAnchors("lib/logger.ts", logger, a)).toBe(false);
+    const cache = "export function get(k: string) { return store.get(k); }";
+    expect(editRelatesToAnchors("lib/cache.ts", cache, a)).toBe(false);
+  });
+
+  it("does not match a.ts against banana.ts (bounded file suffix)", () => {
+    const a = extractAnchors("edit a.ts");
+    expect(editRelatesToAnchors("src/banana.ts", "x", a)).toBe(false);
+  });
+
+  it("does not treat bare Capitalized prose words as symbols", () => {
+    const a = extractAnchors("Update the Profile and return an Error");
+    // "Error"/"Update"/"Profile" are prose, not code anchors
+    expect(a.symbols).not.toContain("Error");
+    expect(a.symbols).not.toContain("Update");
+  });
+});
+
+describe("taskSummary", () => {
+  it("is a short single-line gist of the prompt", () => {
+    const s = taskSummary("add Stripe webhook handling to the billing route\nand follow the auth pattern");
+    expect(s.length).toBeLessThanOrEqual(80);
+    expect(s).not.toContain("\n");
+    expect(s.toLowerCase()).toContain("stripe");
+  });
+});

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBaseline, type RepoDriftBaseline } from "@/core/baseline";
+import { runEditChecks, INLINE_CHECK_MAX_ENTRIES, COOLDOWN_MS } from "@/session/check";
+
+const HELPER_BODY = `export function exponentialBackoff(attempt: number): number {
+  const base = 250;
+  const cap = 30_000;
+  const jitter = Math.random() * 100;
+  return Math.min(cap, base * 2 ** attempt) + jitter;
+}`;
+
+let repo: string;
+let sessionsDir: string;
+let baseline: RepoDriftBaseline;
+
+beforeAll(async () => {
+  repo = realpathSync(mkdtempSync(join(tmpdir(), "vd-check-repo-")));
+  sessionsDir = realpathSync(mkdtempSync(join(tmpdir(), "vd-check-sessions-")));
+  mkdirSync(join(repo, "src", "lib"), { recursive: true });
+  // Declared rule makes the async dominant binding regardless of vote thresholds.
+  writeFileSync(join(repo, "CLAUDE.md"), "- Async: use async/await throughout. No .then() chains.\n");
+  writeFileSync(join(repo, "src", "a.ts"), "export async function a(){ return await fetch('/a'); }\n");
+  writeFileSync(join(repo, "src", "b.ts"), "export async function b(){ return await fetch('/b'); }\n");
+  writeFileSync(join(repo, "src", "c.ts"), "export async function c(){ return await fetch('/c'); }\n");
+  writeFileSync(join(repo, "src", "lib", "backoff.ts"), `${HELPER_BODY}\n`);
+  baseline = await buildBaseline(repo);
+}, 60_000);
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+const loader = async () => baseline;
+
+// Multi-line on purpose: the shared async classifier counts signal per line
+// and needs >= 2 async operations to classify at all.
+const THEN_BODY = `export function loadReport(id: string) {
+  return fetch("/api/report/" + id)
+    .then((res) => res.json())
+    .then((data) => data.rows);
+}`;
+
+const opts = (over: Record<string, unknown> = {}) => ({
+  rootDir: repo,
+  projectHash: "feedfacefeedface",
+  sessionId: "s-check",
+  sessionsDir,
+  file: join(repo, "src", "routes.ts"),
+  body: THEN_BODY,
+  loadBaselineFor: loader,
+  ...over,
+});
+
+describe("runEditChecks", () => {
+  it("flags a .then body against the async/await dominant and produces an FYI", async () => {
+    const out = await runEditChecks(opts({ sessionId: "s-flag" }));
+    expect(out.flags.length).toBeGreaterThanOrEqual(1);
+    const flag = out.flags[0];
+    expect(flag.type).toBe("flag");
+    expect(flag.findingId).toMatch(/^DF-\d+$/);
+    expect(flag.detail.file).toBe("src/routes.ts");
+    expect(out.fyi).toBeTruthy();
+    expect(out.fyi).toContain("[vibedrift]");
+    expect(out.fyi!.toLowerCase()).not.toContain("prevented");
+  });
+
+  it("suppresses the FYI (but keeps flags) within the cooldown window", async () => {
+    const first = await runEditChecks(opts({ sessionId: "s-cool" }));
+    expect(first.fyi).toBeTruthy();
+    const second = await runEditChecks(opts({ sessionId: "s-cool" }));
+    expect(second.flags.length).toBeGreaterThanOrEqual(1);
+    expect(second.fyi).toBeNull();
+  });
+
+  it("FYIs again once the cooldown has expired", async () => {
+    let t = 1_000_000;
+    const now = () => t;
+    const first = await runEditChecks(opts({ sessionId: "s-exp", now }));
+    expect(first.fyi).toBeTruthy();
+    t += COOLDOWN_MS + 1;
+    const third = await runEditChecks(opts({ sessionId: "s-exp", now }));
+    expect(third.fyi).toBeTruthy();
+  });
+
+  it("flags a near-duplicate of an existing helper", async () => {
+    const out = await runEditChecks(
+      opts({ sessionId: "s-dup", file: join(repo, "src", "retry.ts"), body: HELPER_BODY }),
+    );
+    const dup = out.flags.find((f) => f.detail.category === "redundancy");
+    expect(dup).toBeTruthy();
+    expect(dup!.detail.similarTo).toContain("backoff.ts");
+    expect(dup!.detail.similarity).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("stays quiet when the baseline exceeds the inline threshold", async () => {
+    const padded: RepoDriftBaseline = {
+      ...baseline,
+      minhashIndex: Array.from({ length: INLINE_CHECK_MAX_ENTRIES + 1 }, () => baseline.minhashIndex[0]),
+    };
+    const out = await runEditChecks(opts({ sessionId: "s-big", loadBaselineFor: async () => padded }));
+    expect(out.flags).toEqual([]);
+    expect(out.fyi).toBeNull();
+  });
+
+  it("stays quiet when no baseline exists", async () => {
+    const out = await runEditChecks(opts({ sessionId: "s-none", loadBaselineFor: async () => null }));
+    expect(out.flags).toEqual([]);
+    expect(out.fyi).toBeNull();
+  });
+
+  it("numbers findings sequentially across calls in one session", async () => {
+    const a = await runEditChecks(opts({ sessionId: "s-seq" }));
+    const b = await runEditChecks(opts({ sessionId: "s-seq", file: join(repo, "src", "other.ts") }));
+    const ids = [...a.flags, ...b.flags].map((f) => Number(f.findingId!.slice(3)));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/test/unit/session/decision.test.ts
+++ b/test/unit/session/decision.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recordFlagDecision, MAX_REASON_LEN } from "@/session/decision";
+import { appendEvent, sessionFilePath, readSessionEvents } from "@/session/ledger";
+import { projectHash } from "@/core/baseline";
+import type { SessionEvent } from "@/session/types";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-dec-")));
+
+let seq = 0;
+const flag = (sid: string, findingId: string, over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid,
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: "x",
+  channel: "hook",
+  type: "flag",
+  mode: "passive",
+  findingId,
+  detail: {},
+  outcome: null,
+  ...over,
+});
+
+describe("recordFlagDecision", () => {
+  it("appends a decision event against a raised flag", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "live", flag("live", "DF-1"));
+
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      decision: "accept",
+      reason: "the rest of routes/ is async/await; rewriting to match",
+    });
+
+    expect(res).toMatchObject({ ok: true, sid: "live", findingId: "DF-1", decision: "accept" });
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    const dec = events.find((e) => e.type === "decision")!;
+    expect(dec.findingId).toBe("DF-1");
+    expect(dec.channel).toBe("mcp");
+    expect(dec.mode).toBe("passive");
+    expect(dec.detail.decision).toBe("accept");
+    expect(dec.detail.reason).toContain("async/await");
+  });
+
+  it("masks a secret in the reason before persisting", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "live", flag("live", "DF-1"));
+
+    await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      decision: "decline",
+      reason: `config sets OPENAI_API_KEY=${["sk-", "ant-", "api03-", "AAAABBBBCCCCDDDD1234"].join("")} so it's fine`,
+    });
+
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    const reason = events.find((e) => e.type === "decision")!.detail.reason!;
+    expect(reason).not.toContain("AAAABBBBCCCCDDDD1234");
+    expect(reason).toContain("[masked]");
+  });
+
+  it("caps an overlong reason", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "live", flag("live", "DF-1"));
+
+    await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      decision: "park",
+      reason: "a".repeat(MAX_REASON_LEN + 1000),
+    });
+
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    expect(events.find((e) => e.type === "decision")!.detail.reason!.length).toBe(MAX_REASON_LEN);
+  });
+
+  it("rejects an unknown finding id with the known ids as a hint", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "live", flag("live", "DF-1"));
+    await appendEvent(sessionsDir, hash, "live", flag("live", "DF-2"));
+    // an experimental scope signal is NOT a respondable flag
+    await appendEvent(
+      sessionsDir,
+      hash,
+      "live",
+      flag("live", "DF-scope-1", { detail: { experimental: true } }),
+    );
+
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-9",
+      decision: "accept",
+      reason: "typo'd id",
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok && res.code === "unknown_finding") {
+      expect(res.knownFindings).toEqual(["DF-1", "DF-2"]);
+    } else {
+      throw new Error(`expected unknown_finding, got ${JSON.stringify(res)}`);
+    }
+    // nothing recorded
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    expect(events.some((e) => e.type === "decision")).toBe(false);
+  });
+
+  it("reports no_active_session when the repo has no ledger", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp(); // never wrote a ledger for this hash
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      decision: "accept",
+      reason: "x",
+    });
+    expect(res).toEqual({ ok: false, code: "no_active_session" });
+  });
+
+  it("rejects a bad decision value", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      // deliberately invalid
+      decision: "maybe" as unknown as "accept",
+      reason: "x",
+    });
+    expect(res).toEqual({ ok: false, code: "bad_decision" });
+  });
+
+  it("prefers the ledger where a colliding id is still open+undecided", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    // Both concurrent sessions minted DF-1. The NEWER one already responded to
+    // its DF-1 (decided); the older one is still awaiting a response.
+    await appendEvent(sessionsDir, hash, "older", flag("older", "DF-1"));
+    await appendEvent(sessionsDir, hash, "newer", flag("newer", "DF-1"));
+    await appendEvent(sessionsDir, hash, "newer", {
+      ...flag("newer", "DF-1"),
+      type: "decision",
+      channel: "mcp",
+      detail: { decision: "decline", reason: "already handled here" },
+    });
+
+    const base = Date.now();
+    utimesSync(sessionFilePath(sessionsDir, hash, "older"), new Date(base - 60_000), new Date(base - 60_000));
+    utimesSync(sessionFilePath(sessionsDir, hash, "newer"), new Date(base), new Date(base));
+
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      decision: "accept",
+      reason: "this is the still-open one",
+      now: () => base + 1000,
+    });
+
+    // even though "newer" is newer AND also raised DF-1, it's already decided, so
+    // the open+undecided "older" ledger wins.
+    expect(res).toMatchObject({ ok: true, sid: "older" });
+  });
+
+  it("unions known findings across active ledgers in the not-found hint", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    // newest ledger has NO flags (only an edit); an older active one holds DF-3.
+    await appendEvent(sessionsDir, hash, "newer", {
+      ...flag("newer", "DF-1"),
+      type: "edit",
+      findingId: undefined,
+      detail: { file: "a.ts" },
+    });
+    await appendEvent(sessionsDir, hash, "older", flag("older", "DF-3"));
+
+    const base = Date.now();
+    utimesSync(sessionFilePath(sessionsDir, hash, "older"), new Date(base - 60_000), new Date(base - 60_000));
+    utimesSync(sessionFilePath(sessionsDir, hash, "newer"), new Date(base), new Date(base));
+
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-9",
+      decision: "accept",
+      reason: "typo",
+      now: () => base + 1000,
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok && res.code === "unknown_finding") {
+      // the hint sees the OLDER ledger's DF-3, not just the empty newest one
+      expect(res.knownFindings).toContain("DF-3");
+    } else {
+      throw new Error(`expected unknown_finding, got ${JSON.stringify(res)}`);
+    }
+  });
+
+  it("records against the ledger that RAISED the id, not just the newest active one", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    // older ledger raised DF-1
+    await appendEvent(sessionsDir, hash, "older", flag("older", "DF-1"));
+    // newer ledger raised something else
+    await appendEvent(sessionsDir, hash, "newer", flag("newer", "DF-7"));
+
+    // make "newer" strictly newer so newest-first would pick it if we didn't scan
+    const base = Date.now();
+    utimesSync(sessionFilePath(sessionsDir, hash, "older"), new Date(base - 60_000), new Date(base - 60_000));
+    utimesSync(sessionFilePath(sessionsDir, hash, "newer"), new Date(base), new Date(base));
+
+    const res = await recordFlagDecision({
+      sessionsDir,
+      rootDir,
+      findingId: "DF-1",
+      decision: "accept",
+      reason: "belongs to the older session",
+      now: () => base + 1000,
+    });
+
+    expect(res).toMatchObject({ ok: true, sid: "older" });
+    const newerEvents = await readSessionEvents(sessionFilePath(sessionsDir, hash, "newer"));
+    expect(newerEvents.some((e) => e.type === "decision")).toBe(false);
+  });
+});

--- a/test/unit/session/entitlement.test.ts
+++ b/test/unit/session/entitlement.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  computeEntitlement,
+  readEntitlementCache,
+  writeEntitlementCache,
+  isCapturePermitted,
+  SESSION_TRIAL_LIMIT,
+} from "@/session/entitlement";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-ent-")));
+
+describe("computeEntitlement", () => {
+  it("Pro/Enterprise are entitled regardless of trial", () => {
+    expect(computeEntitlement("pro", 99, 5).reason).toBe("pro");
+    expect(computeEntitlement("pro", 99, 5).entitled).toBe(true);
+    expect(computeEntitlement("enterprise", 99, 5).entitled).toBe(true);
+  });
+  it("free with trial remaining is entitled on trial", () => {
+    const e = computeEntitlement("free", 2, 5);
+    expect(e).toMatchObject({ entitled: true, reason: "trial", trialUsed: 2, trialLimit: 5 });
+  });
+  it("free with the trial exhausted is locked", () => {
+    const e = computeEntitlement("free", 5, 5);
+    expect(e).toMatchObject({ entitled: false, reason: "locked" });
+    expect(computeEntitlement("free", 6, 5).entitled).toBe(false);
+  });
+});
+
+describe("entitlement cache", () => {
+  it("round-trips and reads back", () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 3, 5));
+    const back = readEntitlementCache(dir);
+    expect(back).toMatchObject({ entitled: true, reason: "trial", trialUsed: 3 });
+  });
+  it("returns null when absent (no throw)", () => {
+    expect(readEntitlementCache(tmp())).toBeNull();
+  });
+});
+
+describe("isCapturePermitted (hook gate)", () => {
+  it("permits capture when no cache exists yet (watch-session writes it first)", () => {
+    expect(isCapturePermitted(tmp())).toBe(true);
+  });
+  it("permits capture when the cache says entitled", () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5));
+    expect(isCapturePermitted(dir)).toBe(true);
+  });
+  it("BLOCKS capture when the cache says locked", () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 5, 5));
+    expect(isCapturePermitted(dir)).toBe(false);
+  });
+});
+
+describe("SESSION_TRIAL_LIMIT", () => {
+  it("is 5 (decision 8)", () => {
+    expect(SESSION_TRIAL_LIMIT).toBe(5);
+  });
+});

--- a/test/unit/session/follow.test.ts
+++ b/test/unit/session/follow.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionFollower } from "@/session/follow";
+import { appendEvent } from "@/session/ledger";
+import type { SessionEvent } from "@/session/types";
+
+const HASH = "hashhashhashhash";
+let seq = 0;
+const ev = (type: SessionEvent["type"], sid: string): SessionEvent => ({
+  v: 1,
+  sid,
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: HASH,
+  channel: "hook",
+  type,
+  mode: "passive",
+  detail: {},
+});
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-follow-")));
+
+describe("SessionFollower", () => {
+  it("returns new events since the last poll", async () => {
+    const dir = tmp();
+    await appendEvent(dir, HASH, "A", ev("session_start", "A"));
+    await appendEvent(dir, HASH, "A", ev("user_prompt", "A"));
+    const f = new SessionFollower(dir, HASH);
+    const first = await f.poll();
+    expect(first.map((e) => e.type)).toEqual(["session_start", "user_prompt"]);
+    await appendEvent(dir, HASH, "A", ev("edit", "A"));
+    const second = await f.poll();
+    expect(second.map((e) => e.type)).toEqual(["edit"]);
+    const third = await f.poll();
+    expect(third).toEqual([]);
+  });
+
+  it("rotates to a newer session file", async () => {
+    const dir = tmp();
+    await appendEvent(dir, HASH, "A", ev("session_start", "A"));
+    const f = new SessionFollower(dir, HASH);
+    await f.poll();
+    // a newer session B (mtime later than A because written after)
+    await new Promise((r) => setTimeout(r, 15));
+    await appendEvent(dir, HASH, "B", ev("session_start", "B"));
+    const rotated = await f.poll();
+    expect(rotated.map((e) => e.sid)).toEqual(["B"]);
+  });
+
+  it("does not replay a file when leapfrogging back to it (per-file offset)", async () => {
+    const dir = tmp();
+    await appendEvent(dir, HASH, "A", ev("session_start", "A"));
+    const f = new SessionFollower(dir, HASH);
+    expect((await f.poll()).length).toBe(1); // reads A
+    await new Promise((r) => setTimeout(r, 15));
+    await appendEvent(dir, HASH, "B", ev("session_start", "B"));
+    expect((await f.poll()).map((e) => e.sid)).toEqual(["B"]); // switch to B
+    // touch A so it becomes newest again, but add NO new events
+    await new Promise((r) => setTimeout(r, 15));
+    await appendEvent(dir, HASH, "A", ev("edit", "A")); // A now newest, 1 new line
+    const back = await f.poll();
+    // only the NEW A event, never a replay of A's first event
+    expect(back.map((e) => e.type)).toEqual(["edit"]);
+  });
+
+  it("is empty and does not throw when the dir does not exist yet", async () => {
+    const f = new SessionFollower(tmp(), "nope");
+    expect(await f.poll()).toEqual([]);
+  });
+});

--- a/test/unit/session/gauge.test.ts
+++ b/test/unit/session/gauge.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { computeDrift, classifyZone, applyHysteresis, gaugeSignals } from "@/session/gauge";
+import type { SessionEvent } from "@/session/types";
+
+let seq = 0;
+const ev = (type: SessionEvent["type"], over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1, sid: "s", aid: `e${seq++}`, ts: new Date().toISOString(), agent: "claude-code",
+  projectHash: "h", channel: "hook", type, mode: "passive", detail: {}, ...over,
+});
+
+describe("computeDrift (noisy-OR)", () => {
+  it("is 0 when no signal fires", () => {
+    expect(computeDrift(0, 0, 0)).toBe(0);
+  });
+  it("matches the D = 1-(1-0.5a)(1-0.35b)(1-0.4c) family", () => {
+    // all three fully on: 1 - 0.5*0.65*0.6 = 1 - 0.195 = 0.805
+    expect(computeDrift(1, 1, 1)).toBeCloseTo(0.805, 3);
+    // only redundancy fully on: 1 - (1-0.4) = 0.4
+    expect(computeDrift(0, 0, 1)).toBeCloseTo(0.4, 3);
+  });
+  it("is monotonic in each signal", () => {
+    expect(computeDrift(0.5, 0, 0)).toBeGreaterThan(computeDrift(0.2, 0, 0));
+  });
+});
+
+describe("classifyZone", () => {
+  it("splits green/yellow/red at 0.25 and 0.5", () => {
+    expect(classifyZone(0.1)).toBe("green");
+    expect(classifyZone(0.3)).toBe("yellow");
+    expect(classifyZone(0.6)).toBe("red");
+  });
+});
+
+describe("applyHysteresis", () => {
+  it("does not flap on a value hovering right at a boundary", () => {
+    // in green, a value just over 0.25 should not immediately jump to yellow
+    expect(applyHysteresis("green", 0.26)).toBe("green");
+    // but a clear move past the margin does switch
+    expect(applyHysteresis("green", 0.34)).toBe("yellow");
+  });
+  it("is sticky coming back down too", () => {
+    expect(applyHysteresis("yellow", 0.24)).toBe("yellow"); // within margin, stays
+    expect(applyHysteresis("yellow", 0.16)).toBe("green"); // clears margin, drops
+  });
+  it("holds the yellow<->red boundary with margin", () => {
+    expect(applyHysteresis("yellow", 0.52)).toBe("yellow"); // just over 0.5, within margin
+    expect(applyHysteresis("yellow", 0.58)).toBe("red"); // clears margin
+    expect(applyHysteresis("red", 0.48)).toBe("red"); // within margin, stays red
+    expect(applyHysteresis("red", 0.42)).toBe("yellow"); // clears margin, drops
+  });
+  it("jumps multiple zones on a large move", () => {
+    expect(applyHysteresis("green", 0.9)).toBe("red");
+    expect(applyHysteresis("red", 0.0)).toBe("green");
+  });
+});
+
+describe("gaugeSignals", () => {
+  it("computes fractions over the last window of edits", () => {
+    const events = [
+      ev("edit"),
+      ev("flag", { detail: { category: "async_patterns" } }),
+      ev("edit"),
+      ev("flag", { detail: { category: "redundancy" } }),
+      ev("edit"),
+      ev("flag", { detail: { category: "scope" } }),
+    ];
+    const { a, b, c } = gaugeSignals(events, 3);
+    // 3 edits in window, 1 scope, 1 convention, 1 redundancy
+    expect(a).toBeCloseTo(1 / 3, 3);
+    expect(b).toBeCloseTo(1 / 3, 3);
+    expect(c).toBeCloseTo(1 / 3, 3);
+  });
+  it("is all-zero with no edits", () => {
+    expect(gaugeSignals([ev("session_start")], 5)).toEqual({ a: 0, b: 0, c: 0 });
+  });
+});

--- a/test/unit/session/install.test.ts
+++ b/test/unit/session/install.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installHooks, uninstallHooks, hooksStatus, HOOK_MARKER } from "@/session/install";
+
+const HOOK_CMD = "/usr/local/bin/node /x/dist/session/hook-entry.js";
+
+function tmp(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
+
+function makeOpts(sessionsDir: string) {
+  return { hookCommand: HOOK_CMD, sessionsDir, projectHash: "cafebabecafebabe" };
+}
+
+const settingsPath = (repo: string) => join(repo, ".claude", "settings.local.json");
+
+describe("installHooks", () => {
+  it("creates settings.local.json with marker-tagged hooks for all four events", async () => {
+    const repo = tmp("vd-inst-");
+    const res = await installHooks(repo, makeOpts(tmp("vd-sess-")));
+    expect(res.status).toBe("installed");
+    const parsed = JSON.parse(readFileSync(settingsPath(repo), "utf8"));
+    for (const eventName of ["SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"]) {
+      const groups = parsed.hooks[eventName];
+      expect(Array.isArray(groups)).toBe(true);
+      const cmds = groups.flatMap((g: { hooks: Array<{ command: string }> }) =>
+        g.hooks.map((h) => h.command),
+      );
+      expect(cmds.some((c: string) => c.includes(HOOK_MARKER))).toBe(true);
+    }
+    const postGroups = parsed.hooks.PostToolUse;
+    expect(postGroups[0].matcher).toBe("Edit|Write|MultiEdit");
+    expect(postGroups[0].hooks[0].timeout).toBe(10);
+  });
+
+  it("is idempotent: second install returns already and leaves bytes unchanged", async () => {
+    const repo = tmp("vd-idem-");
+    const opts = makeOpts(tmp("vd-sess-"));
+    await installHooks(repo, opts);
+    const before = readFileSync(settingsPath(repo), "utf8");
+    const res = await installHooks(repo, opts);
+    expect(res.status).toBe("already");
+    expect(readFileSync(settingsPath(repo), "utf8")).toBe(before);
+  });
+
+  it("refuses to clobber unparseable settings", async () => {
+    const repo = tmp("vd-clob-");
+    mkdirSync(join(repo, ".claude"));
+    writeFileSync(settingsPath(repo), "{ this is not json");
+    const res = await installHooks(repo, makeOpts(tmp("vd-sess-")));
+    expect(res.status).toBe("aborted_unparseable");
+    expect(readFileSync(settingsPath(repo), "utf8")).toBe("{ this is not json");
+  });
+
+  it("preserves a user's existing hooks", async () => {
+    const repo = tmp("vd-keep-");
+    mkdirSync(join(repo, ".claude"));
+    const original = `{
+  "permissions": { "allow": ["Bash(ls:*)"] },
+  "hooks": {
+    "PostToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo mine" } ] } ]
+  }
+}`;
+    writeFileSync(settingsPath(repo), original);
+    await installHooks(repo, makeOpts(tmp("vd-sess-")));
+    const parsed = JSON.parse(readFileSync(settingsPath(repo), "utf8"));
+    const cmds = parsed.hooks.PostToolUse.flatMap((g: { hooks: Array<{ command: string }> }) =>
+      g.hooks.map((h) => h.command),
+    );
+    expect(cmds).toContain("echo mine");
+    expect(cmds.some((c: string) => c.includes(HOOK_MARKER))).toBe(true);
+    expect(parsed.permissions.allow).toEqual(["Bash(ls:*)"]);
+  });
+});
+
+describe("uninstallHooks", () => {
+  it("deletes the file entirely when we created it and it holds only our entries", async () => {
+    const repo = tmp("vd-del-");
+    const opts = makeOpts(tmp("vd-sess-"));
+    await installHooks(repo, opts);
+    const res = await uninstallHooks(repo, opts);
+    expect(res.status).toBe("removed");
+    expect(existsSync(settingsPath(repo))).toBe(false);
+  });
+
+  it("restores the original bytes exactly, odd formatting included", async () => {
+    const repo = tmp("vd-bytes-");
+    mkdirSync(join(repo, ".claude"));
+    const original = `{\n    "permissions":   { "allow": [] }\n}\n`;
+    writeFileSync(settingsPath(repo), original);
+    const opts = makeOpts(tmp("vd-sess-"));
+    await installHooks(repo, opts);
+    expect(readFileSync(settingsPath(repo), "utf8")).not.toBe(original);
+    const res = await uninstallHooks(repo, opts);
+    expect(res.status).toBe("restored");
+    expect(readFileSync(settingsPath(repo), "utf8")).toBe(original);
+  });
+
+  it("falls back to surgical removal when the user edited settings after install", async () => {
+    const repo = tmp("vd-surg-");
+    const opts = makeOpts(tmp("vd-sess-"));
+    await installHooks(repo, opts);
+    const parsed = JSON.parse(readFileSync(settingsPath(repo), "utf8"));
+    parsed.hooks.PostToolUse.push({
+      matcher: "Bash",
+      hooks: [{ type: "command", command: "echo added-later" }],
+    });
+    writeFileSync(settingsPath(repo), JSON.stringify(parsed, null, 2));
+    const res = await uninstallHooks(repo, opts);
+    expect(res.status).toBe("removed_surgical");
+    const after = JSON.parse(readFileSync(settingsPath(repo), "utf8"));
+    const all = JSON.stringify(after);
+    expect(all).toContain("echo added-later");
+    expect(all).not.toContain(HOOK_MARKER);
+  });
+
+  it("reports not_installed when nothing of ours is present", async () => {
+    const repo = tmp("vd-none-");
+    const res = await uninstallHooks(repo, makeOpts(tmp("vd-sess-")));
+    expect(res.status).toBe("not_installed");
+  });
+});
+
+describe("hooksStatus", () => {
+  it("reflects installed state", async () => {
+    const repo = tmp("vd-stat-");
+    const opts = makeOpts(tmp("vd-sess-"));
+    expect((await hooksStatus(repo)).installed).toBe(false);
+    await installHooks(repo, opts);
+    expect((await hooksStatus(repo)).installed).toBe(true);
+    await uninstallHooks(repo, opts);
+    expect((await hooksStatus(repo)).installed).toBe(false);
+  });
+});

--- a/test/unit/session/intent-state.test.ts
+++ b/test/unit/session/intent-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readIntentState, writeIntentState, emptyIntentState } from "@/session/intent-state";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-intent-")));
+const HASH = "hashhashhashhash";
+
+describe("intent state", () => {
+  it("round-trips state", async () => {
+    const dir = tmp();
+    const s = emptyIntentState();
+    s.locked = true;
+    s.task = "add webhook";
+    s.anchors.files.push("routes/billing.ts");
+    s.unrelatedEdits = 1;
+    await writeIntentState(dir, HASH, "s1", s);
+    const back = await readIntentState(dir, HASH, "s1");
+    expect(back.locked).toBe(true);
+    expect(back.task).toBe("add webhook");
+    expect(back.anchors.files).toEqual(["routes/billing.ts"]);
+    expect(back.unrelatedEdits).toBe(1);
+  });
+
+  it("returns an empty state when none exists (no throw)", async () => {
+    const s = await readIntentState(tmp(), HASH, "none");
+    expect(s).toEqual(emptyIntentState());
+  });
+
+  it("tolerates a corrupt state file", async () => {
+    const dir = tmp();
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(join(dir, HASH), { recursive: true });
+    writeFileSync(join(dir, HASH, "s1.intent.json"), "{ not json");
+    expect(await readIntentState(dir, HASH, "s1")).toEqual(emptyIntentState());
+  });
+});

--- a/test/unit/session/ledger.test.ts
+++ b/test/unit/session/ledger.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, appendFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent, readSessionEvents, sessionFilePath, newActivityId } from "@/session/ledger";
+import type { SessionEvent } from "@/session/types";
+
+const HASH = "abcd1234abcd1234";
+
+const ev = (over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "s1",
+  aid: newActivityId(),
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: HASH,
+  channel: "hook",
+  type: "user_prompt",
+  mode: "passive",
+  detail: { promptText: "add stripe webhook" },
+  ...over,
+});
+
+describe("session ledger", () => {
+  it("appends one JSON line per event and reads them back in order", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    await appendEvent(base, HASH, "s1", ev());
+    await appendEvent(base, HASH, "s1", ev({ type: "edit" }));
+    const file = sessionFilePath(base, HASH, "s1");
+    const lines = readFileSync(file, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const events = await readSessionEvents(file);
+    expect(events.map((e) => e.type)).toEqual(["user_prompt", "edit"]);
+  });
+
+  it("skips corrupt lines on read instead of throwing", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    await appendEvent(base, HASH, "s1", ev());
+    const file = sessionFilePath(base, HASH, "s1");
+    appendFileSync(file, "{not json\n");
+    await appendEvent(base, HASH, "s1", ev({ type: "session_end" }));
+    const events = await readSessionEvents(file);
+    expect(events.map((e) => e.type)).toEqual(["user_prompt", "session_end"]);
+  });
+
+  it("returns [] for a missing file", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    const events = await readSessionEvents(sessionFilePath(base, HASH, "nope"));
+    expect(events).toEqual([]);
+  });
+
+  it("caps a single line at 32KB by BYTES for ASCII prompts", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    await appendEvent(base, HASH, "s1", ev({ detail: { promptText: "x".repeat(64_000) } }));
+    const file = sessionFilePath(base, HASH, "s1");
+    const line = readFileSync(file, "utf8").trim();
+    expect(Buffer.byteLength(line, "utf8")).toBeLessThanOrEqual(32 * 1024);
+    const parsed = JSON.parse(line) as SessionEvent;
+    expect(parsed.detail.truncated).toBe(true);
+  });
+
+  it("caps by BYTES for multibyte prompts (CJK is 3 bytes/char)", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    await appendEvent(base, HASH, "s2", ev({ sid: "s2", detail: { promptText: "文".repeat(40_000) } }));
+    const file = sessionFilePath(base, HASH, "s2");
+    const line = readFileSync(file, "utf8").trim();
+    expect(Buffer.byteLength(line, "utf8")).toBeLessThanOrEqual(32 * 1024);
+    expect((JSON.parse(line) as SessionEvent).detail.truncated).toBe(true);
+  });
+
+  it("sanitizes path-unsafe session ids so they cannot escape the sessions dir", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    await appendEvent(base, HASH, "../../evil", ev({ sid: "../../evil" }));
+    // nothing written outside base
+    const escaped = join(base, "..", "..", "evil.jsonl");
+    expect(existsSync(escaped)).toBe(false);
+    // the sanitized file lives under base/<hash>/
+    const events = await readSessionEvents(sessionFilePath(base, HASH, "../../evil"));
+    expect(events).toHaveLength(1);
+  });
+
+  it("still records when the session id contains a slash", async () => {
+    const base = mkdtempSync(join(tmpdir(), "vd-ledger-"));
+    await appendEvent(base, HASH, "a/b", ev({ sid: "a/b" }));
+    const events = await readSessionEvents(sessionFilePath(base, HASH, "a/b"));
+    expect(events).toHaveLength(1);
+  });
+
+  it("generates unique activity ids", () => {
+    const ids = new Set(Array.from({ length: 200 }, () => newActivityId()));
+    expect(ids.size).toBe(200);
+  });
+});

--- a/test/unit/session/mask.test.ts
+++ b/test/unit/session/mask.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { maskSecrets } from "@/session/mask";
+
+// Fake secret fixtures assembled from split parts so no contiguous secret-shaped
+// literal ever appears in source. These are dummy values (not real keys); the
+// split keeps automated secret scanners quiet while the masker still receives the
+// fully-assembled string and must catch it.
+const j = (...parts: string[]): string => parts.join("");
+const STRIPE = j("sk_", "live_", "4eC39HqLyjWDarjtT1zdp7dc");
+const ANTHROPIC = j("sk-", "ant-", "api03-", "AbCdEf012345678901234567890XyZ");
+const OPENAI_PROJ = j("sk-", "proj-", "abcDEF1234567890ghiJKL");
+const OPENAI_PROJ2 = j("sk-", "proj-", "abcdefghijklmnop");
+const GH_TOKEN = j("ghp", "_", "abcdefghijklmnopqrstuvwxyz123456");
+const SLACK = j("xox", "b-", "2401234567-2409876543210-AbCdEfGhIjKlMnOpQrStUvWx");
+const GOOGLE = j("AIza", "SyD1234567890abcdefghijklmnopqrstuv");
+const NPM = j("npm", "_", "abcdefghijklmnopqrstuvwxyz0123456789");
+const AWS = j("AKIA", "IOSFODNN7EXAMPLE"); // AWS's official docs example key
+const JWT = j("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", ".abcde.fghij");
+const JWT2 = j("eyJhbGciOiJIUzI1NiJ9", ".eyJzdWIiOiIx.SflKxwRJSMeKKF2QT4");
+
+describe("maskSecrets", () => {
+  it("masks common secret shapes", () => {
+    const s = maskSecrets(`use ${AWS} and api_key=abcd1234efgh5678 plus Bearer ${JWT} and ${STRIPE}`);
+    expect(s).not.toContain(AWS);
+    expect(s).not.toContain("abcd1234efgh5678");
+    expect(s).not.toContain(STRIPE);
+    expect(s).toContain("[masked]");
+  });
+
+  it("keeps the key name when masking key=value shapes", () => {
+    expect(maskSecrets("password: hunter2hunter2")).toContain("password");
+    expect(maskSecrets("password: hunter2hunter2")).not.toContain("hunter2hunter2");
+  });
+
+  it("masks provider keys with internal hyphens (Anthropic, OpenAI project)", () => {
+    const s = maskSecrets(`keys: ${ANTHROPIC} and ${OPENAI_PROJ}`);
+    expect(s).not.toContain(ANTHROPIC);
+    expect(s).not.toContain(OPENAI_PROJ);
+  });
+
+  it("masks SNAKE_CASE env-var secrets (leading prefix, no word boundary)", () => {
+    for (const t of [
+      `OPENAI_API_KEY=${OPENAI_PROJ2}`,
+      "DB_PASSWORD=hunter2hunter2",
+      "MY_SERVICE_SECRET: averylongsecretvalue",
+    ]) {
+      const m = maskSecrets(t);
+      expect(m).toContain("[masked]");
+      expect(m).not.toMatch(/hunter2hunter2|averylongsecretvalue|abcdefghijklmnop/);
+    }
+    // the identifier itself is preserved, only the value is masked
+    expect(maskSecrets("DB_PASSWORD=hunter2hunter2")).toContain("DB_PASSWORD");
+  });
+
+  it("masks GitHub tokens and JWTs", () => {
+    const s = maskSecrets(`${GH_TOKEN} ${JWT2}`);
+    expect(s).not.toContain(GH_TOKEN);
+    expect(s).not.toContain(JWT2);
+  });
+
+  it("masks the password in a connection-string URL, keeping scheme + user", () => {
+    for (const [dsn, secret] of [
+      ["postgres://admin:hunter2secret@db.internal:5432/prod", "hunter2secret"],
+      ["mongodb+srv://root:S3cretP4ss@cluster0.mongodb.net/db", "S3cretP4ss"],
+      ["redis://:MyR3disPassw0rd@cache.internal:6379", "MyR3disPassw0rd"],
+    ] as const) {
+      const m = maskSecrets(`the DSN is ${dsn} btw`);
+      expect(m).not.toContain(secret);
+      expect(m).toContain("[masked]");
+    }
+    // the non-secret structure survives for a still-useful trace
+    expect(maskSecrets("postgres://admin:hunter2secret@db.internal/prod")).toContain(
+      "postgres://admin:[masked]@db.internal/prod",
+    );
+  });
+
+  it("masks unprefixed vendor tokens (Slack, Google API key, npm)", () => {
+    for (const t of [SLACK, GOOGLE, NPM]) {
+      const m = maskSecrets(`token: ${t}`);
+      expect(m).toContain("[masked]");
+      expect(m).not.toContain(t);
+    }
+  });
+
+  it("masks PEM private key blocks entirely", () => {
+    const t = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg\n-----END PRIVATE KEY-----";
+    expect(maskSecrets(t)).toBe("[masked]");
+  });
+
+  it("leaves normal prose and code identifiers alone", () => {
+    const t = "add Stripe webhook handling to routes/billing.ts using handleStripeWebhook and requireAuth";
+    expect(maskSecrets(t)).toBe(t);
+  });
+
+  it("leaves short values after key names alone (low-risk, avoids over-masking)", () => {
+    const t = "set token: abc123 in the test fixture";
+    expect(maskSecrets(t)).toBe(t);
+  });
+});

--- a/test/unit/session/mcp-tee.test.ts
+++ b/test/unit/session/mcp-tee.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { teeMcpVerdict, ACTIVE_WINDOW_MS } from "@/session/mcp-tee";
+import { appendEvent, sessionFilePath, readSessionEvents } from "@/session/ledger";
+import { projectHash } from "@/core/baseline";
+import type { SessionEvent } from "@/session/types";
+
+const ev = (sid: string): SessionEvent => ({
+  v: 1,
+  sid,
+  aid: "a",
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: "x",
+  channel: "hook",
+  type: "session_start",
+  mode: "passive",
+  detail: {},
+});
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-tee-")));
+
+describe("teeMcpVerdict", () => {
+  it("appends mcp_ask + mcp_verdict to the active session", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "live", ev("live"));
+
+    await teeMcpVerdict({
+      sessionsDir,
+      rootDir,
+      tool: "validate_change",
+      ask: "validate src/a.ts",
+      verdict: "1 drift: async",
+    });
+
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    const types = events.map((e) => e.type);
+    expect(types).toContain("mcp_ask");
+    expect(types).toContain("mcp_verdict");
+    const ask = events.find((e) => e.type === "mcp_ask")!;
+    expect(ask.channel).toBe("mcp");
+    expect(ask.detail.toolName).toBe("validate_change");
+  });
+
+  it("finds the ledger even when rootDir is given via a symlink (canonicalized)", async () => {
+    const { symlinkSync } = await import("node:fs");
+    const sessionsDir = tmp();
+    const realRoot = tmp();
+    const hash = projectHash(realRoot); // hooks key on the canonical (real) path
+    await appendEvent(sessionsDir, hash, "live", ev("live"));
+
+    // an aliased path to the same repo (the trap: /tmp vs /private/tmp)
+    const linkRoot = join(tmp(), "aliased");
+    symlinkSync(realRoot, linkRoot);
+
+    await teeMcpVerdict({ sessionsDir, rootDir: linkRoot, tool: "t", ask: "a", verdict: "v" });
+
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    expect(events.map((e) => e.type)).toContain("mcp_verdict");
+  });
+
+  it("is a no-op and does not throw when there is no session", async () => {
+    const rootDir = tmp();
+    await expect(
+      teeMcpVerdict({ sessionsDir: tmp(), rootDir, tool: "t", ask: "a", verdict: "v" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not write to a session older than the active window", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "stale", ev("stale"));
+    // age the file well past the window
+    const old = Date.now() / 1000 - (ACTIVE_WINDOW_MS / 1000) - 60;
+    utimesSync(sessionFilePath(sessionsDir, hash, "stale"), old, old);
+
+    await teeMcpVerdict({ sessionsDir, rootDir, tool: "t", ask: "a", verdict: "v" });
+
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "stale"));
+    expect(events.map((e) => e.type)).toEqual(["session_start"]);
+  });
+});

--- a/test/unit/session/normalize.test.ts
+++ b/test/unit/session/normalize.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { normalizeHookPayload, EDIT_TOOLS } from "@/session/normalize";
+
+const base = { session_id: "s1", cwd: "/tmp/x" };
+const ctx = { projectHash: "abcd1234abcd1234" };
+
+describe("normalizeHookPayload", () => {
+  it("maps SessionStart and Stop/SessionEnd", () => {
+    expect(normalizeHookPayload({ ...base, hook_event_name: "SessionStart" }, ctx)?.type).toBe(
+      "session_start",
+    );
+    expect(normalizeHookPayload({ ...base, hook_event_name: "Stop" }, ctx)?.type).toBe(
+      "session_end",
+    );
+    expect(normalizeHookPayload({ ...base, hook_event_name: "SessionEnd" }, ctx)?.type).toBe(
+      "session_end",
+    );
+  });
+
+  it("maps UserPromptSubmit and masks the prompt", () => {
+    const ev = normalizeHookPayload(
+      { ...base, hook_event_name: "UserPromptSubmit", prompt: "use api_key=abcd1234efgh5678 now" },
+      ctx,
+    );
+    expect(ev?.type).toBe("user_prompt");
+    expect(ev?.detail.promptText).toContain("[masked]");
+    expect(ev?.detail.promptText).not.toContain("abcd1234efgh5678");
+  });
+
+  it("accepts user_prompt as an alternate prompt key (docs gap)", () => {
+    const ev = normalizeHookPayload(
+      { ...base, hook_event_name: "UserPromptSubmit", user_prompt: "hello" },
+      ctx,
+    );
+    expect(ev?.detail.promptText).toBe("hello");
+  });
+
+  it("maps PostToolUse Edit with new_string body and line-count diffstat", () => {
+    const ev = normalizeHookPayload(
+      {
+        ...base,
+        hook_event_name: "PostToolUse",
+        tool_name: "Edit",
+        tool_input: { file_path: "/tmp/x/src/a.ts", old_string: "a", new_string: "line1\nline2" },
+      },
+      ctx,
+    );
+    expect(ev?.type).toBe("edit");
+    expect(ev?.detail.file).toBe("/tmp/x/src/a.ts");
+    expect(ev?.detail.diffstat).toBe("+2");
+    expect(ev?.detail.toolName).toBe("Edit");
+  });
+
+  it("maps Write content and file_text variants", () => {
+    const w1 = normalizeHookPayload(
+      {
+        ...base,
+        hook_event_name: "PostToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: "/tmp/x/b.ts", content: "x\ny\nz" },
+      },
+      ctx,
+    );
+    expect(w1?.detail.diffstat).toBe("+3");
+    const w2 = normalizeHookPayload(
+      {
+        ...base,
+        hook_event_name: "PostToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: "/tmp/x/b.ts", file_text: "x\ny" },
+      },
+      ctx,
+    );
+    expect(w2?.detail.diffstat).toBe("+2");
+  });
+
+  it("maps MultiEdit by joining edits", () => {
+    const m = normalizeHookPayload(
+      {
+        ...base,
+        hook_event_name: "PostToolUse",
+        tool_name: "MultiEdit",
+        tool_input: {
+          file_path: "/tmp/x/c.ts",
+          edits: [
+            { old_string: "", new_string: "p" },
+            { old_string: "", new_string: "q" },
+          ],
+        },
+      },
+      ctx,
+    );
+    expect(m?.type).toBe("edit");
+    expect(m?.detail.file).toBe("/tmp/x/c.ts");
+  });
+
+  it("maps PostToolUse Bash to command without recording the command text", () => {
+    const ev = normalizeHookPayload(
+      {
+        ...base,
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "rm -rf secrets/" },
+      },
+      ctx,
+    );
+    expect(ev?.type).toBe("command");
+    expect(JSON.stringify(ev)).not.toContain("rm -rf");
+  });
+
+  it("returns null for unknown events, other tools, and missing session_id", () => {
+    expect(normalizeHookPayload({ ...base, hook_event_name: "Notification" }, ctx)).toBeNull();
+    expect(
+      normalizeHookPayload(
+        { ...base, hook_event_name: "PostToolUse", tool_name: "Read", tool_input: {} },
+        ctx,
+      ),
+    ).toBeNull();
+    expect(normalizeHookPayload({ hook_event_name: "SessionStart" }, ctx)).toBeNull();
+    expect(normalizeHookPayload("not an object", ctx)).toBeNull();
+    expect(normalizeHookPayload(null, ctx)).toBeNull();
+  });
+
+  it("exports the edit tool list", () => {
+    expect(EDIT_TOOLS).toEqual(["Edit", "Write", "MultiEdit"]);
+  });
+});

--- a/test/unit/session/outcomes.test.ts
+++ b/test/unit/session/outcomes.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBaseline, type RepoDriftBaseline } from "@/core/baseline";
+import { recheckFile, detectRevert, type OpenFinding } from "@/session/outcomes";
+
+const tmp = (p: string) => realpathSync(mkdtempSync(join(tmpdir(), p)));
+
+const HELPER = `export function exponentialBackoff(attempt) {
+  const base = 250;
+  const cap = 30000;
+  const jitter = Math.random() * 100;
+  return Math.min(cap, base * 2 ** attempt) + jitter;
+}`;
+
+let baseline: RepoDriftBaseline;
+beforeAll(async () => {
+  const repo = tmp("vd-out-repo-");
+  mkdirSync(join(repo, "src", "lib"), { recursive: true });
+  writeFileSync(join(repo, "CLAUDE.md"), "- Async: use async/await throughout. No .then() chains.\n");
+  for (const n of ["a", "b", "c"]) {
+    writeFileSync(join(repo, "src", `${n}.ts`), `export async function ${n}(){ return await fetch("/${n}"); }\n`);
+  }
+  writeFileSync(join(repo, "src", "lib", "backoff.ts"), `${HELPER}\n`);
+  baseline = await buildBaseline(repo);
+}, 60_000);
+
+const THEN = `export function loadReport(id) {
+  return fetch("/x/" + id)
+    .then((r) => r.json())
+    .then((d) => d.rows);
+}`;
+const CLEAN = `export async function loadReport(id) {
+  const r = await fetch("/x/" + id);
+  const d = await r.json();
+  return d.rows;
+}`;
+
+describe("recheckFile", () => {
+  const open: OpenFinding[] = [{ findingId: "DF-1", file: "src/report.ts", category: "async_patterns" }];
+
+  it("resolves a convention finding once the file is fixed", () => {
+    const { resolved } = recheckFile(baseline, "src/report.ts", CLEAN, open);
+    expect(resolved.map((f) => f.findingId)).toEqual(["DF-1"]);
+  });
+
+  it("does NOT resolve while the finding still stands", () => {
+    const { resolved } = recheckFile(baseline, "src/report.ts", THEN, open);
+    expect(resolved).toEqual([]);
+  });
+
+  it("does NOT resolve a finding on a DIFFERENT file (cross-file safety)", () => {
+    const { resolved } = recheckFile(baseline, "src/other.ts", CLEAN, open);
+    expect(resolved).toEqual([]);
+  });
+
+  it("leaves scope findings alone (never auto-resolved here)", () => {
+    const scopeOpen: OpenFinding[] = [{ findingId: "DF-scope-2", file: "src/report.ts", category: "scope" }];
+    expect(recheckFile(baseline, "src/report.ts", CLEAN, scopeOpen).resolved).toEqual([]);
+  });
+
+  it("does NOT falsely resolve a redundancy when the dup is still present in a multi-function file", () => {
+    // the whole-file query dilutes below threshold, but the per-function query
+    // (via detectDrift) still catches the untouched clone — so no false resolve
+    const dupOpen: OpenFinding[] = [{ findingId: "DF-dup", file: "src/util.ts", category: "redundancy" }];
+    const multiFn = `export function unrelatedOne(a) { return a + 1; }
+${HELPER}
+export function unrelatedTwo(b) { return b - 1; }`;
+    expect(recheckFile(baseline, "src/util.ts", multiFn, dupOpen).resolved).toEqual([]);
+  });
+
+  it("DOES resolve a redundancy once the duplicated function is gone", () => {
+    const dupOpen: OpenFinding[] = [{ findingId: "DF-dup", file: "src/util.ts", category: "redundancy" }];
+    const noDup = `export function unrelatedOne(a) { return a + 1; }
+export function unrelatedTwo(b) { return b - 1; }`;
+    expect(recheckFile(baseline, "src/util.ts", noDup, dupOpen).resolved.map((f) => f.findingId)).toEqual(["DF-dup"]);
+  });
+});
+
+describe("detectRevert", () => {
+  it("flags a byte-exact restore but NOT a reformatted body", () => {
+    const seen: Record<string, string[]> = {};
+    expect(detectRevert("f.ts", "const x = 1;", seen).reverted).toBe(false); // first sight
+    expect(detectRevert("f.ts", "const y = 2;", seen).reverted).toBe(false); // new content
+    expect(detectRevert("f.ts", "const x = 1;", seen).reverted).toBe(true); // byte-exact restore
+    // a reformatted variant (extra spaces) has a different hash -> not a revert
+    expect(detectRevert("f.ts", "const  x  =  1;", seen).reverted).toBe(false);
+  });
+});

--- a/test/unit/session/repo.test.ts
+++ b/test/unit/session/repo.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveRepoRoot, repoIdentity, defaultSessionsDir } from "@/session/repo";
+import { projectHash } from "@/core/baseline";
+
+const tmp = (prefix: string) => realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+
+describe("resolveRepoRoot", () => {
+  it("walks up to the nearest .git ancestor", () => {
+    const a = tmp("vd-repo-");
+    mkdirSync(join(a, ".git"));
+    mkdirSync(join(a, "b", "c"), { recursive: true });
+    expect(resolveRepoRoot(join(a, "b", "c"))).toBe(a);
+  });
+
+  it("prefers the nearest .git when nested", () => {
+    const a = tmp("vd-nested-");
+    mkdirSync(join(a, ".git"));
+    mkdirSync(join(a, "sub", ".git"), { recursive: true });
+    mkdirSync(join(a, "sub", "deep"), { recursive: true });
+    expect(resolveRepoRoot(join(a, "sub", "deep"))).toBe(join(a, "sub"));
+  });
+
+  it("falls back to the input dir when no .git exists", () => {
+    const d = tmp("vd-norepo-");
+    expect(resolveRepoRoot(d)).toBe(d);
+  });
+});
+
+describe("repoIdentity", () => {
+  it("hash matches core projectHash of the resolved root", () => {
+    const d = tmp("vd-id-");
+    const id = repoIdentity(d);
+    expect(id.rootDir).toBe(d);
+    expect(id.projectHash).toBe(projectHash(d));
+  });
+});
+
+describe("defaultSessionsDir", () => {
+  it("lives under ~/.vibedrift/sessions", () => {
+    expect(defaultSessionsDir().endsWith(join(".vibedrift", "sessions"))).toBe(true);
+  });
+});

--- a/test/unit/session/scope.test.ts
+++ b/test/unit/session/scope.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { processPrompt, checkScope } from "@/session/scope";
+import { readIntentState } from "@/session/intent-state";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-scope-")));
+const HASH = "hashhashhashhash";
+
+describe("processPrompt", () => {
+  it("locks on the first prompt, and emits an expansion carrying all files when a follow-up adds one", async () => {
+    const dir = tmp();
+    const lock = await processPrompt(dir, HASH, "s1", "add webhook to routes/billing.ts using `handleStripeWebhook`");
+    expect(lock?.type).toBe("intent_lock");
+    expect(lock?.detail.observed).toBe(""); // first lock
+    expect(lock?.detail.promptText).toContain("webhook");
+
+    const expanded = await processPrompt(dir, HASH, "s1", "also touch routes/orders.ts");
+    expect(expanded?.type).toBe("intent_lock");
+    expect(expanded?.detail.observed).toBe("expanded");
+    // the expansion event carries the FULL current file set (for coverage)
+    expect(expanded?.detail.anchorFiles).toEqual(
+      expect.arrayContaining(["routes/billing.ts", "routes/orders.ts"]),
+    );
+
+    // a prompt that adds no new files emits nothing
+    const noop = await processPrompt(dir, HASH, "s1", "make it clean");
+    expect(noop).toBeNull();
+
+    const state = await readIntentState(dir, HASH, "s1");
+    expect(state.anchors.files).toEqual(expect.arrayContaining(["routes/billing.ts", "routes/orders.ts"]));
+  });
+
+  it("does not lock on a whitespace-only first prompt", async () => {
+    const dir = tmp();
+    expect(await processPrompt(dir, HASH, "s1", "   \n  ")).toBeNull();
+    expect((await readIntentState(dir, HASH, "s1")).locked).toBe(false);
+  });
+});
+
+describe("checkScope", () => {
+  async function lock(dir: string) {
+    await processPrompt(dir, HASH, "s1", "add webhook handling to routes/billing.ts using `handleStripeWebhook`");
+  }
+
+  it("does NOT flag a single unrelated edit (conservative)", async () => {
+    const dir = tmp();
+    await lock(dir);
+    const r = await checkScope(dir, HASH, "s1", "ui/theme.ts", "const palette = { red: 1 };");
+    expect(r.flag).toBeNull();
+    expect(r.fyi).toBeNull();
+  });
+
+  it("flags the SECOND unrelated edit as experimental scope drift", async () => {
+    const dir = tmp();
+    await lock(dir);
+    await checkScope(dir, HASH, "s1", "ui/theme.ts", "const palette = { red: 1 };"); // 1st unrelated
+    const r = await checkScope(dir, HASH, "s1", "ui/layout.ts", "const grid = 12;"); // 2nd unrelated
+    expect(r.flag?.type).toBe("flag");
+    expect(r.flag?.detail.category).toBe("scope");
+    expect(r.flag?.detail.experimental).toBe(true);
+    expect(r.fyi).toBeTruthy();
+    expect(r.fyi!.toLowerCase()).toContain("experimental");
+  });
+
+  it("does NOT count a related edit toward the unrelated tally", async () => {
+    const dir = tmp();
+    await lock(dir);
+    await checkScope(dir, HASH, "s1", "ui/theme.ts", "const x = 1;"); // 1 unrelated
+    await checkScope(dir, HASH, "s1", "routes/billing.ts", "handleStripeWebhook()"); // related, not counted
+    const r = await checkScope(dir, HASH, "s1", "docs/readme.md", "hello"); // 2nd unrelated -> flag
+    expect(r.flag).toBeTruthy();
+  });
+
+  it("is a no-op before intent is locked", async () => {
+    const dir = tmp();
+    const r = await checkScope(dir, HASH, "s1", "anything.ts", "x");
+    expect(r.flag).toBeNull();
+  });
+
+  it("does not re-flag the same file twice", async () => {
+    const dir = tmp();
+    await lock(dir);
+    await checkScope(dir, HASH, "s1", "a.ts", "x"); // 1
+    const first = await checkScope(dir, HASH, "s1", "b.ts", "y"); // 2 -> flag
+    expect(first.flag).toBeTruthy();
+    const again = await checkScope(dir, HASH, "s1", "b.ts", "y2"); // same file
+    expect(again.flag).toBeNull();
+  });
+});

--- a/test/unit/session/session-tee-mcp.test.ts
+++ b/test/unit/session/session-tee-mcp.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as repo from "@/session/repo";
+import { appendEvent, sessionFilePath, readSessionEvents } from "@/session/ledger";
+import { projectHash } from "@/core/baseline";
+import type { SessionEvent } from "@/session/types";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-teewrap-")));
+const startEv = (): SessionEvent => ({
+  v: 1, sid: "live", aid: "a", ts: new Date().toISOString(), agent: "claude-code",
+  projectHash: "x", channel: "hook", type: "session_start", mode: "passive", detail: {},
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("MCP tee summary helpers", () => {
+  it("records a validate_change verdict into the active session", async () => {
+    const sessionsDir = tmp();
+    const rootDir = tmp();
+    const hash = projectHash(rootDir);
+    await appendEvent(sessionsDir, hash, "live", startEv());
+    vi.spyOn(repo, "defaultSessionsDir").mockReturnValue(sessionsDir);
+
+    const { teeValidateChange } = await import("@/mcp/session-tee");
+    await teeValidateChange(
+      { rootDir, targetPath: "/repo/src/api/billing.ts" },
+      { ok: false, conflicts: [{}], duplicateOf: [] },
+    );
+
+    const events = await readSessionEvents(sessionFilePath(sessionsDir, hash, "live"));
+    const verdict = events.find((e) => e.type === "mcp_verdict");
+    expect(verdict?.detail.observed).toContain("1 drift");
+    const ask = events.find((e) => e.type === "mcp_ask");
+    expect(ask?.detail.promptText).toContain("billing.ts");
+  });
+
+  it("no active session: tool still returns, tee is a silent no-op", async () => {
+    vi.spyOn(repo, "defaultSessionsDir").mockReturnValue(tmp());
+    const { teeFindSimilar } = await import("@/mcp/session-tee");
+    await expect(
+      teeFindSimilar({ rootDir: tmp() }, { found: true, matches: [{}, {}] }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/session/summary.test.ts
+++ b/test/unit/session/summary.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { summarize, formatSummary } from "@/session/summary";
+import type { SessionEvent } from "@/session/types";
+
+let seq = 0;
+const ev = (type: SessionEvent["type"], over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "s1",
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: "h",
+  channel: "hook",
+  type,
+  mode: "passive",
+  detail: {},
+  ...over,
+});
+
+describe("summarize", () => {
+  it("counts edits and flags, all open when no outcomes", () => {
+    const s = summarize([
+      ev("session_start"),
+      ev("user_prompt"),
+      ev("edit"),
+      ev("flag", { findingId: "DF-1" }),
+      ev("edit"),
+      ev("flag", { findingId: "DF-2" }),
+      ev("session_end"),
+    ]);
+    expect(s).toMatchObject({ edits: 2, flagged: 2, resolved: 0, held: 0, open: 2 });
+  });
+
+  it("counts a later resolve event against its finding", () => {
+    const s = summarize([
+      ev("edit"),
+      ev("flag", { findingId: "DF-1" }),
+      ev("flag", { findingId: "DF-2" }),
+      ev("resolve", { findingId: "DF-1" }),
+    ]);
+    expect(s).toMatchObject({ flagged: 2, resolved: 1, open: 1 });
+  });
+
+  it("counts a hold and a blocking flag as held", () => {
+    const s = summarize([
+      ev("flag", { findingId: "DF-1", mode: "blocking" }),
+      ev("flag", { findingId: "DF-2" }),
+      ev("hold", { findingId: "DF-2" }),
+    ]);
+    expect(s.held).toBe(2);
+    expect(s.open).toBe(0);
+  });
+
+  it("formatSummary is observational, never claims prevention", () => {
+    const line = formatSummary(summarize([ev("edit"), ev("flag", { findingId: "DF-1" })]));
+    expect(line).toContain("1 flagged");
+    expect(line.toLowerCase()).not.toContain("prevented");
+    expect(line.toLowerCase()).not.toContain("blocked");
+  });
+
+  it("reports coverage of the task's target files", () => {
+    const s = summarize([
+      ev("intent_lock", { detail: { anchorFiles: ["routes/billing.ts", "lib/retry.ts"] } }),
+      ev("edit", { detail: { file: "routes/billing.ts" } }),
+      ev("edit", { detail: { file: "ui/theme.ts" } }),
+    ]);
+    expect(s.coverage).toEqual({ touched: 1, total: 2 });
+    expect(formatSummary(s)).toContain("1/2 task files touched");
+  });
+
+  it("coverage denominator includes files added by a follow-up prompt (last lock wins)", () => {
+    const s = summarize([
+      ev("intent_lock", { detail: { anchorFiles: ["routes/billing.ts"] } }),
+      ev("intent_lock", { detail: { anchorFiles: ["routes/billing.ts", "routes/orders.ts"], observed: "expanded" } }),
+      ev("edit", { detail: { file: "routes/billing.ts" } }),
+    ]);
+    expect(s.coverage).toEqual({ touched: 1, total: 2 });
+  });
+
+  it("keeps experimental scope flags OUT of the headline flagged/open", () => {
+    const s = summarize([
+      ev("edit"),
+      ev("flag", { findingId: "DF-1", detail: { category: "async_patterns" } }),
+      ev("flag", { findingId: "DF-scope-2", detail: { category: "scope", experimental: true } }),
+    ]);
+    expect(s.flagged).toBe(1);
+    expect(s.experimental).toBe(1);
+    expect(s.open).toBe(1);
+    expect(formatSummary(s)).toContain("1 experimental");
+  });
+
+  it("has null coverage when the task named no files", () => {
+    expect(summarize([ev("edit")]).coverage).toBeNull();
+  });
+
+  it("tallies the agent's accept/park/decline decisions", () => {
+    const s = summarize([
+      ev("flag", { findingId: "DF-1" }),
+      ev("flag", { findingId: "DF-2" }),
+      ev("flag", { findingId: "DF-3" }),
+      ev("decision", { findingId: "DF-1", detail: { decision: "accept" } }),
+      ev("decision", { findingId: "DF-2", detail: { decision: "park" } }),
+      ev("decision", { findingId: "DF-3", detail: { decision: "decline" } }),
+    ]);
+    expect(s.decisions).toEqual({ accepted: 1, parked: 1, declined: 1 });
+    expect(formatSummary(s)).toContain("1 accepted, 1 parked, 1 declined");
+  });
+
+  it("keeps only the last decision per finding", () => {
+    const s = summarize([
+      ev("flag", { findingId: "DF-1" }),
+      ev("decision", { findingId: "DF-1", detail: { decision: "park" } }),
+      ev("decision", { findingId: "DF-1", detail: { decision: "accept" } }),
+    ]);
+    expect(s.decisions).toEqual({ accepted: 1, parked: 0, declined: 0 });
+  });
+
+  it("treats a decision as orthogonal to the resolved/open outcome", () => {
+    // DF-1 is both DECLINED (a stated intent) and still OPEN (no re-check cleared it);
+    // DF-2 is ACCEPTED and later RESOLVED. The two axes are counted independently.
+    const s = summarize([
+      ev("flag", { findingId: "DF-1" }),
+      ev("flag", { findingId: "DF-2" }),
+      ev("decision", { findingId: "DF-1", detail: { decision: "decline" } }),
+      ev("decision", { findingId: "DF-2", detail: { decision: "accept" } }),
+      ev("resolve", { findingId: "DF-2" }),
+    ]);
+    expect(s).toMatchObject({ flagged: 2, resolved: 1, open: 1 });
+    expect(s.decisions).toEqual({ accepted: 1, parked: 0, declined: 1 });
+  });
+
+  it("omits the decision clause when there are none", () => {
+    const line = formatSummary(summarize([ev("edit"), ev("flag", { findingId: "DF-1" })]));
+    expect(line).not.toContain("accepted");
+    expect(line).not.toContain("declined");
+  });
+});

--- a/test/unit/session/tape.test.ts
+++ b/test/unit/session/tape.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { formatEventLine } from "@/session/tape";
+import type { SessionEvent } from "@/session/types";
+
+const T0 = Date.parse("2026-07-20T10:00:00.000Z");
+const at = (secs: number) => new Date(T0 + secs * 1000).toISOString();
+
+const ev = (type: SessionEvent["type"], over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "s1",
+  aid: "a",
+  ts: at(0),
+  agent: "claude-code",
+  projectHash: "h",
+  channel: "hook",
+  type,
+  mode: "passive",
+  detail: {},
+  ...over,
+});
+
+// strip ANSI for assertions (build the escape dynamically to satisfy no-control-regex)
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+const plain = (s: string | null) => (s ? s.replace(ANSI, "") : s);
+
+describe("formatEventLine", () => {
+  it("renders a passive flag with id, badge, and category", () => {
+    const line = plain(
+      formatEventLine(
+        ev("flag", {
+          ts: at(6),
+          findingId: "DF-1",
+          detail: { file: "src/a.ts", category: "async_patterns", dominant: "async/await", observed: ".then() chains" },
+        }),
+      ),
+    );
+    // human-readable wall-clock HH:MM:SS (seconds are timezone-invariant); at(6) → :06
+    expect(line).toMatch(/\d\d:\d\d:06/);
+    expect(line).not.toContain("t+");
+    expect(line).toContain("[FLAGGED]");
+    expect(line).toContain("DF-1");
+    expect(line).toContain("[PASSIVE]");
+    expect(line!.toLowerCase()).toContain("async");
+    expect(line!.toLowerCase()).not.toContain("prevented");
+  });
+
+  it("renders a blocking flag as HELD/BLOCKING", () => {
+    const line = plain(formatEventLine(ev("flag", { mode: "blocking", findingId: "DF-3", detail: { file: "x" } })));
+    expect(line).toContain("[BLOCKING]");
+  });
+
+  it("renders mcp_ask as ASKS and mcp_verdict as REPLIES", () => {
+    expect(plain(formatEventLine(ev("mcp_ask", { detail: { promptText: "does backoff.ts exist?" } })))).toContain(
+      "ASKS",
+    );
+    expect(plain(formatEventLine(ev("mcp_verdict", { detail: { observed: "yes, safe to reuse" } })))).toContain(
+      "REPLIES",
+    );
+  });
+
+  it("renders intent_lock and an experimental scope flag", () => {
+    expect(plain(formatEventLine(ev("intent_lock", { detail: { promptText: "add webhook" } })))).toContain(
+      "contract locked",
+    );
+    const scope = plain(
+      formatEventLine(
+        ev("flag", { findingId: "DF-scope-2", detail: { file: "ui/x.ts", category: "scope", observed: "edit unrelated to the task", experimental: true } }),
+      ),
+    );
+    expect(scope).toContain("[EXPERIMENTAL]");
+    expect(scope).toContain("scope");
+  });
+
+  it("renders the agent's accept/park/decline decisions with the reason", () => {
+    const acc = plain(
+      formatEventLine(
+        ev("decision", { ts: at(16), channel: "mcp", findingId: "DF-1", detail: { decision: "accept", reason: "rest of routes/ is async/await" } }),
+      ),
+    );
+    expect(acc).toMatch(/\d\d:\d\d:16/); // at(16) → :16
+    expect(acc).not.toContain("t+");
+    expect(acc).toContain("AGENT");
+    expect(acc).toContain("[ACCEPT]");
+    expect(acc).toContain("DF-1");
+    expect(acc).toContain("rest of routes/ is async/await");
+    // a decision is a stated intent, never a verified outcome
+    expect(acc!.toLowerCase()).not.toContain("resolved");
+    expect(acc!.toLowerCase()).not.toContain("fixed");
+    expect(acc!.toLowerCase()).not.toContain("prevented");
+
+    expect(plain(formatEventLine(ev("decision", { findingId: "DF-2", detail: { decision: "park" } })))).toContain("[PARK]");
+    expect(plain(formatEventLine(ev("decision", { findingId: "DF-3", detail: { decision: "decline" } })))).toContain("[DECLINE]");
+  });
+
+  it("hides a decision event with an unknown/absent decision value", () => {
+    expect(formatEventLine(ev("decision", { findingId: "DF-1", detail: {} }))).toBeNull();
+  });
+
+  it("does not crash on a valid-JSON but wrong-shape event (missing detail)", () => {
+    const bad = { v: 1, type: "flag", findingId: "DF-9" } as unknown as SessionEvent;
+    expect(() => formatEventLine(bad)).not.toThrow();
+  });
+
+  it("renders session/user/edit rows and hides command rows", () => {
+    expect(plain(formatEventLine(ev("session_start")))).toContain("SESSION");
+    expect(plain(formatEventLine(ev("user_prompt", { detail: { promptText: "add webhook" } })))).toContain("add webhook");
+    expect(plain(formatEventLine(ev("edit", { detail: { file: "src/a.ts", diffstat: "+5" } })))).toContain("src/a.ts");
+    expect(formatEventLine(ev("command"))).toBeNull();
+  });
+});

--- a/test/unit/session/upload-schema.test.ts
+++ b/test/unit/session/upload-schema.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { toUploadEvent, UPLOAD_SCHEMA_VERSION } from "@/session/upload-schema";
+import type { SessionEvent, SessionEventType } from "@/session/types";
+
+// Sentinels planted in banned fields. Paths, the advisory-to-agent text, and
+// secrets must NEVER leave the machine in any state. Prompt CONTENT must be fully
+// local by default; under team opt-in, derived anchor tokens may ship but never
+// the verbatim sentence.
+const PATH = "src/SECRETPATHSEGMENT/module.ts";
+const ABS_PATH = "/Users/someone/SECRETPATHSEGMENT/module.ts";
+const SIMILAR = "src/SECRETPATHSEGMENT/other.ts";
+const MSG = "MSGTOAGENTSECRET [vibedrift] flagged foo";
+// fake key assembled from parts so no contiguous secret literal appears in source
+const APIKEY = ["sk-", "ant-", "api03-", "AAAABBBBCCCCDDDD1234"].join("");
+const PROMPT = "PROMPTSENTENCESECRET add billing to the customer service";
+
+// never leaks in ANY state
+const BANNED_ALWAYS = ["SECRETPATHSEGMENT", "MSGTOAGENTSECRET", APIKEY];
+
+let seq = 0;
+const ev = (type: SessionEventType, over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "sess-1",
+  aid: `evt-${seq++}`,
+  ts: "2026-07-21T10:00:00.000Z",
+  agent: "claude-code",
+  projectHash: "abc123hash",
+  channel: "hook",
+  type,
+  mode: "passive",
+  detail: {},
+  ...over,
+});
+
+// One representative-but-hostile event per uploadable kind: every path/free-text
+// field stuffed with a sentinel, plus a top-level msgToAgent and a live-looking key.
+const HOSTILE: SessionEvent[] = [
+  ev("session_start", { detail: { promptText: PROMPT } }),
+  ev("intent_lock", { detail: { promptText: PROMPT, anchorFiles: [PATH, ABS_PATH], observed: "expanded" } }),
+  ev("edit", { detail: { file: ABS_PATH, diffstat: "+38 -4", promptText: PROMPT } }),
+  ev("flag", {
+    findingId: "DF-1",
+    msgToAgent: MSG,
+    detail: { file: PATH, category: "async_patterns", dominant: "async/await", observed: ".then() chains", similarity: 0.9 },
+  }),
+  ev("flag", {
+    findingId: "DF-2",
+    msgToAgent: MSG,
+    detail: { file: PATH, category: "redundancy", similarTo: `${SIMILAR}:12`, similarity: 0.88 },
+  }),
+  ev("resolve", { findingId: "DF-1", detail: { file: PATH }, outcome: "resolved" }),
+  ev("hold", { findingId: "DF-3", detail: { file: PATH } }),
+  ev("mcp_ask", { channel: "mcp", detail: { toolName: "validate_change", promptText: `validate ${PATH}` } }),
+  ev("mcp_verdict", { channel: "mcp", detail: { toolName: "validate_change", observed: "1 drift: async" } }),
+  ev("decision", { channel: "mcp", findingId: "DF-1", detail: { decision: "decline", reason: `keep it, ${APIKEY} is a dev DSN` } }),
+  ev("session_end", {}),
+];
+
+describe("toUploadEvent — derived-only invariant", () => {
+  for (const teamIntentOptIn of [false, true]) {
+    it(`never leaks a path, advisory text, or secret (teamIntentOptIn=${teamIntentOptIn})`, () => {
+      for (const source of HOSTILE) {
+        const mapped = toUploadEvent(source, { teamIntentOptIn });
+        if (mapped === null) continue;
+        const json = JSON.stringify(mapped);
+        for (const banned of BANNED_ALWAYS) {
+          expect(json, `${source.type} leaked "${banned}"`).not.toContain(banned);
+        }
+        expect(mapped.v).toBe(UPLOAD_SCHEMA_VERSION);
+        expect(mapped.sessionId).toBe("sess-1");
+      }
+    });
+  }
+
+  it("keeps prompt content fully local by default (opt-in OFF)", () => {
+    for (const source of HOSTILE) {
+      const mapped = toUploadEvent(source, { teamIntentOptIn: false });
+      if (mapped === null) continue;
+      expect(JSON.stringify(mapped), `${source.type} leaked prompt content`).not.toContain("PROMPTSENTENCESECRET");
+    }
+  });
+
+  it("never ships the prompt SENTENCE verbatim, even under team opt-in", () => {
+    const src = ev("intent_lock", { detail: { promptText: PROMPT, anchorFiles: ["a.ts"] } });
+    const on = toUploadEvent(src, { teamIntentOptIn: true })!;
+    // a derived label may exist (anchor tokens), but never the contiguous sentence
+    expect(on.taskLabel ?? "").not.toContain("add billing to the customer service");
+    expect(on.taskLabel ?? "").not.toContain("PROMPTSENTENCESECRET add");
+  });
+
+  it("drops non-uploadable event kinds (user_prompt, command, recheck)", () => {
+    expect(toUploadEvent(ev("user_prompt", { detail: { promptText: PROMPT } }))).toBeNull();
+    expect(toUploadEvent(ev("command", { detail: { promptText: PROMPT } }))).toBeNull();
+    expect(toUploadEvent(ev("recheck", { detail: { file: PATH } }))).toBeNull();
+  });
+
+  it("carries a file as a hash, never the path", () => {
+    const m = toUploadEvent(ev("edit", { detail: { file: ABS_PATH, diffstat: "+5" } }))!;
+    expect(m.fileHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(m.fileHash).not.toContain("SECRETPATHSEGMENT");
+    expect(m.diffLines).toBe(5);
+  });
+
+  it("keeps derived labels and finding metadata on a flag", () => {
+    const m = toUploadEvent(
+      ev("flag", { findingId: "DF-1", mode: "passive", detail: { file: PATH, category: "async_patterns", dominant: "async/await", observed: ".then() chains", similarity: 0.9 } }),
+    )!;
+    expect(m).toMatchObject({
+      type: "flag",
+      category: "async_patterns",
+      dominant: "async/await",
+      observed: ".then() chains",
+      similarity: 0.9,
+      findingId: "DF-1",
+      mode: "passive",
+    });
+    expect(m.fileHash).toBeDefined();
+  });
+
+  it("carries the decision label always; the reason only under team opt-in (and masked)", () => {
+    const src = ev("decision", { findingId: "DF-1", detail: { decision: "decline", reason: `real reasoning but ${APIKEY} leaks` } });
+
+    const off = toUploadEvent(src, { teamIntentOptIn: false })!;
+    expect(off.decision).toBe("decline");
+    expect(off.reason).toBeUndefined(); // free text stays local by default
+
+    const on = toUploadEvent(src, { teamIntentOptIn: true })!;
+    expect(on.decision).toBe("decline");
+    expect(on.reason).toContain("real reasoning");
+    expect(on.reason).not.toContain(APIKEY); // masked even under opt-in
+  });
+
+  it("secret-masks label fields (defense in depth) but leaves a real slash-bearing label", () => {
+    const m = toUploadEvent(
+      ev("flag", { findingId: "DF-1", detail: { category: "async_patterns", dominant: "async/await", observed: `.then() ${APIKEY}` } }),
+    )!;
+    expect(m.observed).not.toContain("AAAABBBBCCCCDDDD1234");
+    expect(m.observed).toContain("[masked]");
+    expect(m.dominant).toBe("async/await"); // a legit "/"-bearing label is untouched
+  });
+
+  it("secret-masks a taskLabel derived from a prompt (opt-in)", () => {
+    const src = ev("intent_lock", { detail: { promptText: `add OPENAI_API_KEY=${APIKEY} to config`, anchorFiles: ["a.ts"] } });
+    const on = toUploadEvent(src, { teamIntentOptIn: true })!;
+    expect(on.taskLabel ?? "").not.toContain("AAAABBBBCCCCDDDD1234");
+  });
+
+  it("salts the file hash per repo — stable within a repo, different across repos", () => {
+    const mk = (repo: string) => toUploadEvent({ ...ev("edit"), projectHash: repo, detail: { file: "src/x.ts" } })!;
+    expect(mk("repoA").fileHash).toBe(mk("repoA").fileHash); // stable → group-able
+    expect(mk("repoA").fileHash).not.toBe(mk("repoB").fileHash); // salted → no global rainbow
+  });
+
+  it("intent_lock ships a file COUNT always, and a token-derived label only under opt-in", () => {
+    const src = ev("intent_lock", { detail: { promptText: "add `retryWebhook` to billing.ts and orders.ts", anchorFiles: ["billing.ts", "orders.ts"] } });
+
+    const off = toUploadEvent(src, { teamIntentOptIn: false })!;
+    expect(off.taskFileCount).toBe(2);
+    expect(off.taskLabel).toBeUndefined();
+
+    const on = toUploadEvent(src, { teamIntentOptIn: true })!;
+    expect(on.taskFileCount).toBe(2);
+    expect(on.taskLabel).toBeDefined();
+  });
+});

--- a/test/unit/session/uploader.test.ts
+++ b/test/unit/session/uploader.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runUploader, shouldSync } from "@/session/uploader";
+import { appendEvent } from "@/session/ledger";
+import type { UploadEvent } from "@/session/upload-schema";
+import type { SessionEvent } from "@/session/types";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-up-")));
+
+let seq = 0;
+const ev = (type: SessionEvent["type"], over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "s1",
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: "h",
+  channel: "hook",
+  type,
+  mode: "passive",
+  detail: {},
+  ...over,
+});
+
+/** Run the uploader for exactly `ticks` poll cycles, then abort. */
+function runFor(
+  sessionsDir: string,
+  hash: string,
+  post: (e: UploadEvent[]) => Promise<void>,
+  ticks: number,
+  teamIntentOptIn = false,
+): Promise<void> {
+  const controller = new AbortController();
+  let n = 0;
+  return runUploader({
+    sessionsDir,
+    projectHash: hash,
+    teamIntentOptIn,
+    post,
+    signal: controller.signal,
+    sleep: async () => {
+      if (++n >= ticks) controller.abort();
+    },
+  });
+}
+
+describe("shouldSync", () => {
+  it("is off by default and in every partial state", () => {
+    expect(shouldSync({})).toBe(false);
+    expect(shouldSync({ sessionsSyncEnabled: true })).toBe(false); // no token
+    expect(shouldSync({ token: "t" })).toBe(false); // not enabled
+    expect(shouldSync({ sessionsSyncEnabled: false, token: "t" })).toBe(false);
+  });
+  it("is on only when opted in, logged in, and not forced local", () => {
+    expect(shouldSync({ sessionsSyncEnabled: true, token: "t" })).toBe(true);
+    expect(shouldSync({ sessionsSyncEnabled: true, token: "t" }, true)).toBe(false); // --local-only
+  });
+});
+
+describe("runUploader", () => {
+  it("maps and posts new events, dropping non-uploadable kinds and leaking no prompt text", async () => {
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("session_start"));
+    await appendEvent(sessionsDir, hash, "s1", ev("user_prompt", { detail: { promptText: "SECRETPROMPT" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "src/a.ts", diffstat: "+5" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev("flag", { findingId: "DF-1", detail: { file: "src/a.ts", category: "async_patterns", dominant: "async/await", observed: ".then() chains" } }));
+
+    const posted: UploadEvent[] = [];
+    await runFor(sessionsDir, hash, async (e) => void posted.push(...e), 1);
+
+    const types = posted.map((p) => p.type);
+    expect(types).toContain("session_start");
+    expect(types).toContain("edit");
+    expect(types).toContain("flag");
+    expect(types).not.toContain("user_prompt");
+    expect(JSON.stringify(posted)).not.toContain("SECRETPROMPT");
+  });
+
+  it("retries a failed flush on the next tick without throwing", async () => {
+    const sessionsDir = tmp();
+    const hash = "h2";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "src/a.ts", diffstat: "+3" } }));
+
+    const posted: UploadEvent[] = [];
+    let calls = 0;
+    await runFor(
+      sessionsDir,
+      hash,
+      async (e) => {
+        calls++;
+        if (calls === 1) throw new Error("network down");
+        posted.push(...e);
+      },
+      2,
+    );
+
+    expect(calls).toBeGreaterThanOrEqual(2); // first failed, retried
+    expect(posted.length).toBe(1); // the event survived the failure and posted
+  });
+
+  it("ships the decision reason only under team opt-in", async () => {
+    const write = async (dir: string, hash: string) => {
+      await appendEvent(dir, hash, "s1", ev("flag", { findingId: "DF-1", detail: { file: "src/a.ts", category: "async_patterns" } }));
+      await appendEvent(dir, hash, "s1", ev("decision", { channel: "mcp", findingId: "DF-1", detail: { decision: "decline", reason: "different semantics" } }));
+    };
+
+    const offDir = tmp();
+    await write(offDir, "hoff");
+    const off: UploadEvent[] = [];
+    await runFor(offDir, "hoff", async (e) => void off.push(...e), 1, false);
+    const offDec = off.find((p) => p.type === "decision")!;
+    expect(offDec.decision).toBe("decline");
+    expect(offDec.reason).toBeUndefined();
+
+    const onDir = tmp();
+    await write(onDir, "hon");
+    const on: UploadEvent[] = [];
+    await runFor(onDir, "hon", async (e) => void on.push(...e), 1, true);
+    const onDec = on.find((p) => p.type === "decision")!;
+    expect(onDec.decision).toBe("decline");
+    expect(onDec.reason).toContain("different semantics");
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/cli/index.ts", "src/render.ts", "src/mcp/server.ts", "src/tools-core/index.ts"],
+  entry: [
+    "src/cli/index.ts",
+    "src/render.ts",
+    "src/mcp/server.ts",
+    "src/tools-core/index.ts",
+    "src/session/hook-entry.ts",
+  ],
   format: ["esm"],
   target: "node18",
   outDir: "dist",


### PR DESCRIPTION
**Drift Sessions (preview)** — VibeDrift rides inside a Claude Code session and catches drift *while* the agent writes, then keeps a legible record of what it flagged and what the agent did about it.

### What this adds
- **`vibedrift watch-session`** — consent-gated Claude Code hooks record the session to a local, append-only ledger (`~/.vibedrift/sessions/`): prompts (secrets masked), edit metadata, and drift flags. When an edit diverges from the repo's own dominant patterns, a one-line advisory is fed back into the agent in the loop. Local-only, fail-open (a hook error never interrupts the agent).
- **Live event tape** — `watch-session` follows the session in real time: prompts, edits, and flags stream in with a running drift gauge and an end-of-session summary. MCP tool calls join the same tape.
- **Per-flag agent decision** — via an MCP tool the agent records its own call on each flag: **accept** (agree, will fix), **park** (defer to a human), or **decline** (judge the flag wrong) with a one-line reason. Distinct from the *outcome*: a flag resolves only when the finding actually re-runs clean, not because it was accepted.
- **Intent tier + drift gauge** — captures the task from the prompt, locks it, and conservatively flags an edit unrelated to it; a smoothed drift gauge rides the footer.
- **Opt-in hosted sync** — a **derived-only** projection (findings, scores, outcomes, metadata) can be uploaded to a hosted dashboard. Prompts and code never leave the machine; the mapper is an explicit allow-list and file paths ship only as salted hashes.

### Scope & notes
- Drift Sessions is a **Pro** feature with a one-time 5-session trial; the local capture and MCP tools stay local and free.
- This is the **CLI half** — the hosted API and dashboard live in their own repos and merge separately.
- Squashed to a single clean commit; full suite green (2087 tests), lint clean.
- Opened as **draft** — not for merge until the feature is ready to launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4HBwyzpPKgrusnawqaa5n
