### PR TITLE
core: VIBEDRIFT_HOME sandbox override + dev banner

### DIFF
--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -1,4 +1,4 @@
-import { homedir } from "os";
+import { vibedriftHome } from "../core/vibedrift-home.js";
 import { join } from "path";
 import { readFile, writeFile, mkdir, chmod, unlink, stat } from "fs/promises";
 
@@ -93,7 +93,7 @@ export interface VibeDriftConfig {
   sessionsSyncNoticeShown?: boolean;
 }
 
-const DEFAULT_DIR = join(homedir(), ".vibedrift");
+const DEFAULT_DIR = vibedriftHome();
 const DEFAULT_FILE = join(DEFAULT_DIR, "config.json");
 
 export function getConfigDir(): string {

--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -1,4 +1,4 @@
-import { readConfig } from "./config.js";
+import { readConfig, getConfigPath } from "./config.js";
 
 /**
  * Token resolution.
@@ -73,6 +73,6 @@ export function describeSource(source: "flag" | "env" | "config"): string {
   switch (source) {
     case "flag":   return "command-line flag";
     case "env":    return "VIBEDRIFT_TOKEN environment variable";
-    case "config": return "~/.vibedrift/config.json";
+    case "config": return getConfigPath();
   }
 }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { homedir, platform, arch } from "os";
+import { vibedriftHome, isSandboxHome } from "../../core/vibedrift-home.js";
 import { join } from "path";
 import { stat, access, constants } from "fs/promises";
 import { readConfig, getConfigPath, getConfigDir } from "../../auth/config.js";
@@ -104,6 +105,7 @@ export async function runDoctor(): Promise<void> {
   ok("Node",         process.version);
   ok("Platform",     `${platform()} ${arch()}`);
   ok("HOME",         homedir());
+  if (isSandboxHome()) ok("VIBEDRIFT_HOME", `${vibedriftHome()} (DEV MODE sandbox)`);
   console.log("");
 
   // ── Config dir ──
@@ -144,7 +146,7 @@ export async function runDoctor(): Promise<void> {
   }
 
   // History dir (separate from config — must be ~/.vibedrift/scans)
-  const historyDir = join(homedir(), ".vibedrift", "scans");
+  const historyDir = join(vibedriftHome(), "scans");
   try {
     const info = await stat(historyDir);
     if (info.isDirectory()) ok("Scan history", historyDir);

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -5,7 +5,7 @@ import {
   fetchCredits,
   VibeDriftApiError,
 } from "../../auth/api.js";
-import { patchConfig, readConfig } from "../../auth/config.js";
+import { patchConfig, readConfig, getConfigPath } from "../../auth/config.js";
 import { openInBrowser } from "../../auth/browser.js";
 import { previewToken } from "../../auth/resolver.js";
 
@@ -122,6 +122,7 @@ async function handleLoginSuccess(
     apiUrl: options.apiUrl,
   });
   console.log(chalk.green("  ✓ Logged in successfully."));
+  console.log(chalk.dim(`  Token stored at ${getConfigPath()}`));
   console.log("");
   console.log(`  Account: ${chalk.bold(result.email)}`);
   console.log(`  Plan:    ${chalk.bold(result.plan)}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,8 +25,19 @@ import { runWatch } from "./commands/watch.js";
 import { runWatchSession } from "./commands/watch-session.js";
 import { runHook } from "./commands/hook.js";
 import { getVersion } from "../core/version.js";
+import { vibedriftHome, isSandboxHome } from "../core/vibedrift-home.js";
 
 const VERSION = getVersion();
+
+// Sandbox banner: VIBEDRIFT_HOME redirects ALL machine-global state (auth
+// config, caches, ledgers, entitlement) away from ~/.vibedrift, so a dev shell
+// can never pollute the real store or a real dashboard. stderr keeps MCP stdio
+// clean; the session hook has its own entrypoint and stays banner-free.
+if (isSandboxHome()) {
+  process.stderr.write(
+    `◆ DEV MODE · VIBEDRIFT_HOME=${vibedriftHome()} · state isolated from ~/.vibedrift\n`,
+  );
+}
 
 function parseScoreThreshold(value: string): number {
   const n = parseFloat(value);

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -13,7 +13,7 @@
  * so a stale baseline is detected and rebuilt rather than silently served.
  */
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
+import { vibedriftHome } from "./vibedrift-home.js";
 import { join, resolve } from "node:path";
 import { realpathSync } from "node:fs";
 import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
@@ -29,7 +29,7 @@ import type { AnalysisContext } from "./types.js";
 import type { DriftFinding, DriftCategory } from "../drift/types.js";
 import type { IntentHint } from "../intent/types.js";
 
-const CACHE_DIR = join(homedir(), ".vibedrift", "baseline-cache");
+const CACHE_DIR = join(vibedriftHome(), "baseline-cache");
 /** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
 export const BASELINE_VERSION = 3;
 

--- a/src/core/embedding-index.ts
+++ b/src/core/embedding-index.ts
@@ -13,14 +13,14 @@
  * with the baseline key so it can be invalidated when the repo changes.
  */
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
+import { vibedriftHome } from "./vibedrift-home.js";
 import { join } from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 
 // Resolved lazily (not a module const) so it honors the current HOME — tests
-// redirect HOME to a tmp dir, and homedir() reads $HOME first on POSIX.
+// set VIBEDRIFT_HOME (preferred) or redirect HOME to a tmp dir.
 function indexDir(): string {
-  return join(homedir(), ".vibedrift", "embedding-index");
+  return join(vibedriftHome(), "embedding-index");
 }
 // Bump when the entry shape or vector semantics change, to invalidate all
 // cached indexes at once (mirrors BASELINE_VERSION in core/baseline.ts).

--- a/src/core/findings-cache.ts
+++ b/src/core/findings-cache.ts
@@ -17,13 +17,13 @@
  */
 
 import { readFile, writeFile, mkdir, readdir, stat, unlink } from "fs/promises";
-import { homedir } from "os";
+import { vibedriftHome } from "./vibedrift-home.js";
 import { createHash } from "crypto";
 import { join } from "path";
 import type { Finding, SourceFile, SupportedLanguage } from "./types.js";
 import { projectHash } from "./baseline.js";
 
-const ROOT_DIR = join(homedir(), ".vibedrift", "findings-cache");
+const ROOT_DIR = join(vibedriftHome(), "findings-cache");
 const TTL_MS = 30 * 24 * 3600 * 1000;
 const MAX_CACHE_BYTES = 500 * 1024 * 1024;
 

--- a/src/core/git-metadata.ts
+++ b/src/core/git-metadata.ts
@@ -17,12 +17,12 @@ import { promisify } from "util";
 import { createHash } from "crypto";
 import { readFile, writeFile, mkdir, stat } from "fs/promises";
 import { join } from "path";
-import { homedir } from "os";
+import { vibedriftHome } from "./vibedrift-home.js";
 import type { FileGitMetadata } from "./types.js";
 
 const execFileP = promisify(execFile);
 
-const CACHE_DIR = join(homedir(), ".vibedrift", "git-metadata-cache");
+const CACHE_DIR = join(vibedriftHome(), "git-metadata-cache");
 const GIT_TIMEOUT_MS = 10_000;
 const MAX_BUFFER = 50 * 1024 * 1024; // 50MB — accommodates very large histories
 

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile, writeFile, mkdir, unlink } from "fs/promises";
-import { homedir } from "os";
+import { vibedriftHome } from "./vibedrift-home.js";
 import { createHash } from "crypto";
 import { join } from "path";
 import type { CategoryScores, Finding, DriftFindingReport } from "./types.js";
