### PR TITLE
ci: release-rehearsal gate + prod publish guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
       - run: npm run build
       - run: npm test
 
+
+  # The install experience, tested for real: publish to a throwaway local
+  # registry, install FROM it into a clean prefix, smoke the installed CLI in
+  # a sandbox (incl. the npx single-bin invariant that broke 0.17.0). A red X
+  # here means the release would break for users - it cannot be merged.
+  release-rehearsal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22.x"
+          cache: npm
+      - run: npm ci
+      - run: bash scripts/release-rehearsal.sh
+
   # Dogfooding: VibeDrift scans itself. The fail threshold is DISABLED for now —
   # v4 decompressed scoring (SCORING_VERSION v4) lowered the self-score below the
   # old 75 floor, so the gate is commented out pending recalibration after the

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "calibrate": "tsx test/calibration/precision-recall.ts",
     "calibrate:monotonic": "tsx test/calibration/run.ts",
     "handbook": "node scripts/build-handbook.mjs",
-    "prepublishOnly": "npm run lint && npm run typecheck && npm run test && npm run build"
+    "prepublishOnly": "node scripts/publish-guard.mjs && npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "keywords": [
     "vibe-coding",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "calibrate": "tsx test/calibration/precision-recall.ts",
     "calibrate:monotonic": "tsx test/calibration/run.ts",
     "handbook": "node scripts/build-handbook.mjs",
-    "prepublishOnly": "node scripts/publish-guard.mjs && npm run lint && npm run typecheck && npm run test && npm run build"
+    "prepublishOnly": "node scripts/publish-guard.mjs && npm run lint && npm run typecheck && npm run build && npm run test"
   },
   "keywords": [
     "vibe-coding",

--- a/scripts/publish-guard.mjs
+++ b/scripts/publish-guard.mjs
@@ -10,7 +10,11 @@
  */
 const reg = process.env.npm_config_registry || "";
 const isLocal = /localhost|127\.0\.0\.1/.test(reg);
-if (!isLocal && process.env.VIBEDRIFT_RELEASE !== "1") {
+// The rehearsal sets this explicitly: npm does not reliably expose --registry
+// to lifecycle scripts across platforms/versions, and the guard must never
+// block the sandbox path.
+const isSandbox = process.env.VIBEDRIFT_PUBLISH_SANDBOX === "1";
+if (!isLocal && !isSandbox && process.env.VIBEDRIFT_RELEASE !== "1") {
   console.error(
     "\npublish blocked: prod releases go through scripts/release.sh\n" +
     "(it runs the gate, bumps, tags, publishes, and creates the GitHub release).\n" +

--- a/scripts/publish-guard.mjs
+++ b/scripts/publish-guard.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * Publish guard: a prod `npm publish` may only happen through the sanctioned
+ * release flow. Local/rehearsal registries are always allowed, so the release
+ * rehearsal and any localhost testing keep working with zero ceremony.
+ *
+ *   allowed:  npm publish --registry http://localhost:4873   (rehearsal)
+ *   allowed:  VIBEDRIFT_RELEASE=1 npm publish                (scripts/release.sh)
+ *   refused:  npm publish                                    (casual/accidental)
+ */
+const reg = process.env.npm_config_registry || "";
+const isLocal = /localhost|127\.0\.0\.1/.test(reg);
+if (!isLocal && process.env.VIBEDRIFT_RELEASE !== "1") {
+  console.error(
+    "\npublish blocked: prod releases go through scripts/release.sh\n" +
+    "(it runs the gate, bumps, tags, publishes, and creates the GitHub release).\n" +
+    "Rehearse against a local registry instead: bash scripts/release-rehearsal.sh\n",
+  );
+  process.exit(1);
+}

--- a/scripts/release-rehearsal.sh
+++ b/scripts/release-rehearsal.sh
@@ -68,7 +68,7 @@ say "registry up (pid $VERDACCIO_PID)"
 #      an anonymous-publish registry)
 (
   cd "$ROOT"
-  npm publish --registry "$REG" --//localhost:${PORT}/:_authToken=rehearsal
+  VIBEDRIFT_PUBLISH_SANDBOX=1 npm publish --registry "$REG" --//localhost:${PORT}/:_authToken=rehearsal
 )
 say "published ${NAME}@${VERSION} to the rehearsal registry"
 

--- a/scripts/release-rehearsal.sh
+++ b/scripts/release-rehearsal.sh
@@ -18,7 +18,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PORT="${REHEARSAL_PORT:-4873}"
 REG="http://localhost:${PORT}"
-WORK="$(mktemp -d -t vd-rehearsal)"
+TMPBASE="${TMPDIR:-/tmp}"; TMPBASE="${TMPBASE%/}"
+WORK="$(mktemp -d "$TMPBASE/vd-rehearsal.XXXXXX")"
 VERDACCIO_PID=""
 
 cleanup() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,7 +38,7 @@ TAG="v$VERSION"
 
 # 3. Publish to npm (prepublishOnly gate re-runs the sanity checks).
 echo "==> npm publish $TAG"
-npm publish --access public
+VIBEDRIFT_RELEASE=1 npm publish --access public
 
 # 4. Push the version commit + tag.
 echo "==> git push --follow-tags"


### PR DESCRIPTION
## What

Locks in the release-rehearsal permanently:

- **CI job `release-rehearsal`** runs on every PR and main push: publishes the checkout to a throwaway local registry, installs FROM it into a clean prefix, and smoke-runs the installed CLI in a sandbox — including the npx single-bin invariant that broke 0.17.0. A red X here means the release would break for users, so it can't be merged. This PR's own checks are the first live run.
- **Publish guard** (`scripts/publish-guard.mjs`, first step of `prepublishOnly`): a casual `npm publish` against the public registry now refuses with instructions. Local/rehearsal registries are always allowed with zero ceremony; `scripts/release.sh` sets the release env and remains the one sanctioned prod path.
- Rehearsal script made portable to Linux CI runners (GNU mktemp template; trailing-slash `TMPDIR`).

## Verification

- Guard negative: `npm publish --dry-run` → blocked with the guidance message.
- Guard positive: full rehearsal against the local registry → `REHEARSAL PASSED` end to end.
- The `release-rehearsal` check on this PR is the CI job proving itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4HBwyzpPKgrusnawqaa5n