### PR TITLE
session: resolve findings only on positive absence

### DIFF
--- a/src/drift/architectural-contradiction.ts
+++ b/src/drift/architectural-contradiction.ts
@@ -233,6 +233,35 @@ export function classifyDataAccessLabel(content: string, path: string): string |
   return DATA_ACCESS_NAMES[primary.pattern];
 }
 
+/**
+ * PRESENCE, not majority: does this body still show the given data-access
+ * label at all? classifyDataAccessLabel picks the body's primary pattern by
+ * evidence count, so a single raw-SQL call is outvoted by the ORM calls
+ * around it — correct for a vote, wrong for "is the flagged call still there".
+ * Returns null when the label is outside this axis's vocabulary.
+ *
+ * Known limit: this hard-codes language "typescript" for EVERY path, including
+ * .py/.go/.rs, exactly as classifyDataAccessLabel does. It is inert today for
+ * two reasons, both of which could stop holding: detectDataAccess reads only
+ * `content` and `relativePath` and never branches on `language` (unlike
+ * detectErrorHandling in this same file, which does), and the two entry points
+ * lie identically, so a label produced by one is recognized by the other. The
+ * hazard is that the `as DriftFile` cast makes the field look meaningful, so a
+ * future language-conditional branch inside detectDataAccess would silently
+ * read every file as TypeScript here — and this function now sits on the
+ * session re-check's resolution path, where a miss reads as "the flagged
+ * pattern is gone". Tracked in todo.md; the fix is to thread the real detected
+ * language through both entry points.
+ */
+export function hasDataAccessPattern(content: string, path: string, label: string): boolean | null {
+  const wanted = (Object.keys(DATA_ACCESS_NAMES) as DataAccessPattern[]).find(
+    (p) => DATA_ACCESS_NAMES[p] === label,
+  );
+  if (!wanted) return null;
+  const hits = detectDataAccess({ content, relativePath: path, language: "typescript" } as DriftFile);
+  return hits.some((h) => h.pattern === wanted && h.evidence.length > 0);
+}
+
 const ERROR_HANDLING_NAMES: Record<ErrorHandlingPattern, string> = {
   wrap_with_context: "error wrapping with context",
   raw_propagation: "raw error propagation",

--- a/src/drift/async-style.ts
+++ b/src/drift/async-style.ts
@@ -53,3 +53,26 @@ export function classifyAsyncStyle(content: string): AsyncStyle | null {
   if (awaitRatio < 0.3) return "then_chains";
   return "mixed";
 }
+
+/** A display name back to its style key, or null when the string isn't one of
+ *  this axis's names. */
+export function asyncStyleFromName(label: string): AsyncStyle | null {
+  for (const key of Object.keys(ASYNC_STYLE_NAMES) as AsyncStyle[]) {
+    if (ASYNC_STYLE_NAMES[key] === label) return key;
+  }
+  return null;
+}
+
+/**
+ * PRESENCE, not dominance: does this chunk still contain the style at all?
+ * classifyAsyncStyle answers "what is this body mostly", which is the right
+ * question for a vote and the wrong one for "did the flagged code go away" — a
+ * half-converted body reads as mixed, and a converted neighbour can outvote an
+ * untouched `.then()` chain. Presence never goes quiet like that.
+ */
+export function hasAsyncStyle(content: string, style: AsyncStyle): boolean {
+  const { awaitCount, thenCount } = asyncCounts(content);
+  if (style === "async_await") return awaitCount > 0;
+  if (style === "then_chains") return thenCount > 0;
+  return awaitCount > 0 && thenCount > 0;
+}

--- a/src/drift/return-shape-consistency.ts
+++ b/src/drift/return-shape-consistency.ts
@@ -154,12 +154,16 @@ function countMatches(re: RegExp, s: string): number {
  * toward "throws" when the function exposes no other error-return shape. Ties
  * break by SHAPE_PRIORITY (most distinctive wins).
  */
-function classifyShape(body: string): ReturnShape | null {
-  // Strip line comments so "// throw new Error" doesn't trigger.
-  const stripped = body
+// Strip line comments so "// throw new Error" doesn't trigger.
+function stripComments(body: string): string {
+  return body
     .replace(/\/\/.*$/gm, "")
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/^\s*#.*$/gm, "");
+}
+
+function classifyShape(body: string): ReturnShape | null {
+  const stripped = stripComments(body);
 
   const counts: Record<ReturnShape, number> = {
     throws: 0,
@@ -195,6 +199,18 @@ function classifyShape(body: string): ReturnShape | null {
 export function classifyReturnShapeLabel(body: string): string | null {
   const shape = classifyShape(body);
   return shape ? SHAPE_NAMES[shape] : null;
+}
+
+/**
+ * PRESENCE, not dominance: does this body still use the given shape anywhere?
+ * classifyShape returns the shape a body uses MOST, so a body that added a new
+ * error path reads as something else while the flagged one is still in it.
+ * Returns null when the label is outside this axis's vocabulary.
+ */
+export function hasReturnShape(body: string, label: string): boolean | null {
+  const wanted = (Object.keys(SHAPE_NAMES) as ReturnShape[]).find((s) => SHAPE_NAMES[s] === label);
+  if (!wanted) return null;
+  return SHAPE_PATTERNS[wanted].test(stripComments(body));
 }
 
 /**

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -14,6 +14,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { loadBaselineUnchecked, type RepoDriftBaseline } from "../core/baseline.js";
 import { detectDrift } from "./detect.js";
+import type { FindingAnchor } from "./finding-anchor.js";
 import { newActivityId, safeSegment } from "./ledger.js";
 import { SESSIONS_SCHEMA_VERSION } from "./types.js";
 import type { SessionEvent } from "./types.js";
@@ -43,6 +44,9 @@ export interface EditCheckOutcome {
   /** the baseline that was loaded (if any), so callers can reuse it for the
    *  finding-scoped outcome re-check without loading it twice */
   baseline: RepoDriftBaseline | null;
+  /** findingId to the construct the finding was raised against. Local only:
+   *  this feeds the session's outcome sidecar and is never part of an event. */
+  anchors: Record<string, FindingAnchor>;
 }
 
 function statePath(opts: EditCheckOptions): string {
@@ -86,26 +90,26 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   try {
     baseline = await load(opts.rootDir);
   } catch {
-    return { flags: [], fyi: null, baseline: null };
+    return { flags: [], fyi: null, baseline: null, anchors: {} };
   }
   if (!baseline || baseline.minhashIndex.length > INLINE_CHECK_MAX_ENTRIES) {
-    return { flags: [], fyi: null, baseline: null };
+    return { flags: [], fyi: null, baseline: null, anchors: {} };
   }
 
   const relPath = relative(opts.rootDir, opts.file) || opts.file;
 
-  let conflictsByDim: Map<string, { dominantPattern: string; yourPattern: string; fixHint: string }>;
-  let dupsByLoc: Map<string, { relativePath: string; name: string; line: number; similarity: number }>;
+  let detected: ReturnType<typeof detectDrift>;
   try {
-    const detected = detectDrift(baseline, relPath, opts.body);
-    conflictsByDim = detected.conflicts;
-    dupsByLoc = detected.dups;
+    detected = detectDrift(baseline, relPath, opts.body);
   } catch {
-    return { flags: [], fyi: null, baseline };
+    return { flags: [], fyi: null, baseline, anchors: {} };
   }
+  const conflictsByDim = detected.conflicts;
+  const dupsByLoc = detected.dups;
 
   const state = await readState(opts);
   const flags: SessionEvent[] = [];
+  const anchors: Record<string, FindingAnchor> = {};
   const candidates: Array<{ key: string; message: string; event: SessionEvent }> = [];
 
   const mkFlag = (detail: SessionEvent["detail"]): SessionEvent => ({
@@ -131,6 +135,8 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
       observed: c.yourPattern,
     });
     flags.push(event);
+    const site = detected.conflictSites.get(dimension);
+    if (site && event.findingId) anchors[event.findingId] = { ...site, observed: c.yourPattern };
     candidates.push({
       key: `${relPath}|${dimension}`,
       message: `[vibedrift] flagged ${relPath} (${event.findingId}): ${c.fixHint}`,
@@ -148,6 +154,8 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
       similarity: topDup.similarity,
     });
     flags.push(event);
+    const site = detected.dupSites.get(where);
+    if (site && event.findingId) anchors[event.findingId] = { ...site, observed: where };
     candidates.push({
       key: `${relPath}|redundancy`,
       message: `[vibedrift] flagged ${relPath} (${event.findingId}): new function duplicates ${topDup.name} at ${where} (${topDup.similarity.toFixed(2)} similar); prefer importing it.`,
@@ -167,5 +175,5 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   }
 
   if (flags.length > 0) await writeState(opts, state);
-  return { flags, fyi, baseline };
+  return { flags, fyi, baseline, anchors };
 }

--- a/src/session/detect.ts
+++ b/src/session/detect.ts
@@ -11,6 +11,7 @@
 import { validateChangeAgainstBaseline } from "../tools-core/index.js";
 import { extractAllFunctions } from "../codedna/function-extractor.js";
 import { detectLanguage } from "../core/language.js";
+import { anchorTokenHash, anchorTokens, type AnchorSite } from "./finding-anchor.js";
 import type { RepoDriftBaseline } from "../core/baseline.js";
 
 const MAX_FUNCTIONS = 5;
@@ -29,6 +30,36 @@ export interface DetectedDup {
 export interface Detected {
   conflicts: Map<string, DetectedConflict>;
   dups: Map<string, DetectedDup>;
+  /** which query saw each conflict, keyed by dimension. */
+  conflictSites: Map<string, AnchorSite>;
+  /** which query saw each duplicate, keyed by "path:line". */
+  dupSites: Map<string, AnchorSite>;
+}
+
+interface Query {
+  body: string;
+  site: AnchorSite;
+}
+
+/** A function site is sharper than the whole-body site: it survives the file
+ *  changing around it, so it wins even when the whole body reported first.
+ *  Used for duplicates, where the map key IS the observed label (the matched
+ *  location), so every query filed under a key reported that same label. */
+function keepSharper(sites: Map<string, AnchorSite>, key: string, site: AnchorSite): void {
+  const prev = sites.get(key);
+  if (!prev || (prev.kind === "file" && site.kind === "function")) sites.set(key, site);
+}
+
+/** The site a conflict was seen at, kept next to the label seen there. A
+ *  dimension can carry several labels at once (a body with both a raw driver
+ *  call and a fetch), and the recorded label is the one the FIRST query
+ *  reported, so a sharper site may only replace it when that later query
+ *  reported the SAME label. Otherwise the anchor would name a construct that
+ *  never carried the flagged pattern, and an edit to that construct would clear
+ *  a finding whose flagged code is untouched. */
+interface ConflictSite {
+  site: AnchorSite;
+  yourPattern: string;
 }
 
 /** Throws only if validateChangeAgainstBaseline throws; callers wrap. */
@@ -37,14 +68,29 @@ export function detectDrift(
   relFile: string,
   content: string,
 ): Detected {
-  const queries: string[] = [content];
+  const queries: Query[] = [
+    {
+      body: content,
+      site: { kind: "file", tokenHash: anchorTokenHash(content), tokens: anchorTokens(content) },
+    },
+  ];
   try {
     const language = detectLanguage(relFile);
     if (language) {
       const fns = extractAllFunctions([
         { path: relFile, relativePath: relFile, language, content, lineCount: content.split("\n").length },
       ]);
-      for (const fn of fns.slice(0, MAX_FUNCTIONS)) queries.push(fn.rawBody);
+      for (const fn of fns.slice(0, MAX_FUNCTIONS)) {
+        queries.push({
+          body: fn.rawBody,
+          site: {
+            kind: "function",
+            symbol: fn.name,
+            tokenHash: anchorTokenHash(fn.rawBody),
+            tokens: anchorTokens(fn.rawBody),
+          },
+        });
+      }
     }
   } catch {
     // extraction is an accuracy booster, never a requirement
@@ -52,16 +98,29 @@ export function detectDrift(
 
   const conflicts = new Map<string, DetectedConflict>();
   const dups = new Map<string, DetectedDup>();
+  const seenConflicts = new Map<string, ConflictSite>();
+  const dupSites = new Map<string, AnchorSite>();
   for (const q of queries) {
-    const result = validateChangeAgainstBaseline(baseline, relFile, q);
+    const result = validateChangeAgainstBaseline(baseline, relFile, q.body);
     for (const c of result.conflicts) {
-      if (!conflicts.has(c.dimension)) conflicts.set(c.dimension, c);
+      const prev = seenConflicts.get(c.dimension);
+      if (!prev) {
+        conflicts.set(c.dimension, c);
+        seenConflicts.set(c.dimension, { site: q.site, yourPattern: c.yourPattern });
+        continue;
+      }
+      if (prev.yourPattern === c.yourPattern && prev.site.kind === "file" && q.site.kind === "function") {
+        seenConflicts.set(c.dimension, { site: q.site, yourPattern: c.yourPattern });
+      }
     }
     for (const d of result.duplicateOf) {
       const key = `${d.relativePath}:${d.line}`;
       const prev = dups.get(key);
       if (!prev || d.similarity > prev.similarity) dups.set(key, d);
+      keepSharper(dupSites, key, q.site);
     }
   }
-  return { conflicts, dups };
+  const conflictSites = new Map<string, AnchorSite>();
+  for (const [dimension, seen] of seenConflicts) conflictSites.set(dimension, seen.site);
+  return { conflicts, dups, conflictSites, dupSites };
 }

--- a/src/session/finding-anchor.ts
+++ b/src/session/finding-anchor.ts
@@ -1,0 +1,180 @@
+/**
+ * Finding anchors: the construct a session finding was actually raised against.
+ *
+ * The flag path judges the EDIT (the hunk the agent just wrote); the re-check
+ * judges the whole file as it now sits on disk. That asymmetry is deliberate —
+ * a finding must not resolve because of a function the edit never touched — but
+ * it means the re-check has to re-find the flagged construct rather than ask
+ * "does this file still smell?". The classifiers answer the second question and
+ * go quiet in four ways that have nothing to do with the code being fixed: a
+ * capped number of per-function queries, a majority vote over the whole body, a
+ * "mixed" verdict that maps to no pattern at all, and a similarity query that
+ * falls under the duplicate threshold because the surrounding file grew.
+ *
+ * So each finding carries an anchor: what kind of construct was flagged, its
+ * name, a hash of its normalized tokens, a bounded prefix of those tokens, and
+ * the pattern label that was observed. The re-check resolves only on the
+ * POSITIVE ABSENCE of that construct, never on a classifier's silence.
+ *
+ * The token prefix exists because the name and the hash both go missing for a
+ * construct that was merely WRAPPED: only top-level `function`/`const` forms
+ * are indexed, so moving a flagged function into a class or an object literal
+ * drops it out of the index while its code is byte-identical on disk. The
+ * prefix lets the re-check ask the one question that survives wrapping — is
+ * this exact token sequence still somewhere in the file?
+ *
+ * Anchors are local: they live in the per-session outcome sidecar next to the
+ * ledger and are never part of a session event (see upload-schema.ts, which
+ * builds the wire shape from an allow-list that has no anchor field), so the
+ * token prefix costs nothing on the wire and nothing new leaves the machine.
+ */
+
+import { createHash } from "node:crypto";
+import { extractAllFunctions, tokenizeBody } from "../codedna/function-extractor.js";
+import { detectLanguage } from "../core/language.js";
+import { validateChangeAgainstBaseline } from "../tools-core/index.js";
+import { asyncStyleFromName, hasAsyncStyle } from "../drift/async-style.js";
+import { hasDataAccessPattern } from "../drift/architectural-contradiction.js";
+import { hasReturnShape } from "../drift/return-shape-consistency.js";
+import type { RepoDriftBaseline } from "../core/baseline.js";
+
+/** Where a signal was seen. A function site is sharper than a file site: it can
+ *  be re-found by name, by token hash, or by token-sequence containment after
+ *  the file around it changes. */
+export interface AnchorSite {
+  kind: "file" | "function";
+  symbol?: string;
+  tokenHash: string;
+  /** the construct's normalized tokens, capped at ANCHOR_MAX_TOKENS. Optional
+   *  because the sidecar is parsed without field validation, so a truncated or
+   *  hand-edited one can arrive without it. */
+  tokens?: string[];
+}
+
+export interface FindingAnchor extends AnchorSite {
+  /** the pattern label that was observed (e.g. ".then() chains"), or, for a
+   *  duplicate, the location it matched. A bounded detector vocabulary. */
+  observed: string;
+}
+
+function hashTokens(tokens: string[]): string {
+  return createHash("sha256").update(tokens.join(" ")).digest("hex").slice(0, 16);
+}
+
+/** Identity of a construct by its NORMALIZED tokens, so a reformat, a comment
+ *  edit, or a rename of the function itself does not lose the anchor. */
+export function anchorTokenHash(body: string): string {
+  return hashTokens(tokenizeBody(body));
+}
+
+/**
+ * How many normalized tokens of the flagged construct the anchor keeps. This
+ * codebase runs 4 to 12 tokens per line of code, so 400 covers a 30-to-100-line
+ * function whole and caps a longer one at its first 400 tokens, which is about
+ * 2.5KB of JSON per anchor in the sidecar. Truncating to a PREFIX is safe in
+ * one direction only, and it is the safe one: a prefix is contained whenever
+ * the whole sequence is, so a truncated anchor can keep a finding open that a
+ * full one would have kept open too, and can never clear one.
+ */
+export const ANCHOR_MAX_TOKENS = 400;
+
+/** The construct's normalized tokens, bounded for storage. */
+export function anchorTokens(body: string): string[] {
+  return tokenizeBody(body).slice(0, ANCHOR_MAX_TOKENS);
+}
+
+/**
+ * Is this exact normalized token sequence still somewhere in `content`?
+ *
+ * Answers the one question that survives wrapping: the construct's name and its
+ * whole-body hash both change when it is moved into a class or an object
+ * literal, but its token sequence does not. Comparison is on joined tokens with
+ * space delimiters on both ends, so a match can only start and end on a token
+ * boundary (the tokenizer never emits a token containing a space).
+ *
+ * An empty or absent sequence answers false: no evidence is not evidence of
+ * presence, and the caller falls back to its pattern check.
+ */
+export function tokensContainedIn(tokens: string[] | undefined, content: string): boolean {
+  if (!tokens || tokens.length === 0) return false;
+  const haystack = ` ${tokenizeBody(content).join(" ")} `;
+  return haystack.includes(` ${tokens.join(" ")} `);
+}
+
+export interface FileConstructs {
+  /** token hash of every function in the file — uncapped, computed once. */
+  hashes: Set<string>;
+  /** function name to its raw body (first declaration wins). */
+  bodies: Map<string, string>;
+}
+
+/**
+ * Index every function in the file's current content, once per re-check. Null
+ * when the content cannot be read as source at all (unknown language), because
+ * then absence cannot be established and nothing may resolve.
+ */
+export function fileConstructs(relFile: string, content: string): FileConstructs | null {
+  const language = detectLanguage(relFile);
+  if (!language) return null;
+  const fns = extractAllFunctions([
+    {
+      path: relFile,
+      relativePath: relFile,
+      language,
+      content,
+      lineCount: content.split("\n").length,
+    },
+  ]);
+  const hashes = new Set<string>();
+  const bodies = new Map<string, string>();
+  for (const fn of fns) {
+    hashes.add(hashTokens(fn.bodyTokens));
+    if (!bodies.has(fn.name)) bodies.set(fn.name, fn.rawBody);
+  }
+  return { hashes, bodies };
+}
+
+/**
+ * Is the anchored signal still present in this body? Presence, not dominance:
+ * a body that half-converted, or that is outnumbered by its neighbours, still
+ * CONTAINS what was flagged. Unknown categories and labels answer "present", so
+ * an unrecognized finding stays open instead of clearing on a guess.
+ */
+export function signalPresent(
+  category: string,
+  anchor: FindingAnchor,
+  body: string,
+  relFile: string,
+  baseline: RepoDriftBaseline,
+): boolean {
+  switch (category) {
+    case "async_patterns": {
+      const style = asyncStyleFromName(anchor.observed);
+      return style === null ? true : hasAsyncStyle(body, style);
+    }
+    case "architectural_consistency": {
+      const present = hasDataAccessPattern(body, relFile, anchor.observed);
+      return present === null ? true : present;
+    }
+    case "return_shape_consistency": {
+      const present = hasReturnShape(body, anchor.observed);
+      return present === null ? true : present;
+    }
+    case "redundancy": {
+      // One similarity call over the index the flag path already used, not a
+      // rescan of the file. A file anchor has no single body to re-query, so it
+      // stays open.
+      //
+      // `body` is the anchored function's own body when that function is still
+      // indexed; when it is not, the caller passes the whole file, and a
+      // whole-file query DILUTES a small clone below the duplicate threshold.
+      // That is why the caller checks token containment before it gets here:
+      // this query is trusted to say "gone" only for a construct whose token
+      // sequence is already known to be absent from the file.
+      if (anchor.kind !== "function") return true;
+      return validateChangeAgainstBaseline(baseline, relFile, body).duplicateOf.length > 0;
+    }
+    default:
+      return true;
+  }
+}

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -130,9 +130,14 @@ async function main(): Promise<number> {
         body,
       });
 
-      // Finding-scoped resolution: re-run the detection over the file's CURRENT
-      // full content (read from disk — the post-edit state), not the edit hunk,
-      // so a finding resolves only when its own signal is genuinely gone.
+      // Finding-scoped resolution: measure each open finding against its own
+      // anchored construct in the file's whole current content rather than the
+      // edit hunk, so a finding resolves only when the construct it was raised
+      // against is gone or has stopped carrying the flagged pattern. Normally
+      // that content is read from disk (the post-edit state); when the read
+      // fails we fall back to the edit body, which is the whole file for a
+      // Write but only the hunk for an Edit, so on that fallback the re-check
+      // is best-effort and sees less than the file.
       if (res.baseline) {
         let currentContent = body;
         try {
@@ -164,7 +169,13 @@ async function main(): Promise<number> {
         }
         await appendEvent(sessionsDir, projectHash, event.sid, flag);
         if (flag.findingId && flag.detail.file && flag.detail.category) {
-          outcomes.open.push({ findingId: flag.findingId, file: flag.detail.file, category: flag.detail.category });
+          // The anchor rides in the local sidecar only, never in the event.
+          outcomes.open.push({
+            findingId: flag.findingId,
+            file: flag.detail.file,
+            category: flag.detail.category,
+            anchor: res.anchors[flag.findingId],
+          });
         }
       }
       if (!fyi && !suppressFyi) fyi = res.fyi;

--- a/src/session/outcomes.ts
+++ b/src/session/outcomes.ts
@@ -1,18 +1,56 @@
 /**
- * Finding-scoped outcomes (Phase 4): a finding resolves only when the SAME
- * finding re-runs over its actual inputs and passes — never because some
- * unrelated file was edited. Re-check is triggered by an edit to the finding's
- * own file: the new body is re-validated, and an open convention/redundancy
- * finding whose signal no longer fires is resolved. Scope findings are
+ * Finding-scoped outcomes (Phase 4): a finding resolves only when the construct
+ * it was actually raised against is gone from the file — never because some
+ * unrelated file was edited, and never because a classifier went quiet. The
+ * re-check is triggered by an edit to the finding's own file: every function in
+ * the file's current content is indexed once, and each open finding is measured
+ * against its own anchor (see finding-anchor.ts). Scope findings are
  * experimental and not auto-resolved here. Revert detection is byte-exact and
  * best-effort (a formatter changes bytes, so it never false-positives) and
  * stays out of the resolution rate.
+ *
+ * Known limits, stated plainly so nobody reads the resolved count as complete:
+ *  - A RESOLVE IS ABOUT ONE CONSTRUCT, NOT THE FILE. The hook keeps at most one
+ *    open finding per (file, category): a second flag of the same category on
+ *    the same file is deduped away and never becomes an open finding (see
+ *    hook-entry.ts). So a file can hold several constructs carrying the same
+ *    flagged pattern while only the first is anchored, and resolving that one
+ *    fires a resolve event for the file+category while the unflagged siblings
+ *    still carry the identical pattern. Read a resolve as "the construct that
+ *    was flagged is gone", never as "this file is clean".
+ *  - a RENAMED file is never re-checked; the re-check matches on the exact path
+ *    the finding was raised on, so the finding stays open under the old name.
+ *  - a fix applied by something the hook does not observe (a shell rewrite, a
+ *    formatter, an editor outside the agent) never triggers a re-check at all,
+ *    so the self-corrected count is structurally an undercount.
+ *  - a function that is renamed AND rewritten in one step is indistinguishable
+ *    from a deleted one by name, and its token sequence no longer matches, so
+ *    all that holds its finding open is the file-wide presence check; it
+ *    resolves once the flagged pattern is nowhere in the file, and if the
+ *    rewrite kept the pattern the same edit raises it again.
+ *  - the containment test errs toward keeping findings open: a short, generic
+ *    token sequence that happens to recur elsewhere in the file holds its
+ *    finding open even after the flagged construct was fixed. That is the
+ *    intended direction (a stale open finding costs a re-flag; a false resolve
+ *    costs the user's trust), but it means "still open" is weaker evidence than
+ *    "resolved".
+ *  - an anchor with no stored token sequence (the sidecar is parsed without
+ *    field validation, so a truncated or hand-edited one can lack it) has
+ *    nothing to test containment against, and its missing-symbol case falls
+ *    back to the file-wide presence check alone.
+ *  - scope findings never auto-resolve.
  */
 
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { detectDrift } from "./detect.js";
+import {
+  fileConstructs,
+  signalPresent,
+  tokensContainedIn,
+  ANCHOR_MAX_TOKENS,
+  type FindingAnchor,
+} from "./finding-anchor.js";
 import { safeSegment } from "./ledger.js";
 import type { RepoDriftBaseline } from "../core/baseline.js";
 
@@ -20,6 +58,11 @@ export interface OpenFinding {
   findingId: string;
   file: string;
   category: string;
+  /** the construct this finding was raised against. Absent on findings carried
+   *  over from a session that predates anchoring; those never auto-resolve,
+   *  because absence cannot be established for a construct that was never
+   *  identified. */
+  anchor?: FindingAnchor;
 }
 
 export interface OutcomeState {
@@ -34,13 +77,26 @@ export function emptyOutcomeState(): OutcomeState {
   return { open: [], hashes: {} };
 }
 
-/** Re-run the drift detection over the file's CURRENT full content (not the
- *  edit hunk) using the SAME multi-query decomposition the flag path uses, and
- *  return the open findings on that file whose signal is genuinely gone. Using
- *  the same detection avoids the dilution trap where a whole-body query misses
- *  a per-function duplicate; using the full file (not the hunk) avoids resolving
- *  a finding on a function the current edit did not even touch. Fail-open: on
- *  any error nothing resolves (a finding stays open rather than falsely clears). */
+/**
+ * Return the open findings on this file whose anchored construct is positively
+ * gone from the file's CURRENT full content (not the edit hunk, so a finding on
+ * a function the edit never touched cannot resolve).
+ *
+ * A finding resolves in exactly two ways: the construct it was raised against
+ * is still in the file but no longer carries the pattern that was flagged, or
+ * that construct is gone — its token sequence is nowhere in the file — AND the
+ * pattern is absent from the whole file. A vanished NAME is never enough on its
+ * own, because only top-level `function`/`const` forms are indexed and a move
+ * into a class or an object literal would otherwise clear a finding whose code
+ * is untouched. It never resolves because a classifier declined to answer: the
+ * file's functions are indexed uncapped here, so a construct past the flag
+ * path's query cap is still found, and presence is asked per construct, so a
+ * majority elsewhere in the file cannot outvote it.
+ *
+ * Fail-open throughout: an unreadable file, an unknown language, an unanchored
+ * finding, or any thrown error leaves findings OPEN rather than falsely
+ * clearing them.
+ */
 export function recheckFile(
   baseline: RepoDriftBaseline,
   relFile: string,
@@ -50,19 +106,65 @@ export function recheckFile(
   const here = open.filter((f) => f.file === relFile && f.category !== "scope");
   if (here.length === 0) return { resolved: [] };
 
-  let conflictDims: Set<string>;
-  let hasDup: boolean;
+  // Indexed ONCE for the whole re-check: per-finding extraction would be
+  // functions x findings work on a path with a hard time budget.
+  let constructs: ReturnType<typeof fileConstructs>;
   try {
-    const d = detectDrift(baseline, relFile, content);
-    conflictDims = new Set(d.conflicts.keys());
-    hasDup = d.dups.size > 0;
+    constructs = fileConstructs(relFile, content);
   } catch {
     return { resolved: [] };
   }
+  if (!constructs) return { resolved: [] };
 
-  const resolved = here.filter((f) =>
-    f.category === "redundancy" ? !hasDup : !conflictDims.has(f.category),
-  );
+  const resolved: OpenFinding[] = [];
+  for (const f of here) {
+    const anchor = f.anchor;
+    if (!anchor) continue;
+    try {
+      // Byte-for-byte (modulo formatting and comments) still in the file.
+      if (constructs.hashes.has(anchor.tokenHash)) continue;
+
+      if (anchor.kind === "function" && anchor.symbol) {
+        const body = constructs.bodies.get(anchor.symbol);
+        if (body === undefined) {
+          // A missing symbol is NOT proof the code is gone. Only top-level
+          // `function`/`const` forms are indexed, so moving the flagged
+          // function into a class or an object literal drops the name from the
+          // index while the flagged code sits byte-identical on disk.
+          //
+          // First ask the question that survives wrapping: is the construct's
+          // own token sequence still somewhere in this file? If it is, the code
+          // moved rather than went away, and the finding stays open no matter
+          // what any pattern predicate says. This matters most for redundancy,
+          // whose predicate is a similarity query: wrapping the clone in a
+          // class adds tokens that pull the score under the duplicate
+          // threshold, so the query goes quiet on code that never changed.
+          // Only a COMPLETE sequence is evidence the construct is unchanged. A
+          // capped one holds the first ANCHOR_MAX_TOKENS tokens, so containment
+          // proves the prefix survived, not that the flagged pattern did: in a
+          // long function the pattern often sits past the cap, and a genuine fix
+          // there would otherwise hold the finding open forever.
+          const whole = (anchor.tokens?.length ?? 0) < ANCHOR_MAX_TOKENS;
+          if (whole && tokensContainedIn(anchor.tokens, content)) continue;
+          // Not contained: the construct is genuinely not in this file in the
+          // form it was flagged in. Fall back to the presence predicate over
+          // the whole file, so a renamed-and-reshaped construct still has to
+          // have dropped the flagged pattern before anything resolves.
+          if (!signalPresent(f.category, anchor, content, relFile, baseline)) resolved.push(f);
+          continue;
+        }
+        if (!signalPresent(f.category, anchor, body, relFile, baseline)) resolved.push(f);
+        continue;
+      }
+
+      // A whole-body anchor (an edit that held no extractable function): ask the
+      // presence predicate over the whole file, which is a superset of what was
+      // flagged, so it errs toward keeping the finding open.
+      if (!signalPresent(f.category, anchor, content, relFile, baseline)) resolved.push(f);
+    } catch {
+      // this finding stays open
+    }
+  }
   return { resolved };
 }
 

--- a/test/fixtures/classifier-bodies.txt
+++ b/test/fixtures/classifier-bodies.txt
@@ -1,0 +1,393 @@
+# Characterization corpus for the three shared single-body classifiers
+# (async style, data access, return shape). Each block is delimited by a
+# "=== <name> <origin> ===" line. A block tagged with a source path was taken
+# from that file; a block tagged `synthetic` is hand-written, either for
+# vocabulary the sources above do not exercise (ORM, raw SQL, repository, tuple
+# returns) or to sit on a threshold or priority tie-break the real code never
+# comes near.
+#
+# The source-path tag records where a body came from, not a standing guarantee
+# that it still matches: nine of the ten still appear verbatim in their file,
+# and the classifyShape slice predates the stripComments extraction, so it no
+# longer does. Nothing re-reads these paths at test time; a body is a frozen
+# input either way.
+#
+# The classifiers feed the composite score, so their output over this corpus is
+# frozen in classifier-golden.test.ts and must stay byte-identical.
+=== maskSecrets src/session/mask.ts ===
+export function maskSecrets(text: string): string {
+  let out = text;
+  for (const re of BLOCK_RULES) {
+    out = out.replace(re, "[masked]");
+  }
+  // Mask only the password in a connection-string userinfo, preserving scheme+user.
+  out = out.replace(URL_CRED_RULE, (_m, prefix: string) => `${prefix}[masked]@`);
+  out = out.replace(KEYED_RULE, (_m, key: string, sep: string) => `${key}${sep}[masked]`);
+  return out;
+}
+=== deepAnalyze src/mcp/deep-client.ts ===
+export async function deepAnalyze(
+  functions: MlFunctionPayload[],
+  language: string,
+  queryId?: string,
+): Promise<DeepResult> {
+  const empty = { intentMismatches: [], duplicates: [] };
+
+  const tok = await resolveToken();
+  if (!tok?.token) return { degraded: true, reason: "no_token", ...empty };
+
+  const apiUrl = await resolveApiUrl();
+  const request: MlAnalyzeRequest = {
+    language,
+    file_count: new Set(functions.map((f) => f.file)).size,
+    functions,
+    deviations: [],
+    llm_validations: [],
+    defer_persist: false, // MCP deep checks persist + count for billing
+    source: "mcp", // 1/50-unit billing + Haiku validation server-side
+  };
+
+  try {
+    const resp = await callMlApi(request, tok.token, apiUrl);
+    // When candidates are fed alongside the query (queryId set), the server
+    // returns query-vs-candidate AND candidate-vs-candidate pairs intermixed.
+    // Keep only the ones that involve the query — the function the agent is
+    // actually judging — and drop the candidate-vs-candidate noise.
+    const dupes = (resp.duplicates ?? []).filter(
+      (d) => !queryId || d.function_a === queryId || d.function_b === queryId,
+    );
+    const intents = (resp.intent_mismatches ?? []).filter(
+      (m) => !queryId || m.function_id === queryId,
+    );
+    return {
+      degraded: false,
+      intentMismatches: intents.map((m) => ({
+        kind: "intent" as const,
+        detail: m.name,
+        confidence: m.confidence,
+        verdict: m.llm_verdict,
+      })),
+      duplicates: dupes.map((d) => {
+        const other = d.function_a === queryId ? d.function_b : d.function_a;
+        return {
+          kind: "duplicate" as const,
+          detail: queryId ? `${queryId} ≈ ${other}` : `${d.function_a} ≈ ${d.function_b}`,
+          confidence: d.confidence,
+          verdict: d.llm_verdict ?? d.verdict,
+        };
+      }),
+    };
+  } catch (e) {
+    return { degraded: true, reason: classifyDegradeReason(e), ...empty };
+  }
+}
+=== runUploaderOnce src/session/uploader.ts ===
+export async function runUploaderOnce(opts: FlushOptions): Promise<FlushResult> {
+  const batchSize = opts.batchSize && opts.batchSize > 0 ? opts.batchSize : DEFAULT_BATCH;
+  const maxBuffer = opts.maxBuffer && opts.maxBuffer > 0 ? opts.maxBuffer : DEFAULT_MAX_BUFFER;
+  const budgetMs = opts.budgetMs ?? 30_000;
+  const now = opts.now ?? (() => Date.now());
+  const start = now();
+
+  const store = new UploadStateStore(opts.sessionsDir, opts.projectHash);
+  await store.load();
+  const follower = new UploadFollower(opts.sessionsDir, opts.projectHash, store);
+
+  let pending: TaggedUpload[] = [];
+  let locked = false;
+  while (!opts.signal?.aborted && now() - start < budgetMs) {
+    const budget = maxBuffer - pending.length;
+    let batch: Awaited<ReturnType<UploadFollower["poll"]>> = [];
+    if (budget > 0) {
+      try {
+        batch = await follower.poll(budget);
+      } catch {
+        batch = [];
+      }
+    }
+    for (const t of batch) {
+      const u = toUploadEvent(t.event, { teamIntentOptIn: opts.teamIntentOptIn });
+      if (u) pending.push({ event: u, file: t.file, endOffset: t.endOffset });
+    }
+    // Nothing queued and nothing new arrived -> the ledger is fully drained.
+    if (pending.length === 0) {
+      if (batch.length === 0) break;
+      continue; // events all filtered out (non-uploadable); poll for more
+    }
+    const before = pending.length;
+    const out = await drain(pending, batchSize, opts.post, store);
+    pending = out.pending;
+    if (out.locked) locked = true;
+    // Hold, or no forward progress with nothing new to read -> give up this run.
+    if (out.backOff) break;
+    if (pending.length >= before && batch.length === 0) break;
+  }
+  return { locked };
+}
+=== detectRevert src/session/outcomes.ts ===
+export function detectRevert(
+  relFile: string,
+  body: string,
+  hashes: Record<string, string[]>,
+): { reverted: boolean } {
+  const h = createHash("sha256").update(body).digest("hex").slice(0, 16);
+  const seen = hashes[relFile] ?? [];
+  const reverted = seen.includes(h);
+  const next = [...seen, h].slice(-MAX_HASHES_PER_FILE);
+  hashes[relFile] = next;
+  return { reverted };
+}
+=== readOutcomeState src/session/outcomes.ts ===
+export async function readOutcomeState(
+  sessionsDir: string,
+  projectHash: string,
+  sessionId: string,
+): Promise<OutcomeState> {
+  try {
+    const raw = await readFile(statePath(sessionsDir, projectHash, sessionId), "utf8");
+    const parsed = JSON.parse(raw) as Partial<OutcomeState>;
+    return {
+      open: Array.isArray(parsed.open) ? parsed.open : [],
+      hashes: parsed.hashes && typeof parsed.hashes === "object" ? parsed.hashes : {},
+    };
+  } catch {
+    return emptyOutcomeState();
+  }
+}
+=== validateChange src/tools-core/tools/validate-change.ts ===
+export function validateChange(
+  baseline: RepoDriftBaseline,
+  relTarget: string,
+  body: string,
+): ValidateChangeResult {
+  const conflicts: Conflict[] = [];
+
+  // For each dimension we can classify a single body in: find the dominant
+  // (detector vote, else declared rule), classify the proposed body with the
+  // SAME classifier the detector uses, and flag a conflict when they differ.
+  // The classifier returns the dimension's DISPLAY label, matching what the
+  // vote stores, so the comparison is apples-to-apples.
+  for (const check of DIM_CHECKS) {
+    const dom = effectiveDominant(baseline, check);
+    if (!dom) continue;
+    const mine = check.classify(body, relTarget);
+    if (!mine || mine === dom.display) continue;
+    const where =
+      dom.source === "declared" ? ` (declared in ${dom.cite})` : dom.refFiles[0] ? ` See ${dom.refFiles[0]}.` : "";
+    conflicts.push({
+      dimension: check.dimension,
+      dominantPattern: dom.display,
+      yourPattern: mine,
+      fixHint: `Repo uses ${dom.display}; this change uses ${mine}.${where}`,
+    });
+  }
+
+  const index = baseline.minhashIndex.filter((e) => e.relativePath !== relTarget);
+  const duplicateOf = findSimilarToBody(body, index, { threshold: DUPLICATE_THRESHOLD, cap: MAX_MATCHES });
+
+  const referenceFiles = conflicts.length
+    ? (baseline.perCategoryVote[conflicts[0].dimension]?.dominantFiles ?? []).slice(0, 3)
+    : [];
+
+  // Low confidence when the dimension we judged is itself only weakly dominant
+  // (near the 70% bar) — a frozen-baseline vote can't see the proposed change
+  // tipping the balance. A declared-rule fallback (no vote) is binding, so it
+  // stays high. Honest hedge per the deferred delta-vote.
+  const judgedVote = conflicts.length
+    ? baseline.perCategoryVote[conflicts[0].dimension]
+    : baseline.perCategoryVote.async_patterns;
+  const confidence: "high" | "low" = judgedVote && judgedVote.consistencyScore < THIN_MARGIN ? "low" : "high";
+
+  return {
+    ok: conflicts.length === 0 && duplicateOf.length === 0,
+    conflicts,
+    duplicateOf,
+    referenceFiles,
+    confidence,
+  };
+}
+=== classifyShape src/drift/return-shape-consistency.ts ===
+function classifyShape(body: string): ReturnShape | null {
+  // Strip line comments so "// throw new Error" doesn't trigger.
+  const stripped = body
+    .replace(/\/\/.*$/gm, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*#.*$/gm, "");
+
+  const counts: Record<ReturnShape, number> = {
+    throws: 0,
+    result_type: countMatches(SHAPE_COUNT_PATTERNS.result_type, stripped),
+    tuple: countMatches(SHAPE_COUNT_PATTERNS.tuple, stripped),
+    result_object: countMatches(SHAPE_COUNT_PATTERNS.result_object, stripped),
+    null_sentinel: countMatches(SHAPE_COUNT_PATTERNS.null_sentinel, stripped),
+  };
+
+  const strongThrows = countMatches(STRONG_THROW, stripped);
+  const bareThrows = countMatches(ANY_THROW, stripped) - countMatches(THROW_NEW, stripped);
+  const hasOtherShape =
+    counts.result_type + counts.tuple + counts.result_object + counts.null_sentinel > 0;
+  counts.throws = strongThrows + (hasOtherShape ? 0 : bareThrows);
+
+  let best: ReturnShape | null = null;
+  let bestCount = 0;
+  for (const shape of SHAPE_PRIORITY) {
+    if (counts[shape] > bestCount) {
+      best = shape;
+      bestCount = counts[shape];
+=== classifyAsyncStyle src/drift/async-style.ts ===
+export function classifyAsyncStyle(content: string): AsyncStyle | null {
+  const { awaitCount, thenCount } = asyncCounts(content);
+  const total = awaitCount + thenCount;
+  if (total < 2) return null;
+  const awaitRatio = awaitCount / total;
+  if (awaitRatio > 0.7) return "async_await";
+  if (awaitRatio < 0.3) return "then_chains";
+  return "mixed";
+}
+=== extractFunctionBodies src/drift/return-shape-consistency.ts ===
+ * throw / return null / etc.". Same trick as analyzers/complexity.ts.
+ */
+function extractFunctionBodies(file: DriftFile): FunctionExtraction[] {
+  const content = file.content;
+
+  // One pattern per language — we don't need to know which matched, just
+  // where functions start and what they're called.
+  const functionPattern =
+    /(?:(?:async\s+)?function\s+(\w+)|(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_]\w*)\s*=>|def\s+(\w+)|func\s+(?:\([^)]*\)\s+)?(\w+)|(?:pub\s+)?(?:async\s+)?fn\s+(\w+))/g;
+
+  const starts: { name: string; index: number; line: number }[] = [];
+  let match;
+  while ((match = functionPattern.exec(content)) !== null) {
+    const name = match[1] || match[2] || match[3] || match[4] || match[5];
+    if (!name) continue;
+    const line = getLineNumber(content, match.index);
+    starts.push({ name, index: match.index, line });
+  }
+
+  const out: FunctionExtraction[] = [];
+  for (let i = 0; i < starts.length; i++) {
+    const start = starts[i];
+    const end = i + 1 < starts.length ? starts[i + 1].index : content.length;
+    out.push({
+      file: file.relativePath,
+      name: start.name,
+      line: start.line,
+      bodySlice: content.slice(start.index, end),
+    });
+  }
+  return out;
+}
+=== classifyDataAccessLabel src/drift/architectural-contradiction.ts ===
+export function classifyDataAccessLabel(content: string, path: string): string | null {
+  const hits = detectDataAccess({ content, relativePath: path, language: "typescript" } as DriftFile);
+  if (hits.length === 0) return null;
+  const primary = hits
+    .slice()
+    .sort((a, b) => b.evidence.length - a.evidence.length || DATA_ACCESS_PRIORITY.indexOf(a.pattern) - DATA_ACCESS_PRIORITY.indexOf(b.pattern))[0];
+  return DATA_ACCESS_NAMES[primary.pattern];
+}
+=== loadUserRowsRawSql synthetic ===
+export async function loadUserRows(id: string) {
+  const rows = await db.query("SELECT * FROM users WHERE id = $1", [id]);
+  const count = await db.query("SELECT count(*) FROM sessions WHERE user_id = $1", [id]);
+  return { rows, count };
+}
+=== listActiveUsersOrm synthetic ===
+export async function listActiveUsers(team: string) {
+  const users = await prisma.user.findMany({ where: { team, active: true } });
+  const seats = await prisma.seat.findAll({ where: { team } });
+  return users.map((u) => ({ ...u, seats: seats.length }));
+}
+=== saveOrderViaRepository synthetic ===
+export async function saveOrder(order: Order) {
+  const existing = await orderRepo.findById(order.id);
+  if (existing) {
+    return store.update(order);
+  }
+  return repository.insert(order);
+}
+=== fetchInvoiceThenChain synthetic ===
+export function fetchInvoice(id: string) {
+  return fetch("/api/invoice/" + id)
+    .then((res) => res.json())
+    .then((data) => data.invoice);
+}
+=== readSettingsNullSentinel synthetic ===
+export function readSettings(raw: string) {
+  if (!raw) return null;
+  const parsed = JSON.parse(raw);
+  if (!parsed.theme) return undefined;
+  return parsed;
+}
+=== parseAmountTuple synthetic ===
+func parseAmount(raw string) (int64, error) {
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+=== createSessionResultObject synthetic ===
+export function createSession(user: string) {
+  if (!user) {
+    return { error: "missing user", session: null };
+  }
+  const session = { user, id: newId() };
+  return { error: null, session };
+}
+=== assertPositiveThrows synthetic ===
+export function assertPositive(n: number): number {
+  if (Number.isNaN(n)) {
+    throw new TypeError("not a number");
+  }
+  if (n <= 0) throw new RangeError("must be positive");
+  return n;
+}
+=== retryMostlyAwait synthetic ===
+export async function retryWithBackoff(fn: () => Promise<Row[]>) {
+  const first = await fn();
+  const second = await fn();
+  const third = await fn();
+  const fourth = await fn();
+  return fn().then((rows) => [...first, ...second, ...third, ...fourth, ...rows]);
+}
+=== syncQueueMostlyThen synthetic ===
+export function syncQueue(client: QueueClient) {
+  return client
+    .drain()
+    .then((jobs) => jobs.filter(Boolean))
+    .then((jobs) => jobs.map(normalize))
+    .then((jobs) => jobs.slice(0, 50))
+    .then(async (jobs) => await persist(jobs));
+}
+=== hydrateEvenSplit synthetic ===
+export async function hydrateRows(id: string) {
+  const rows = await readRows(id);
+  return enrich(rows).then((out) => out.slice(0, 10));
+}
+=== decodeTokenShapeTie synthetic ===
+export function decodeToken(raw: string) {
+  const [value, err] = parse(raw);
+  if (err) {
+    return { error: err, value: null };
+  }
+  return [value, err];
+}
+=== readCursorShapeTie synthetic ===
+export function readCursor(raw: string) {
+  if (!raw) return null;
+  const parsed = decode(raw);
+  if (!parsed.ok) {
+    return { error: "bad cursor", cursor: null };
+  }
+  return parsed.cursor;
+}
+=== loadProfileAccessTie synthetic ===
+export async function loadProfile(userId: string) {
+  const cached = await repo.get(userId);
+  if (cached) return cached;
+  const res = await fetch("/api/profiles/" + userId);
+  const extra = await fetch("/api/profiles/" + userId + "/extra");
+  await repo.put(userId, res);
+  return { ...res, extra };
+}

--- a/test/unit/drift/classifier-golden.test.ts
+++ b/test/unit/drift/classifier-golden.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Characterization golden for the three shared single-body classifiers.
+ *
+ * These classifiers are not session-only helpers: they feed the drift detectors
+ * and therefore the composite score every user sees. Any refactor that pulls a
+ * shared helper out of them must leave their output over this corpus
+ * byte-identical. The corpus lives in test/fixtures/classifier-bodies.txt and
+ * mixes slices of this repo's own code with realistic bodies for vocabulary the
+ * repo itself never uses (ORM, raw SQL, tuple returns) and with boundary bodies
+ * that sit ON the thresholds and priority tie-breaks the real code never comes
+ * near.
+ *
+ * What this file catches is bounded by that corpus: it holds a rule only when
+ * some body straddles it. The boundary bodies are what make moving an async
+ * cutoff or reordering a priority list fail here — without them a classifier can
+ * be rewritten around this test.
+ *
+ * A value below that looks wrong is still the CONTRACT: this file records what
+ * the classifiers do today, not what they should ideally do. Changing one means
+ * changing the score, so it is a deliberate act, never a refactor side effect.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { classifyAsyncStyle } from "@/drift/async-style";
+import { classifyDataAccessLabel } from "@/drift/architectural-contradiction";
+import { classifyReturnShapeLabel } from "@/drift/return-shape-consistency";
+
+const CORPUS = readFileSync(new URL("../../fixtures/classifier-bodies.txt", import.meta.url), "utf8");
+
+/** The same file path for every body, so a path-sensitive rule (isRepoFile)
+ *  cannot vary between cases. */
+const PATH = "src/app/service.ts";
+
+function loadBodies(): Map<string, string> {
+  const parts = CORPUS.split(/^=== (.+) ===$/m);
+  const out = new Map<string, string>();
+  for (let i = 1; i < parts.length; i += 2) {
+    out.set(parts[i].trim().split(" ")[0], parts[i + 1].replace(/^\n/, "").replace(/\n$/, ""));
+  }
+  return out;
+}
+
+// name, classifyAsyncStyle, classifyDataAccessLabel, classifyReturnShapeLabel
+const GOLDEN: [string, string | null, string | null, string | null][] = [
+  ["maskSecrets", null, null, null],
+  ["deepAnalyze", "async_await", null, null],
+  ["runUploaderOnce", "async_await", "repository pattern", null],
+  ["detectRevert", null, null, null],
+  ["readOutcomeState", null, null, null],
+  ["validateChange", null, null, null],
+  ["classifyShape", null, null, null],
+  ["classifyAsyncStyle", null, null, "null/undefined sentinels"],
+  ["extractFunctionBodies", null, null, "null/undefined sentinels"],
+  ["classifyDataAccessLabel", null, null, "null/undefined sentinels"],
+  ["loadUserRowsRawSql", "async_await", "direct database calls", null],
+  ["listActiveUsersOrm", "async_await", "ORM methods", null],
+  ["saveOrderViaRepository", null, "repository pattern", null],
+  ["fetchInvoiceThenChain", "then_chains", "inline HTTP client calls", null],
+  ["readSettingsNullSentinel", null, null, "null/undefined sentinels"],
+  ["parseAmountTuple", null, null, "tuple returns (value, error)"],
+  ["createSessionResultObject", null, null, "error-object returns"],
+  ["assertPositiveThrows", null, null, "throws on error"],
+  // Boundary bodies. Everything above sits at an await ratio of 0 or 1 and
+  // shows one pattern per axis, so it pins no threshold and no tie-break: both
+  // async cutoffs and both priority orders can be rewritten with the rows above
+  // still green. These six sit ON the boundaries instead — 0.8 and 0.2 straddle
+  // the 0.7/0.3 cutoffs, 0.5 lands in the mixed band, and the last three each
+  // hold two patterns at equal evidence, so only the priority order decides.
+  ["retryMostlyAwait", "async_await", null, null],
+  ["syncQueueMostlyThen", "then_chains", null, null],
+  ["hydrateEvenSplit", "mixed", null, null],
+  ["decodeTokenShapeTie", null, null, "tuple returns (value, error)"],
+  ["readCursorShapeTie", null, null, "error-object returns"],
+  ["loadProfileAccessTie", "async_await", "inline HTTP client calls", null],
+];
+
+describe("shared single-body classifiers (characterization golden)", () => {
+  const bodies = loadBodies();
+
+  it("covers every body in the corpus", () => {
+    expect([...bodies.keys()]).toEqual(GOLDEN.map(([name]) => name));
+  });
+
+  it.each(GOLDEN)("%s classifies identically", (name, async_, dataAccess, returnShape) => {
+    const body = bodies.get(name)!;
+    expect(body.length).toBeGreaterThan(0);
+    expect(classifyAsyncStyle(body)).toBe(async_);
+    expect(classifyDataAccessLabel(body, PATH)).toBe(dataAccess);
+    expect(classifyReturnShapeLabel(body)).toBe(returnShape);
+  });
+});

--- a/test/unit/session/outcome-anchors.test.ts
+++ b/test/unit/session/outcome-anchors.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Fidelity fixtures for finding-scoped resolution: every case here raises a
+ * REAL finding through runEditChecks (the flag path an agent edit takes) and
+ * then re-checks the file's full post-edit content, exactly as the hook does.
+ *
+ * Each fixture is a way the re-check used to lose sight of the flagged code
+ * while that code was still byte-identical on disk.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBaseline, type RepoDriftBaseline } from "@/core/baseline";
+import { runEditChecks } from "@/session/check";
+import { readOutcomeState, recheckFile, writeOutcomeState, type OpenFinding } from "@/session/outcomes";
+import { fileConstructs, ANCHOR_MAX_TOKENS } from "@/session/finding-anchor";
+import { classifyDataAccessLabel } from "@/drift/architectural-contradiction";
+import type { SessionEvent } from "@/session/types";
+
+const HELPER_BODY = `export function exponentialBackoff(attempt: number): number {
+  const base = 250;
+  const cap = 30_000;
+  const jitter = Math.random() * 100;
+  return Math.min(cap, base * 2 ** attempt) + jitter;
+}`;
+
+let repo: string;
+let sessionsDir: string;
+let baseline: RepoDriftBaseline;
+
+beforeAll(async () => {
+  repo = realpathSync(mkdtempSync(join(tmpdir(), "vd-anchor-repo-")));
+  sessionsDir = realpathSync(mkdtempSync(join(tmpdir(), "vd-anchor-sessions-")));
+  mkdirSync(join(repo, "src", "data"), { recursive: true });
+  mkdirSync(join(repo, "src", "lib"), { recursive: true });
+  // Declared rules make both dominants binding regardless of vote thresholds.
+  writeFileSync(
+    join(repo, "CLAUDE.md"),
+    "# Conventions\n- Async: use async/await throughout. No .then() chains.\n- Data access: go through Prisma ORM methods only.\n",
+  );
+  for (const n of ["users", "orders", "teams", "seats"]) {
+    writeFileSync(
+      join(repo, "src", "data", `${n}.ts`),
+      `export async function list_${n}(team: string) {\n  const rows = await prisma.${n}.findMany({ where: { team } });\n  const extra = await prisma.${n}.findOne({ where: { team } });\n  return [...rows, extra];\n}\n`,
+    );
+  }
+  writeFileSync(join(repo, "src", "lib", "backoff.ts"), `${HELPER_BODY}\n`);
+  baseline = await buildBaseline(repo);
+}, 60_000);
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+/** Raise findings the way the hook does, and hand back the open findings the
+ *  hook would have recorded (one per flag). */
+async function raise(
+  sessionId: string,
+  relFile: string,
+  body: string,
+): Promise<{ flags: SessionEvent[]; open: OpenFinding[] }> {
+  const out = await runEditChecks({
+    rootDir: repo,
+    projectHash: "feedfacefeedface",
+    sessionId,
+    sessionsDir,
+    file: join(repo, relFile),
+    body,
+    loadBaselineFor: async () => baseline,
+  });
+  const open = out.flags.map((f) => ({
+    findingId: f.findingId!,
+    file: f.detail.file!,
+    category: f.detail.category!,
+    anchor: out.anchors[f.findingId!],
+  }));
+  return { flags: out.flags, open };
+}
+
+const only = (open: OpenFinding[], category: string): OpenFinding[] => {
+  const hit = open.filter((f) => f.category === category);
+  expect(hit).toHaveLength(1);
+  return hit;
+};
+
+describe("fidelity: the flagged code is still there", () => {
+  it("a duplicate past the function-query cap does not clear", async () => {
+    const { open } = await raise("s-cap", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    expect(dup[0].anchor).toMatchObject({ kind: "function", symbol: "exponentialBackoff" });
+
+    // The clone is the 7th function in the file, past the 5-function cap the
+    // multi-query decomposition uses, and the whole-file query dilutes it.
+    const whole = `export function one(a: number) { return a + 1; }
+export function two(a: number) { return a + 2; }
+export function three(a: number) { return a + 3; }
+export function four(a: number) { return a + 4; }
+export function five(a: number) { return a + 5; }
+export function six(a: number) { return a + 6; }
+${HELPER_BODY}`;
+    expect(recheckFile(baseline, "src/util.ts", whole, dup).resolved).toEqual([]);
+  });
+
+  it("raw SQL in a method outvoted by the file's ORM calls does not clear", async () => {
+    const method = `  async purgeSessions(userId: string) {
+    await db.query("DELETE FROM sessions WHERE user_id = $1", [userId]);
+    await db.query("INSERT INTO audit_log (kind) VALUES ('purge')", []);
+    return true;
+  }`;
+    const { open } = await raise("s-sql", "src/data/sessions.ts", method);
+    const arch = only(open, "architectural_consistency");
+    // A class method is not an extractable function, so the anchor is the whole
+    // edited body and presence is asked over the whole file.
+    expect(arch[0].anchor).toMatchObject({ kind: "file", observed: "raw SQL queries" });
+
+    const whole = `export class SessionStore {
+  async findSession(id: string) {
+    return prisma.session.findOne({ where: { id } });
+  }
+  async listSessions(userId: string) {
+    return prisma.session.findMany({ where: { userId } });
+  }
+  async countSessions(userId: string) {
+    const all = await prisma.session.findAll({ where: { userId } });
+    return all.length;
+  }
+${method}
+}`;
+    expect(recheckFile(baseline, "src/data/sessions.ts", whole, arch).resolved).toEqual([]);
+  });
+
+  it("a half-converted body still holding a .then() chain does not clear", async () => {
+    const then = `export function loadReport(id: string) {
+  return readRows(id)
+    .then((rows) => rows.filter(Boolean))
+    .then((rows) => rows.slice(0, 20));
+}`;
+    const { open } = await raise("s-half", "src/reports.ts", then);
+    const async_ = only(open, "async_patterns");
+    expect(async_[0].anchor).toMatchObject({
+      kind: "function",
+      symbol: "loadReport",
+      observed: ".then() chains",
+    });
+
+    // Half converted: one await, one surviving .then() — the file now reads as
+    // "mixed", which the dimension check cannot classify at all.
+    const half = `export async function loadReport(id: string) {
+  const rows = await readRows(id);
+  return rows.filter(Boolean).then((r) => r.slice(0, 20));
+}`;
+    expect(recheckFile(baseline, "src/reports.ts", half, async_).resolved).toEqual([]);
+  });
+
+  it("a 4:1 whole-file majority does not clear the untouched .then() function", async () => {
+    const syncRows = `export function syncRows(id: string) {
+  return readRows(id)
+    .then((rows) => rows.map(normalize))
+    .then((rows) => rows.filter(Boolean));
+}`;
+    const { open } = await raise("s-ratio", "src/sync.ts", syncRows);
+    const async_ = only(open, "async_patterns");
+
+    // Eight awaits against two .then() lines: the file's majority reads
+    // async/await while the flagged function is untouched.
+    const whole = `export async function pullUsers(team: string) {
+  const rows = await prisma.users.findMany({ where: { team } });
+  return await hydrate(rows);
+}
+export async function pullOrders(team: string) {
+  const rows = await prisma.orders.findMany({ where: { team } });
+  return await hydrate(rows);
+}
+export async function pullTeams(team: string) {
+  const rows = await prisma.teams.findMany({ where: { team } });
+  return await hydrate(rows);
+}
+export async function pullSeats(team: string) {
+  const rows = await prisma.seats.findMany({ where: { team } });
+  return await hydrate(rows);
+}
+export function normalize(row: Row) {
+  return { ...row, id: String(row.id) };
+}
+${syncRows}`;
+    expect(recheckFile(baseline, "src/sync.ts", whole, async_).resolved).toEqual([]);
+  });
+});
+
+const INVOICE_THEN = `export function loadInvoice(id: string) {
+  return readRows(id)
+    .then((rows) => rows.map(normalize))
+    .then((rows) => rows[0]);
+}`;
+const REPORT_THEN = `export function loadReport(id: string) {
+  return readRows(id)
+    .then((rows) => rows.filter(Boolean))
+    .then((rows) => rows.slice(0, 20));
+}`;
+const REPORT_CONVERTED = `export async function loadReport(id: string) {
+  const rows = await readRows(id);
+  const kept = await Promise.all(rows.filter(Boolean));
+  return kept.slice(0, 20);
+}`;
+
+/** Two anchors on one file, measured independently. This is a property of
+ *  recheckFile, not a session the hook can produce: the hook keeps at most one
+ *  open finding per (file, category), so a second async_patterns flag on
+ *  src/reports.ts is deduped away and never becomes a second open finding. What
+ *  this pins is that recheckFile judges each anchor on its own construct — the
+ *  guarantee the hook relies on when several files, or several categories on
+ *  one file, are open at once. */
+describe("recheckFile judges each anchor independently", () => {
+  it("resolves the converted function and keeps the untouched one open", async () => {
+    const first = await raise("s-disc", "src/reports.ts", INVOICE_THEN);
+    const second = await raise("s-disc", "src/reports.ts", REPORT_THEN);
+    const invoice = only(first.open, "async_patterns")[0];
+    const report = only(second.open, "async_patterns")[0];
+    expect(invoice.findingId).not.toBe(report.findingId);
+
+    const whole = `${INVOICE_THEN}\n${REPORT_CONVERTED}`;
+    const { resolved } = recheckFile(baseline, "src/reports.ts", whole, [invoice, report]);
+    expect(resolved.map((f) => f.findingId)).toEqual([report.findingId]);
+  });
+});
+
+/** The flagged clone, byte-identical, wrapped in a construct the extractor does
+ *  not index. The symbol leaves the index while the code sits on disk. */
+const CLONE_IN_CLASS = `export class Backoff {
+  exponentialBackoff(attempt: number): number {
+    const base = 250;
+    const cap = 30_000;
+    const jitter = Math.random() * 100;
+    return Math.min(cap, base * 2 ** attempt) + jitter;
+  }
+}`;
+
+const CLONE_IN_OBJECT = `export const backoff = {
+  exponentialBackoff(attempt: number): number {
+    const base = 250;
+    const cap = 30_000;
+    const jitter = Math.random() * 100;
+    return Math.min(cap, base * 2 ** attempt) + jitter;
+  },
+};`;
+
+describe("a redundancy finding whose clone was wrapped, not removed", () => {
+  it("does not clear when the flagged clone moves verbatim into a class", async () => {
+    const { open } = await raise("s-dup-class", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    expect(dup[0].anchor).toMatchObject({ kind: "function", symbol: "exponentialBackoff" });
+    expect(recheckFile(baseline, "src/util.ts", CLONE_IN_CLASS, dup).resolved).toEqual([]);
+  });
+
+  it("does not clear when the flagged clone moves verbatim into an object literal", async () => {
+    const { open } = await raise("s-dup-object", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    expect(recheckFile(baseline, "src/util.ts", CLONE_IN_OBJECT, dup).resolved).toEqual([]);
+  });
+
+  it("clears when the duplicated function is genuinely deleted", async () => {
+    const { open } = await raise("s-dup-deleted", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    const gone = `export function formatLabel(name: string): string {
+  const trimmed = name.trim();
+  const upper = trimmed.toUpperCase();
+  return upper.slice(0, 40);
+}`;
+    expect(recheckFile(baseline, "src/util.ts", gone, dup).resolved.map((f) => f.findingId)).toEqual(
+      dup.map((f) => f.findingId),
+    );
+  });
+
+  it("clears when the duplicated body is genuinely rewritten under the same name", async () => {
+    const { open } = await raise("s-dup-rewritten", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    const rewritten = `export function exponentialBackoff(attempt: number): number {
+  const table = [100, 250, 500, 1000, 2000];
+  const idx = Math.min(attempt, table.length - 1);
+  return table[idx];
+}`;
+    expect(recheckFile(baseline, "src/util.ts", rewritten, dup).resolved.map((f) => f.findingId)).toEqual(
+      dup.map((f) => f.findingId),
+    );
+  });
+
+  it("clears when the clone is rewritten inside the class it was moved into", async () => {
+    const { open } = await raise("s-dup-class-fixed", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    const fixed = `export class Backoff {
+  exponentialBackoff(attempt: number): number {
+    const table = [100, 250, 500, 1000, 2000];
+    const idx = Math.min(attempt, table.length - 1);
+    return table[idx];
+  }
+}`;
+    expect(recheckFile(baseline, "src/util.ts", fixed, dup).resolved.map((f) => f.findingId)).toEqual(
+      dup.map((f) => f.findingId),
+    );
+  });
+
+  it("survives the sidecar's JSON round-trip across two separate re-checks", async () => {
+    const { open } = await raise("s-dup-roundtrip", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+
+    await writeOutcomeState(sessionsDir, "feedfacefeedface", "s-dup-roundtrip", {
+      open: dup,
+      hashes: {},
+    });
+    const first = await readOutcomeState(sessionsDir, "feedfacefeedface", "s-dup-roundtrip");
+    expect(first.open[0].anchor?.tokens?.length).toBeGreaterThan(0);
+    expect(recheckFile(baseline, "src/util.ts", CLONE_IN_CLASS, first.open).resolved).toEqual([]);
+
+    // Written back and re-read: the token sequence must not be lost between turns.
+    await writeOutcomeState(sessionsDir, "feedfacefeedface", "s-dup-roundtrip", first);
+    const second = await readOutcomeState(sessionsDir, "feedfacefeedface", "s-dup-roundtrip");
+    expect(second.open[0].anchor?.tokens).toEqual(first.open[0].anchor?.tokens);
+    expect(recheckFile(baseline, "src/util.ts", CLONE_IN_CLASS, second.open).resolved).toEqual([]);
+  });
+});
+
+describe("the anchored construct moved or went away", () => {
+  it("does not clear when the function is renamed but its body is unchanged", async () => {
+    const { open } = await raise("s-rename", "src/reports.ts", REPORT_THEN);
+    const async_ = only(open, "async_patterns");
+    const renamed = REPORT_THEN.replace("loadReport", "fetchReport");
+    expect(recheckFile(baseline, "src/reports.ts", renamed, async_).resolved).toEqual([]);
+  });
+
+  it("does not clear when the flagged function moves verbatim into a class", async () => {
+    const { open } = await raise("s-classmove", "src/reports.ts", REPORT_THEN);
+    const async_ = only(open, "async_patterns");
+    expect(async_[0].anchor).toMatchObject({ kind: "function", symbol: "loadReport" });
+
+    // Same statements, same order, now a class method. Only top-level
+    // `function`/`const` forms are indexed, so the symbol leaves the index
+    // while the flagged .then() chain is still byte-identical on disk.
+    const moved = `export class ReportService {
+  loadReport(id: string) {
+    return readRows(id)
+      .then((rows) => rows.filter(Boolean))
+      .then((rows) => rows.slice(0, 20));
+  }
+}`;
+    expect(recheckFile(baseline, "src/reports.ts", moved, async_).resolved).toEqual([]);
+  });
+
+  it("clears a long function that was genuinely fixed and then moved", async () => {
+    // The anchor stores at most ANCHOR_MAX_TOKENS, so for a long function it is
+    // a PREFIX. Here the flagged .then() chain sits past that cap, so the prefix
+    // survives the fix untouched. Treating a capped sequence as proof the
+    // construct is unchanged would hold this finding open forever, which is a
+    // false NON-resolve: the code really was fixed.
+    const filler = Array.from(
+      { length: 160 },
+      (_, i) => `  const v${i} = compute(${i}, base, scale);`,
+    ).join("\n");
+    const long = `export function loadReport(id: string) {
+${filler}
+  return readRows(id)
+    .then((rows) => rows.filter(Boolean))
+    .then((rows) => rows.slice(0, 20));
+}`;
+    const { open } = await raise("s-longfix", "src/reports.ts", long);
+    const async_ = only(open, "async_patterns");
+    expect(async_[0].anchor?.tokens?.length).toBe(ANCHOR_MAX_TOKENS);
+
+    // Converted to async/await AND moved into a class, so the symbol leaves the
+    // index and only the (unchanged) prefix is still contained in the file.
+    const fixedAndMoved = `export class ReportService {
+  async loadReport(id: string) {
+${filler}
+    const rows = await readRows(id);
+    return rows.filter(Boolean).slice(0, 20);
+  }
+}`;
+    expect(
+      recheckFile(baseline, "src/reports.ts", fixedAndMoved, async_).resolved.map((f) => f.findingId),
+    ).toEqual(async_.map((f) => f.findingId));
+  });
+
+  it("clears when the flagged function is deleted outright", async () => {
+    const { open } = await raise("s-delete", "src/reports.ts", REPORT_THEN);
+    const async_ = only(open, "async_patterns");
+    const gone = `export async function loadRows(id: string) {
+  const rows = await readRows(id);
+  return await hydrate(rows);
+}`;
+    expect(recheckFile(baseline, "src/reports.ts", gone, async_).resolved.map((f) => f.findingId)).toEqual(
+      async_.map((f) => f.findingId),
+    );
+  });
+
+  it("clears a whole-body anchor once the flagged pattern is genuinely gone", async () => {
+    const method = `  async purgeSessions(userId: string) {
+    await db.query("DELETE FROM sessions WHERE user_id = $1", [userId]);
+    await db.query("INSERT INTO audit_log (kind) VALUES ('purge')", []);
+    return true;
+  }`;
+    const { open } = await raise("s-sql-fixed", "src/data/sessions.ts", method);
+    const arch = only(open, "architectural_consistency");
+    const fixed = `export class SessionStore {
+  async purgeSessions(userId: string) {
+    await prisma.session.delete({ where: { userId } });
+    await prisma.auditLog.create({ data: { kind: "purge", userId } });
+    return true;
+  }
+}`;
+    expect(recheckFile(baseline, "src/data/sessions.ts", fixed, arch).resolved.map((f) => f.findingId)).toEqual(
+      arch.map((f) => f.findingId),
+    );
+  });
+
+  it("resolves nothing for a file the extractor cannot read as source", async () => {
+    const { open } = await raise("s-unparsed", "src/reports.ts", REPORT_THEN);
+    const moved = only(open, "async_patterns").map((f) => ({ ...f, file: "notes/scratch.txt" }));
+    expect(recheckFile(baseline, "notes/scratch.txt", "", moved).resolved).toEqual([]);
+  });
+});
+
+/** fetchInvoice is HTTP-only; loadInvoiceRows goes straight at the driver. Two
+ *  queries of the same edit therefore report DIFFERENT labels on the data-access
+ *  dimension, and the whole-body query (whose db.query evidence outweighs the
+ *  fetches) reports "direct database calls" first. */
+const MIXED_ACCESS = `export function fetchInvoice(id: string) {
+  const res = fetch("/api/invoices/" + id);
+  const meta = fetch("/api/invoices/" + id + "/meta");
+  return [res, meta];
+}
+export function loadInvoiceRows(id: string) {
+  const a = db.query("SELECT * FROM invoices WHERE id = $1", [id]);
+  const b = db.query("SELECT * FROM invoice_lines WHERE invoice_id = $1", [id]);
+  const c = db.query("SELECT * FROM invoice_taxes WHERE invoice_id = $1", [id]);
+  return [a, b, c];
+}`;
+
+describe("the anchor names a construct that carried the flagged label", () => {
+  it("pairs the site and the label from the SAME query on a multi-label axis", async () => {
+    const rel = "src/billing/invoices.ts";
+    const { open } = await raise("s-pairing", rel, MIXED_ACCESS);
+    const arch = only(open, "architectural_consistency")[0];
+    const anchor = arch.anchor!;
+    expect(anchor.observed).toBe("direct database calls");
+
+    // Whatever construct the anchor names, that construct's own body must be
+    // what the stored label describes — otherwise the finding is anchored to
+    // code that never carried the pattern, and any edit to it clears a finding
+    // whose flagged code is untouched.
+    const anchored =
+      anchor.kind === "function"
+        ? fileConstructs(rel, MIXED_ACCESS)!.bodies.get(anchor.symbol!)
+        : MIXED_ACCESS;
+    expect(anchored).toBeDefined();
+    expect(classifyDataAccessLabel(anchored!, rel)).toBe(anchor.observed);
+  });
+});

--- a/test/unit/session/outcomes.test.ts
+++ b/test/unit/session/outcomes.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildBaseline, type RepoDriftBaseline } from "@/core/baseline";
+import { runEditChecks } from "@/session/check";
 import { recheckFile, detectRevert, type OpenFinding } from "@/session/outcomes";
 
 const tmp = (p: string) => realpathSync(mkdtempSync(join(tmpdir(), p)));
@@ -14,9 +15,13 @@ const HELPER = `export function exponentialBackoff(attempt) {
   return Math.min(cap, base * 2 ** attempt) + jitter;
 }`;
 
+let repo: string;
+let sessionsDir: string;
 let baseline: RepoDriftBaseline;
+
 beforeAll(async () => {
-  const repo = tmp("vd-out-repo-");
+  repo = tmp("vd-out-repo-");
+  sessionsDir = tmp("vd-out-sessions-");
   mkdirSync(join(repo, "src", "lib"), { recursive: true });
   writeFileSync(join(repo, "CLAUDE.md"), "- Async: use async/await throughout. No .then() chains.\n");
   for (const n of ["a", "b", "c"]) {
@@ -25,6 +30,32 @@ beforeAll(async () => {
   writeFileSync(join(repo, "src", "lib", "backoff.ts"), `${HELPER}\n`);
   baseline = await buildBaseline(repo);
 }, 60_000);
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+/** Raise a finding the way the hook does, so the open finding carries the same
+ *  anchor the real flag path produces. */
+async function raise(sessionId: string, relFile: string, body: string): Promise<OpenFinding[]> {
+  const out = await runEditChecks({
+    rootDir: repo,
+    projectHash: "feedfacefeedface",
+    sessionId,
+    sessionsDir,
+    file: join(repo, relFile),
+    body,
+    loadBaselineFor: async () => baseline,
+  });
+  expect(out.flags.length).toBeGreaterThanOrEqual(1);
+  return out.flags.map((f) => ({
+    findingId: f.findingId!,
+    file: f.detail.file!,
+    category: f.detail.category!,
+    anchor: out.anchors[f.findingId!],
+  }));
+}
 
 const THEN = `export function loadReport(id) {
   return fetch("/x/" + id)
@@ -38,11 +69,14 @@ const CLEAN = `export async function loadReport(id) {
 }`;
 
 describe("recheckFile", () => {
-  const open: OpenFinding[] = [{ findingId: "DF-1", file: "src/report.ts", category: "async_patterns" }];
+  let open: OpenFinding[];
+  beforeAll(async () => {
+    open = await raise("s-then", "src/report.ts", THEN);
+  });
 
   it("resolves a convention finding once the file is fixed", () => {
     const { resolved } = recheckFile(baseline, "src/report.ts", CLEAN, open);
-    expect(resolved.map((f) => f.findingId)).toEqual(["DF-1"]);
+    expect(resolved.map((f) => f.findingId)).toEqual(open.map((f) => f.findingId));
   });
 
   it("does NOT resolve while the finding still stands", () => {
@@ -60,21 +94,26 @@ describe("recheckFile", () => {
     expect(recheckFile(baseline, "src/report.ts", CLEAN, scopeOpen).resolved).toEqual([]);
   });
 
-  it("does NOT falsely resolve a redundancy when the dup is still present in a multi-function file", () => {
-    // the whole-file query dilutes below threshold, but the per-function query
-    // (via detectDrift) still catches the untouched clone — so no false resolve
-    const dupOpen: OpenFinding[] = [{ findingId: "DF-dup", file: "src/util.ts", category: "redundancy" }];
+  it("never resolves a finding that carries no anchor", () => {
+    const legacy: OpenFinding[] = [{ findingId: "DF-legacy", file: "src/report.ts", category: "async_patterns" }];
+    expect(recheckFile(baseline, "src/report.ts", CLEAN, legacy).resolved).toEqual([]);
+  });
+
+  it("does NOT falsely resolve a redundancy when the dup is still present in a multi-function file", async () => {
+    const dupOpen = await raise("s-dup", "src/util.ts", HELPER);
     const multiFn = `export function unrelatedOne(a) { return a + 1; }
 ${HELPER}
 export function unrelatedTwo(b) { return b - 1; }`;
     expect(recheckFile(baseline, "src/util.ts", multiFn, dupOpen).resolved).toEqual([]);
   });
 
-  it("DOES resolve a redundancy once the duplicated function is gone", () => {
-    const dupOpen: OpenFinding[] = [{ findingId: "DF-dup", file: "src/util.ts", category: "redundancy" }];
+  it("DOES resolve a redundancy once the duplicated function is gone", async () => {
+    const dupOpen = await raise("s-dup2", "src/util.ts", HELPER);
     const noDup = `export function unrelatedOne(a) { return a + 1; }
 export function unrelatedTwo(b) { return b - 1; }`;
-    expect(recheckFile(baseline, "src/util.ts", noDup, dupOpen).resolved.map((f) => f.findingId)).toEqual(["DF-dup"]);
+    expect(recheckFile(baseline, "src/util.ts", noDup, dupOpen).resolved.map((f) => f.findingId)).toEqual(
+      dupOpen.map((f) => f.findingId),
+    );
   });
 });
 

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,61 @@
 # CLI backlog
 
+- **Session re-check: three residual resolve defects, all reproduced by an adversarial pass.** The
+  anchoring work closed the four original false-resolve classes, but these survive and are known:
+  (a) **redundancy, wrap plus one token.** The anchor holds the flagged construct's exact token
+  sequence, so a clone moved verbatim into a class stays open, but changing a single identifier
+  while wrapping breaks containment and falls through to a whole-file duplicate query, which is
+  structurally blind to class and object-literal methods, so a near-verbatim clone resolves. The
+  honest scope of the current guarantee is "survives a byte-for-byte wrap", not "no false resolve".
+  Proper fix is the extractor bullet below, or a similarity test (minhash the anchor tokens against
+  sliding windows) rather than exact containment.
+  (b) **hunk-fallback resolves on less evidence.** When `readFile` throws, `hook-entry.ts` re-checks
+  against the edit body, which for an Edit is only the hunk, so an unrelated small hunk contains
+  neither the symbol nor the tokens nor the pattern and the finding clears. Every other failure path
+  in the module fails open. Fix: skip the re-check entirely on read failure.
+
+- **Root fix: `extractAllFunctions` does not index class or object-literal methods.** The JS/TS
+  patterns in `src/codedna/function-extractor.ts` match only `function name(` and
+  `const name = (`, so a method inside `class Foo { bar() {} }` or `const foo = { bar() {} }` is
+  invisible to every consumer of the extractor. The session re-check works around this with a
+  token-sequence containment test on the finding anchor (`src/session/finding-anchor.ts`), which
+  keeps a wrapped construct's finding open, but the underlying blindness is still there: a
+  class-heavy file contributes far fewer indexed functions than it has. Widening the extractor is
+  the proper fix and it is NOT a local change: the same function feeds Code DNA fingerprinting,
+  op-sequence analysis, the duplicate index, and therefore the composite score for every user, so
+  new methods would appear as new index entries and shift duplicate counts and scores across the
+  board. Needs a corpus before/after on score movement, and probably a `SCORING_VERSION` bump,
+  before it can ship.
+
+- **`hasDataAccessPattern` / `classifyDataAccessLabel` hard-code language "typescript".** Both
+  entry points in `src/drift/architectural-contradiction.ts` build a synthetic `DriftFile` with
+  `language: "typescript"` for every path, including .py/.go/.rs. Inert today (the data-access
+  detector reads only content and relative path, and the two lie identically so they stay
+  symmetric), but `hasDataAccessPattern` now sits on the session re-check's resolution path, where
+  a missed pattern reads as "the flagged code is gone". Thread the real `detectLanguage(path)`
+  result through both, and add a non-TS case to the drift tests so the symmetry is pinned.
+
+<<<<<<< HEAD
+=======
+- **In-session drift covers only three dimensions.** `DIM_CHECKS`
+  (`src/tools-core/tools/validate-change.ts:108-133`) has async_patterns, return_shape_consistency and
+  architectural_consistency; plus `redundancy` (`src/session/check.ts`) and experimental `scope`
+  (`src/session/scope.ts`). The scan has 13 `DriftCategory` values. Widening the in-loop set is higher
+  leverage than any dashboard metric work, because it raises the ceiling on what a session can
+  possibly report at all: with three dimensions live, the honest ceiling of the sessions dashboard is
+  "here are the few things we noticed". Security and auth are notably unreachable in-session today, so
+  any compliance-flavoured session metric is not just unbuilt, it has no signal to build on.
+
+- **Native-sessions nudge: auto-detect headless (currently env-override only).** The SessionStart
+  nudge suppresses asks/budget-burn in non-interactive contexts via an explicit
+  `VIBEDRIFT_HOOK_NONINTERACTIVE=1` override (`src/session/nudge.ts`), which the N2 plugin/CI sets.
+  Auto-detecting headless `claude -p` from the hook payload/env (e.g. `CLAUDE_CODE_ENTRYPOINT`) was
+  deferred — the exact value needs one confirming payload capture (small metered `claude -p` run).
+  Until then a raw `claude -p` outside the plugin can burn the 3-ask budget to an implicit decline;
+  low harm (a headless-only repo has no human to nudge). Confirm the entrypoint value, then key
+  `isNonInteractive()` off it too.
+
+>>>>>>> 0b31e24 (todo: note the three-dimension in-loop ceiling)
 - **DOCX sections are still tag/kind-mixed for analyzer findings.** The per-file
   Drift/Static tally is now kind-based (matching terminal/HTML and the composite), but
   DOCX's "STATIC ANALYSIS FINDINGS" section lists drift-kind analyzer findings (naming,

--- a/todo.md
+++ b/todo.md
@@ -35,8 +35,6 @@
   a missed pattern reads as "the flagged code is gone". Thread the real `detectLanguage(path)`
   result through both, and add a non-TS case to the drift tests so the symmetry is pinned.
 
-<<<<<<< HEAD
-=======
 - **In-session drift covers only three dimensions.** `DIM_CHECKS`
   (`src/tools-core/tools/validate-change.ts:108-133`) has async_patterns, return_shape_consistency and
   architectural_consistency; plus `redundancy` (`src/session/check.ts`) and experimental `scope`
@@ -46,16 +44,6 @@
   "here are the few things we noticed". Security and auth are notably unreachable in-session today, so
   any compliance-flavoured session metric is not just unbuilt, it has no signal to build on.
 
-- **Native-sessions nudge: auto-detect headless (currently env-override only).** The SessionStart
-  nudge suppresses asks/budget-burn in non-interactive contexts via an explicit
-  `VIBEDRIFT_HOOK_NONINTERACTIVE=1` override (`src/session/nudge.ts`), which the N2 plugin/CI sets.
-  Auto-detecting headless `claude -p` from the hook payload/env (e.g. `CLAUDE_CODE_ENTRYPOINT`) was
-  deferred — the exact value needs one confirming payload capture (small metered `claude -p` run).
-  Until then a raw `claude -p` outside the plugin can burn the 3-ask budget to an implicit decline;
-  low harm (a headless-only repo has no human to nudge). Confirm the entrypoint value, then key
-  `isNonInteractive()` off it too.
-
->>>>>>> 0b31e24 (todo: note the three-dimension in-loop ceiling)
 - **DOCX sections are still tag/kind-mixed for analyzer findings.** The per-file
   Drift/Static tally is now kind-based (matching terminal/HTML and the composite), but
   DOCX's "STATIC ANALYSIS FINDINGS" section lists drift-kind analyzer findings (naming,


### PR DESCRIPTION
## The bug

A Drift Session finding could report itself **resolved while the flagged code never changed.**

The raise runs the drift check on the edit hunk. The re-check ran it on the whole file, and cleared a
finding whenever the signal simply stopped firing. Absence of a signal is not evidence the code was
fixed, and there were four ways it went quiet on code that was still sitting there byte-identical:

- the re-check only queries the first five functions in a file, so drift past function five was invisible
- the data-access classifier reports a body's *majority* pattern, so one raw SQL call is outvoted by the file's ORM calls
- the async classifier returns `mixed` for a half-converted file, which maps to no conflict at all
- moving a flagged function verbatim into a class dropped its name from the index, and a missing name was read as "deleted"

This matters because it inflates the self-corrected count, which is the number that backs the claim
that a resolution is verified rather than taken on the agent's word.

## The fix

Every finding now carries an **anchor**: the construct it was actually raised against, identified by
symbol, a token hash, and the observed pattern label. The re-check asks a narrower question, "is
*this* construct still present," and resolves only on positive absence of the flagged pattern, never
on classifier silence.

Three presence predicates sit beside the classifiers they correct, so presence is tested rather than
dominance. When the anchored symbol has vanished, the construct's own token sequence is checked
against the file first, so a construct that was merely wrapped or moved keeps its finding open.

Anchors live only in the local per-session sidecar. Nothing new crosses the network: the upload
mapping still builds its payload from an explicit allow-list, and there is no anchor field on it.

## Known limits, stated rather than papered over

These are documented in the module header and in `todo.md`:

- a clone that is both wrapped *and* edited by a token can still clear, because the underlying
  extractor does not index class or object-literal methods
- a re-check triggered after a failed file read falls back to the edit hunk and sees less than the file
- the hook keeps at most one open finding per file and category, so a resolve means "the flagged
  construct is gone", never "this file is clean"
- fixes made by tools the hook does not observe never trigger a re-check, so the self-corrected count
  is structurally an undercount

## Notes for review

Fail-open is preserved everywhere: an unparseable file, an unknown language, a finding with no anchor,
or any thrown error all leave a finding **open** rather than clearing it.

The classifier golden was extended with boundary bodies after we found it did not bind: both async
thresholds could be moved and it still passed. It now fails on those mutations.

Branched off `main` and independent of the native-sessions work, which stays on its own branch while
it is dogfooded.

---
🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code).

https://claude.ai/code/session_01M4HBwyzpPKgrusnawqaa5n
