### PR TITLE
docs: rewrite the README around the three channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ npx @vibedrift/cli
 ## Contents
 
 - [What drift is](#what-drift-is)
-- [Quick start](#quick-start)
+- [The three channels](#the-three-channels)
+- [The CLI: you run it](#the-cli-you-run-it)
+- [The MCP server: your agent asks](#the-mcp-server-your-agent-asks)
 - [Drift Sessions](#drift-sessions-preview)
-- [In the loop: the MCP server](#in-the-loop-the-mcp-server)
 - [What it detects](#what-it-detects)
 - [Scanning and reports](#scanning-and-reports)
 - [Configuration](#configuration)
@@ -48,7 +49,21 @@ One handler throws a typed error, the next returns a plain object. Eight service
 
 That gap is **drift**. Linters miss it by design: a linter checks one file against a rulebook. VibeDrift checks your codebase against *itself*. It learns the patterns your code already agrees on, flags the files that deviate, and points at the exact line.
 
-## Quick start
+## The three channels
+
+VibeDrift reaches your code three ways. One local engine, three different moments.
+
+| Channel | Who starts it | What you get | Tier |
+| --- | --- | --- | --- |
+| **[CLI](#the-cli-you-run-it)**<br>`vibedrift` | **You**, after the code exists | Scans, HTML reports, a CI gate, continuous watch, a git pre-push gate | Free (`watch`, the pre-push gate and deep scan are Pro) |
+| **[MCP server](#the-mcp-server-your-agent-asks)**<br>`vibedrift mcp` | **Your agent**, before it writes | Seven tools it can call: the repo's dominant pattern, near duplicates, whether a file drifts | Free (an opt-in `deep` flag on two tools is metered) |
+| **[Drift Sessions](#drift-sessions-preview)**<br>`vibedrift watch-session` | **VibeDrift**, while the edit happens (Claude Code only today) | A one line advisory in the agent's context whether it asked or not, on a live tape | Pro, one time 5 session trial |
+
+The last two are different plumbing. MCP is **pull**: a long lived process your agent connects to over stdio, so it only helps when the agent chooses to ask. Drift Sessions is **push**: it rides Claude Code's own hooks, so VibeDrift gets a word in whether the agent asks or not. Run both and they join up: while a Drift Session is active, the MCP server's verdicts tee into that same session ledger, so the agent's questions and VibeDrift's flags read as one dialogue. Without an active session the MCP tools simply answer and write nothing.
+
+> **One word, two meanings.** `vibedrift hook` is the **git** pre-push gate, part of the CLI channel. The **agent hooks** behind Drift Sessions are a Claude Code feature and have nothing to do with git. Different command, different mechanism.
+
+## The CLI: you run it
 
 ```bash
 npx @vibedrift/cli
@@ -68,54 +83,9 @@ vibedrift --format terminal    # print to stdout instead
 
 Requires Node.js 20 or newer.
 
-## Drift Sessions (preview)
+## The MCP server: your agent asks
 
-**A scan tells you about drift after the code exists. Drift Sessions catches it while your agent is still typing.**
-
-`vibedrift watch-session` rides inside a Claude Code session through the agent's own hooks. When an edit diverges from the patterns your repo already follows, VibeDrift writes a one line advisory straight into the agent's context, so the agent can correct itself on the spot instead of waiting for a review it will never see.
-
-```bash
-vibedrift watch-session
-```
-
-<div align="center">
-<img src="docs/media/drift-sessions-live-tape.gif" alt="The Drift Sessions live event tape: prompts, edits, and drift flags streaming in real time" width="840" />
-</div>
-
-You watch the whole thing happen on a **live event tape**. Prompts show as `USER`, the agent's edits as `AGENT`, and VibeDrift's own flags and outcomes as `VIBEDRIFT`, all on one stream with a running count and a smoothed drift gauge in the footer. If the VibeDrift MCP server is also connected, the agent's questions join the same tape as `ASKS` and `REPLIES` rows, so the agent asking VibeDrift and VibeDrift flagging the agent read as a single dialogue.
-
-Outcomes are real, not guessed. A finding is marked resolved only when the same finding re-runs over the re-edited file and passes, so the summary's open and resolved counts mean something.
-
-### What it records, and where
-
-Everything lands in one append-only JSONL ledger per session:
-
-```
-~/.vibedrift/sessions/<projectHash>/<sessionId>.jsonl
-```
-
-| Recorded | Never recorded |
-| --- | --- |
-| Your prompts, with secrets masked | Your source code |
-| Edit metadata: repo relative path and a diffstat | The diff body |
-| Drift flags, MCP calls, and their outcomes | The agent's transcript file |
-
-The capture hook is fully offline and fails open: a hook error, a timeout, or an input shape it does not recognize exits cleanly and never interrupts your agent. Installation writes marker tagged entries into the project's `.claude/settings.local.json` behind an explicit consent prompt, and `--uninstall` removes exactly what it added. Recorded ledgers always remain yours.
-
-```bash
-vibedrift watch-session --status      # is it installed for this repo?
-vibedrift watch-session --no-watch    # install without following the tape
-vibedrift watch-session --uninstall   # remove the hooks
-vibedrift watch-session --sync on     # opt in to the hosted dashboard
-```
-
-Sync is off by default. Turning it on uploads a derived projection only, meaning findings, outcomes, and metadata, to [vibedrift.ai/dashboard/sessions](https://vibedrift.ai/dashboard/sessions). Never your code or your prompts, and file paths travel as per-repo hashes rather than real paths.
-
-> Drift Sessions is a **Pro** feature with a one time **5 session free trial**, and a free account is all it takes to start. After the trial the live tape locks behind a summary of what it caught. See [pricing](https://vibedrift.ai/pricing).
-
-## In the loop: the MCP server
-
-Drift Sessions watches. The MCP server answers. It lets your agent interrogate your codebase *before* it writes a line, so new code matches the first time.
+**Your agent pulls.** The MCP server lets it interrogate your codebase *before* it writes a line, so new code matches the first time.
 
 ```bash
 claude mcp add vibedrift -- npx -y @vibedrift/cli mcp
@@ -141,20 +111,62 @@ Seven tools ship with the server:
 | `find_similar_function` | An existing near duplicate, so the agent reuses instead of rewriting |
 | `validate_change` | Whether a proposed function would introduce drift or duplicate something |
 | `init` | One time repo setup, so every tool skips non product code |
-| `respond_to_flag` | The agent's call on a live Drift Sessions flag: accept, park, or decline |
+| `respond_to_flag` | The agent's call on a live [Drift Sessions](#drift-sessions-preview) flag: accept, park, or decline |
 
 <div align="center">
 <img src="docs/handbook/assets/09-mcp-loop.svg" alt="The agent loop: tool calls answered from a cached baseline on your machine" width="840" />
 </div>
 
-These run on your machine and need no login. The baseline builds itself on first use, so if a tool returns `no_baseline`, run `vibedrift` once in that repo. Two of them, `validate_change` and `find_similar_function`, also take an opt-in `deep` flag that sends the function to the cloud checker. It stays off unless the agent asks for it.
+These run on your machine and need no login. The baseline builds itself on the first tool call in a repo, once, then caches. A `no_baseline` reply means there was no code to analyze or the build failed, not that you skipped a setup step.
 
-### Without MCP
+Two of them, `validate_change` and `find_similar_function`, also take an opt-in `deep` flag that checks your function against the [cloud checker](#deep-scan). It needs an account, it is metered, and it is the only part of this channel that leaves your machine: the first deep call in a repo sends your functions to be embedded, and later calls send the function being written plus the handful of existing functions it might duplicate. It stays off unless the agent asks for it.
 
-The same five in-loop checks are a plain import and an Agent Skill over the same engine:
+No MCP client? The five query tools above, everything except `init` and `respond_to_flag` which are MCP only, are also plain functions: `import { validateChange, findSimilarFunction } from "@vibedrift/cli/tools"` ([docs/tools-api.md](./docs/tools-api.md)), or a self contained [Agent Skill](./skills/vibedrift/SKILL.md).
 
-- **Import:** `import { validateChange, findSimilarFunction } from "@vibedrift/cli/tools"` ([docs/tools-api.md](./docs/tools-api.md))
-- **Agent Skill:** a self contained skill at [`skills/vibedrift/`](./skills/vibedrift/SKILL.md)
+## Drift Sessions (preview)
+
+**VibeDrift pushes.** A scan finds drift after the code exists, and MCP only helps when the agent thinks to ask. Drift Sessions flags a drifting edit while your agent is still typing, asked or not.
+
+`vibedrift watch-session` rides inside a Claude Code session through the agent's own hooks, which Claude Code runs at session start, on each prompt, after each edit, and when the session stops. When an edit diverges from the patterns your repo already follows, VibeDrift writes a one line advisory straight into the agent's context, so the agent can correct itself on the spot instead of waiting for a review it will never see.
+
+```bash
+vibedrift watch-session
+```
+
+<div align="center">
+<img src="docs/media/drift-sessions-live-tape.gif" alt="The Drift Sessions live event tape: prompts, edits, and drift flags streaming in real time" width="840" />
+</div>
+
+You watch the whole thing happen on a **live event tape**. Prompts show as `USER`, the agent's edits as `AGENT`, and VibeDrift's own flags and outcomes as `VIBEDRIFT`, all on one stream with a running count and a smoothed drift gauge in the footer. If the [MCP server](#the-mcp-server-your-agent-asks) is also connected, its verdict calls (`validate_change`, `check_file_drift`, `find_similar_function`) join the same tape as `ASKS` and `REPLIES` rows, so the agent asking VibeDrift and VibeDrift flagging the agent read as a single dialogue.
+
+Outcomes are real, not guessed. A finding is marked resolved only when the same finding re-runs over the re-edited file and passes, so the summary's open and resolved counts mean something.
+
+### What it records, and where
+
+Everything lands in one append-only JSONL ledger per session:
+
+```
+~/.vibedrift/sessions/<projectHash>/<sessionId>.jsonl
+```
+
+| Recorded | Never recorded |
+| --- | --- |
+| Your prompts, with secrets masked | Your source code |
+| Edit metadata: repo relative path and a diffstat | The diff body |
+| Drift flags, MCP calls, and their outcomes | The agent's transcript file |
+
+The capture hook is fully offline and fails open: a hook error, a timeout, or an input shape it does not recognize exits cleanly and never interrupts your agent. Installation writes marker tagged entries into the project's `.claude/settings.local.json` behind an explicit consent prompt, and `--uninstall` removes exactly what it added. Recorded ledgers always remain yours.
+
+```bash
+vibedrift watch-session --status      # is it installed for this repo?
+vibedrift watch-session --no-watch    # install without following the tape
+vibedrift watch-session --uninstall   # remove the agent hooks
+vibedrift watch-session --sync on     # opt in to the hosted dashboard
+```
+
+Sync is off by default. Turning it on uploads a derived projection only, meaning findings, outcomes, and metadata, to [vibedrift.ai/dashboard/sessions](https://vibedrift.ai/dashboard/sessions). Never your code or your prompts, and file paths travel as per-repo hashes rather than real paths.
+
+> Drift Sessions is a **Pro** feature with a one time **5 session free trial**, and a free account is all it takes to start. After the trial, capture stops: no more in-context advisories, and the tape locks behind a summary of what the trial caught. See [pricing](https://vibedrift.ai/pricing).
 
 ## What it detects
 
@@ -170,7 +182,7 @@ Findings roll into two independent numbers:
 - **Vibe Drift Score** (0 to 100) across Architectural Consistency, Redundancy, Security Consistency, and Intent Clarity. How consistent your code is with its own dominant patterns.
 - **Hygiene Score** (0 to 100). Generic quality checks, kept separate so they never contaminate the drift number.
 
-Coverage is not uniform across languages. Scoring, duplicate detection, and Security Consistency run on all five; several convention detectors, including imports, exports, error handling, and test structure, are JS/TS only today.
+Coverage is not uniform across languages. Scoring, duplicate detection, and Security Consistency run on all five; several convention detectors, including exports, error handling, and test structure, are JS/TS only today.
 
 Drift is always measured against your repo's own behavior, never an external style guide. A minority directory that is internally consistent is not drift. The [Developer Handbook](#developer-handbook) explains the dominance vote and the Code DNA fingerprinting that finds near duplicates.
 
@@ -190,7 +202,7 @@ vibedrift --diff main            # only what differs from a branch
 | `--diff [ref]` | Scope to files changed in git, uncommitted vs `HEAD` by default |
 | `--include` / `--exclude <glob>` | Filter the files scanned, repeatable |
 | `--deep` | AI deep analysis, requires `vibedrift login` |
-| `--write-context` | Write committable `.vibedrift/` context files, requires `vibedrift login` |
+| `--write-context` | Write committable `.vibedrift/` context files, requires a free account |
 | `--inject-context` | Inject the context summary into `CLAUDE.md` in a managed block |
 | `--local-only` | Skip every network call |
 | `--since <scanId>` | Diff against a specific saved scan |
@@ -246,14 +258,14 @@ jobs:
 
 A [GitHub Action](https://github.com/skhan75/vibedrift-actions) is also available if you want a score delta comment posted on the pull request.
 
-To gate locally instead, `vibedrift hook install` writes a git pre-push hook that blocks a push below your threshold. Bypass once with `git push --no-verify`.
+To gate locally instead, `vibedrift hook install` writes a git pre-push hook that blocks a push below your threshold (Pro). That is the git hook, not the agent hooks behind [Drift Sessions](#drift-sessions-preview). Bypass once with `git push --no-verify`.
 
 ## Privacy
 
 - **Analysis runs on your machine.** Parsing, pattern detection, and scoring are all local. Nothing about how VibeDrift reaches a verdict depends on a server.
 - **`--local-only` skips every network call**, even when you are signed in. Reach for it when you want a scan with zero egress.
 - **Signed out, only the anonymous beacon leaves.** After each scan VibeDrift posts language, file count, lines of code, scan time, CLI version, finding count, score, whether the scan was deep, whether the directory is a git repo, whether intent hints were found, and whether you were signed in. No code, no paths, no identifiers. Opt out with `vibedrift telemetry disable`, `VIBEDRIFT_TELEMETRY_DISABLED=1`, or `--local-only`.
-- **Signed in, each scan syncs its result to your dashboard**, which is how your history and score trend appear on vibedrift.ai. That payload carries repo-relative paths and code snippets from findings, so use `--local-only` on anything you would rather keep entirely local.
+- **Signed in, each scan syncs its result to your dashboard**, which is how your history and score trend appear on vibedrift.ai. That payload carries repo-relative paths and code snippets from findings, so use `--local-only` on anything you would rather keep entirely local. The HTML report also pings once when you open it in a browser, carrying the scan id and a timestamp and nothing else. Reports produced signed out or under `--local-only` have no such ping.
 - **`--deep` is opt in per run.** It sends function-level snippets and their repo-relative paths, never whole files.
 - **Update check.** Once a day the CLI asks npm whether a newer version exists. Cached, silent on failure, skipped under `--local-only` and when telemetry is off.
 - Auth state lives at `~/.vibedrift/config.json` (mode `0600`) and scan history at `~/.vibedrift/scans/`, never inside your project tree.
@@ -274,8 +286,8 @@ To gate locally instead, `vibedrift hook install` writes a git pre-push hook tha
 | `vibedrift ignore <globs...>` | Append path globs to `.vibedriftignore` |
 | `vibedrift watch [path]` | Re-scan and refresh `.vibedrift/` on file changes (Pro) |
 | `vibedrift watch-session [path]` | [Drift Sessions](#drift-sessions-preview), the live agent tape (preview) |
-| `vibedrift mcp` | Run the MCP server over stdio |
-| `vibedrift hook <action>` | Manage the git pre-push drift gate (install is Pro) |
+| `vibedrift mcp` | Run the [MCP server](#the-mcp-server-your-agent-asks) over stdio |
+| `vibedrift hook <action>` | Manage the **git** pre-push drift gate, not the agent hooks (install is Pro) |
 | `vibedrift login` / `logout` | Account auth |
 | `vibedrift status` | Current account, plan, and token |
 | `vibedrift usage` | This billing period's scan usage |
@@ -288,12 +300,12 @@ To gate locally instead, `vibedrift hook install` writes a git pre-push hook tha
 
 ## Pricing
 
-The CLI is MIT licensed and the local engine is free forever, including the MCP tools.
+The CLI is MIT licensed and the local engine is free forever, including the local MCP tools.
 
 | Tier | Includes |
 | --- | --- |
-| **Free** | Unlimited local scans, all MCP tools, a monthly deep scan allowance, a 5 session Drift Sessions trial |
-| **Pro** | Drift Sessions, `watch`, the pre-push gate, and more deep scans |
+| **Free** | Unlimited local scans, the MCP server's local tools, a monthly deep scan allowance, a 5 session Drift Sessions trial |
+| **Pro** | Drift Sessions, `watch`, the git pre-push gate, and more deep scans |
 | **Enterprise** | Custom terms, contact sales |
 
 Current numbers live at [vibedrift.ai/pricing](https://vibedrift.ai/pricing).

--- a/README.md
+++ b/README.md
@@ -1,26 +1,52 @@
 <div align="center">
 
-<img src="assets/vibedrift-logo.png" alt="VibeDrift" width="120" height="120" />
+<img src="assets/vibedrift-logo.png" alt="VibeDrift" width="104" height="104" />
 
-# VibeDrift
+# vibedrift
 
-### Your AI agent gets worse as your project grows.
+### Your AI drives. VibeDrift navigates.
 
-It forgets your patterns, repeats code, and breaks what worked. **VibeDrift catches the drift before it spreads** — locally, on your machine.
+[![Website](https://img.shields.io/badge/vibedrift.ai-FFD000?style=flat&labelColor=1a1a1a)](https://vibedrift.ai)
+[![npm](https://img.shields.io/npm/v/@vibedrift/cli.svg?color=FFD000&labelColor=1a1a1a)](https://www.npmjs.com/package/@vibedrift/cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?labelColor=1a1a1a)](./LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?style=flat&labelColor=1a1a1a)](https://discord.gg/YVcQ65Jt3Q)
 
-[![Website](https://img.shields.io/badge/vibedrift.ai-FFD000?style=flat&labelColor=1a1a1a)](https://vibedrift.ai) [![npm](https://img.shields.io/npm/v/@vibedrift/cli.svg?color=FFD000)](https://www.npmjs.com/package/@vibedrift/cli) [![Vibe Drift Score](https://img.shields.io/badge/Vibe_Drift_Score-91-3FB950?style=flat&labelColor=1a1a1a)](https://vibedrift.ai/guide) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE) [![Discord](https://img.shields.io/badge/Discord-join-5865F2?style=flat)](https://discord.gg/YVcQ65Jt3Q)
+**Open source · Analysis runs on your machine · JS/TS, plus Python, Go and Rust**
 
-**Free · Open source · Runs on your machine**
+```bash
+npx @vibedrift/cli
+```
 
 </div>
 
 ---
 
-Every fresh agent session starts with no memory of the conventions your codebase already settled on. So it makes reasonable choices that just aren't *your* choices. One handler throws a typed error; the next returns a plain object. Eight services use a repository layer; the ninth reaches for raw SQL. Everything compiles, everything passes review, and the codebase slowly stops agreeing with itself.
+## Contents
 
-That gap is **drift** — and it's invisible to linters, because a linter checks one file at a time. VibeDrift checks your codebase *against itself*: it learns the patterns your code already agrees on, then flags every file that deviates, and points you at the exact line.
+- [What drift is](#what-drift-is)
+- [Quick start](#quick-start)
+- [Drift Sessions](#drift-sessions-preview)
+- [In the loop: the MCP server](#in-the-loop-the-mcp-server)
+- [What it detects](#what-it-detects)
+- [Scanning and reports](#scanning-and-reports)
+- [Configuration](#configuration)
+- [Deep scan](#deep-scan)
+- [CI integration](#ci-integration)
+- [Privacy](#privacy)
+- [Command reference](#command-reference)
+- [Pricing](#pricing)
+- [Developer Handbook](#developer-handbook)
+- [Contributing](#contributing)
+- [License](#license)
+- [Links](#links)
 
-> Full documentation, the scoring guide, and what each finding means live at **[vibedrift.ai/guide](https://vibedrift.ai/guide)**.
+## What drift is
+
+Every fresh agent session starts with no memory of the conventions your codebase already settled on. So it makes reasonable choices that are not *your* choices.
+
+One handler throws a typed error, the next returns a plain object. Eight services go through a repository layer, the ninth reaches for raw SQL. Everything compiles, everything passes review, and the codebase slowly stops agreeing with itself.
+
+That gap is **drift**. Linters miss it by design: a linter checks one file against a rulebook. VibeDrift checks your codebase against *itself*. It learns the patterns your code already agrees on, flags the files that deviate, and points at the exact line.
 
 ## Quick start
 
@@ -28,159 +54,74 @@ That gap is **drift** — and it's invisible to linters, because a linter checks
 npx @vibedrift/cli
 ```
 
-That's it. No install, no signup. Scans the current directory and opens an interactive HTML report. Your code never leaves your machine.
+No install, no signup. Scans the current directory and opens an interactive HTML report.
 
-Install globally if you prefer:
+Install globally if you scan often:
 
 ```bash
 npm i -g @vibedrift/cli
-vibedrift                       # scan ./
-vibedrift ./path/to/project     # scan a specific path
+
+vibedrift                      # scan ./
+vibedrift ./path/to/project    # scan a specific path
+vibedrift --format terminal    # print to stdout instead
 ```
 
-## Configure once
+Requires Node.js 20 or newer.
 
-Set up exclusions and defaults in one step:
+## Drift Sessions (preview)
+
+**A scan tells you about drift after the code exists. Drift Sessions catches it while your agent is still typing.**
+
+`vibedrift watch-session` rides inside a Claude Code session through the agent's own hooks. When an edit diverges from the patterns your repo already follows, VibeDrift writes a one line advisory straight into the agent's context, so the agent can correct itself on the spot instead of waiting for a review it will never see.
 
 ```bash
-vibedrift init
+vibedrift watch-session
 ```
 
-`init` detects fixtures and generated code, then asks which paths to skip, your CI score floor, your default report format, and whether to install a pre-push hook. It writes two committable files: **`.vibedriftignore`** (which paths to skip) and **`.vibedrift/config.json`** (behavior — default format, CI threshold). Commit them so your whole team scans the same way.
+<div align="center">
+<img src="docs/media/drift-sessions-live-tape.gif" alt="The Drift Sessions live event tape: prompts, edits, and drift flags streaming in real time" width="840" />
+</div>
 
-Quick one-offs without the wizard:
+You watch the whole thing happen on a **live event tape**. Prompts show as `USER`, the agent's edits as `AGENT`, and VibeDrift's own flags and outcomes as `VIBEDRIFT`, all on one stream with a running count and a smoothed drift gauge in the footer. If the VibeDrift MCP server is also connected, the agent's questions join the same tape as `ASKS` and `REPLIES` rows, so the agent asking VibeDrift and VibeDrift flagging the agent read as a single dialogue.
+
+Outcomes are real, not guessed. A finding is marked resolved only when the same finding re-runs over the re-edited file and passes, so the summary's open and resolved counts mean something.
+
+### What it records, and where
+
+Everything lands in one append-only JSONL ledger per session:
+
+```
+~/.vibedrift/sessions/<projectHash>/<sessionId>.jsonl
+```
+
+| Recorded | Never recorded |
+| --- | --- |
+| Your prompts, with secrets masked | Your source code |
+| Edit metadata: repo relative path and a diffstat | The diff body |
+| Drift flags, MCP calls, and their outcomes | The agent's transcript file |
+
+The capture hook is fully offline and fails open: a hook error, a timeout, or an input shape it does not recognize exits cleanly and never interrupts your agent. Installation writes marker tagged entries into the project's `.claude/settings.local.json` behind an explicit consent prompt, and `--uninstall` removes exactly what it added. Recorded ledgers always remain yours.
 
 ```bash
-vibedrift ignore "**/fixtures/**"     # add a path glob to .vibedriftignore
-vibedrift --exclude "**/*.spec.*"     # skip files for a single scan
-vibedrift --include "src/**"          # scan only these for a single scan
+vibedrift watch-session --status      # is it installed for this repo?
+vibedrift watch-session --no-watch    # install without following the tape
+vibedrift watch-session --uninstall   # remove the hooks
+vibedrift watch-session --sync on     # opt in to the hosted dashboard
 ```
 
-`.vibedriftignore` uses gitignore syntax and is honored by **both the CLI and the MCP server**, so excluded paths stop counting toward your score in either (`init` and `ignore` refresh the baseline for you). Use it for test fixtures, generated code, and vendored files that aren't really *yours*.
+Sync is off by default. Turning it on uploads a derived projection only, meaning findings, outcomes, and metadata, to [vibedrift.ai/dashboard/sessions](https://vibedrift.ai/dashboard/sessions). Never your code or your prompts, and file paths travel as per-repo hashes rather than real paths.
 
-## What it finds
+> Drift Sessions is a **Pro** feature with a one time **5 session free trial**, and a free account is all it takes to start. After the trial the live tape locks behind a summary of what it caught. See [pricing](https://vibedrift.ai/pricing).
 
-- Architectural inconsistencies (half your handlers use a repository, the rest hit raw SQL)
-- Hidden duplicates: two functions doing the same thing under different names
-- Convention drift across naming, imports, error handling, async style, and logging
-- Security gaps: hardcoded secrets, injection risks, and routes that skip the auth the rest of your code applies
-- Dead code, complexity hotspots, and half-finished or placeholder implementations
+## In the loop: the MCP server
 
-Under the hood, VibeDrift learns your repo's dominant patterns by majority vote, fingerprints logic with Code DNA to catch near-duplicates, and rolls findings into a **Vibe Drift Score** and a **Hygiene Score**. See the [Developer Handbook](./docs/handbook/) for the engine and the [scoring guide](https://vibedrift.ai/guide) for how findings are weighted.
-
-**Supported languages:** JavaScript, TypeScript, Python, Go, Rust.
-
-## From detection to prevention
-
-Catching drift after it ships is a postmortem. The real win is checking *while* the agent writes.
-
-1. **Detect** — `vibedrift` scans your repo, scores it against its own conventions, and shows the evidence. Great for audits and CI gates.
-2. **Prevent in the loop** — the [MCP server](#mcp-server) lets your agent ask the codebase about itself *before* it writes a line, so new code matches the first time.
-3. **Prevent at the source** — [VibeLang](https://thevibelang.org), where behavioral intent becomes compiler-enforced, so drift can't compile.
-
-Detection tells you, in-loop prevention nudges you, language-level prevention makes it impossible. MCP is the rung that's live today.
-
-## Commands
-
-```
-vibedrift [path]            Scan a project (default command)
-vibedrift watch [path]      Re-scan on file changes (Pro)
-vibedrift watch-session     Drift Sessions (preview): record agent sessions to a local ledger
-vibedrift mcp               Run the MCP server (Claude Code / Cursor / any MCP client)
-vibedrift login / logout    Account auth
-vibedrift status            Account, plan, and token
-vibedrift hook <action>     Install or remove a git pre-push drift gate
-vibedrift doctor            Diagnose install, auth, and API
-vibedrift update            Update to the latest version
-```
-
-Common scan options:
-
-```
---format <html|terminal|json|csv|docx>   output format (html is the default)
---fail-on-score <n>                       exit 1 if the score is below n (CI gate)
---diff [ref]                              scan only files changed in git (vs HEAD, or vs a ref/branch)
---deep                                    AI-powered deep analysis (requires login)
---include / --exclude <glob>              filter the files scanned (repeatable)
---write-context                           write committable .vibedrift/ context files
---inject-context                          inject the context summary into CLAUDE.md (managed block; pairs with --write-context)
---local-only                              skip every network call (fully offline)
-```
-
-Run `vibedrift --help` for the complete list.
-
-### Drift Sessions (preview)
-
-Drift Sessions are a **Pro** feature, with a one-time **5-session free trial** (a free
-account is all it takes to start). After the trial the live tape locks behind a summary
-of what it caught, and `vibedrift upgrade` unlocks unlimited sessions. Your locally
-recorded ledgers always remain yours.
-
-`vibedrift watch-session` registers Claude Code hooks for the current repo (with an
-explicit consent prompt) so your agent session is recorded to a local, append-only
-ledger under `~/.vibedrift/sessions/`: your prompts (secrets masked), edit metadata,
-and any drift flags VibeDrift raised, with one-line advisory notes delivered into the
-agent's own context when an edit diverges from the repo's dominant patterns. Your
-prompts and code never leave your machine: the capture hook is fully offline, never
-reads the agent's transcript file, and never stores full edit bodies. (The
-`watch-session` viewer itself checks your session entitlement with the server on
-start — that is the only network on this surface, and it is off the hook's path.)
-Hooks fail open — an error or timeout never interrupts your agent. `--status` reports
-the install state; `--uninstall` removes exactly what was added.
-
-Run `vibedrift watch-session` and it follows a **live event tape**: each prompt,
-edit, and drift flag streams in as it happens, with a running count, a smoothed
-drift gauge, and an end-of-session summary (including how many of the task's
-target files you actually touched). It captures the task from your prompt — the
-files and symbols you named — and, conservatively, flags an edit that looks
-unrelated to any of them (experimental, so verify before trusting it). When a
-later edit fixes a flagged file, the finding is marked **resolved** — the same
-finding re-run over the new code, never a guess — so the summary's resolved and
-open counts are real. If the VibeDrift MCP is also enabled, the agent's own
-questions (`validate_change`, `check_file_drift`, `find_similar_function`) join the
-same tape as ASKS/REPLIES rows, so the whole exchange reads as one dialogue. Use
-`--no-watch` to install without following.
-
-Everything above stays on your machine. To review sessions across machines or with your team, opt into a hosted dashboard with `vibedrift watch-session --sync on`: it uploads a derived-only projection (findings, scores, and outcomes, never your code, prompts, or real file paths) to [vibedrift.ai/dashboard/sessions](https://vibedrift.ai/dashboard/sessions).
-
-## Deep scan
-
-`vibedrift --deep` adds cloud-powered analysis that local static checks cannot do: semantic duplicate detection, name-versus-behavior intent checks, an in-loop Claude verdict on borderline matches, and a synthesized coherence report graded against your own patterns. The default output summarizes the AI results the scan produced inline (the coherence grade on paid plans, the AI summary, and the top finding); the full AI analysis is in the report and under `--format terminal`. Scope it to your change set with `--diff`:
-
-```bash
-vibedrift login
-vibedrift . --deep              # full-repo deep scan
-vibedrift . --deep --diff       # deep-scan only what you changed (fast pre-PR check)
-vibedrift . --deep --diff main  # deep-scan everything that differs from a branch
-```
-
-Deep scan sends function snippets only (never full files or file paths), processed in memory and not stored. The free tier includes a monthly allowance of deep scans; see [vibedrift.ai](https://vibedrift.ai) for current plans.
-
-## MCP server
-
-VibeDrift ships an MCP server so an AI coding agent can consult your repo's own conventions while it writes — turning drift detection into drift prevention. It exposes seven tools — five your agent calls in-loop, a setup tool, and one for Drift Sessions:
-
-- `get_intent_hints` reads the conventions your `CLAUDE.md` / `AGENTS.md` / `.cursorrules` declare
-- `get_dominant_pattern` returns the repo's majority pattern for a dimension, with examples to copy
-- `check_file_drift` checks whether a file matches the repo's patterns
-- `find_similar_function` finds an existing near-duplicate so the agent reuses instead of rewriting
-- `validate_change` checks whether a proposed function would introduce drift or duplicate something
-- `init` sets the repo up (writes `.vibedriftignore` and `.vibedrift/config.json`, refreshes the baseline)
-- `respond_to_flag` records the agent's call on a live [Drift Sessions](#drift-sessions-preview) flag (accept, park, or decline) to the local session ledger
-
-These tools run on your machine, send no code, and need no login. They build the repo's baseline automatically on first use. (The `validate_change` and `find_similar_function` tools can opt into a deeper semantic pass, which is the only part that's metered.)
-
-### Install in any MCP client
-
-VibeDrift is a standard [MCP](https://modelcontextprotocol.io) server launched over stdio with `npx -y @vibedrift/cli mcp`.
-
-**Claude Code** (writes the config for you):
+Drift Sessions watches. The MCP server answers. It lets your agent interrogate your codebase *before* it writes a line, so new code matches the first time.
 
 ```bash
 claude mcp add vibedrift -- npx -y @vibedrift/cli mcp
 ```
 
-**Cursor, GitHub Copilot, Windsurf, Antigravity, OpenAI Codex, Kiro, Claude Desktop, VS Code, Zed, and any other MCP client** use the same command in their MCP config:
+Any other MCP client uses the same stdio command:
 
 ```json
 {
@@ -190,80 +131,191 @@ claude mcp add vibedrift -- npx -y @vibedrift/cli mcp
 }
 ```
 
-If a tool returns `no_baseline`, run `vibedrift` once in that repo to build it.
+Seven tools ship with the server:
+
+| Tool | What the agent gets |
+| --- | --- |
+| `get_intent_hints` | The conventions your `CLAUDE.md`, `AGENTS.md`, or `.cursorrules` already declare |
+| `get_dominant_pattern` | The repo's majority pattern for a dimension, with example files to copy |
+| `check_file_drift` | Whether a file diverges from those patterns, and how |
+| `find_similar_function` | An existing near duplicate, so the agent reuses instead of rewriting |
+| `validate_change` | Whether a proposed function would introduce drift or duplicate something |
+| `init` | One time repo setup, so every tool skips non product code |
+| `respond_to_flag` | The agent's call on a live Drift Sessions flag: accept, park, or decline |
+
+<div align="center">
+<img src="docs/handbook/assets/09-mcp-loop.svg" alt="The agent loop: tool calls answered from a cached baseline on your machine" width="840" />
+</div>
+
+These run on your machine and need no login. The baseline builds itself on first use, so if a tool returns `no_baseline`, run `vibedrift` once in that repo. Two of them, `validate_change` and `find_similar_function`, also take an opt-in `deep` flag that sends the function to the cloud checker. It stays off unless the agent asks for it.
 
 ### Without MCP
 
-The same five tools are also a plain import and an Agent Skill over the same engine, for agents that do not speak MCP:
+The same five in-loop checks are a plain import and an Agent Skill over the same engine:
 
-- **Import:** `import { validateChange, findSimilarFunction } from "@vibedrift/cli/tools"` (see [docs/tools-api.md](./docs/tools-api.md))
-- **Agent Skill:** a self-contained skill at [`skills/vibedrift/`](./skills/vibedrift/SKILL.md)
+- **Import:** `import { validateChange, findSimilarFunction } from "@vibedrift/cli/tools"` ([docs/tools-api.md](./docs/tools-api.md))
+- **Agent Skill:** a self contained skill at [`skills/vibedrift/`](./skills/vibedrift/SKILL.md)
+
+## What it detects
+
+- **Architectural inconsistency.** Half your handlers use a repository, the rest hit raw SQL.
+- **Hidden duplicates.** Two functions doing the same job under different names.
+- **Convention drift** across naming, imports, exports, error handling, async style, logging, comments, and test structure.
+- **Security consistency.** Routes that skip the auth the rest of your code applies, plus hardcoded secrets and injection risks.
+- **Phantom scaffolding.** Placeholder and half finished implementations that look done.
+- **Hygiene.** Dead code, complexity hotspots, and TODO density.
+
+Findings roll into two independent numbers:
+
+- **Vibe Drift Score** (0 to 100) across Architectural Consistency, Redundancy, Security Consistency, and Intent Clarity. How consistent your code is with its own dominant patterns.
+- **Hygiene Score** (0 to 100). Generic quality checks, kept separate so they never contaminate the drift number.
+
+Coverage is not uniform across languages. Scoring, duplicate detection, and Security Consistency run on all five; several convention detectors, including imports, exports, error handling, and test structure, are JS/TS only today.
+
+Drift is always measured against your repo's own behavior, never an external style guide. A minority directory that is internally consistent is not drift. The [Developer Handbook](#developer-handbook) explains the dominance vote and the Code DNA fingerprinting that finds near duplicates.
+
+## Scanning and reports
+
+```bash
+vibedrift --format terminal      # print to stdout instead of opening HTML
+vibedrift --json > report.json   # machine readable
+vibedrift --diff main            # only what differs from a branch
+```
+
+| Flag | Effect |
+| --- | --- |
+| `--format <type>` | `html` (default), `terminal`, `json`, `csv`, `docx` |
+| `--output <path>` | Write the report to a file |
+| `--fail-on-score <n>` | Exit 1 when the score falls below `n` |
+| `--diff [ref]` | Scope to files changed in git, uncommitted vs `HEAD` by default |
+| `--include` / `--exclude <glob>` | Filter the files scanned, repeatable |
+| `--deep` | AI deep analysis, requires `vibedrift login` |
+| `--write-context` | Write committable `.vibedrift/` context files, requires `vibedrift login` |
+| `--inject-context` | Inject the context summary into `CLAUDE.md` in a managed block |
+| `--local-only` | Skip every network call |
+| `--since <scanId>` | Diff against a specific saved scan |
+
+Scans compare themselves against your previous run automatically when history exists. Run `vibedrift --help` for the full list.
+
+## Configuration
+
+```bash
+vibedrift init
+```
+
+`init` detects fixtures and generated code, then asks which paths to skip, your CI score floor, and your default report format. It writes two committable files:
+
+| File | Holds |
+| --- | --- |
+| `.vibedriftignore` | Which paths to skip, gitignore syntax |
+| `.vibedrift/config.json` | Default report format and CI score threshold |
+
+Commit both so your whole team scans the same way. `.vibedriftignore` is honored by the CLI *and* the MCP server, so excluded paths stop counting toward your score in either. Use it for test fixtures, generated code, and vendored files that are not really yours.
+
+Skip the wizard with `vibedrift ignore "**/fixtures/**"` to append a glob, or `vibedrift init --yes` to accept the detected defaults non interactively.
+
+## Deep scan
+
+`--deep` adds cloud analysis that local static checks cannot do: semantic duplicate detection, name versus behavior intent checks, and a synthesized coherence report graded against your own patterns (Pro).
+
+```bash
+vibedrift login
+vibedrift --deep            # full repo
+vibedrift --deep --diff     # only what you changed, a fast pre-PR check
+```
+
+Deep scan sends function-level snippets and their repo-relative paths, never whole files. Free accounts include a monthly deep scan allowance; see [pricing](https://vibedrift.ai/pricing).
 
 ## CI integration
 
-A GitHub Action runs VibeDrift on pull requests, posts a score-delta comment, and can fail the check:
+Any runner works, since `--fail-on-score` sets the exit code:
 
 ```yaml
 # .github/workflows/vibedrift.yml
 name: VibeDrift
 on: [pull_request]
-permissions:
-  pull-requests: write
 jobs:
   drift-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: skhan75/vibedrift-actions@v1
-        with:
-          fail-on-score: 70
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npx @vibedrift/cli --local-only --format terminal --fail-on-score 70
 ```
 
-See the [Action repository](https://github.com/skhan75/vibedrift-actions) for all inputs and outputs.
+A [GitHub Action](https://github.com/skhan75/vibedrift-actions) is also available if you want a score delta comment posted on the pull request.
+
+To gate locally instead, `vibedrift hook install` writes a git pre-push hook that blocks a push below your threshold. Bypass once with `git push --no-verify`.
 
 ## Privacy
 
-- **Your code never leaves your machine.** No source, file contents, or file paths are ever sent.
-- **Anonymous scan beacon, on by default for everyone.** After each scan VibeDrift sends a small anonymous beacon: language, file count, lines of code, scan time, CLI version, finding count, and score. No code, no paths, no identifiers. Turn it off with `vibedrift telemetry disable`, `VIBEDRIFT_TELEMETRY_DISABLED=1`, or `--local-only`.
-- **Update check.** Once a day, scans check the npm registry for a newer version (cached, fails silently, skipped under `--local-only`).
-- **`--local-only`** skips every network call, even when logged in.
-- Auth state lives at `~/.vibedrift/config.json` (mode 0600); scan history at `~/.vibedrift/scans/`, never in your project tree.
-
-### Environment variables
+- **Analysis runs on your machine.** Parsing, pattern detection, and scoring are all local. Nothing about how VibeDrift reaches a verdict depends on a server.
+- **`--local-only` skips every network call**, even when you are signed in. Reach for it when you want a scan with zero egress.
+- **Signed out, only the anonymous beacon leaves.** After each scan VibeDrift posts language, file count, lines of code, scan time, CLI version, finding count, score, whether the scan was deep, whether the directory is a git repo, whether intent hints were found, and whether you were signed in. No code, no paths, no identifiers. Opt out with `vibedrift telemetry disable`, `VIBEDRIFT_TELEMETRY_DISABLED=1`, or `--local-only`.
+- **Signed in, each scan syncs its result to your dashboard**, which is how your history and score trend appear on vibedrift.ai. That payload carries repo-relative paths and code snippets from findings, so use `--local-only` on anything you would rather keep entirely local.
+- **`--deep` is opt in per run.** It sends function-level snippets and their repo-relative paths, never whole files.
+- **Update check.** Once a day the CLI asks npm whether a newer version exists. Cached, silent on failure, skipped under `--local-only` and when telemetry is off.
+- Auth state lives at `~/.vibedrift/config.json` (mode `0600`) and scan history at `~/.vibedrift/scans/`, never inside your project tree.
 
 | Variable | Purpose |
-|---|---|
-| `VIBEDRIFT_TOKEN` | Bearer token for CI / non-interactive use |
+| --- | --- |
+| `VIBEDRIFT_TOKEN` | Bearer token for CI and non interactive use |
 | `VIBEDRIFT_API_URL` | Override the API base URL |
-| `VIBEDRIFT_TELEMETRY_DISABLED` | Set to `1` to turn off the beacon and update check |
+| `VIBEDRIFT_TELEMETRY_DISABLED` | Set to `1` to turn off the beacon and the update check |
+| `VIBEDRIFT_NO_BROWSER` | Set to `1` to never auto open a browser |
+
+## Command reference
+
+| Command | Does |
+| --- | --- |
+| `vibedrift [path]` | Scan a project. The default command. |
+| `vibedrift init [path]` | Guided setup: `.vibedriftignore` and `.vibedrift/config.json` |
+| `vibedrift ignore <globs...>` | Append path globs to `.vibedriftignore` |
+| `vibedrift watch [path]` | Re-scan and refresh `.vibedrift/` on file changes (Pro) |
+| `vibedrift watch-session [path]` | [Drift Sessions](#drift-sessions-preview), the live agent tape (preview) |
+| `vibedrift mcp` | Run the MCP server over stdio |
+| `vibedrift hook <action>` | Manage the git pre-push drift gate (install is Pro) |
+| `vibedrift login` / `logout` | Account auth |
+| `vibedrift status` | Current account, plan, and token |
+| `vibedrift usage` | This billing period's scan usage |
+| `vibedrift upgrade` | Open the pricing page |
+| `vibedrift billing` | Open the Stripe customer portal |
+| `vibedrift telemetry <action>` | Enable or disable the anonymous beacon |
+| `vibedrift doctor` | Diagnose install, auth, and API connectivity |
+| `vibedrift update` | Update to the latest version |
+| `vibedrift feedback [message]` | Send feedback straight to the maintainer |
+
+## Pricing
+
+The CLI is MIT licensed and the local engine is free forever, including the MCP tools.
+
+| Tier | Includes |
+| --- | --- |
+| **Free** | Unlimited local scans, all MCP tools, a monthly deep scan allowance, a 5 session Drift Sessions trial |
+| **Pro** | Drift Sessions, `watch`, the pre-push gate, and more deep scans |
+| **Enterprise** | Custom terms, contact sales |
+
+Current numbers live at [vibedrift.ai/pricing](https://vibedrift.ai/pricing).
 
 ## Developer Handbook
 
-Want to know how VibeDrift actually works inside? The **Developer Handbook** walks the whole engine: the scan pipeline, every static analyzer, cross-file drift detection, Security Consistency across JavaScript, TypeScript, Python, Go, and Rust, the Code DNA fingerprinting layer, the scoring engine, the MCP server, and how to add your own detector or language.
+Fifteen chapters covering the whole engine: the scan pipeline, every static analyzer, cross-file drift detection, Security Consistency across all five languages, Code DNA fingerprinting, the scoring engine, the MCP server, Drift Sessions, and how to add your own detector or language.
 
-- **Read it on the web:** [vibedrift.ai/handbook](https://vibedrift.ai/handbook)
-- **Read it here on GitHub:** [`docs/handbook/`](./docs/handbook/) (the chapters render as normal markdown)
-- **Offline:** open [`docs/handbook/DEVELOPER_HANDBOOK_OSS.html`](./docs/handbook/DEVELOPER_HANDBOOK_OSS.html), a single self-contained file
+- **Web:** [vibedrift.ai/handbook](https://vibedrift.ai/handbook)
+- **GitHub:** [`docs/handbook/`](./docs/handbook/)
+- **Offline:** [`docs/handbook/DEVELOPER_HANDBOOK_OSS.html`](./docs/handbook/DEVELOPER_HANDBOOK_OSS.html), one self contained file
 
-The handbook is compiled from the markdown chapters in `docs/handbook/` by a zero-dependency script (`npm run handbook`). To improve it, edit a chapter and rebuild. See [`docs/handbook/README.md`](./docs/handbook/README.md).
+Build it yourself with `npm run handbook`.
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup and how to add an analyzer, [AGENTS.md](./AGENTS.md) for codebase conventions, and [SECURITY.md](./SECURITY.md) for reporting security issues. To understand the engine before you change it, start with the [Developer Handbook](#developer-handbook).
+Contributions are welcome. Start with [CONTRIBUTING.md](./CONTRIBUTING.md) for setup and how to add an analyzer, [AGENTS.md](./AGENTS.md) for codebase conventions, and [SECURITY.md](./SECURITY.md) for reporting vulnerabilities. Read the [Developer Handbook](#developer-handbook) before changing the engine.
 
 ## License
 
-MIT. See [LICENSE](./LICENSE). The CLI runs entirely on your machine; the optional cloud deep-scan service it talks to is a separate hosted product.
+MIT. See [LICENSE](./LICENSE). The CLI runs entirely on your machine. The optional cloud deep-scan service it can talk to is a separate hosted product.
 
 ## Links
 
-- **Website:** [vibedrift.ai](https://vibedrift.ai)
-- **Docs & scoring guide:** [vibedrift.ai/guide](https://vibedrift.ai/guide)
-- **Developer Handbook:** [vibedrift.ai/handbook](https://vibedrift.ai/handbook)
-- **Blog:** [vibedrift.ai/blog](https://vibedrift.ai/blog)
-- **Releases:** [vibedrift.ai/releases](https://vibedrift.ai/releases)
-- **FAQ:** [vibedrift.ai/faq](https://vibedrift.ai/faq)
-- **Issues:** [GitHub Issues](https://github.com/VibeDrift/VibeDrift/issues)
-- **Community:** [Discord](https://discord.gg/YVcQ65Jt3Q)
+[Website](https://vibedrift.ai) · [Docs and scoring guide](https://vibedrift.ai/guide) · [Handbook](https://vibedrift.ai/handbook) · [Blog](https://vibedrift.ai/blog) · [Releases](https://vibedrift.ai/releases) · [FAQ](https://vibedrift.ai/faq) · [Issues](https://github.com/VibeDrift/VibeDrift/issues) · [Discord](https://discord.gg/YVcQ65Jt3Q)


### PR DESCRIPTION
Rewrites the README and restructures it around the three ways VibeDrift reaches your code. The old one was a wall of prose, and a reader could not tell how the pieces related or which one they wanted.

## The three channels

A comparison table sits near the top so the model lands in seconds:

| Channel | Who starts it | Tier |
| --- | --- | --- |
| **CLI** `vibedrift` | **You**, after the code exists | Free (`watch`, pre-push gate and deep scan are Pro) |
| **MCP server** `vibedrift mcp` | **Your agent**, before it writes | Free (opt-in `deep` flag on two tools is metered) |
| **Drift Sessions** `vibedrift watch-session` | **VibeDrift**, while the edit happens | Pro, one time 5 session trial |

MCP is **pull** (a stdio process your agent connects to, so it only helps when the agent thinks to ask). Drift Sessions is **push** (it rides Claude Code's hooks, so VibeDrift speaks up whether the agent asks or not). Run both and MCP verdicts tee into the live session tape.

Also calls out a naming collision that was quietly causing confusion: **`vibedrift hook` is the git pre-push gate**, which has nothing to do with the **agent hooks** behind Drift Sessions. Same word, two mechanisms, both in the same document.

## Other changes

- Hero uses the product title card lockup and the tagline **"Your AI drives. VibeDrift navigates."**
- Table of contents added.
- Drift Sessions is a headline section with the live event tape recording rather than a paragraph describing it.
- The 17-command surface moved to a reference table near the bottom.
- Tables replace paragraphs wherever a table reads faster.

## Accuracy pass

Every claim was verified against source, then adversarially re-checked twice. That turned up real errors, including some introduced during this rewrite:

| Was | Actually |
| --- | --- |
| "Your code never leaves your machine. No file paths are ever sent." | Not true when signed in: each scan syncs its result to the dashboard, including repo-relative paths and finding snippets |
| MCP `deep` flag "sends that one function" | The first deep call embeds **every function in the repo**; later calls also send the existing functions a change might duplicate |
| Deep scan sends "no file paths" | It sends function-level snippets **and** their repo-relative paths |
| MCP tools "send no code" | Two accept an opt-in `deep` flag that does |
| MCP verdicts always join the session ledger | Only while a Drift Session is active, which is the Pro path. The common free case writes nothing |
| All MCP questions appear on the tape | Only three of the seven tools tee |
| "After the trial the live tape locks" | Capture stops entirely: no more in-context advisories, not just a locked viewer |
| Imports listed as JS/TS only | Import-style drift is multi-language as of #72 |
| `--write-context` "requires login" | Requires a free account |
| Sessions sync uploads "scores" | The upload schema has no score field; paths travel as per-repo hashes |
| Coherence report listed with the free allowance | Pro only |
| Beacon field list | Was missing four fields, and the HTML report's open-ping was undocumented |
| `Vibe Drift Score 91` badge | Unreproducible and stale by construction, so dropped |
| Claude Code requirement buried in prose | Now named in the table, so a Cursor user does not buy into a channel they cannot use |

Deliberately **not** documented: `vibedrift enable` and `vibedrift decline`. They are on an unreleased branch, so documenting them would be a false claim.

## Needs a separate decision

While verifying the privacy section I found what looks like an unintended leak in `src/ml-client/sanitize-result.ts`. `sanitizeFilesList`, which strips file contents, is unreachable from the top-level `files:` call, so signed-in scans upload raw `content` for every file. The module's own header comment says contents are dropped, so the intent is clear. **This PR only makes the README honest about current behavior; it does not change the code.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)