@@ -33,7 +33,7 @@ import { projectHash } from "./baseline.js";
  * is better than a misleading one.
  */
 
-const ROOT_DIR = join(homedir(), ".vibedrift", "scans");
+const ROOT_DIR = join(vibedriftHome(), "scans");
 const HISTORY_SCHEMA_VERSION = 3;
 const HISTORY_RETENTION = 10;
 

--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -26,12 +26,12 @@
  */
 
 import { readFile, writeFile, mkdir } from "fs/promises";
-import { homedir } from "os";
+import { vibedriftHome } from "./vibedrift-home.js";
 import { join } from "path";
 
 const PACKAGE_NAME = "@vibedrift/cli";
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
-const CACHE_PATH = join(homedir(), ".vibedrift", "version-check.json");
+const CACHE_PATH = join(vibedriftHome(), "version-check.json");
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const REQUEST_TIMEOUT_MS = 2000;
 
@@ -79,7 +79,7 @@ async function readCache(): Promise<CacheEntry | null> {
 
 async function writeCache(latest: string): Promise<void> {
   try {
-    await mkdir(join(homedir(), ".vibedrift"), { recursive: true, mode: 0o700 });
+    await mkdir(vibedriftHome(), { recursive: true, mode: 0o700 });
     const entry: CacheEntry = { latest, checkedAt: Date.now() };
     await writeFile(CACHE_PATH, JSON.stringify(entry));
   } catch {

--- a/src/core/vibedrift-home.ts
+++ b/src/core/vibedrift-home.ts
@@ -1,0 +1,32 @@
+/**
+ * Machine-global VibeDrift state root (`~/.vibedrift` by default).
+ *
+ * `VIBEDRIFT_HOME` overrides it for sandboxed development and testing: every
+ * piece of home-anchored state (auth config, caches, scan history, session
+ * ledgers, entitlement) moves with it, so a dev run can never touch the real
+ * store or show up on a real dashboard. The repo-local `.vibedrift/` project
+ * config directory is a different thing and is never affected by this.
+ *
+ * Contract: set VIBEDRIFT_HOME before the process starts (spawn-time env).
+ * This helper reads at call time, but several state modules snapshot their
+ * root into module consts at import — mutating the env mid-process splits
+ * state across two roots. New code should call this lazily, not snapshot.
+ * Zero imports beyond node builtins — the session hook entrypoint stays on
+ * its fast path.
+ */
+
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/** The state root: $VIBEDRIFT_HOME when set and non-blank, else ~/.vibedrift. */
+export function vibedriftHome(): string {
+  const env = process.env.VIBEDRIFT_HOME;
+  if (env && env.trim().length > 0) return resolve(env.trim());
+  return join(homedir(), ".vibedrift");
+}
+
+/** True when a sandbox override is active (drives the DEV MODE banner). */
+export function isSandboxHome(): boolean {
+  const env = process.env.VIBEDRIFT_HOME;
+  return Boolean(env && env.trim().length > 0);
+}

--- a/src/session/entitlement.ts
+++ b/src/session/entitlement.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { vibedriftHome } from "../core/vibedrift-home.js";
 import { isPaidPlan, type Plan } from "../auth/plan.js";
 
 export const SESSION_TRIAL_LIMIT = 5;
@@ -42,7 +42,7 @@ function cachePath(baseDir: string): string {
 
 /** Default cache dir is ~/.vibedrift; tests pass an explicit dir. */
 export function entitlementDir(): string {
-  return join(homedir(), ".vibedrift");
+  return vibedriftHome();
 }
 
 export function readEntitlementCache(baseDir: string = entitlementDir()): SessionEntitlement | null {

--- a/src/session/repo.ts
+++ b/src/session/repo.ts
@@ -6,7 +6,7 @@
 
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { homedir } from "node:os";
+import { vibedriftHome } from "../core/vibedrift-home.js";
 import { projectHash, canonicalizeRoot } from "../core/baseline.js";
 
 export function resolveRepoRoot(cwd: string): string {
@@ -20,7 +20,7 @@ export function resolveRepoRoot(cwd: string): string {
 }
 
 export function defaultSessionsDir(): string {
-  return join(homedir(), ".vibedrift", "sessions");
+  return join(vibedriftHome(), "sessions");
 }
 
 export function repoIdentity(cwd: string): { rootDir: string; projectHash: string } {

--- a/test/unit/core/vibedrift-home.test.ts
+++ b/test/unit/core/vibedrift-home.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { vibedriftHome, isSandboxHome } from "@/core/vibedrift-home";
+import { entitlementDir } from "@/session/entitlement";
+import { defaultSessionsDir } from "@/session/repo";
+
+const ORIGINAL = process.env.VIBEDRIFT_HOME;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.VIBEDRIFT_HOME;
+  else process.env.VIBEDRIFT_HOME = ORIGINAL;
+});
+
+describe("vibedriftHome", () => {
+  it("defaults to ~/.vibedrift when the override is unset", () => {
+    delete process.env.VIBEDRIFT_HOME;
+    expect(vibedriftHome()).toBe(join(homedir(), ".vibedrift"));
+    expect(isSandboxHome()).toBe(false);
+  });
+
+  it("honors VIBEDRIFT_HOME and trims whitespace", () => {
+    process.env.VIBEDRIFT_HOME = "  /tmp/vd-sandbox  ";
+    expect(vibedriftHome()).toBe("/tmp/vd-sandbox");
+    expect(isSandboxHome()).toBe(true);
+  });
+
+  it("resolves a relative override to an absolute path (never cwd-anchored state)", () => {
+    process.env.VIBEDRIFT_HOME = "sandbox-rel";
+    const got = vibedriftHome();
+    expect(got.startsWith("/") || /^[A-Za-z]:[\\/]/.test(got)).toBe(true);
+    expect(got.endsWith("sandbox-rel")).toBe(true);
+  });
+
+  it("treats a blank override as unset (no accidental relative-path state)", () => {
+    process.env.VIBEDRIFT_HOME = "   ";
+    expect(vibedriftHome()).toBe(join(homedir(), ".vibedrift"));
+    expect(isSandboxHome()).toBe(false);
+  });
+
+  it("moves the call-time state dirs with the override", () => {
+    process.env.VIBEDRIFT_HOME = "/tmp/vd-sandbox";
+    expect(entitlementDir()).toBe("/tmp/vd-sandbox");
+    expect(defaultSessionsDir()).toBe(join("/tmp/vd-sandbox", "sessions"));
+  });
+
+  it("reads the env at call time, not import time", () => {
+    delete process.env.VIBEDRIFT_HOME;
+    const before = vibedriftHome();
+    process.env.VIBEDRIFT_HOME = "/tmp/vd-late";
+    expect(vibedriftHome()).toBe("/tmp/vd-late");
+    expect(vibedriftHome()).not.toBe(before);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     globals: true,
     root: ".",
     include: ["test/**/*.test.ts"],
+    // A dev shell's sandbox override must never leak into tests: suites that
+    // isolate state by redirecting HOME would silently lose to VIBEDRIFT_HOME
+    // (and test writes would land in the dev's sandbox). Blank = unset.
+    env: { VIBEDRIFT_HOME: "" },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## What

Adds a `VIBEDRIFT_HOME` environment override for the machine-global state root, so development and testing can run fully isolated from a user's real `~/.vibedrift`.

- New `vibedriftHome()` helper: `$VIBEDRIFT_HOME` when set (trimmed, resolved to an absolute path), else `~/.vibedrift`. All ten home-anchored state modules now resolve through it: auth config, baseline cache, findings cache, scan history, git-metadata cache, embedding index, update-check cache, session ledgers, entitlement cache, and doctor's history path.
- **DEV MODE banner** on stderr whenever the override is active, so a sandboxed shell can never be mistaken for a real one. stderr keeps MCP stdio clean; the session hook entrypoint is separate and stays banner-free.
- `doctor` reports the active override; `status`/`login` now print the real config path instead of a hardcoded `~/.vibedrift/config.json`.

## What is deliberately NOT affected

- Repo-local `.vibedrift/` project config and `.vibedriftignore` (a different concept from the home store).
- `~/.claude` detection in watch-session (that path is about the agent, not VibeDrift state).

## Verification

- Full unit suite green, lint/typecheck clean.
- Tests can no longer inherit a dev shell's sandbox: vitest clears `VIBEDRIFT_HOME`, and the previously-reproducible cross-contamination (update-check suite failing under a sandboxed shell) now passes.
- Live smoke: with the override set, `scan` writes baseline/findings/history entirely into the sandbox while the real `~/.vibedrift` is untouched; without it, behavior is byte-identical and no banner prints.
- Relative overrides resolve to absolute paths, so state can never be silently anchored to a scanned repo's cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4HBwyzpPKgrusnawqaa5n
