### PR TITLE
session: native Drift Sessions (enable, hooks, turn flush)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ explicitly under **Breaking** so CI users can recalibrate.
 
 ## [Unreleased]
 
+**Drift Sessions goes native.** Your AI agent drifts while it works: a `.then()` chain in an
+async/await repo, a helper that already exists, a convention quietly broken. Drift Sessions
+catches that in the agent's own decision loop, as the edit happens, not in review three days
+later. The advisory lands in the agent's context, the agent fixes, parks, or pushes back with a
+reason, and a finding only counts as resolved when the same check re-runs over the new code and
+passes. As of this release none of it needs a terminal running: `vibedrift enable` once per repo,
+and every session is watched from then on.
+
 ### Added
 
 - **`vibedrift enable`: turning Drift Sessions on is one typed command.** Typing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to `@vibedrift/cli` are documented here. The format
 follows Keep-a-Changelog loosely; breaking-shape changes are called out
 explicitly under **Breaking** so CI users can recalibrate.
 
+## [Unreleased]
+
+### Added
+
+- **`vibedrift enable`: turning Drift Sessions on is one typed command.** Typing
+  `vibedrift enable` in a repo is the consent, and the command prints exactly what you are
+  consenting to: your prompts (secrets masked) and edit metadata are recorded to a local
+  ledger, nothing leaves your machine unless you separately turn on hosted sync, and hooks
+  fail open so an error or timeout never interrupts your agent. It installs the Claude Code
+  hooks when the agent is present and writes a local consent receipt you can inspect.
+  `vibedrift decline` is the permanent no for a repo: you are not asked again and capture
+  stays off, reversible anytime with `vibedrift enable`. `vibedrift enable --dir <path>`
+  activates every repo under a directory after showing you the resolved path and asking for
+  a typed confirmation; your home directory and filesystem roots are refused.
+- **Sessions run natively: no watch-session terminal needed.** In an enabled repo the hooks
+  capture the session on their own, and with hosted sync on, each agent turn ships its
+  events to your dashboard in the background as the turn ends. Keeping `vibedrift
+  watch-session` open is now optional: it is still the live tape, but no longer the thing
+  that makes syncing work.
+- **Claude asks once at session start.** In a repo where VibeDrift is installed but sessions
+  were never enabled or declined, Claude asks in plain language at the start of a new
+  session whether to turn on live drift monitoring. Saying yes enables it through the new
+  `enable` MCP tool, which never activates without your explicit confirmation. Saying no, or
+  ignoring the question, declines the repo so you are not asked again. A repo that never
+  gets an answer is asked at most three times, then the asks stop for good; the last ask
+  says so, and `vibedrift enable` or `vibedrift decline` always sets the answer explicitly.
+  Sessions marked non-interactive (CI, headless runs) are never asked.
+
+### Changed
+
+- **Uploads are durable and survive restarts.** Sync progress is now recorded per ledger
+  file and advances only after the server confirms receipt. Close the terminal mid-upload,
+  lose the network, or reboot: the next flush resumes exactly where the last one stopped,
+  and sessions recorded while nothing was syncing are backfilled, oldest first, the next
+  time anything syncs. Re-sends are recognized server-side, so nothing is double-counted.
+  `vibedrift watch-session` now catches up on that backlog when it starts instead of only
+  following the newest session.
+- **The trial and Pro work the same on the native path.** The free trial still covers your
+  first five sessions with everything on, and while on trial the session-start ask tells you
+  how many trial sessions you have used. When the trial is spent, a single line at session
+  start tells you capture is paused and how to upgrade; your local ledgers stay yours.
+  Upgrading to Pro takes effect on your next agent turn, with no restart and no
+  watch-session required.
+
 ## 0.18.1 — 2026-07-27
 
 ### Fixed

--- a/scripts/NATIVE-SESSIONS-SELFTEST.md
+++ b/scripts/NATIVE-SESSIONS-SELFTEST.md
@@ -1,0 +1,66 @@
+# Native Drift Sessions — founder self-test
+
+Everything runs against the **local dev stack** in a throwaway sandbox
+(`VIBEDRIFT_HOME` + `VIBEDRIFT_API_URL` are redirected), so nothing touches
+production, your real `~/.vibedrift`, or the real dashboard.
+
+## 0. Prereqs
+
+- Local API up on `:8000` (branch `feat/native-sessions-api`) + its Supabase +
+  seeded dev tokens. (`GET http://localhost:8000/health` → `{"status":"ok"}`.)
+- `npm run build` in this repo (the scripts use `dist/`).
+
+## 1. One-command round-trip proof
+
+```bash
+npm run build
+bash scripts/native-sessions-e2e.sh
+```
+
+This drives the whole native pipeline and self-verifies each stage:
+
+1. `vibedrift enable` → hooks installed + activation recorded `active`
+2. `SessionStart` hook → activation **nudge** injected in an un-activated repo,
+   **silent** in the activated one
+3. edit hooks → events captured to the **local ledger** (asserts **no edit body
+   leaks** into the ledger)
+4. `Stop` hook → detached `session-flush` uploads to the local API
+5. `GET /v1/sessions` → the session shows up on the dashboard read path
+6. `GET /v1/sessions/rollup` → `engaged` / `self_corrected` split present
+
+Ends in `E2E PASSED`. Any failure prints the exact stage.
+
+## 2. Try it on YOUR OWN repo (interactive)
+
+Point a real sandbox at the local stack, then use Claude Code normally:
+
+```bash
+export VIBEDRIFT_HOME="$HOME/.vibedrift-dev"      # sandbox, not the real store
+export VIBEDRIFT_API_URL="http://localhost:8000"
+mkdir -p "$VIBEDRIFT_HOME"
+cat > "$VIBEDRIFT_HOME/config.json" <<EOF
+{"token":"vd_live_dev_pro_0000000000000000000","plan":"pro",
+ "apiUrl":"http://localhost:8000","sessionsSyncEnabled":true}
+EOF
+
+cd /path/to/your/repo
+node /path/to/vibedrift-public/dist/cli/index.js enable .   # typed consent
+```
+
+Now open Claude Code in that repo and work. Each **turn end** (Stop) flushes to
+the dashboard within a couple of seconds — no `watch-session` window needed.
+Watch the live tape too if you want: `… dist/cli/index.js watch-session`.
+
+To see the nudge flow instead of pre-enabling: **don't** run `enable`; start a
+Claude Code session and the SessionStart hook injects the ask (the model relays
+it, you answer yes → it calls the `enable` MCP tool → native Allow/Deny prompt).
+
+## 3. Turn it off
+
+```bash
+node …/dist/cli/index.js decline .                  # this repo, permanent
+node …/dist/cli/index.js watch-session --uninstall  # remove the hooks entirely
+```
+
+Everything above is sandbox-scoped: delete `$VIBEDRIFT_HOME` to reset.
+No production surface (npm/Fly/Vercel) is touched by any of this.

--- a/scripts/NATIVE-SESSIONS-SELFTEST.md
+++ b/scripts/NATIVE-SESSIONS-SELFTEST.md
@@ -51,6 +51,13 @@ Now open Claude Code in that repo and work. Each **turn end** (Stop) flushes to
 the dashboard within a couple of seconds — no `watch-session` window needed.
 Watch the live tape too if you want: `… dist/cli/index.js watch-session`.
 
+**Seeing it in the dashboard.** The uploaded turns land in the local Supabase
+(`session_meta` / `session_events`) — confirmed by step-1's `GET /v1/sessions`.
+The dashboard reads those tables directly, so to view them run the
+`landing-native-sessions` worktree pointed at the **local** Supabase and sign in
+as the seeded pro user (dashboard env/auth setup is its own step, outside this
+CLI sandbox).
+
 To see the nudge flow instead of pre-enabling: **don't** run `enable`; start a
 Claude Code session and the SessionStart hook injects the ask (the model relays
 it, you answer yes → it calls the `enable` MCP tool → native Allow/Deny prompt).

--- a/scripts/NATIVE-SESSIONS-SELFTEST.md
+++ b/scripts/NATIVE-SESSIONS-SELFTEST.md
@@ -1,4 +1,4 @@
-# Native Drift Sessions — founder self-test
+# Native Drift Sessions self-test
 
 Everything runs against the **local dev stack** in a throwaway sandbox
 (`VIBEDRIFT_HOME` + `VIBEDRIFT_API_URL` are redirected), so nothing touches
@@ -6,7 +6,7 @@ production, your real `~/.vibedrift`, or the real dashboard.
 
 ## 0. Prereqs
 
-- Local API up on `:8000` (branch `feat/native-sessions-api`) + its Supabase +
+- Local API up on `:8000` (a dev API with the sessions endpoints) + its Supabase +
   seeded dev tokens. (`GET http://localhost:8000/health` → `{"status":"ok"}`.)
 - `npm run build` in this repo (the scripts use `dist/`).
 
@@ -48,11 +48,11 @@ node /path/to/vibedrift-public/dist/cli/index.js enable .   # typed consent
 ```
 
 Now open Claude Code in that repo and work. Each **turn end** (Stop) flushes to
-the dashboard within a couple of seconds — no `watch-session` window needed.
+the dashboard within a couple of seconds, no `watch-session` window needed.
 Watch the live tape too if you want: `… dist/cli/index.js watch-session`.
 
 **Seeing it in the dashboard.** The uploaded turns land in the local Supabase
-(`session_meta` / `session_events`) — confirmed by step-1's `GET /v1/sessions`.
+(`session_meta` / `session_events`), confirmed by step-1's `GET /v1/sessions`.
 The dashboard reads those tables directly, so to view them run the
 `landing-native-sessions` worktree pointed at the **local** Supabase and sign in
 as the seeded pro user (dashboard env/auth setup is its own step, outside this

--- a/scripts/native-sessions-e2e.sh
+++ b/scripts/native-sessions-e2e.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Native Drift Sessions — end-to-end sandbox self-test.
+#
+# Drives the WHOLE native pipeline against the local dev stack, with zero risk
+# to production (VIBEDRIFT_HOME + VIBEDRIFT_API_URL are redirected to the
+# sandbox), and verifies the round-trip:
+#
+#   vibedrift enable  ->  hooks installed + activation recorded
+#   SessionStart hook ->  activation nudge injected
+#   edit hooks        ->  events captured to the local ledger
+#   Stop hook         ->  detached session-flush uploads to the local API
+#   GET /v1/sessions  ->  the session shows up on the (dashboard) read path
+#   GET /v1/sessions/rollup -> engaged / self_corrected metrics present
+#
+# Prereqs: the local stack is up (API on :8000 on feat/native-sessions-api, its
+# Supabase, and the seeded dev tokens). Run `npm run build` first (this script
+# will build if dist/ is missing).
+#
+# Usage:
+#   bash scripts/native-sessions-e2e.sh
+#   VD_API_URL=http://localhost:8000 VD_TOKEN=vd_live_dev_pro_0000000000000000000 bash scripts/native-sessions-e2e.sh
+set -euo pipefail
+
+API_URL="${VD_API_URL:-http://localhost:8000}"
+TOKEN="${VD_TOKEN:-vd_live_dev_pro_0000000000000000000}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli/index.js"
+HOOK="$ROOT/dist/session/hook-entry.js"
+
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗ %s\033[0m\n' "$1"; exit 1; }
+step() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+# ---- preflight -------------------------------------------------------------
+step "Preflight"
+[ -f "$HOOK" ] || { echo "  building dist…"; (cd "$ROOT" && npm run build >/dev/null); }
+[ -f "$HOOK" ] || fail "dist not built"
+code=$(curl -s -m 3 -o /dev/null -w '%{http_code}' "$API_URL/health" || true)
+[ "$code" = "200" ] || fail "local API not healthy at $API_URL (got $code) — bring the dev stack up first"
+code=$(curl -s -m 3 -o /dev/null -w '%{http_code}' -X POST "$API_URL/v1/sessions/ingest" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"events":[]}' || true)
+[ "$code" = "200" ] || fail "seeded token rejected by ingest (got $code) — reseed the dev stack"
+pass "local stack healthy, token accepts ingest"
+
+# ---- isolated sandbox ------------------------------------------------------
+SB="$(mktemp -d)"; REPO="$(mktemp -d)"
+export VIBEDRIFT_HOME="$SB"
+export VIBEDRIFT_API_URL="$API_URL"
+trap 'rm -rf "$SB" "$REPO"' EXIT
+mkdir -p "$REPO/.git" "$REPO/.claude" "$SB"
+printf '{"token":"%s","plan":"pro","apiUrl":"%s","sessionsSyncEnabled":true}\n' "$TOKEN" "$API_URL" > "$SB/config.json"
+SID="e2e-$$-$(date +%s)"
+pass "sandbox home=$SB  repo=$REPO  session=$SID"
+
+hook() { echo "$1" | node "$HOOK" 2>/dev/null || true; }
+
+# Build + fire a PostToolUse Write edit; content is passed as argv so quotes in
+# the code never break the JSON payload.
+edit_hook() {
+  python3 -c "import json,sys;print(json.dumps({'session_id':'$SID','cwd':'$REPO','hook_event_name':'PostToolUse','tool_name':'Write','tool_input':{'file_path':sys.argv[1],'content':sys.argv[2]}}))" "$1" "$2" \
+    | node "$HOOK" 2>/dev/null || true
+}
+
+# ---- enable ----------------------------------------------------------------
+step "1. vibedrift enable (typed consent = active + hooks)"
+node "$CLI" enable "$REPO" >/dev/null 2>&1 || fail "enable failed"
+[ -f "$REPO/.claude/settings.local.json" ] || fail "hooks not installed"
+grep -q '"state": "active"' "$SB/activation.json" || grep -q '"state":"active"' "$SB/activation.json" || fail "activation not recorded active"
+pass "hooks installed, activation = active"
+
+# ---- SessionStart nudge (an already-active repo stays silent) --------------
+step "2. SessionStart nudge"
+NEWREPO="$(mktemp -d)"; mkdir -p "$NEWREPO/.git"
+out="$(hook "{\"session_id\":\"$SID-x\",\"cwd\":\"$NEWREPO\",\"hook_event_name\":\"SessionStart\",\"source\":\"startup\"}")"
+echo "$out" | grep -q "NOT active" || fail "un-activated repo did not get the nudge"
+pass "un-activated repo nudged"
+out="$(hook "{\"session_id\":\"$SID\",\"cwd\":\"$REPO\",\"hook_event_name\":\"SessionStart\",\"source\":\"startup\"}")"
+[ -z "$out" ] || fail "activated repo should stay silent, got: $out"
+pass "activated repo silent"
+rm -rf "$NEWREPO"
+
+# ---- capture a turn: prompt + a diverging edit + a fixing edit -------------
+step "3. Capture a turn (prompt, flagged edit, resolving edit)"
+printf -- '- Async: use async/await throughout. No .then() chains.\n' > "$REPO/CLAUDE.md"
+mkdir -p "$REPO/src"
+for n in a b c; do printf 'export async function %s(){ return await fetch("/%s"); }\n' "$n" "$n" > "$REPO/src/$n.ts"; done
+# build a baseline so the drift check has something to compare against
+node "$CLI" "$REPO" --local-only --format terminal >/dev/null 2>&1 || true
+hook "{\"session_id\":\"$SID\",\"cwd\":\"$REPO\",\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"add a report loader\"}"
+# a .then() edit trips the async-consistency flag
+edit_hook "$REPO/src/report.ts" 'export function loadReport(id){ return fetch("/r/"+id).then(r=>r.json()).then(d=>d.rows); }'
+# fix it to async/await -> resolves
+edit_hook "$REPO/src/report.ts" 'export async function loadReport(id){ const r = await fetch("/r/"+id); const d = await r.json(); return d.rows; }'
+LEDGER="$(find "$SB/sessions" -name "$SID.jsonl" 2>/dev/null | head -1)"
+[ -n "$LEDGER" ] && [ -f "$LEDGER" ] || fail "no ledger written"
+grep -q '"type":"edit"' "$LEDGER" || fail "no edit event captured"
+pass "ledger captured $(wc -l < "$LEDGER" | tr -d ' ') events (prompt, edits, flags/resolves)"
+grep -q 'loadReport' "$LEDGER" && fail "edit BODY leaked into the ledger (privacy)" || pass "no edit body in the ledger"
+
+# ---- Stop hook -> detached flush -> upload ---------------------------------
+step "4. Stop hook spawns the flush -> upload to the local API"
+hook "{\"session_id\":\"$SID\",\"cwd\":\"$REPO\",\"hook_event_name\":\"Stop\"}"
+found=""
+for i in $(seq 1 40); do
+  sleep 0.25
+  resp="$(curl -s -m 3 "$API_URL/v1/sessions?limit=200" -H "Authorization: Bearer $TOKEN" || true)"
+  if echo "$resp" | grep -q "$SID"; then found=1; break; fi
+done
+[ -n "$found" ] || fail "session $SID never appeared on GET /v1/sessions (flush/upload failed)"
+pass "session reached the API read path (dashboard would see it)"
+
+# ---- rollup metrics --------------------------------------------------------
+step "5. Rollup KPIs (engaged / self_corrected split)"
+roll="$(curl -s -m 3 "$API_URL/v1/sessions/rollup" -H "Authorization: Bearer $TOKEN" || true)"
+echo "$roll" | grep -q '"engaged"' || fail "rollup missing engaged metric"
+echo "$roll" | grep -q '"self_corrected"' || fail "rollup missing self_corrected metric"
+pass "rollup carries the engaged + self_corrected split"
+echo "  rollup: $roll"
+
+step "E2E PASSED — native capture → flush → API → dashboard read path is live."

--- a/src/auth/api.ts
+++ b/src/auth/api.ts
@@ -219,6 +219,15 @@ export async function consumeSessionTrial(
 
 export interface SessionIngestResponse {
   accepted: number;
+  /** Per-event acknowledgments (frozen wire contract v1). Absent on legacy servers. */
+  results?: Array<{
+    activityId: string;
+    status: "accepted" | "duplicate" | "rejected" | "held";
+    code?: string;
+  }>;
+  /** Free-plan trial state, so trial burn is never invisible (L-N4). */
+  trial_used?: number;
+  trial_limit?: number;
 }
 
 /** Upload a batch of DERIVED-ONLY session events (Phase 5). Only invoked by the

--- a/src/cli/commands/enable.ts
+++ b/src/cli/commands/enable.ts
@@ -1,0 +1,189 @@
+/**
+ * `vibedrift enable` / `vibedrift decline` — the activation answers for
+ * native Drift Sessions.
+ *
+ * O18 posture: TYPING `vibedrift enable` in a terminal IS the consent — no
+ * second prompt. The command still prints exactly what it activated (informed
+ * consent means the disclosure ships with the answer). `--dir` is broader and
+ * therefore ALWAYS typed-confirms after showing the canonicalized path, and
+ * hard-refuses `$HOME` and filesystem roots (O19).
+ *
+ * `vibedrift decline` records a permanent no for the repo: the nudge never
+ * fires again and capture stays off (the hook gate reads the same store).
+ * Reversible any time by running `vibedrift enable`.
+ *
+ * Both answers append a local consent receipt. Hooks install here only when a
+ * supported agent is detected; the baseline stays lazy (first scan builds it).
+ */
+
+import readline from "readline";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import chalk from "chalk";
+import { repoIdentity, defaultSessionsDir } from "../../session/repo.js";
+import {
+  installHooks,
+  hooksStatus,
+  resolveHookCommand,
+  detectClaudeCode,
+} from "../../session/install.js";
+import {
+  recordAnswer,
+  addDirGrant,
+  resolveGrantPath,
+  DirGrantRefusedError,
+} from "../../session/activation.js";
+import { appendConsentReceipt } from "../../session/consent.js";
+import { vibedriftHome } from "../../core/vibedrift-home.js";
+
+export interface EnableOptions {
+  /** Grant a directory scope instead of a single repo (always typed-confirms). */
+  dir?: string;
+  /** Test/advanced seams; default to the real locations. */
+  sessionsDir?: string;
+  activationHome?: string;
+  homeDir?: string;
+  hookCommand?: string;
+  confirm?: (question: string) => Promise<boolean>;
+}
+
+export type EnableStatus =
+  | "enabled"
+  | "enabled_no_agent"
+  | "dir_granted"
+  | "dir_refused"
+  | "dir_declined"
+  | "aborted_unparseable";
+
+export type DeclineStatus = "declined";
+
+async function askConfirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((res) => rl.question(question, res));
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+function printDisclosure(ledgerDir: string): void {
+  console.log(
+    chalk.dim(
+      [
+        "  What this records: your prompts (secrets masked) and edit metadata,",
+        `  to a LOCAL ledger under ${ledgerDir} — nothing leaves this machine`,
+        "  unless you separately turn on hosted sync. Hooks fail open: an error",
+        "  or timeout never interrupts your agent.",
+        "  Change your mind anytime: vibedrift decline",
+      ].join("\n"),
+    ),
+  );
+}
+
+export async function runEnable(targetPath: string, options: EnableOptions = {}): Promise<EnableStatus> {
+  const activationHome = options.activationHome ?? vibedriftHome();
+  const sessionsDir = options.sessionsDir ?? defaultSessionsDir();
+  const at = new Date().toISOString();
+
+  // ---- directory scope (O19) ----
+  if (options.dir !== undefined) {
+    let granted: string;
+    try {
+      granted = resolveGrantPath(options.dir);
+    } catch (err) {
+      if (err instanceof DirGrantRefusedError) {
+        console.error(`${chalk.red("✗")} ${err.message}`);
+      } else {
+        console.error(`${chalk.red("✗")} cannot grant ${options.dir}: not an accessible directory`);
+      }
+      process.exitCode = 1;
+      return "dir_refused";
+    }
+    const confirm = options.confirm ?? askConfirm;
+    const ok = await confirm(
+      [
+        `This grants Drift Sessions for EVERY repo under:`,
+        `  ${chalk.bold(granted)}`,
+        "New repos there activate without being asked again (an explicit",
+        "`vibedrift decline` in a repo still wins).",
+        "Grant this directory? [y/N] ",
+      ].join("\n"),
+    );
+    if (!ok) {
+      console.log("Nothing granted.");
+      return "dir_declined";
+    }
+    addDirGrant(granted, activationHome);
+    appendConsentReceipt(activationHome, { v: 1, at, action: "dir-grant", surface: "dir-grant", grantPath: granted });
+    console.log(`${chalk.green("✓")} Drift Sessions active for repos under ${granted}.`);
+    return "dir_granted";
+  }
+
+  // ---- single repo: the typed command is the consent ----
+  const { rootDir, projectHash } = repoIdentity(resolve(targetPath));
+  const ledgerDir = join(sessionsDir, projectHash);
+  recordAnswer(projectHash, "active", "cli-enable", activationHome);
+  const receiptOk = appendConsentReceipt(ledgerDir, {
+    v: 1,
+    at,
+    action: "enable",
+    surface: "cli-enable",
+    projectHash,
+    rootDir,
+  });
+
+  const home = options.homeDir ?? homedir();
+  if (!detectClaudeCode(rootDir, home)) {
+    console.log(`${chalk.green("✓")} Drift Sessions enabled for this repo.`);
+    console.log(
+      chalk.dim(
+        "  No supported agent detected yet (Claude Code is the first). Capture starts\n  once its hooks are installed — re-run `vibedrift enable` after setting it up.",
+      ),
+    );
+    printDisclosure(ledgerDir);
+    return "enabled_no_agent";
+  }
+
+  const already = await hooksStatus(rootDir);
+  if (!already.installed) {
+    const res = await installHooks(rootDir, {
+      hookCommand: options.hookCommand ?? resolveHookCommand(),
+      sessionsDir,
+      projectHash,
+    });
+    if (res.status === "aborted_unparseable") {
+      console.error(
+        `Could not parse ${res.file}; refusing to modify it. Your answer was recorded — fix the JSON and re-run \`vibedrift enable\`.`,
+      );
+      process.exitCode = 1;
+      return "aborted_unparseable";
+    }
+    console.log(`${chalk.green("✓")} Drift Sessions enabled — hooks installed for this repo (${res.file}).`);
+  } else {
+    console.log(`${chalk.green("✓")} Drift Sessions enabled — hooks were already installed (${already.file}).`);
+  }
+  if (!receiptOk) console.log(chalk.yellow("  note: could not write the local consent receipt (answer still recorded)."));
+  printDisclosure(ledgerDir);
+  console.log(chalk.dim("  follow live: vibedrift watch-session"));
+  return "enabled";
+}
+
+export async function runDecline(
+  targetPath: string,
+  options: Pick<EnableOptions, "sessionsDir" | "activationHome"> = {},
+): Promise<DeclineStatus> {
+  const activationHome = options.activationHome ?? vibedriftHome();
+  const sessionsDir = options.sessionsDir ?? defaultSessionsDir();
+  const { rootDir, projectHash } = repoIdentity(resolve(targetPath));
+  recordAnswer(projectHash, "declined", "cli-decline", activationHome);
+  appendConsentReceipt(join(sessionsDir, projectHash), {
+    v: 1,
+    at: new Date().toISOString(),
+    action: "decline",
+    surface: "cli-decline",
+    projectHash,
+    rootDir,
+  });
+  console.log(`${chalk.green("✓")} Drift Sessions declined for this repo — you won't be asked again and capture stays off here.`);
+  console.log(chalk.dim("  hooks (if any) stay inert; remove them entirely: vibedrift watch-session --uninstall"));
+  console.log(chalk.dim("  changed your mind? vibedrift enable"));
+  return "declined";
+}

--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -22,11 +22,14 @@ import { runUploader, shouldSync } from "../../session/uploader.js";
 import { parseJsonlLines } from "../../session/ledger.js";
 import { summarize } from "../../session/summary.js";
 import { readConfig, patchConfig } from "../../auth/config.js";
-import { postSessionIngest } from "../../auth/api.js";
+import { postSessionIngest, type SessionIngestResponse } from "../../auth/api.js";
 import type { UploadEvent } from "../../session/upload-schema.js";
 
 interface UploadPlan {
-  post: (events: UploadEvent[]) => Promise<void>;
+  /** Returns the server ack so the uploader can commit durable offsets
+   *  contiguously (frozen wire contract v1); throws VibeDriftApiError(402)
+   *  when the whole batch is entitlement-locked. */
+  post: (events: UploadEvent[]) => Promise<SessionIngestResponse>;
   teamIntentOptIn: boolean;
 }
 import {
@@ -351,9 +354,7 @@ async function resolveUploadPlan(options: WatchSessionOptions): Promise<UploadPl
     const apiUrl = cfg.apiUrl;
     return {
       teamIntentOptIn: cfg.sessionsTeamIntentOptIn === true,
-      post: async (events) => {
-        await postSessionIngest(token, events, { apiUrl });
-      },
+      post: (events) => postSessionIngest(token, events, { apiUrl }),
     };
   } catch {
     return undefined; // config unreadable → no sync, local unaffected

--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -10,13 +10,21 @@
  */
 
 import readline from "readline";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
 import chalk from "chalk";
 import { repoIdentity, defaultSessionsDir } from "../../session/repo.js";
-import { installHooks, uninstallHooks, hooksStatus } from "../../session/install.js";
+import {
+  installHooks,
+  uninstallHooks,
+  hooksStatus,
+  resolveHookCommand,
+  detectClaudeCode,
+} from "../../session/install.js";
+import { recordAnswer } from "../../session/activation.js";
+import { appendConsentReceipt } from "../../session/consent.js";
+import { vibedriftHome } from "../../core/vibedrift-home.js";
 import { runLiveTape } from "../../session/live.js";
 import { runUploader, shouldSync } from "../../session/uploader.js";
 import { parseJsonlLines } from "../../session/ledger.js";
@@ -58,6 +66,8 @@ export interface WatchSessionOptions {
   sessionsDir?: string;
   hookCommand?: string;
   homeDir?: string;
+  /** Root of the activation store (default vibedriftHome()). */
+  activationHome?: string;
   confirm?: (question: string) => Promise<boolean>;
   /** Inject the resolved entitlement (bypasses the network); tests use this.
    *  Return null to simulate "login required". */
@@ -80,23 +90,6 @@ export type WatchSessionStatus =
   | "login_required"
   | "sync_updated"
   | "aborted_unparseable";
-
-function detectClaudeCode(repoRoot: string, homeDir: string): boolean {
-  return (
-    existsSync(join(repoRoot, ".claude")) || existsSync(join(homeDir, ".claude", "settings.json"))
-  );
-}
-
-/** Absolute `node <dist>/session/hook-entry.js` so hooks never depend on PATH.
- *  At runtime this module lives in dist/cli/, so the entry is a sibling tree.
- *  Both paths are double-quoted so a node install or repo checkout under a
- *  directory containing spaces still runs (the shell would otherwise split it);
- *  the trailing ` #vibedrift-hook` marker stays a shell comment. */
-function resolveHookCommand(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const entry = resolve(here, "..", "session", "hook-entry.js");
-  return `"${process.execPath}" "${entry}"`;
-}
 
 async function askConsent(question: string): Promise<boolean> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -247,6 +240,18 @@ export async function runWatchSession(
     process.exitCode = 1;
     return "aborted_unparseable";
   }
+  // The user just consented (prompt or --yes): record the explicit answer so
+  // the nudge never fires here. Grandfathered installs (the early-return
+  // "already" path above) deliberately never reach this line.
+  recordAnswer(projectHash, "active", "watch-session", options.activationHome ?? vibedriftHome());
+  appendConsentReceipt(ledgerDir, {
+    v: 1,
+    at: new Date().toISOString(),
+    action: "enable",
+    surface: "watch-session",
+    projectHash,
+    rootDir,
+  });
   const installed = res.status === "already" ? "already" : "installed";
   if (installed === "already") {
     console.log(`${chalk.green("●")} Drift Sessions hooks already installed (${res.file}).`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import { runDoctor } from "./commands/doctor.js";
 import { runFeedback } from "./commands/feedback.js";
 import { runWatch } from "./commands/watch.js";
 import { runWatchSession } from "./commands/watch-session.js";
+import { runEnable, runDecline } from "./commands/enable.js";
 import { runHook } from "./commands/hook.js";
 import { getVersion } from "../core/version.js";
 import { vibedriftHome, isSandboxHome } from "../core/vibedrift-home.js";
@@ -286,6 +287,29 @@ program
       localOnly: options.localOnly === true,
       watch: options.watch !== false && !options.uninstall && !options.status && !sync,
     });
+  });
+
+// ──── Drift Sessions activation answers ────
+program
+  .command("enable")
+  .description(
+    "Drift Sessions: activate this repo — typing this command is the consent; records prompts (secrets masked) + edit metadata to a local ledger",
+  )
+  .argument("[path]", "path to project directory", ".")
+  .option(
+    "--dir <path>",
+    "grant a directory scope: every repo under it activates (shown resolved, always asks for typed confirmation; $HOME and roots are refused)",
+  )
+  .action(async (path: string, options) => {
+    await runEnable(path, { dir: options.dir });
+  });
+
+program
+  .command("decline")
+  .description("Drift Sessions: decline for this repo — never asked again, capture stays off (reverse anytime with `vibedrift enable`)")
+  .argument("[path]", "path to project directory", ".")
+  .action(async (path: string) => {
+    await runDecline(path);
   });
 
 // ──── Telemetry subcommand ────

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,6 +21,7 @@ import { registerFindSimilarFunction } from "./tools/find-similar-function.js";
 import { registerValidateChange } from "./tools/validate-change.js";
 import { registerRespondToFlag } from "./tools/respond-to-flag.js";
 import { registerInit } from "./tools/init.js";
+import { registerEnable } from "./tools/enable.js";
 
 const SERVER_INSTRUCTIONS = `VibeDrift detects drift in AI-generated code — where new code diverges from the patterns the rest of the codebase already follows.
 
@@ -40,7 +41,7 @@ For a deeper, AI-validated pass on a CHANGE SET (before committing or opening a 
 The --deep workflows (semantic-duplicate confirmation, intent lie-detection, the coherence audit) are a paid Pro feature; the local tools above stay free.`;
 
 /**
- * Build the server with the seven local tools registered. The local tools are
+ * Build the server with the eight local tools registered. The local tools are
  * free for everyone; deep checks are metered server-side inside the tools.
  */
 export function createServer(): McpServer {
@@ -49,6 +50,7 @@ export function createServer(): McpServer {
     { instructions: SERVER_INSTRUCTIONS },
   );
   registerInit.register(server);
+  registerEnable.register(server);
   registerGetIntentHints.register(server);
   registerGetDominantPattern.register(server);
   registerCheckFileDrift.register(server);

--- a/src/mcp/tools/enable.ts
+++ b/src/mcp/tools/enable.ts
@@ -1,0 +1,31 @@
+/**
+ * enable — MCP adapter.
+ *
+ * Channel-neutral logic (run + types) lives in
+ * src/tools-core/tools/enable.ts. This adapter registers it on an MCP server
+ * and, per O18, marks it `_meta["anthropic/requiresUserInteraction"]:true` so
+ * Claude Code raises its native Allow/Deny prompt on EVERY call — the hard
+ * consent gate for turning on capture in a repo.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { run, inputSchema } from "../../tools-core/tools/enable.js";
+import { toToolResult } from "../envelope.js";
+
+export * from "../../tools-core/tools/enable.js";
+
+export const registerEnable = {
+  run,
+  register(server: McpServer): void {
+    server.registerTool(
+      "enable",
+      {
+        title: "Enable VibeDrift Drift Sessions for this repo",
+        description:
+          "Answer the VibeDrift activation nudge. To turn it ON, pass the user's explicit affirmative in `confirm` (this call raises an Allow/Deny prompt — the user must also approve it). To turn it OFF for this repo, pass decline:true. Records the answer in the machine-global activation store + a local consent receipt, and installs the Claude Code hooks on enable. Local; no network.",
+        inputSchema,
+        _meta: { "anthropic/requiresUserInteraction": true },
+      },
+      async (args) => toToolResult(await run(args)),
+    );
+  },
+};

--- a/src/session/activation.ts
+++ b/src/session/activation.ts
@@ -5,9 +5,10 @@
  * One small JSON file under the VibeDrift home — the SessionStart hook reads
  * it on its fast path (single file read, well inside the 0.2s budget), the
  * enable/decline surfaces write it. States per projectHash:
- *   - no entry / no `state`  -> unanswered (the nudge may fire, budget-gated)
+ *   - no entry / no `state`  -> unanswered (the nudge may fire, budget-gated;
+ *                               capture continues for legacy grandfathered repos)
  *   - "active"               -> capture on, never nudge
- *   - "declined"             -> capture per legacy rules, never nudge again
+ *   - "declined"             -> capture OFF (the hook returns early), never nudge again
  *
  * The ask BUDGET (L-N8 as amended): at most one ask per genuinely new
  * interactive session, at most ASK_BUDGET total; expiry writes an IMPLICIT
@@ -164,11 +165,18 @@ export class DirGrantRefusedError extends Error {
 }
 
 /** Canonicalize and validate a dir-grant path (O19). Throws on $HOME, any
- *  filesystem root, or a nonexistent directory. Returns the resolved path. */
+ *  ANCESTOR of $HOME (e.g. `/Users`, `/home` — broader than $HOME itself), any
+ *  filesystem root, or a nonexistent directory. Returns the resolved path. A
+ *  subdirectory of home (e.g. `~/work`) is the intended grant and is allowed. */
 export function resolveGrantPath(input: string): string {
   const real = realpathSync(resolve(input));
   const home = realpathSync(homedir());
-  if (real === home) throw new DirGrantRefusedError(real, "granting your entire home directory is auto-capture-everything, which is explicitly rejected; grant a work directory instead (e.g. ~/work)");
+  if (home === real || home.startsWith(real + sep)) {
+    throw new DirGrantRefusedError(
+      real,
+      "granting your home directory (or a parent of it) is auto-capture-everything, which is explicitly rejected; grant a work directory instead (e.g. ~/work)",
+    );
+  }
   const { root } = parse(real);
   if (real === root) throw new DirGrantRefusedError(real, "granting a filesystem root would capture everything on the machine");
   return real;

--- a/src/session/activation.ts
+++ b/src/session/activation.ts
@@ -1,0 +1,183 @@
+/**
+ * Machine-global activation store (L-N3/L-N8): per-repo consent state for
+ * native Drift Sessions, plus directory-scope grants (L-N9).
+ *
+ * One small JSON file under the VibeDrift home — the SessionStart hook reads
+ * it on its fast path (single file read, well inside the 0.2s budget), the
+ * enable/decline surfaces write it. States per projectHash:
+ *   - no entry / no `state`  -> unanswered (the nudge may fire, budget-gated)
+ *   - "active"               -> capture on, never nudge
+ *   - "declined"             -> capture per legacy rules, never nudge again
+ *
+ * The ask BUDGET (L-N8 as amended): at most one ask per genuinely new
+ * interactive session, at most ASK_BUDGET total; expiry writes an IMPLICIT
+ * decline deterministically (never via a permission-gated tool). `vibedrift
+ * enable` reverses any decline at any time.
+ *
+ * Dir grants (O19): stored canonicalized; `$HOME` and filesystem roots are
+ * REFUSED outright — a grant that broad is indistinguishable from the
+ * auto-capture-everything design that was explicitly rejected.
+ *
+ * Legacy grandfather: a repo with hooks installed but NO record here keeps
+ * capturing (existing users are never silently flipped); "declined" always
+ * wins over everything.
+ *
+ * Writes are atomic (tmp + rename) and fail-open; readers treat a missing or
+ * corrupt file as empty.
+ */
+
+import { mkdirSync, readFileSync, renameSync, realpathSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, parse, resolve, sep } from "node:path";
+import { vibedriftHome } from "../core/vibedrift-home.js";
+
+export const ASK_BUDGET = 3;
+
+export type ActivationState = "active" | "declined";
+export type AnswerSurface =
+  | "cli-enable"
+  | "cli-decline"
+  | "mcp-enable"
+  | "mcp-decline"
+  | "watch-session"
+  | "budget-expiry"
+  | "dir-grant";
+
+export interface ProjectActivation {
+  state?: ActivationState;
+  /** ISO timestamp of the recorded answer (absent while unanswered). */
+  at?: string;
+  surface?: AnswerSurface;
+  /** Asks consumed so far (unanswered repos only, budget-gated). */
+  askCount?: number;
+  /** The one-time "run `vibedrift enable`" breadcrumb was already shown. */
+  breadcrumbShown?: boolean;
+}
+
+export interface ActivationStore {
+  v: 1;
+  projects: Record<string, ProjectActivation>;
+  dirGrants: Array<{ path: string; at: string }>;
+}
+
+const EMPTY: ActivationStore = { v: 1, projects: {}, dirGrants: [] };
+
+export function activationPath(home: string = vibedriftHome()): string {
+  return join(home, "activation.json");
+}
+
+/** Synchronous on purpose: the hook fast path calls this. Fail-open. */
+export function loadActivation(home: string = vibedriftHome()): ActivationStore {
+  try {
+    const parsed = JSON.parse(readFileSync(activationPath(home), "utf8")) as Partial<ActivationStore>;
+    if (!parsed || parsed.v !== 1) return structuredClone(EMPTY);
+    return {
+      v: 1,
+      projects: typeof parsed.projects === "object" && parsed.projects !== null ? parsed.projects : {},
+      dirGrants: Array.isArray(parsed.dirGrants) ? parsed.dirGrants : [],
+    };
+  } catch {
+    return structuredClone(EMPTY);
+  }
+}
+
+function saveActivation(store: ActivationStore, home: string = vibedriftHome()): void {
+  try {
+    mkdirSync(home, { recursive: true, mode: 0o700 });
+    const path = activationPath(home);
+    const tmp = `${path}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(store), { mode: 0o600 });
+    renameSync(tmp, path);
+  } catch {
+    // fail-open: an unwritable store degrades to "unanswered" next time
+  }
+}
+
+/** Effective status for a repo root: an explicit answer wins; otherwise a
+ *  covering dir grant means active; otherwise unanswered. */
+export function projectStatus(
+  store: ActivationStore,
+  projectHash: string,
+  rootDir?: string,
+): ActivationState | "unanswered" {
+  const rec = store.projects[projectHash];
+  if (rec?.state) return rec.state;
+  if (rootDir && isUnderGrant(store, rootDir)) return "active";
+  return "unanswered";
+}
+
+export function isUnderGrant(store: ActivationStore, rootDir: string): boolean {
+  const root = resolve(rootDir);
+  return store.dirGrants.some((g) => root === g.path || root.startsWith(g.path + sep));
+}
+
+export function recordAnswer(
+  projectHash: string,
+  state: ActivationState,
+  surface: AnswerSurface,
+  home: string = vibedriftHome(),
+): void {
+  const store = loadActivation(home);
+  const prev = store.projects[projectHash] ?? {};
+  store.projects[projectHash] = { ...prev, state, at: new Date().toISOString(), surface };
+  saveActivation(store, home);
+}
+
+export interface AskOutcome {
+  /** true when the nudge may fire this session. */
+  ask: boolean;
+  /** asks consumed INCLUDING this one when ask=true. */
+  askCount: number;
+  /** true exactly once: this call exhausted the budget (implicit decline
+   *  recorded; caller should surface the one-line breadcrumb). */
+  budgetExpired: boolean;
+}
+
+/**
+ * Consume one ask from the budget for an unanswered repo. Call ONLY for a
+ * genuinely new interactive session (the hook gate decides that). When the
+ * budget is exhausted, records the implicit decline deterministically.
+ */
+export function consumeAsk(projectHash: string, home: string = vibedriftHome()): AskOutcome {
+  const store = loadActivation(home);
+  const rec = store.projects[projectHash] ?? {};
+  if (rec.state) return { ask: false, askCount: rec.askCount ?? 0, budgetExpired: false };
+  const count = (rec.askCount ?? 0) + 1;
+  if (count > ASK_BUDGET) {
+    // Shouldn't happen (expiry records a decline), but stay safe.
+    return { ask: false, askCount: rec.askCount ?? 0, budgetExpired: false };
+  }
+  const expiring = count === ASK_BUDGET;
+  store.projects[projectHash] = expiring
+    ? { ...rec, askCount: count, state: "declined", at: new Date().toISOString(), surface: "budget-expiry", breadcrumbShown: true }
+    : { ...rec, askCount: count };
+  saveActivation(store, home);
+  // The final ask still fires (it IS the third ask); expiry means no fourth.
+  return { ask: true, askCount: count, budgetExpired: expiring };
+}
+
+export class DirGrantRefusedError extends Error {
+  constructor(public readonly resolved: string, reason: string) {
+    super(`refusing directory grant on ${resolved}: ${reason}`);
+    this.name = "DirGrantRefusedError";
+  }
+}
+
+/** Canonicalize and validate a dir-grant path (O19). Throws on $HOME, any
+ *  filesystem root, or a nonexistent directory. Returns the resolved path. */
+export function resolveGrantPath(input: string): string {
+  const real = realpathSync(resolve(input));
+  const home = realpathSync(homedir());
+  if (real === home) throw new DirGrantRefusedError(real, "granting your entire home directory is auto-capture-everything, which is explicitly rejected; grant a work directory instead (e.g. ~/work)");
+  const { root } = parse(real);
+  if (real === root) throw new DirGrantRefusedError(real, "granting a filesystem root would capture everything on the machine");
+  return real;
+}
+
+export function addDirGrant(resolvedPath: string, home: string = vibedriftHome()): void {
+  const store = loadActivation(home);
+  if (!store.dirGrants.some((g) => g.path === resolvedPath)) {
+    store.dirGrants.push({ path: resolvedPath, at: new Date().toISOString() });
+    saveActivation(store, home);
+  }
+}

--- a/src/session/activation.ts
+++ b/src/session/activation.ts
@@ -10,10 +10,13 @@
  *   - "active"               -> capture on, never nudge
  *   - "declined"             -> capture OFF (the hook returns early), never nudge again
  *
- * The ask BUDGET (L-N8 as amended): at most one ask per genuinely new
- * interactive session, at most ASK_BUDGET total; expiry writes an IMPLICIT
- * decline deterministically (never via a permission-gated tool). `vibedrift
- * enable` reverses any decline at any time.
+ * The ask BUDGET (L-N8, reconciled with the grandfather rule 2026-07-26): at
+ * most one ask per genuinely new interactive session, at most ASK_BUDGET total.
+ * Expiry stops ASKING (marks `breadcrumbShown`, leaves a one-line breadcrumb)
+ * but deliberately does NOT write `declined` — so a legacy repo that was already
+ * capturing is never silently flipped off just because its nudges went ignored.
+ * Only an explicit `vibedrift enable`/`decline` sets `state`; the ask itself
+ * self-limits via `askCount`.
  *
  * Dir grants (O19): stored canonicalized; `$HOME` and filesystem roots are
  * REFUSED outright — a grant that broad is indistinguishable from the
@@ -136,8 +139,10 @@ export interface AskOutcome {
 
 /**
  * Consume one ask from the budget for an unanswered repo. Call ONLY for a
- * genuinely new interactive session (the hook gate decides that). When the
- * budget is exhausted, records the implicit decline deterministically.
+ * genuinely new interactive session (the hook gate decides that). The budget
+ * self-limits via `askCount` — the (ASK_BUDGET+1)th call returns ask:false —
+ * so expiry does NOT need to (and must not) write `declined`, which would flip
+ * a grandfathered capturing repo off (L-N8 reconciled with grandfather).
  */
 export function consumeAsk(projectHash: string, home: string = vibedriftHome()): AskOutcome {
   const store = loadActivation(home);
@@ -145,12 +150,14 @@ export function consumeAsk(projectHash: string, home: string = vibedriftHome()):
   if (rec.state) return { ask: false, askCount: rec.askCount ?? 0, budgetExpired: false };
   const count = (rec.askCount ?? 0) + 1;
   if (count > ASK_BUDGET) {
-    // Shouldn't happen (expiry records a decline), but stay safe.
+    // Budget already spent: no more asks (askCount self-limits; no state written).
     return { ask: false, askCount: rec.askCount ?? 0, budgetExpired: false };
   }
   const expiring = count === ASK_BUDGET;
+  // Expiry marks breadcrumbShown but leaves `state` alone — capture (for a
+  // grandfathered repo) continues; only an explicit enable/decline sets state.
   store.projects[projectHash] = expiring
-    ? { ...rec, askCount: count, state: "declined", at: new Date().toISOString(), surface: "budget-expiry", breadcrumbShown: true }
+    ? { ...rec, askCount: count, breadcrumbShown: true }
     : { ...rec, askCount: count };
   saveActivation(store, home);
   // The final ask still fires (it IS the third ask); expiry means no fourth.

--- a/src/session/consent.ts
+++ b/src/session/consent.ts
@@ -1,0 +1,43 @@
+/**
+ * Consent receipts (local-only v1): an append-only `consent.log` JSONL file
+ * recording every activation answer — enable, decline, dir grant, budget
+ * expiry — with when and through which surface it happened.
+ *
+ * Per-repo receipts live under `sessions/<hash>/consent.log`; machine-level
+ * receipts (dir grants) live at the VibeDrift home root. `.log` keeps them
+ * structurally outside the uploadable event stream (the uploader follows
+ * `.jsonl` only), so a receipt can never leave the machine by construction.
+ *
+ * Best-effort: a receipt write failure must never block the answer itself —
+ * callers get `false` back and surface a warning instead.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export const CONSENT_LOG = "consent.log";
+
+export interface ConsentReceipt {
+  v: 1;
+  /** ISO timestamp of the answer. */
+  at: string;
+  action: "enable" | "decline" | "dir-grant";
+  /** Which surface recorded it (AnswerSurface from the activation store). */
+  surface: string;
+  projectHash?: string;
+  /** Canonicalized repo root (enable/decline receipts). */
+  rootDir?: string;
+  /** Canonicalized granted directory (dir-grant receipts). */
+  grantPath?: string;
+}
+
+/** Append one receipt line to `<dir>/consent.log`. Returns false on failure. */
+export function appendConsentReceipt(dir: string, receipt: ConsentReceipt): boolean {
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    appendFileSync(join(dir, CONSENT_LOG), JSON.stringify(receipt) + "\n", { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/session/entitlement.ts
+++ b/src/session/entitlement.ts
@@ -13,6 +13,11 @@ import { isPaidPlan, type Plan } from "../auth/plan.js";
 
 export const SESSION_TRIAL_LIMIT = 5;
 
+/** How long a cached entitlement is trusted before the native flush re-asks
+ *  the server. Long enough that a busy session adds ~no extra requests, short
+ *  enough that a trial burned on another machine lands quickly. */
+export const ENTITLEMENT_TTL_MS = 15 * 60_000;
+
 export type EntitlementReason = "pro" | "trial" | "locked";
 
 export interface SessionEntitlement {
@@ -21,6 +26,9 @@ export interface SessionEntitlement {
   plan: Plan;
   trialUsed: number;
   trialLimit: number;
+  /** ISO time the server was last asked. Absent on caches written before this
+   *  field existed, which counts as stale (see `shouldRefreshEntitlement`). */
+  checkedAt?: string;
 }
 
 /** Pure policy: Pro/Enterprise always entitled; free entitled while trial remains. */
@@ -56,25 +64,115 @@ export function readEntitlementCache(baseDir: string = entitlementDir()): Sessio
       plan: (parsed.plan as Plan) ?? "free",
       trialUsed: typeof parsed.trialUsed === "number" ? parsed.trialUsed : 0,
       trialLimit: typeof parsed.trialLimit === "number" ? parsed.trialLimit : SESSION_TRIAL_LIMIT,
+      ...(typeof parsed.checkedAt === "string" ? { checkedAt: parsed.checkedAt } : {}),
     };
   } catch {
     return null;
   }
 }
 
-export function writeEntitlementCache(baseDir: string, e: SessionEntitlement): void {
+export function writeEntitlementCache(
+  baseDir: string,
+  e: SessionEntitlement,
+  now: () => number = Date.now,
+): void {
   try {
     mkdirSync(baseDir, { recursive: true, mode: 0o700 });
-    writeFileSync(cachePath(baseDir), JSON.stringify(e), { mode: 0o600 });
+    const stamped: SessionEntitlement = e.checkedAt
+      ? e
+      : { ...e, checkedAt: new Date(now()).toISOString() };
+    writeFileSync(cachePath(baseDir), JSON.stringify(stamped), { mode: 0o600 });
   } catch {
     // best-effort; a missing cache fails OPEN (capture), never closed
   }
 }
 
+/**
+ * Should the native flush re-ask the server for entitlement?
+ *
+ * The native path has no `watch-session` to refresh this cache, so the
+ * Stop-spawned flush owns it. Policy:
+ * - no cache, or a missing/unparseable `checkedAt` -> ask (nothing current);
+ * - LOCKED -> always ask, so upgrading to Pro unlocks on the very next turn
+ *   rather than after a TTL the user cannot see;
+ * - a future `checkedAt` (clock skew, restored backup) -> ask, so a bad stamp
+ *   can never pin the cache open forever;
+ * - otherwise ask only once the TTL has elapsed.
+ */
+export function shouldRefreshEntitlement(
+  cached: SessionEntitlement | null,
+  nowMs: number,
+  ttlMs: number = ENTITLEMENT_TTL_MS,
+): boolean {
+  if (!cached) return true;
+  if (!cached.entitled) return true;
+  if (!cached.checkedAt) return true;
+  const at = Date.parse(cached.checkedAt);
+  if (Number.isNaN(at)) return true;
+  const age = nowMs - at;
+  return age < 0 || age >= ttlMs;
+}
+
 /** The hook's gate: capture unless the cache explicitly says locked. A missing
- *  cache permits capture — watch-session writes the cache before hooks are
- *  useful, and failing open avoids silently dropping a paying user's session. */
+ *  cache permits capture — the flush writes the cache within the first session,
+ *  and failing open avoids silently dropping a paying user's session. */
 export function isCapturePermitted(baseDir: string = entitlementDir()): boolean {
   const cached = readEntitlementCache(baseDir);
   return cached ? cached.entitled : true;
+}
+
+/** The server's answer shape (mirrors `SessionEntitlementResponse`). */
+export interface EntitlementFetchResult {
+  plan: Plan;
+  trial_used: number;
+  trial_limit: number;
+}
+
+export interface RefreshEntitlementOptions {
+  baseDir: string;
+  /** Ask the server. Must reject (not resolve) on failure. */
+  fetch: () => Promise<EntitlementFetchResult>;
+  /** Skip the TTL check and ask regardless (used after a 402). */
+  force?: boolean;
+  now?: () => number;
+  ttlMs?: number;
+}
+
+function isFiniteInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Refresh the entitlement cache from the server, TTL-gated.
+ *
+ * This is the native path's cache owner. `watch-session` refreshes the cache
+ * as a side effect of starting up, but the native flow has no watch-session,
+ * so without this the cache is never written and `isCapturePermitted` fails
+ * open forever — the paywall would never bite.
+ *
+ * Fail-open throughout: an unreachable server or a malformed answer leaves the
+ * existing cache exactly as it was and returns it. A network blip must never
+ * lock a paying user out, and it must never silently unlock a spent trial
+ * either, which is why nothing is written unless the server actually answered.
+ */
+export async function refreshEntitlementCache(
+  opts: RefreshEntitlementOptions,
+): Promise<SessionEntitlement | null> {
+  const now = opts.now ?? Date.now;
+  const cached = readEntitlementCache(opts.baseDir);
+  if (!opts.force && !shouldRefreshEntitlement(cached, now(), opts.ttlMs)) return cached;
+
+  let answer: EntitlementFetchResult;
+  try {
+    answer = await opts.fetch();
+  } catch {
+    return cached; // offline / server error: keep what we had
+  }
+  if (!isFiniteInt(answer?.trial_used) || !isFiniteInt(answer?.trial_limit)) {
+    return cached; // malformed: better a stale truth than a fabricated one
+  }
+
+  const fresh = computeEntitlement(answer.plan, answer.trial_used, answer.trial_limit);
+  writeEntitlementCache(opts.baseDir, fresh, now);
+  return readEntitlementCache(opts.baseDir) ?? fresh;
 }

--- a/src/session/flush-run.ts
+++ b/src/session/flush-run.ts
@@ -1,0 +1,79 @@
+/**
+ * The per-turn flush, as a testable unit.
+ *
+ * `session-flush.ts` is a detached entrypoint script whose body runs on import,
+ * so the orchestration it performs lives here instead: entitlement refresh,
+ * then upload, then the post-402 correction.
+ *
+ * Why entitlement lives on this path: sessions are Pro-only with a 5-session
+ * trial (decision 8), and the hook's gate (`isCapturePermitted`) reads a LOCAL
+ * cache because the hook itself must never touch the network. In the classic
+ * flow `watch-session` refreshed that cache. The native flow has no
+ * watch-session, so without a refresh here the cache is never written, the gate
+ * fails open forever, and the paywall never applies. This flush is the natural
+ * owner: it already runs once per turn, detached, off the hook's critical path,
+ * and it already holds a token.
+ *
+ * Fail-open throughout. An unreachable entitlement endpoint leaves the cache
+ * untouched and the upload proceeds; only an answer from the server can lock a
+ * machine, never a network blip.
+ */
+
+import { refreshEntitlementCache, type EntitlementFetchResult } from "./entitlement.js";
+import { runUploaderOnce } from "./uploader.js";
+import type { IngestAck } from "./ingest-ack.js";
+import type { UploadEvent } from "./upload-schema.js";
+
+export interface FlushRunOptions {
+  /** Entitlement-cache dir (the VibeDrift home root). */
+  baseDir: string;
+  sessionsDir: string;
+  projectHash: string;
+  teamIntentOptIn?: boolean;
+  /** Ask the server for entitlement; must reject on failure. */
+  fetchEntitlement: () => Promise<EntitlementFetchResult>;
+  post: (events: UploadEvent[]) => Promise<IngestAck | void>;
+  budgetMs?: number;
+  now?: () => number;
+}
+
+export interface FlushRunResult {
+  /** The uploader ran (it may still have had nothing queued). */
+  uploaded: boolean;
+  /** The account is out of trial: capture stops on the next hook event. */
+  locked: boolean;
+}
+
+export async function runFlush(opts: FlushRunOptions): Promise<FlushRunResult> {
+  const { baseDir, now } = opts;
+
+  // 1. Pre-flight: TTL-gated, and always re-asked while locked so an upgrade
+  //    takes effect on the very next turn.
+  const entitlement = await refreshEntitlementCache({
+    baseDir,
+    now,
+    fetch: opts.fetchEntitlement,
+  });
+
+  // 2. A known-locked account uploads nothing: the server would only 402 it.
+  //    A null entitlement means we could not ask, which fails open (upload).
+  if (entitlement && !entitlement.entitled) return { uploaded: false, locked: true };
+
+  const { locked } = await runUploaderOnce({
+    sessionsDir: opts.sessionsDir,
+    projectHash: opts.projectHash,
+    teamIntentOptIn: opts.teamIntentOptIn,
+    post: opts.post,
+    budgetMs: opts.budgetMs,
+  });
+
+  // 3. The server locked us mid-flush. Re-ask (forced, past the TTL) so the
+  //    cache reflects the server's truth rather than a value we invented, and
+  //    the hook gate stops capturing on the next event.
+  if (locked) {
+    await refreshEntitlementCache({ baseDir, now, force: true, fetch: opts.fetchEntitlement });
+    return { uploaded: true, locked: true };
+  }
+
+  return { uploaded: true, locked: false };
+}

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -20,7 +20,8 @@
  * (no file is parsed), so the cold cost stays ~60-80ms.
  */
 
-import { relative, resolve, isAbsolute, basename } from "node:path";
+import { relative, resolve, isAbsolute, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
 
 const SELF_TIMEOUT_MS = 2000;
@@ -41,6 +42,38 @@ async function readStdin(): Promise<string> {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * Spawn the detached session-flush child (Stop-hook path). Gated on hosted-sync
+ * opt-in + a token — a local-only or logged-out user spawns nothing. The child
+ * is fully detached and unref'd so it outlives this hook, which returns at once.
+ * Fail-open: any error just means no flush (watch-session / the next turn cover
+ * delivery). `VIBEDRIFT_SESSION_FLUSH_CMD` is a test seam.
+ */
+async function maybeSpawnFlush(projectHash: string, sessionsDir: string): Promise<void> {
+  try {
+    const [{ readConfig }, { shouldSync }] = await Promise.all([
+      import("../auth/config.js"),
+      import("./uploader.js"),
+    ]);
+    const cfg = await readConfig();
+    if (!shouldSync(cfg, false) || !cfg.token) return;
+
+    const { spawn } = await import("node:child_process");
+    // Test seam: an executable path invoked with (projectHash, sessionsDir).
+    const override = process.env.VIBEDRIFT_SESSION_FLUSH_CMD;
+    const [cmd, args] = override
+      ? [override, [projectHash, sessionsDir]]
+      : [
+          process.execPath,
+          [resolve(dirname(fileURLToPath(import.meta.url)), "session-flush.js"), projectHash, sessionsDir],
+        ];
+    const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+    child.unref();
+  } catch {
+    // fail-open: no flush spawned
+  }
 }
 
 async function main(): Promise<number> {
@@ -141,6 +174,13 @@ async function main(): Promise<number> {
 
   const sessionsDir = defaultSessionsDir();
   await appendEvent(sessionsDir, projectHash, event.sid, event);
+
+  // End of a turn (Claude Code fires Stop per response): ship this turn's
+  // events so the dashboard streams live WITHOUT watch-session open. The hook
+  // stays offline — it only spawns a detached child (fail-open, opt-in gated).
+  if (event.type === "session_end") {
+    await maybeSpawnFlush(projectHash, sessionsDir);
+  }
 
   // Capture the task intent from prompts; lock it on the first one.
   if (event.type === "user_prompt" && event.detail.promptText) {

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -149,7 +149,29 @@ async function main(): Promise<number> {
     }
   }
 
-  if (!capturePermitted) return 0;
+  if (!capturePermitted) {
+    // Locked account: capture nothing, but do two things so the paywall is
+    // neither invisible nor a one-way door.
+    //  1. Say so once per new interactive session. `watch-session` has a full
+    //     lock screen; the native path's only user-visible channel is this.
+    //  2. Still spawn the Stop flush, which refreshes entitlement — otherwise
+    //     a locked machine could never learn it had been upgraded to Pro.
+    if (normalized.type === "session_start") {
+      const source =
+        typeof (payload as Record<string, unknown>).source === "string"
+          ? ((payload as Record<string, unknown>).source as string)
+          : undefined;
+      const { isNewInteractiveSource, isNonInteractive, buildLockNotice } = await import("./nudge.js");
+      const ent = readEntitlementCache();
+      if (ent && !ent.entitled && isNewInteractiveSource(source) && !isNonInteractive()) {
+        process.stdout.write(JSON.stringify(buildLockNotice({ entitlement: ent })) + "\n");
+      }
+    }
+    if (normalized.type === "session_end") {
+      await maybeSpawnFlush(projectHash, defaultSessionsDir());
+    }
+    return 0;
+  }
 
   // The in-memory body hand-off must never reach the ledger.
   const { body, ...event } = normalized;

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -82,8 +82,41 @@ async function main(): Promise<number> {
   // Entitlement gate (decision 8): a LOCKED account captures nothing. The check
   // reads a local cache written by `watch-session` — no network on this path.
   // Fail-open: a missing/unreadable cache permits capture.
-  const { isCapturePermitted } = await import("./entitlement.js");
-  if (!isCapturePermitted()) return 0;
+  const { isCapturePermitted, readEntitlementCache } = await import("./entitlement.js");
+  const capturePermitted = isCapturePermitted();
+
+  // Activation gate (L-N3): an explicit `decline` stops capture entirely; an
+  // un-activated (unanswered) repo emits the SessionStart nudge but otherwise
+  // captures per the legacy grandfather (a repo only carries these hooks via a
+  // deliberate repo-local install, which post-activation records `active`).
+  const { loadActivation, projectStatus, consumeAsk } = await import("./activation.js");
+  const status = projectStatus(loadActivation(), projectHash, rootDir);
+  if (status === "declined") return 0;
+
+  if (
+    normalized.type === "session_start" &&
+    status === "unanswered" &&
+    capturePermitted
+  ) {
+    const source =
+      typeof (payload as Record<string, unknown>).source === "string"
+        ? ((payload as Record<string, unknown>).source as string)
+        : undefined;
+    const { isNewInteractiveSource, isNonInteractive, buildNudgeOutput } = await import("./nudge.js");
+    if (isNewInteractiveSource(source) && !isNonInteractive()) {
+      const outcome = consumeAsk(projectHash);
+      if (outcome.ask) {
+        const out = buildNudgeOutput({
+          repoName: basename(rootDir),
+          entitlement: readEntitlementCache(),
+          lastAsk: outcome.budgetExpired,
+        });
+        process.stdout.write(JSON.stringify(out) + "\n");
+      }
+    }
+  }
+
+  if (!capturePermitted) return 0;
 
   // The in-memory body hand-off must never reach the ledger.
   const { body, ...event } = normalized;

--- a/src/session/ingest-ack.ts
+++ b/src/session/ingest-ack.ts
@@ -1,0 +1,96 @@
+/**
+ * Ingest positive-ack contract (client half). Frozen wire shape v1:
+ *
+ *   200 { accepted, results: [{ activityId, status, code? }], trial_used?, trial_limit? }
+ *   402 { detail, trial_used, trial_limit }   -> whole batch entitlement-locked
+ *
+ * Statuses: "accepted" | "duplicate" advance the commit watermark;
+ * "rejected" is PERMANENT (malformed/banned-field) — logged, then treated as
+ * committable so one bad event can never wedge a file's watermark forever;
+ * "held" is TRANSIENT (unknown_type version-skew, session_locked, db_error) —
+ * the event stays pending, nothing past it commits, the uploader retries.
+ *
+ * Legacy servers return only { accepted }: the whole batch commits when
+ * accepted covers the batch; anything less holds everything (we cannot know
+ * WHICH events landed, and re-sends are safe under idempotency). A post that
+ * resolves with NO body at all (test seams, ancient callers) counts as a full
+ * accept — resolution was the only success signal that path ever had.
+ */
+
+import type { UploadEvent } from "./upload-schema.js";
+
+export type IngestResultStatus = "accepted" | "duplicate" | "rejected" | "held";
+
+export interface IngestAck {
+  accepted: number;
+  results?: Array<{ activityId: string; status: IngestResultStatus; code?: string }>;
+  trial_used?: number;
+  trial_limit?: number;
+}
+
+/** An upload event tagged with its ledger source for durable-offset commits. */
+export interface TaggedUpload {
+  event: UploadEvent;
+  /** Ledger file basename the event came from. */
+  file: string;
+  /** String offset just past this event's line in the utf8-decoded ledger. */
+  endOffset: number;
+}
+
+export interface AckReconciliation {
+  /** Per source file: highest CONTIGUOUS offset safe to persist. */
+  commitUpTo: Map<string, number>;
+  /** Events that must stay pending (held / unacknowledged). */
+  held: TaggedUpload[];
+  /** activityIds permanently rejected by the server (logged by the caller). */
+  rejectedIds: string[];
+}
+
+const COMMITTABLE: ReadonlySet<IngestResultStatus> = new Set(["accepted", "duplicate", "rejected"]);
+
+/**
+ * Fold a batch's server ack into per-file contiguous commit offsets.
+ * `sent` must be in ledger order per file (the follower guarantees it).
+ */
+export function reconcileAck(sent: TaggedUpload[], ack: IngestAck | undefined | null): AckReconciliation {
+  const out: AckReconciliation = { commitUpTo: new Map(), held: [], rejectedIds: [] };
+  if (sent.length === 0) return out;
+
+  // Legacy shape: no per-event results. All-or-nothing.
+  if (!ack || !Array.isArray(ack.results)) {
+    if (!ack || ack.accepted >= sent.length) {
+      for (const t of sent) out.commitUpTo.set(t.file, Math.max(out.commitUpTo.get(t.file) ?? 0, t.endOffset));
+    } else {
+      out.held.push(...sent);
+    }
+    return out;
+  }
+
+  const byId = new Map(ack.results.map((r) => [r.activityId, r]));
+  // Contiguity is per source file: a held/unknown event blocks later events of
+  // ITS file only (other files' prefixes commit independently).
+  const blocked = new Set<string>();
+  for (const t of sent) {
+    if (blocked.has(t.file)) {
+      out.held.push(t);
+      continue;
+    }
+    const r = byId.get(t.event.activityId);
+    if (r && COMMITTABLE.has(r.status)) {
+      if (r.status === "rejected") out.rejectedIds.push(t.event.activityId);
+      out.commitUpTo.set(t.file, Math.max(out.commitUpTo.get(t.file) ?? 0, t.endOffset));
+    } else {
+      // held, or missing from results: stop this file's watermark here.
+      blocked.add(t.file);
+      out.held.push(t);
+    }
+  }
+  return out;
+}
+
+/** True when the error is the whole-batch entitlement lock (HTTP 402). */
+export function isIngestLocked(err: unknown): boolean {
+  return Boolean(
+    err && typeof err === "object" && "status" in err && (err as { status?: unknown }).status === 402,
+  );
+}

--- a/src/session/install.ts
+++ b/src/session/install.ts
@@ -13,9 +13,31 @@
  */
 
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const HOOK_MARKER = "vibedrift-hook";
+
+/** Absolute `node <dist>/session/hook-entry.js` so hooks never depend on PATH.
+ *  Every bundle entry lives one level under dist/ (cli/, mcp/, session/), so
+ *  the sibling-tree math holds regardless of which bundle inlined this module.
+ *  Both paths are double-quoted so a node install or repo checkout under a
+ *  directory containing spaces still runs (the shell would otherwise split it);
+ *  the trailing ` #vibedrift-hook` marker stays a shell comment. */
+export function resolveHookCommand(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const entry = resolve(here, "..", "session", "hook-entry.js");
+  return `"${process.execPath}" "${entry}"`;
+}
+
+/** Claude Code is the first supported agent: a repo-local .claude/ or a
+ *  user-level ~/.claude/settings.json counts as "present". */
+export function detectClaudeCode(repoRoot: string, homeDir: string): boolean {
+  return (
+    existsSync(join(repoRoot, ".claude")) || existsSync(join(homeDir, ".claude", "settings.json"))
+  );
+}
 
 /** The events Phase 1 listens to. PostToolUse is scoped to edit tools. */
 const HOOK_EVENTS: Array<{ event: string; matcher?: string }> = [

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -1,0 +1,95 @@
+/**
+ * The SessionStart activation nudge (L-N3 / L-N8).
+ *
+ * When a repo is un-activated, the hook injects a one-time instruction into the
+ * model's context asking the human, in plain language, whether to enable Drift
+ * Sessions here. The relay is best-effort (the model may not surface it); the
+ * FIRING is deterministic. Verified against Claude Code 2.1.216:
+ *
+ * - A hook injects model-visible context by printing
+ *   `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":…}}`
+ *   to stdout. `additionalContext` is model-visible, not shown verbatim.
+ * - The deterministic USER-visible channel is the top-level `systemMessage`
+ *   field (exit-0 stderr is ignored; exit 2 blocks — neither is usable here).
+ * - SessionStart stdin carries `source` ∈ {startup, resume, clear, compact}.
+ *
+ * L-N8 budget: ask at most once per genuinely NEW interactive session
+ * (`source` ∈ {startup, clear}); never on resume/compact; never in a
+ * non-interactive/headless context; at most ASK_BUDGET times, then an implicit
+ * decline is recorded and a one-line breadcrumb is shown. No per-turn
+ * re-injection — this fires on SessionStart only.
+ *
+ * This module is pure (classifiers + string builders); hook-entry supplies the
+ * effects (activation store read, budget consume, stdout write).
+ */
+
+import type { SessionEntitlement } from "./entitlement.js";
+
+/** The four documented Claude Code SessionStart `source` values. */
+export type StartSource = "startup" | "resume" | "clear" | "compact";
+
+/** A genuinely new interactive session that may consume one ask. `resume` and
+ *  `compact` are continuations of an existing session and never re-ask. */
+export function isNewInteractiveSource(source: string | undefined): boolean {
+  return source === "startup" || source === "clear";
+}
+
+/** Deterministic non-interactive signal: the plugin / CI sets this on headless
+ *  invocations so an unattended run never asks or burns the ask budget. Kept as
+ *  an explicit env override rather than an inferred entrypoint value — the
+ *  latter needs a confirming payload capture and is a follow-up (see todo). */
+export function isNonInteractive(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.VIBEDRIFT_HOOK_NONINTERACTIVE;
+  return v === "1" || v === "true";
+}
+
+export interface NudgeOutput {
+  hookSpecificOutput: { hookEventName: "SessionStart"; additionalContext: string };
+  /** One-line user-visible notice (trial count / breadcrumb). */
+  systemMessage?: string;
+}
+
+export interface NudgeContext {
+  repoName: string;
+  /** Present when the account is on the free trial — drives the honest
+   *  "session N of 5" line so trial usage is never invisible (L-N4). */
+  entitlement?: SessionEntitlement | null;
+  /** True on the final (budget-exhausting) ask: fold in the breadcrumb. */
+  lastAsk?: boolean;
+}
+
+const BREADCRUMB = "Run `vibedrift enable` in this repo anytime to turn on VibeDrift drift monitoring.";
+
+/** The model-facing relay instruction. Imperative (relays reliably in testing)
+ *  and carries the soft-decline path (N1: the concierge skill formalizes it in
+ *  N2; until then it rides here). */
+export function buildNudgeInstruction(ctx: NudgeContext): string {
+  const trialLine =
+    ctx.entitlement && ctx.entitlement.reason === "trial"
+      ? ` The user is on the free trial (${ctx.entitlement.trialUsed} of ${ctx.entitlement.trialLimit} sessions used); mention that enabling starts a monitored session.`
+      : "";
+  return [
+    `VibeDrift is installed but NOT active in this repository ("${ctx.repoName}").`,
+    `Before starting the user's task, ask them once, in plain language:`,
+    `  "Want me to enable VibeDrift live drift monitoring for this repo?"`,
+    `- If they say yes: call the VibeDrift \`enable\` tool for this repo, then continue.`,
+    `- If they say no or "not now": call \`enable\` with {"decline": true} so this is not asked again.`,
+    `- If they ignore the question or just restate their task: treat that as "not now" and call \`enable\` with {"decline": true} — do not keep asking.`,
+    `Never enable anything without an explicit yes.${trialLine}`,
+  ].join("\n");
+}
+
+/** Build the stdout object the hook prints on a nudging SessionStart. */
+export function buildNudgeOutput(ctx: NudgeContext): NudgeOutput {
+  const out: NudgeOutput = {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: buildNudgeInstruction(ctx),
+    },
+  };
+  if (ctx.lastAsk) out.systemMessage = BREADCRUMB;
+  else if (ctx.entitlement && ctx.entitlement.reason === "trial") {
+    out.systemMessage = `VibeDrift trial: ${ctx.entitlement.trialUsed} of ${ctx.entitlement.trialLimit} sessions used.`;
+  }
+  return out;
+}

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -58,7 +58,8 @@ export interface NudgeContext {
   lastAsk?: boolean;
 }
 
-const BREADCRUMB = "Run `vibedrift enable` in this repo anytime to turn on VibeDrift drift monitoring.";
+const BREADCRUMB =
+  "VibeDrift won't ask again in this repo — run `vibedrift enable` or `vibedrift decline` to set it explicitly.";
 
 /** The model-facing relay instruction. Imperative (relays reliably in testing)
  *  and carries the soft-decline path (N1: the concierge skill formalizes it in

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -80,6 +80,30 @@ export function buildNudgeInstruction(ctx: NudgeContext): string {
   ].join("\n");
 }
 
+/** A user-visible-only hook output: no model-facing instruction attached. */
+export interface NoticeOutput {
+  systemMessage: string;
+}
+
+/**
+ * The paywall signal for the native path. `watch-session` has a full lock
+ * screen; the native flow has no terminal we own, so the honest equivalent is
+ * one `systemMessage` line on SessionStart.
+ *
+ * Honesty constraints (§6): state only that recording is paused. Never claim
+ * anything was prevented, blocked, or deleted — the trial's local ledgers are
+ * untouched and still the user's.
+ */
+export function buildLockNotice(ctx: { entitlement: SessionEntitlement }): NoticeOutput {
+  const limit = ctx.entitlement.trialLimit;
+  return {
+    systemMessage:
+      `VibeDrift: your ${limit}-session trial is used up, so this session is not being recorded. ` +
+      `Run \`vibedrift upgrade\` to keep Drift Sessions watching. ` +
+      `Your existing local session history stays on this machine.`,
+  };
+}
+
 /** Build the stdout object the hook prints on a nudging SessionStart. */
 export function buildNudgeOutput(ctx: NudgeContext): NudgeOutput {
   const out: NudgeOutput = {

--- a/src/session/session-flush.ts
+++ b/src/session/session-flush.ts
@@ -11,6 +11,11 @@
  * nothing. Fail-open in the strong sense: any error exits 0 and loses nothing
  * (durable offsets + idempotent ingest mean the next turn's flush resumes).
  *
+ * It also owns the entitlement cache the hook gate reads (see flush-run.ts):
+ * the native path has no `watch-session` to refresh it, so the paywall would
+ * otherwise never apply. The Stop hook spawns this even when capture is
+ * locked, so upgrading to Pro is picked up on the next turn.
+ *
  * Only Node built-ins are imported statically so startup stays cheap; the
  * workhorse modules load dynamically inside the guarded run.
  *
@@ -42,12 +47,15 @@ async function main(): Promise<void> {
 
   const token = cfg.token;
   const apiUrl = cfg.apiUrl;
-  const { postSessionIngest } = await import("../auth/api.js");
-  const { runUploaderOnce } = await import("./uploader.js");
-  await runUploaderOnce({
+  const { postSessionIngest, fetchSessionEntitlement } = await import("../auth/api.js");
+  const { vibedriftHome } = await import("../core/vibedrift-home.js");
+  const { runFlush } = await import("./flush-run.js");
+  await runFlush({
+    baseDir: vibedriftHome(),
     sessionsDir,
     projectHash,
     teamIntentOptIn: cfg.sessionsTeamIntentOptIn === true,
+    fetchEntitlement: () => fetchSessionEntitlement(token, { apiUrl }),
     post: (events) => postSessionIngest(token, events, { apiUrl }),
   });
 }

--- a/src/session/session-flush.ts
+++ b/src/session/session-flush.ts
@@ -1,0 +1,60 @@
+/**
+ * vibedrift session-flush: a short-lived, detached child the Stop hook spawns
+ * at the end of every agent turn to ship that turn's derived events to the
+ * dashboard — so a repo streams live WITHOUT `watch-session` open (the native
+ * promise). One-shot: it drains the project's upload backlog to durable offsets
+ * and exits.
+ *
+ * Kept OFF the hook's critical path by design: the Stop hook only spawns this
+ * (fast, unref'd) and returns immediately; the network work happens here, out
+ * of band. Gated on hosted-sync opt-in + a token — a local-only user spawns
+ * nothing. Fail-open in the strong sense: any error exits 0 and loses nothing
+ * (durable offsets + idempotent ingest mean the next turn's flush resumes).
+ *
+ * Only Node built-ins are imported statically so startup stays cheap; the
+ * workhorse modules load dynamically inside the guarded run.
+ *
+ * argv: [node, session-flush.js, <projectHash>, <sessionsDir>]. Both are
+ * optional — a missing pair is re-derived from cwd.
+ */
+
+/** Absolute ceiling so a hung network can never leave a zombie child. */
+const HARD_TIMEOUT_MS = 35_000;
+
+const guard = setTimeout(() => process.exit(0), HARD_TIMEOUT_MS);
+guard.unref?.();
+
+async function main(): Promise<void> {
+  const [, , argHash, argDir] = process.argv;
+
+  const { readConfig } = await import("../auth/config.js");
+  const { shouldSync } = await import("./uploader.js");
+  const cfg = await readConfig();
+  if (!shouldSync(cfg, false) || !cfg.token) return; // local-only / logged out: nothing to do
+
+  let projectHash = argHash;
+  let sessionsDir = argDir;
+  if (!projectHash || !sessionsDir) {
+    const { repoIdentity, defaultSessionsDir } = await import("./repo.js");
+    if (!sessionsDir) sessionsDir = defaultSessionsDir();
+    if (!projectHash) projectHash = repoIdentity(process.cwd()).projectHash;
+  }
+
+  const token = cfg.token;
+  const apiUrl = cfg.apiUrl;
+  const { postSessionIngest } = await import("../auth/api.js");
+  const { runUploaderOnce } = await import("./uploader.js");
+  await runUploaderOnce({
+    sessionsDir,
+    projectHash,
+    teamIntentOptIn: cfg.sessionsTeamIntentOptIn === true,
+    post: (events) => postSessionIngest(token, events, { apiUrl }),
+  });
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    clearTimeout(guard);
+    process.exit(0);
+  });

--- a/src/session/upload-follower.ts
+++ b/src/session/upload-follower.ts
@@ -1,0 +1,143 @@
+/**
+ * Upload-side ledger reader: ALL session files, resumable, with backpressure.
+ *
+ * The live tape's SessionFollower deliberately tails only the newest ledger
+ * file (that is what a viewer wants). The uploader needs the opposite: every
+ * ledger file in the project dir, oldest first, each resumed from its durable
+ * committed offset — so sessions recorded while nothing watched are backfilled
+ * the next time any uploader runs, and a restart never re-reads what was
+ * already acknowledged.
+ *
+ * Backpressure (panel amendment R1): poll(budget) never returns more events
+ * than the caller can hold, and NEVER advances a read position past an event
+ * it did not hand over — so a first-run backfill flood (weeks of ledgers)
+ * cannot overflow the pending buffer into silent drops. Unread remainder is
+ * simply read again next poll from the same position.
+ *
+ * Same reading discipline as the tape follower: whole-file utf8 read, string
+ * offsets, advance only past complete lines (half-written tails re-read next
+ * poll), corrupt lines skipped (they still advance the offset — a torn line
+ * must not wedge the file). Fail-open: any I/O error yields fewer events,
+ * never a crash.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { Buffer } from "node:buffer";
+import { safeSegment } from "./ledger.js";
+import type { UploadStateStore } from "./upload-state.js";
+import type { SessionEvent } from "./types.js";
+
+export interface TrackedEvent {
+  event: SessionEvent;
+  /** Ledger file basename (durable-offset key). */
+  file: string;
+  /** String offset just past this event's line in the utf8-decoded content. */
+  endOffset: number;
+}
+
+export class UploadFollower {
+  private readonly dir: string;
+  /** In-run read position per file (string offsets); seeded from the store. */
+  private readonly readOffsets = new Map<string, number>();
+  /** Byte size at last full read, so unchanged files are skipped without a read. */
+  private readonly lastSizes = new Map<string, number>();
+
+  constructor(
+    sessionsDir: string,
+    projectHash: string,
+    private readonly store: UploadStateStore,
+  ) {
+    this.dir = join(sessionsDir, safeSegment(projectHash));
+  }
+
+  /**
+   * Return up to `budget` parsed events across all ledger files, oldest file
+   * first (mtime, name tie-break), each in ledger order with its endOffset.
+   */
+  async poll(budget: number): Promise<TrackedEvent[]> {
+    if (budget <= 0) return [];
+    let names: string[];
+    try {
+      names = await readdir(this.dir);
+    } catch {
+      return [];
+    }
+    const files: Array<{ name: string; mtime: number; size: number }> = [];
+    for (const name of names) {
+      if (!name.endsWith(".jsonl")) continue;
+      try {
+        const s = await stat(join(this.dir, name));
+        files.push({ name, mtime: s.mtimeMs, size: s.size });
+      } catch {
+        // vanished between readdir and stat
+      }
+    }
+    files.sort((a, b) => a.mtime - b.mtime || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    const out: TrackedEvent[] = [];
+    for (const f of files) {
+      if (out.length >= budget) break;
+      const started = this.readOffsets.has(f.name);
+      const seen = this.lastSizes.get(f.name);
+      if (started && seen !== undefined && seen === f.size) continue; // append-only: nothing new
+
+      let raw: string;
+      try {
+        raw = await readFile(join(this.dir, f.name), "utf8");
+      } catch {
+        continue;
+      }
+
+      let start = this.readOffsets.get(f.name) ?? this.store.get(f.name);
+      if (raw.length < start) start = 0; // truncated/replaced: re-read (dedup absorbs)
+      if (raw.length <= start) {
+        this.readOffsets.set(f.name, start);
+        this.lastSizes.set(f.name, Buffer.byteLength(raw, "utf8"));
+        continue;
+      }
+
+      const slice = raw.slice(start);
+      const lastNl = slice.lastIndexOf("\n");
+      if (lastNl < 0) {
+        // only a partial line so far: wait, and force a re-read next poll
+        this.readOffsets.set(f.name, start);
+        this.lastSizes.delete(f.name);
+        continue;
+      }
+
+      // Walk line by line so each event carries its own endOffset, stopping
+      // at the budget WITHOUT advancing past unreturned events (backpressure).
+      let cursor = start;
+      let consumedTo = start;
+      let hitBudget = false;
+      for (const line of slice.slice(0, lastNl).split("\n")) {
+        const end = cursor + line.length + 1; // +1 for the newline
+        if (line.trim()) {
+          if (out.length >= budget) {
+            hitBudget = true;
+            break;
+          }
+          try {
+            out.push({ event: JSON.parse(line) as SessionEvent, file: f.name, endOffset: end });
+            consumedTo = end;
+          } catch {
+            consumedTo = end; // corrupt line: skip it, never wedge the file
+          }
+        } else {
+          consumedTo = end;
+        }
+        cursor = end;
+      }
+      this.readOffsets.set(f.name, consumedTo);
+      if (hitBudget || consumedTo < start + lastNl + 1) {
+        // more remains in this file: force a re-read next poll
+        this.lastSizes.delete(f.name);
+        break;
+      }
+      this.lastSizes.set(f.name, Buffer.byteLength(raw, "utf8"));
+    }
+    return out;
+  }
+
+}

--- a/src/session/upload-state.ts
+++ b/src/session/upload-state.ts
@@ -1,0 +1,121 @@
+/**
+ * Durable per-ledger-file upload offsets (the N0 heart).
+ *
+ * The uploader used to keep offsets in memory and tail only the newest ledger
+ * file, so sessions recorded while no watcher ran never reached the dashboard
+ * (G1). This store persists, per ledger file, the offset up to which every
+ * event has been POSITIVELY acknowledged — so any later uploader resumes
+ * exactly where the last one stopped, across files and process restarts.
+ *
+ * Offsets are indexes into the utf8-DECODED file content (string indexes),
+ * matching how the followers read (whole-file readFile("utf8") + slicing), so
+ * they are stable across processes reading the same bytes.
+ *
+ * Fail-open everywhere: missing/corrupt state resumes from zero (safe — the
+ * ingest endpoint is idempotent per activity id and replays report
+ * "duplicate"). Writes are atomic (tmp + rename) and MAX-MERGE against the
+ * on-disk state, so racing uploaders can only ever move offsets forward.
+ */
+
+import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { safeSegment } from "./ledger.js";
+
+const STATE_VERSION = 1 as const;
+const STATE_FILE = "upload-state.json";
+
+interface UploadStateShape {
+  v: typeof STATE_VERSION;
+  files: Record<string, { offset: number }>;
+}
+
+export function uploadStatePath(sessionsDir: string, projectHash: string): string {
+  return join(sessionsDir, safeSegment(projectHash), STATE_FILE);
+}
+
+function parseState(raw: string): Record<string, { offset: number }> {
+  try {
+    const parsed = JSON.parse(raw) as Partial<UploadStateShape>;
+    if (!parsed || parsed.v !== STATE_VERSION || typeof parsed.files !== "object" || parsed.files === null) {
+      return {};
+    }
+    const out: Record<string, { offset: number }> = {};
+    for (const [file, v] of Object.entries(parsed.files)) {
+      const off = (v as { offset?: unknown } | null)?.offset;
+      if (typeof off === "number" && Number.isFinite(off) && off >= 0) out[file] = { offset: off };
+    }
+    return out;
+  } catch {
+    return {}; // corrupt: resume from zero, dedup absorbs re-sends
+  }
+}
+
+export class UploadStateStore {
+  private readonly dir: string;
+  private readonly path: string;
+  private files: Record<string, { offset: number }> = {};
+
+  constructor(sessionsDir: string, projectHash: string) {
+    this.dir = join(sessionsDir, safeSegment(projectHash));
+    this.path = uploadStatePath(sessionsDir, projectHash);
+  }
+
+  /** Load persisted offsets; prune entries for ledgers that no longer exist. Never throws. */
+  async load(): Promise<void> {
+    let raw: string;
+    try {
+      raw = await readFile(this.path, "utf8");
+    } catch {
+      this.files = {};
+      return;
+    }
+    const loaded = parseState(raw);
+    try {
+      const existing = new Set(await readdir(this.dir));
+      for (const file of Object.keys(loaded)) if (!existing.has(file)) delete loaded[file];
+    } catch {
+      // listing failed: keep entries rather than forget progress
+    }
+    this.files = loaded;
+  }
+
+  /** Committed offset for a ledger basename (0 when unknown). */
+  get(file: string): number {
+    return this.files[file]?.offset ?? 0;
+  }
+
+  /**
+   * Merge offsets forward and persist atomically. Re-reads the on-disk state
+   * first and max-merges BOTH ways, so a racing slower uploader can never
+   * rewind a faster one. Never throws — a failed persist just means the next
+   * run re-sends a little, which dedup absorbs.
+   */
+  async commit(entries: ReadonlyMap<string, number>): Promise<void> {
+    let changed = false;
+    for (const [file, off] of entries) {
+      if (off > (this.files[file]?.offset ?? 0)) {
+        this.files[file] = { offset: off };
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    try {
+      // max-merge with whatever is on disk right now (racing uploader)
+      try {
+        const onDisk = parseState(await readFile(this.path, "utf8"));
+        for (const [file, v] of Object.entries(onDisk)) {
+          if (v.offset > (this.files[file]?.offset ?? 0)) this.files[file] = { offset: v.offset };
+        }
+      } catch {
+        // no/corrupt on-disk state: ours wins
+      }
+      await mkdir(this.dir, { recursive: true, mode: 0o700 });
+      const body = JSON.stringify({ v: STATE_VERSION, files: this.files } satisfies UploadStateShape);
+      const tmp = `${this.path}.tmp.${process.pid}`;
+      await writeFile(tmp, body, { mode: 0o600 });
+      await rename(tmp, this.path);
+    } catch {
+      // fail-open: offsets stay in memory for this run
+    }
+  }
+}

--- a/src/session/upload-state.ts
+++ b/src/session/upload-state.ts
@@ -24,6 +24,12 @@ import { safeSegment } from "./ledger.js";
 const STATE_VERSION = 1 as const;
 const STATE_FILE = "upload-state.json";
 
+/** Process-unique tmp suffix. `process.pid` alone collides when two stores in
+ *  the SAME process commit concurrently (unit tests, or two in-process
+ *  uploaders), which would tear the tmp file; a monotonic counter makes every
+ *  write target a distinct tmp path so the rename stays atomic. */
+let tmpCounter = 0;
+
 interface UploadStateShape {
   v: typeof STATE_VERSION;
   files: Record<string, { offset: number }>;
@@ -111,7 +117,7 @@ export class UploadStateStore {
       }
       await mkdir(this.dir, { recursive: true, mode: 0o700 });
       const body = JSON.stringify({ v: STATE_VERSION, files: this.files } satisfies UploadStateShape);
-      const tmp = `${this.path}.tmp.${process.pid}`;
+      const tmp = `${this.path}.tmp.${process.pid}.${tmpCounter++}`;
       await writeFile(tmp, body, { mode: 0o600 });
       await rename(tmp, this.path);
     } catch {

--- a/src/session/uploader.ts
+++ b/src/session/uploader.ts
@@ -71,6 +71,10 @@ interface DrainOutcome {
   pending: TaggedUpload[];
   /** true when the server said hold (402 or held-class results). */
   backOff: boolean;
+  /** true ONLY for the 402 entitlement lock — never for held-class results or
+   *  a transient network failure. The caller uses this to lock capture at once
+   *  instead of waiting for the next scheduled entitlement refresh. */
+  locked: boolean;
 }
 
 /** Flush as many whole batches as the server accepts; stop at the first hold
@@ -88,8 +92,8 @@ async function drain(
     try {
       ack = await post(chunk.map((t) => t.event));
     } catch (err) {
-      if (isIngestLocked(err)) return { pending, backOff: true };
-      return { pending, backOff: false }; // network/transient: retry next tick
+      if (isIngestLocked(err)) return { pending, backOff: true, locked: true };
+      return { pending, backOff: false, locked: false }; // network/transient: retry next tick
     }
     const rec = reconcileAck(chunk, ack ?? undefined);
     if (rec.commitUpTo.size > 0) await store.commit(rec.commitUpTo);
@@ -97,9 +101,14 @@ async function drain(
       process.stderr.write(`vibedrift sync: event ${id} permanently rejected by server\n`);
     }
     pending = [...rec.held, ...pending.slice(chunk.length)];
-    if (rec.held.length > 0) return { pending, backOff: true };
+    if (rec.held.length > 0) return { pending, backOff: true, locked: false };
   }
-  return { pending, backOff: false };
+  return { pending, backOff: false, locked: false };
+}
+
+export interface FlushResult {
+  /** The server answered 402: the account is out of trial and not paid. */
+  locked: boolean;
 }
 
 export interface FlushOptions extends UploaderOptions {
@@ -119,8 +128,13 @@ export interface FlushOptions extends UploaderOptions {
  * version-skew / transient — the next turn's flush retries), when it stops
  * making progress, or when the time budget elapses. Never throws; a failure
  * loses nothing (durable offsets + idempotent ingest).
+ *
+ * Returns `{ locked }` — true only when the server answered 402 (the account
+ * is out of trial). The caller writes that through to the entitlement cache so
+ * the hook gate stops capturing on the next event, instead of the paywall
+ * staying invisible until the next scheduled refresh.
  */
-export async function runUploaderOnce(opts: FlushOptions): Promise<void> {
+export async function runUploaderOnce(opts: FlushOptions): Promise<FlushResult> {
   const batchSize = opts.batchSize && opts.batchSize > 0 ? opts.batchSize : DEFAULT_BATCH;
   const maxBuffer = opts.maxBuffer && opts.maxBuffer > 0 ? opts.maxBuffer : DEFAULT_MAX_BUFFER;
   const budgetMs = opts.budgetMs ?? 30_000;
@@ -132,6 +146,7 @@ export async function runUploaderOnce(opts: FlushOptions): Promise<void> {
   const follower = new UploadFollower(opts.sessionsDir, opts.projectHash, store);
 
   let pending: TaggedUpload[] = [];
+  let locked = false;
   while (!opts.signal?.aborted && now() - start < budgetMs) {
     const budget = maxBuffer - pending.length;
     let batch: Awaited<ReturnType<UploadFollower["poll"]>> = [];
@@ -154,10 +169,12 @@ export async function runUploaderOnce(opts: FlushOptions): Promise<void> {
     const before = pending.length;
     const out = await drain(pending, batchSize, opts.post, store);
     pending = out.pending;
+    if (out.locked) locked = true;
     // Hold, or no forward progress with nothing new to read -> give up this run.
     if (out.backOff) break;
     if (pending.length >= before && batch.length === 0) break;
   }
+  return { locked };
 }
 
 export async function runUploader(opts: UploaderOptions): Promise<void> {

--- a/src/session/uploader.ts
+++ b/src/session/uploader.ts
@@ -1,32 +1,44 @@
 /**
- * Drift Sessions derived-only uploader (Phase 5). A resident reader — the tape
- * follower's sibling — that tails the active ledger, maps each new event to its
- * derived `UploadEvent` (src/session/upload-schema.ts), batches them, and hands
- * them to an injected `post`. It runs ONLY when the caller has confirmed opt-in +
- * login (`watch-session` gates it); it is never on the hook's critical path.
+ * Drift Sessions derived-only uploader — durable, resumable, ack-gated (N0).
  *
- * Fail-open in the strong sense: a failed flush never throws and never loses the
- * batch — the events stay queued and are retried on the next tick, with a hard
- * buffer cap so a long outage can't grow memory without bound. When sync is off
- * (or `--local-only`, or logged out) the caller simply never starts this, so
- * local behaviour is byte-identical.
+ * Reads EVERY ledger file for the project (oldest first) through the
+ * UploadFollower, maps each event to its derived `UploadEvent`
+ * (src/session/upload-schema.ts), posts batches through the injected `post`,
+ * and persists per-file offsets ONLY through the contiguous prefix of events
+ * the server positively acknowledged (accepted / duplicate / permanently
+ * rejected). Held events (entitlement lock, version skew, transient server
+ * trouble) stay pending, nothing past them commits, and intake backpressure
+ * keeps the buffer bounded instead of dropping — so a first-run backfill of
+ * weeks of ledgers arrives complete (the R1 rule), and a lock never advances
+ * offsets over unstored data (the R3 rule).
+ *
+ * It runs ONLY when the caller has confirmed opt-in + login (`watch-session`
+ * gates it today; the MCP streamer and session-flush share this loop); it is
+ * never on the hook's critical path. Fail-open in the strong sense: a failed
+ * flush never throws and never loses events — they stay queued, retried after
+ * a backoff, and a process death resumes from the durable offsets (re-sends
+ * are absorbed by server idempotency).
  */
 
-import { SessionFollower } from "./follow.js";
+import { UploadFollower } from "./upload-follower.js";
+import { UploadStateStore } from "./upload-state.js";
+import { reconcileAck, isIngestLocked, type IngestAck, type TaggedUpload } from "./ingest-ack.js";
 import { toUploadEvent, type UploadEvent } from "./upload-schema.js";
-import type { SessionEvent } from "./types.js";
 
 const DEFAULT_BATCH = 50;
 const DEFAULT_INTERVAL_MS = 1000;
-const MAX_BUFFER = 2000;
-/** Cap the best-effort flush after Ctrl-C so a hanging network can't freeze the
- *  terminal (the tape's cleanup awaits this). A refused connection rejects fast;
- *  this only bounds a truly hanging socket. */
+const DEFAULT_MAX_BUFFER = 2000;
+/** Ticks to skip draining after a hold-class response (locked account,
+ *  version skew): retrying every second would hammer a server that already
+ *  said "not now". Intake continues under backpressure; only sending pauses. */
+const HOLD_BACKOFF_TICKS = 30;
+/** Cap the best-effort flush after Ctrl-C so a hanging network can't freeze
+ *  the terminal (the tape's cleanup awaits this). */
 const SHUTDOWN_FLUSH_MS = 2500;
 
 /** Whether hosted sync should run this session: opted in, logged in, and not
- *  forced local for this run. Pure so the gate is unit-testable. Off by default
- *  in every dimension — sync never starts by accident. */
+ *  forced local for this run. Pure so the gate is unit-testable. Off by
+ *  default in every dimension — sync never starts by accident. */
 export function shouldSync(
   cfg: { sessionsSyncEnabled?: boolean; token?: string },
   localOnly?: boolean,
@@ -40,66 +52,102 @@ export interface UploaderOptions {
   /** Ship the two derived free-text fields (decision reason + intent label).
    *  Off unless the team explicitly opted in — the code-egress boundary. */
   teamIntentOptIn?: boolean;
-  /** POST a batch of derived events. Injected so the loop is testable and so the
-   *  transport (auth, apiUrl) stays out of this module. Must reject on failure. */
-  post: (events: UploadEvent[]) => Promise<void>;
+  /** POST a batch of derived events; resolves with the server ack (legacy
+   *  servers: `{ accepted }` only). Must reject on failure; a rejection with
+   *  status 402 means the whole batch is entitlement-locked. */
+  post: (events: UploadEvent[]) => Promise<IngestAck | void>;
   batchSize?: number;
   intervalMs?: number;
+  /** Pending-buffer bound; intake pauses (backpressure) at this size. */
+  maxBuffer?: number;
   signal?: AbortSignal;
   /** injectable sleeper for tests; defaults to real setTimeout */
   sleep?: (ms: number) => Promise<void>;
+  /** ticks to pause sending after a hold-class response (test seam). */
+  holdBackoffTicks?: number;
 }
 
-/** Try to flush as many whole batches as possible; stop at the first failure so
- *  the rest is retried next tick. Never throws. Returns the events still queued. */
+interface DrainOutcome {
+  pending: TaggedUpload[];
+  /** true when the server said hold (402 or held-class results). */
+  backOff: boolean;
+}
+
+/** Flush as many whole batches as the server accepts; stop at the first hold
+ *  or failure so the rest is retried later. Commits durable offsets for every
+ *  contiguously-acknowledged prefix. Never throws. */
 async function drain(
-  pending: UploadEvent[],
+  pending: TaggedUpload[],
   batchSize: number,
-  post: (e: UploadEvent[]) => Promise<void>,
-): Promise<UploadEvent[]> {
+  post: UploaderOptions["post"],
+  store: UploadStateStore,
+): Promise<DrainOutcome> {
   while (pending.length > 0) {
     const chunk = pending.slice(0, batchSize);
+    let ack: IngestAck | void;
     try {
-      await post(chunk);
-    } catch {
-      break; // keep everything from here on; retry next tick
+      ack = await post(chunk.map((t) => t.event));
+    } catch (err) {
+      if (isIngestLocked(err)) return { pending, backOff: true };
+      return { pending, backOff: false }; // network/transient: retry next tick
     }
-    pending.splice(0, chunk.length);
+    const rec = reconcileAck(chunk, ack ?? undefined);
+    if (rec.commitUpTo.size > 0) await store.commit(rec.commitUpTo);
+    for (const id of rec.rejectedIds) {
+      process.stderr.write(`vibedrift sync: event ${id} permanently rejected by server\n`);
+    }
+    pending = [...rec.held, ...pending.slice(chunk.length)];
+    if (rec.held.length > 0) return { pending, backOff: true };
   }
-  return pending;
+  return { pending, backOff: false };
 }
 
 export async function runUploader(opts: UploaderOptions): Promise<void> {
   const batchSize = opts.batchSize && opts.batchSize > 0 ? opts.batchSize : DEFAULT_BATCH;
   const interval = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const maxBuffer = opts.maxBuffer && opts.maxBuffer > 0 ? opts.maxBuffer : DEFAULT_MAX_BUFFER;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
-  const follower = new SessionFollower(opts.sessionsDir, opts.projectHash);
-  let pending: UploadEvent[] = [];
+
+  const store = new UploadStateStore(opts.sessionsDir, opts.projectHash);
+  await store.load();
+  const follower = new UploadFollower(opts.sessionsDir, opts.projectHash, store);
+
+  let pending: TaggedUpload[] = [];
+  let holdTicks = 0;
 
   while (!opts.signal?.aborted) {
-    let batch: SessionEvent[];
-    try {
-      batch = await follower.poll();
-    } catch {
-      batch = []; // fail-open: a read error is an empty tick, never a crash
+    // Intake under backpressure: never read more than the buffer can hold, so
+    // read positions never advance past events we could not queue (R1).
+    const budget = maxBuffer - pending.length;
+    if (budget > 0) {
+      let batch: Awaited<ReturnType<UploadFollower["poll"]>>;
+      try {
+        batch = await follower.poll(budget);
+      } catch {
+        batch = []; // fail-open: a read error is an empty tick, never a crash
+      }
+      for (const t of batch) {
+        const u = toUploadEvent(t.event, { teamIntentOptIn: opts.teamIntentOptIn });
+        if (u) pending.push({ event: u, file: t.file, endOffset: t.endOffset });
+      }
     }
-    for (const ev of batch) {
-      const u = toUploadEvent(ev, { teamIntentOptIn: opts.teamIntentOptIn });
-      if (u) pending.push(u);
-    }
-    // Cap the buffer: under a long outage, drop the OLDEST derived events rather
-    // than grow memory unbounded (they are advisory analytics, not the ledger).
-    if (pending.length > MAX_BUFFER) pending = pending.slice(pending.length - MAX_BUFFER);
 
-    pending = await drain(pending, batchSize, opts.post);
+    if (holdTicks > 0) {
+      holdTicks--;
+    } else if (pending.length > 0) {
+      const out = await drain(pending, batchSize, opts.post, store);
+      pending = out.pending;
+      if (out.backOff) holdTicks = opts.holdBackoffTicks ?? HOLD_BACKOFF_TICKS;
+    }
 
     if (opts.signal?.aborted) break;
     await sleep(interval);
   }
-  // A final best-effort flush on shutdown, time-bounded so a hanging network
-  // can't wedge the terminal after Ctrl-C (the tape cleanup awaits this task).
+
+  // Final best-effort flush on shutdown, time-bounded so a hanging network
+  // can't wedge the terminal after Ctrl-C.
   await Promise.race([
-    drain(pending, batchSize, opts.post),
+    drain(pending, batchSize, opts.post, store),
     new Promise<void>((r) => setTimeout(r, SHUTDOWN_FLUSH_MS)),
   ]);
 }

--- a/src/session/uploader.ts
+++ b/src/session/uploader.ts
@@ -102,6 +102,64 @@ async function drain(
   return { pending, backOff: false };
 }
 
+export interface FlushOptions extends UploaderOptions {
+  /** Hard cap on total flush time (default 30s) so a slow network never wedges
+   *  a Stop-spawned child. */
+  budgetMs?: number;
+  /** Test seam for the clock; defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * One-shot flush: drain the WHOLE project backlog to durable offsets, then
+ * return. Shared by the Stop-hook session-flush (a short-lived detached child
+ * that ships the turn's events) — no interval loop, no resident process.
+ *
+ * Stops when the ledger is fully drained, when the server holds (402 /
+ * version-skew / transient — the next turn's flush retries), when it stops
+ * making progress, or when the time budget elapses. Never throws; a failure
+ * loses nothing (durable offsets + idempotent ingest).
+ */
+export async function runUploaderOnce(opts: FlushOptions): Promise<void> {
+  const batchSize = opts.batchSize && opts.batchSize > 0 ? opts.batchSize : DEFAULT_BATCH;
+  const maxBuffer = opts.maxBuffer && opts.maxBuffer > 0 ? opts.maxBuffer : DEFAULT_MAX_BUFFER;
+  const budgetMs = opts.budgetMs ?? 30_000;
+  const now = opts.now ?? (() => Date.now());
+  const start = now();
+
+  const store = new UploadStateStore(opts.sessionsDir, opts.projectHash);
+  await store.load();
+  const follower = new UploadFollower(opts.sessionsDir, opts.projectHash, store);
+
+  let pending: TaggedUpload[] = [];
+  while (!opts.signal?.aborted && now() - start < budgetMs) {
+    const budget = maxBuffer - pending.length;
+    let batch: Awaited<ReturnType<UploadFollower["poll"]>> = [];
+    if (budget > 0) {
+      try {
+        batch = await follower.poll(budget);
+      } catch {
+        batch = [];
+      }
+    }
+    for (const t of batch) {
+      const u = toUploadEvent(t.event, { teamIntentOptIn: opts.teamIntentOptIn });
+      if (u) pending.push({ event: u, file: t.file, endOffset: t.endOffset });
+    }
+    // Nothing queued and nothing new arrived -> the ledger is fully drained.
+    if (pending.length === 0) {
+      if (batch.length === 0) break;
+      continue; // events all filtered out (non-uploadable); poll for more
+    }
+    const before = pending.length;
+    const out = await drain(pending, batchSize, opts.post, store);
+    pending = out.pending;
+    // Hold, or no forward progress with nothing new to read -> give up this run.
+    if (out.backOff) break;
+    if (pending.length >= before && batch.length === 0) break;
+  }
+}
+
 export async function runUploader(opts: UploaderOptions): Promise<void> {
   const batchSize = opts.batchSize && opts.batchSize > 0 ? opts.batchSize : DEFAULT_BATCH;
   const interval = opts.intervalMs ?? DEFAULT_INTERVAL_MS;

--- a/src/tools-core/tools/enable.ts
+++ b/src/tools-core/tools/enable.ts
@@ -1,0 +1,124 @@
+/**
+ * enable — the in-loop activation answer for native Drift Sessions.
+ *
+ * Channel-neutral core (no MCP import). The agent calls this after the user
+ * answers the SessionStart nudge:
+ *   - yes  → `{ rootDir, confirm: "<the user's literal affirmative>" }`
+ *   - no   → `{ rootDir, decline: true }`
+ *
+ * Consent model (O18): the MCP adapter marks this tool
+ * `_meta["anthropic/requiresUserInteraction"]:true`, so Claude Code shows its
+ * native Allow/Deny prompt on every call — that click is the HARD consent. The
+ * `confirm` string is a second, in-band affirmative: an enable with no `confirm`
+ * is refused (`needs_confirmation`) so the tool can never activate a repo the
+ * user did not explicitly agree to. Declining needs no `confirm`.
+ *
+ * On enable: records `active` in the machine-global activation store, appends a
+ * local consent receipt, and installs the agent hooks when a supported agent is
+ * present. The drift baseline stays LAZY — the first scan / first edit-check
+ * builds it; enable does not block on it.
+ */
+
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { repoIdentity, defaultSessionsDir } from "../../session/repo.js";
+import {
+  installHooks,
+  hooksStatus,
+  resolveHookCommand,
+  detectClaudeCode,
+} from "../../session/install.js";
+import { recordAnswer } from "../../session/activation.js";
+import { appendConsentReceipt } from "../../session/consent.js";
+import type { StructuredBase } from "../result.js";
+
+// zod raw shape (matches the other tools-core tools).
+import { z } from "zod";
+
+export const inputSchema = {
+  rootDir: z.string().describe("Absolute path to the repository root to activate"),
+  confirm: z
+    .string()
+    .optional()
+    .describe(
+      "The user's literal affirmative (e.g. their 'yes, enable it'). REQUIRED to enable — omit only when declining.",
+    ),
+  decline: z
+    .boolean()
+    .optional()
+    .describe("Set true to record the user's 'no / not now' so this repo is never asked again."),
+};
+
+export interface EnableArgs {
+  rootDir: string;
+  confirm?: string;
+  decline?: boolean;
+}
+
+export interface EnableResult extends StructuredBase {
+  action: "enabled" | "declined" | "needs_confirmation";
+  projectHash: string;
+  rootDir: string;
+  hooksInstalled?: boolean;
+}
+
+export async function run(args: EnableArgs): Promise<EnableResult> {
+  const { rootDir, projectHash } = repoIdentity(resolve(args.rootDir));
+  const sessionsDir = defaultSessionsDir();
+  const ledgerDir = join(sessionsDir, projectHash);
+  const at = new Date().toISOString();
+
+  if (args.decline === true) {
+    recordAnswer(projectHash, "declined", "mcp-decline", undefined);
+    appendConsentReceipt(ledgerDir, { v: 1, at, action: "decline", surface: "mcp-decline", projectHash, rootDir });
+    return {
+      status: "ok",
+      action: "declined",
+      projectHash,
+      rootDir,
+      message: "Drift Sessions declined for this repo — it won't be asked again. Reverse anytime by calling enable with a confirmation.",
+    };
+  }
+
+  // Enable requires the in-band affirmative (the forced Allow/Deny prompt is the
+  // other half of consent). No confirmation → do not activate.
+  if (!args.confirm || args.confirm.trim().length === 0) {
+    return {
+      status: "partial",
+      action: "needs_confirmation",
+      projectHash,
+      rootDir,
+      message:
+        "Enable needs the user's explicit confirmation. Ask them, then call enable again with `confirm` set to their affirmative (or pass decline:true if they say no).",
+    };
+  }
+
+  recordAnswer(projectHash, "active", "mcp-enable", undefined);
+  appendConsentReceipt(ledgerDir, { v: 1, at, action: "enable", surface: "mcp-enable", projectHash, rootDir });
+
+  let hooksInstalled = false;
+  if (detectClaudeCode(rootDir, homedir())) {
+    const existing = await hooksStatus(rootDir);
+    if (existing.installed) {
+      hooksInstalled = true;
+    } else {
+      const res = await installHooks(rootDir, {
+        hookCommand: resolveHookCommand(),
+        sessionsDir,
+        projectHash,
+      });
+      hooksInstalled = res.status === "installed" || res.status === "already";
+    }
+  }
+
+  return {
+    status: "ok",
+    action: "enabled",
+    projectHash,
+    rootDir,
+    hooksInstalled,
+    message: hooksInstalled
+      ? "Drift Sessions active for this repo. Capture begins on the next edit; the drift baseline builds on the first scan or edit-check."
+      : "Drift Sessions active for this repo (answer recorded). No supported agent hook detected yet, so capture starts once Claude Code hooks are installed.",
+  };
+}

--- a/test/integration/mcp.test.ts
+++ b/test/integration/mcp.test.ts
@@ -14,6 +14,7 @@ const THEN_BODY = ["export function feature(){", "  return a()", "    .then(r =>
 
 const EXPECTED_TOOLS = [
   "check_file_drift",
+  "enable",
   "find_similar_function",
   "get_dominant_pattern",
   "get_intent_hints",
@@ -69,9 +70,47 @@ describe("MCP integration — Pro plan (tools serve)", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("advertises exactly the seven tools", async () => {
+  it("advertises exactly the eight tools", async () => {
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(EXPECTED_TOOLS);
+  });
+
+  it("enable carries the requiresUserInteraction consent meta", async () => {
+    const { tools } = await client.listTools();
+    const enable = tools.find((t) => t.name === "enable") as { _meta?: Record<string, unknown> } | undefined;
+    expect(enable?._meta?.["anthropic/requiresUserInteraction"]).toBe(true);
+  });
+
+  it("enable refuses to activate without a confirmation, then activates with one", async () => {
+    const enableRepo = mkdtempSync(join(tmpdir(), "vd-mcp-enable-"));
+    mkdirSync(join(enableRepo, ".git"));
+    // no confirm -> needs_confirmation, records nothing
+    const refused = (await client.callTool({
+      name: "enable",
+      arguments: { rootDir: enableRepo },
+    })) as { structuredContent?: { status?: string; action?: string } };
+    expect(refused.structuredContent?.action).toBe("needs_confirmation");
+    expect(refused.structuredContent?.status).toBe("partial");
+    // with the user's affirmative -> activates
+    const ok = (await client.callTool({
+      name: "enable",
+      arguments: { rootDir: enableRepo, confirm: "yes, enable it" },
+    })) as { structuredContent?: { status?: string; action?: string } };
+    expect(ok.structuredContent?.action).toBe("enabled");
+    expect(ok.structuredContent?.status).toBe("ok");
+    rmSync(enableRepo, { recursive: true, force: true });
+  });
+
+  it("enable with decline:true records a no without a confirmation", async () => {
+    const declineRepo = mkdtempSync(join(tmpdir(), "vd-mcp-decline-"));
+    mkdirSync(join(declineRepo, ".git"));
+    const res = (await client.callTool({
+      name: "enable",
+      arguments: { rootDir: declineRepo, decline: true },
+    })) as { structuredContent?: { status?: string; action?: string } };
+    expect(res.structuredContent?.action).toBe("declined");
+    expect(res.structuredContent?.status).toBe("ok");
+    rmSync(declineRepo, { recursive: true, force: true });
   });
 
   const calls: Array<[string, Record<string, unknown>]> = [
@@ -120,7 +159,7 @@ describe("MCP integration — signed-out user gets the local tools free", () => 
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("still advertises exactly the seven tools", async () => {
+  it("still advertises exactly the eight tools", async () => {
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(EXPECTED_TOOLS);
   });

--- a/test/integration/session-hook.test.ts
+++ b/test/integration/session-hook.test.ts
@@ -105,6 +105,19 @@ describe("hook entry (integration)", () => {
     ).toBe(0);
   });
 
+  it("exits 0 and writes nothing on a payload missing session_id", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    const r = runHook(home, {
+      cwd: repo,
+      hook_event_name: "UserPromptSubmit",
+      prompt: "hello",
+    });
+    expect(r.status).toBe(0);
+    expect(existsSync(join(home, ".vibedrift", "sessions"))).toBe(false);
+  });
+
   it("delivers an advisory via exit 2 + stderr when an edit diverges from the baseline", () => {
     const home = tmp("vd-home-");
     const repo = tmp("vd-repo-");

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -147,8 +147,12 @@ describe("SessionStart nudge (integration)", () => {
       JSON.stringify({ entitled: false, reason: "locked", plan: "free", trialUsed: 5, trialLimit: 5 }),
     );
     const r = runStart(home, repo, "startup");
-    expect(r.stdout.trim()).toBe("");
     expect(existsSync(join(home, ".vibedrift", "sessions"))).toBe(false);
+    // A locked account is never asked to ENABLE (no model-facing nudge) — it is
+    // told why recording stopped. The lock notice is a bare systemMessage.
+    const out = JSON.parse(r.stdout.trim());
+    expect(out).not.toHaveProperty("hookSpecificOutput");
+    expect(out.systemMessage).toContain("trial is used up");
   });
 });
 
@@ -207,5 +211,107 @@ describe("Stop-hook session-flush spawn (integration)", () => {
     flushHook(home, repo, { VIBEDRIFT_SESSION_FLUSH_CMD: markerScript(marker) });
     spawnSync("sleep", ["0.4"]);
     expect(existsSync(marker)).toBe(false);
+  });
+});
+
+describe("entitlement lock in the native path (integration)", () => {
+  function config(home: string, cfg: Record<string, unknown>): void {
+    mkdirSync(join(home, ".vibedrift"), { recursive: true });
+    writeFileSync(join(home, ".vibedrift", "config.json"), JSON.stringify(cfg));
+  }
+
+  function entitlement(home: string, e: Record<string, unknown>): void {
+    mkdirSync(join(home, ".vibedrift"), { recursive: true });
+    writeFileSync(join(home, ".vibedrift", "sessions-entitlement.json"), JSON.stringify(e));
+  }
+
+  const LOCKED = {
+    entitled: false,
+    reason: "locked",
+    plan: "free",
+    trialUsed: 5,
+    trialLimit: 5,
+    checkedAt: new Date().toISOString(),
+  };
+
+  function activate(home: string, repo: string): void {
+    // capture a projectHash by running one startup, then mark the repo active
+    runStart(home, repo, "startup");
+    const store = JSON.parse(readFileSync(join(home, ".vibedrift", "activation.json"), "utf8"));
+    const hash = Object.keys(store.projects)[0];
+    store.projects[hash] = { state: "active", surface: "cli-enable" };
+    writeFileSync(join(home, ".vibedrift", "activation.json"), JSON.stringify(store));
+  }
+
+  const stopHook = (home: string, repo: string, extraEnv: Record<string, string> = {}) =>
+    spawnSync(TSX, [ENTRY], {
+      input: JSON.stringify({ session_id: "end-1", cwd: repo, hook_event_name: "Stop" }),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home, VIBEDRIFT_HOOK_DEBUG: "", ...extraEnv },
+      timeout: 30_000,
+    });
+
+  it("tells the user why nothing is recorded when the trial is spent", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    entitlement(home, LOCKED);
+    const r = runStart(home, repo, "startup", "s2");
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.systemMessage).toContain("trial is used up");
+    expect(out.systemMessage).toContain("vibedrift upgrade");
+  });
+
+  it("captures nothing while locked", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    const before = readdirSync(join(home, ".vibedrift", "sessions"), { recursive: true }).length;
+    entitlement(home, LOCKED);
+    runStart(home, repo, "startup", "s3");
+    const after = readdirSync(join(home, ".vibedrift", "sessions"), { recursive: true }).length;
+    expect(after).toBe(before); // no new ledger written
+  });
+
+  it("STILL spawns the flush on Stop while locked, so upgrading can unlock", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    entitlement(home, LOCKED);
+    config(home, { token: "t", plan: "free", sessionsSyncEnabled: true });
+    const marker = join(tmp("vd-lock-marker-"), "fired");
+    const r = stopHook(home, repo, { VIBEDRIFT_SESSION_FLUSH_CMD: markerScript(marker) });
+    expect(r.status).toBe(0);
+    const deadline = Date.now() + 4000;
+    while (!existsSync(marker) && Date.now() < deadline) spawnSync("sleep", ["0.05"]);
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it("stays silent while locked in a non-interactive context (no upsell in CI logs)", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    entitlement(home, LOCKED);
+    const r = runStart(home, repo, "startup", "s5", { VIBEDRIFT_HOOK_NONINTERACTIVE: "1" });
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("stays silent while locked on resume/compact (not a new session)", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    entitlement(home, LOCKED);
+    expect(runStart(home, repo, "resume", "s6").stdout.trim()).toBe("");
+    expect(runStart(home, repo, "compact", "s7").stdout.trim()).toBe("");
+  });
+
+  it("emits no lock notice while the account is still entitled", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    entitlement(home, { ...LOCKED, entitled: true, reason: "trial", trialUsed: 1 });
+    const r = runStart(home, repo, "startup", "s4");
+    expect(r.stdout.trim() === "" || !r.stdout.includes("trial is used up")).toBe(true);
   });
 });

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, realpathSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -86,7 +86,7 @@ describe("SessionStart nudge (integration)", () => {
     expect(r.stdout.trim()).toBe("");
   });
 
-  it("asks at most 3 times, then records an implicit decline with the breadcrumb", () => {
+  it("asks at most 3 times, then goes quiet WITHOUT declining (capture continues)", () => {
     const home = tmp("vd-nudge-home-");
     const repo = repoDir();
     // three genuinely-new sessions
@@ -96,15 +96,34 @@ describe("SessionStart nudge (integration)", () => {
     expect(a.stdout).toContain("additionalContext");
     expect(b.stdout).toContain("additionalContext");
     expect(c.stdout).toContain("additionalContext");
-    // the third (final) ask carries the breadcrumb + records the implicit decline
+    // the third (final) ask carries the breadcrumb
     expect(JSON.parse(c.stdout.trim()).systemMessage).toContain("vibedrift enable");
-    const store = activation(home);
-    const rec = Object.values(store.projects)[0];
-    expect(rec.state).toBe("declined");
-    expect(rec.surface).toBe("budget-expiry");
-    // a fourth session is silent
-    const d = runStart(home, repo, "startup", "s4");
-    expect(d.stdout.trim()).toBe("");
+    // ...but expiry must NOT write `declined` — the repo stays unanswered so a
+    // grandfathered install keeps capturing.
+    const rec = Object.values(activation(home).projects)[0] as { state?: string; breadcrumbShown?: boolean };
+    expect(rec.state).toBeUndefined();
+    expect(rec.breadcrumbShown).toBe(true);
+    // a fourth session is silent (no re-nudge)
+    expect(runStart(home, repo, "startup", "s4").stdout.trim()).toBe("");
+    // and capture still works: an edit event after expiry lands in the ledger
+    spawnSync(TSX, [ENTRY], {
+      input: JSON.stringify({
+        session_id: "s4",
+        cwd: repo,
+        hook_event_name: "PostToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: join(repo, "x.ts"), content: "export const x = 1;\n" },
+      }),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home, VIBEDRIFT_HOOK_DEBUG: "" },
+      timeout: 30_000,
+    });
+    const sessions = join(home, ".vibedrift", "sessions");
+    const captured = readFileSync(
+      join(sessions, readdirSync(sessions)[0], "s4.jsonl"),
+      "utf8",
+    );
+    expect(captured).toContain('"type":"edit"');
   });
 
   it("shows the honest trial line when the account is on the free trial", () => {

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ENTRY = join(process.cwd(), "src", "session", "hook-entry.ts");
+const TSX = join(process.cwd(), "node_modules", ".bin", "tsx");
+
+function tmp(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
+
+function runStart(
+  home: string,
+  repo: string,
+  source: string,
+  sessionId = "s1",
+  extraEnv: Record<string, string> = {},
+) {
+  return spawnSync(TSX, [ENTRY], {
+    input: JSON.stringify({ session_id: sessionId, cwd: repo, hook_event_name: "SessionStart", source }),
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, USERPROFILE: home, VIBEDRIFT_HOOK_DEBUG: "", ...extraEnv },
+    timeout: 30_000,
+  });
+}
+
+function activation(home: string): { projects: Record<string, { state?: string; surface?: string }> } {
+  return JSON.parse(readFileSync(join(home, ".vibedrift", "activation.json"), "utf8"));
+}
+
+function repoDir(): string {
+  const repo = tmp("vd-nudge-repo-");
+  mkdirSync(join(repo, ".git"));
+  return repo;
+}
+
+describe("SessionStart nudge (integration)", () => {
+  it("emits the activation nudge for an un-activated repo on a new interactive session", () => {
+    const home = tmp("vd-nudge-home-");
+    const r = runStart(home, repoDir(), "startup");
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    expect(out.hookSpecificOutput.additionalContext).toContain("NOT active");
+  });
+
+  it("stays silent on resume/compact (continuation, not a new session)", () => {
+    const home = tmp("vd-nudge-home-");
+    const repo = repoDir();
+    expect(runStart(home, repo, "resume").stdout.trim()).toBe("");
+    expect(runStart(home, repo, "compact").stdout.trim()).toBe("");
+  });
+
+  it("stays silent in a non-interactive/headless context and does not burn budget", () => {
+    const home = tmp("vd-nudge-home-");
+    const repo = repoDir();
+    const r = runStart(home, repo, "startup", "s1", { VIBEDRIFT_HOOK_NONINTERACTIVE: "1" });
+    expect(r.stdout.trim()).toBe("");
+    // no ask consumed -> no activation record yet
+    expect(existsSync(join(home, ".vibedrift", "activation.json"))).toBe(false);
+  });
+
+  it("stays silent once the repo is declined", () => {
+    const home = tmp("vd-nudge-home-");
+    const repo = repoDir();
+    // first startup nudges + records askCount 1; decline it explicitly
+    runStart(home, repo, "startup");
+    const store = activation(home);
+    const hash = Object.keys(store.projects)[0];
+    // write a decline directly
+    const path = join(home, ".vibedrift", "activation.json");
+    const cur = JSON.parse(readFileSync(path, "utf8"));
+    cur.projects[hash] = { state: "declined", surface: "cli-decline" };
+    writeFileSync(path, JSON.stringify(cur));
+    const r = runStart(home, repo, "startup", "s2");
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("asks at most 3 times, then records an implicit decline with the breadcrumb", () => {
+    const home = tmp("vd-nudge-home-");
+    const repo = repoDir();
+    // three genuinely-new sessions
+    const a = runStart(home, repo, "startup", "s1");
+    const b = runStart(home, repo, "startup", "s2");
+    const c = runStart(home, repo, "startup", "s3");
+    expect(a.stdout).toContain("additionalContext");
+    expect(b.stdout).toContain("additionalContext");
+    expect(c.stdout).toContain("additionalContext");
+    // the third (final) ask carries the breadcrumb + records the implicit decline
+    expect(JSON.parse(c.stdout.trim()).systemMessage).toContain("vibedrift enable");
+    const store = activation(home);
+    const rec = Object.values(store.projects)[0];
+    expect(rec.state).toBe("declined");
+    expect(rec.surface).toBe("budget-expiry");
+    // a fourth session is silent
+    const d = runStart(home, repo, "startup", "s4");
+    expect(d.stdout.trim()).toBe("");
+  });
+
+  it("shows the honest trial line when the account is on the free trial", () => {
+    const home = tmp("vd-nudge-home-");
+    const repo = repoDir();
+    mkdirSync(join(home, ".vibedrift"), { recursive: true });
+    writeFileSync(
+      join(home, ".vibedrift", "sessions-entitlement.json"),
+      JSON.stringify({ entitled: true, reason: "trial", plan: "free", trialUsed: 2, trialLimit: 5 }),
+    );
+    const r = runStart(home, repo, "startup");
+    expect(JSON.parse(r.stdout.trim()).systemMessage).toContain("2 of 5");
+  });
+
+  it("captures nothing and never nudges when the account is locked", () => {
+    const home = tmp("vd-nudge-home-");
+    const repo = repoDir();
+    mkdirSync(join(home, ".vibedrift"), { recursive: true });
+    writeFileSync(
+      join(home, ".vibedrift", "sessions-entitlement.json"),
+      JSON.stringify({ entitled: false, reason: "locked", plan: "free", trialUsed: 5, trialLimit: 5 }),
+    );
+    const r = runStart(home, repo, "startup");
+    expect(r.stdout.trim()).toBe("");
+    expect(existsSync(join(home, ".vibedrift", "sessions"))).toBe(false);
+  });
+});

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, realpathSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** Write an executable shell script that records its first two argv into `marker`. */
+function markerScript(marker: string): string {
+  const path = join(tmp("vd-flush-seam-"), "seam.sh");
+  writeFileSync(path, `#!/usr/bin/env bash\nprintf '%s %s' "$1" "$2" > ${marker}\n`, { mode: 0o755 });
+  chmodSync(path, 0o755);
+  return path;
+}
 
 const ENTRY = join(process.cwd(), "src", "session", "hook-entry.ts");
 const TSX = join(process.cwd(), "node_modules", ".bin", "tsx");
@@ -122,5 +130,63 @@ describe("SessionStart nudge (integration)", () => {
     const r = runStart(home, repo, "startup");
     expect(r.stdout.trim()).toBe("");
     expect(existsSync(join(home, ".vibedrift", "sessions"))).toBe(false);
+  });
+});
+
+describe("Stop-hook session-flush spawn (integration)", () => {
+  const flushHook = (
+    home: string,
+    repo: string,
+    extraEnv: Record<string, string> = {},
+  ) =>
+    spawnSync(TSX, [ENTRY], {
+      input: JSON.stringify({ session_id: "end-1", cwd: repo, hook_event_name: "Stop" }),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home, VIBEDRIFT_HOOK_DEBUG: "", ...extraEnv },
+      timeout: 30_000,
+    });
+
+  function config(home: string, cfg: Record<string, unknown>): void {
+    mkdirSync(join(home, ".vibedrift"), { recursive: true });
+    writeFileSync(join(home, ".vibedrift", "config.json"), JSON.stringify(cfg));
+  }
+
+  it("spawns the flush on Stop when hosted sync is opted in + logged in", () => {
+    const home = tmp("vd-flush-home-");
+    const repo = repoDir();
+    const marker = join(tmp("vd-flush-marker-"), "fired");
+    config(home, { token: "t", plan: "pro", sessionsSyncEnabled: true });
+    const r = flushHook(home, repo, { VIBEDRIFT_SESSION_FLUSH_CMD: markerScript(marker) });
+    expect(r.status).toBe(0);
+    // detached child is async; poll briefly for the marker
+    const deadline = Date.now() + 4000;
+    while (!existsSync(marker) && Date.now() < deadline) {
+      spawnSync("sleep", ["0.05"]);
+    }
+    expect(existsSync(marker)).toBe(true);
+    const [hash, dir] = readFileSync(marker, "utf8").split(" ");
+    expect(hash).toMatch(/^[0-9a-f]{16}$/); // projectHash
+    expect(dir).toContain(".vibedrift"); // sessionsDir
+  });
+
+  it("spawns nothing when hosted sync is off (local-only stays offline)", () => {
+    const home = tmp("vd-flush-home-");
+    const repo = repoDir();
+    const marker = join(tmp("vd-flush-marker-"), "fired");
+    config(home, { token: "t", plan: "pro", sessionsSyncEnabled: false });
+    flushHook(home, repo, { VIBEDRIFT_SESSION_FLUSH_CMD: markerScript(marker) });
+    // give any (erroneous) child time to run
+    spawnSync("sleep", ["0.4"]);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("spawns nothing when logged out", () => {
+    const home = tmp("vd-flush-home-");
+    const repo = repoDir();
+    const marker = join(tmp("vd-flush-marker-"), "fired");
+    config(home, { plan: "pro", sessionsSyncEnabled: true }); // no token
+    flushHook(home, repo, { VIBEDRIFT_SESSION_FLUSH_CMD: markerScript(marker) });
+    spawnSync("sleep", ["0.4"]);
+    expect(existsSync(marker)).toBe(false);
   });
 });

--- a/test/unit/cli/enable.test.ts
+++ b/test/unit/cli/enable.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { runEnable, runDecline } from "@/cli/commands/enable";
+import { loadActivation, projectStatus } from "@/session/activation";
+import { repoIdentity } from "@/session/repo";
+
+function tmp(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
+
+function repoWithAgent(): string {
+  const repo = tmp("vd-en-");
+  mkdirSync(join(repo, ".git"));
+  mkdirSync(join(repo, ".claude"));
+  return repo;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe("runEnable — single repo", () => {
+  it("typing enable is the consent: records active, installs hooks, writes a receipt", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-en-sess-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runEnable(repo, { sessionsDir, activationHome });
+    expect(status).toBe("enabled");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(true);
+
+    const { projectHash } = repoIdentity(repo);
+    const store = loadActivation(activationHome);
+    expect(projectStatus(store, projectHash)).toBe("active");
+    expect(store.projects[projectHash].surface).toBe("cli-enable");
+
+    const receipt = JSON.parse(readFileSync(join(sessionsDir, projectHash, "consent.log"), "utf8").trim());
+    expect(receipt.action).toBe("enable");
+    expect(receipt.surface).toBe("cli-enable");
+  });
+
+  it("records the answer even with no agent, but does not install hooks", async () => {
+    const repo = tmp("vd-en-noagent-");
+    mkdirSync(join(repo, ".git"));
+    const sessionsDir = tmp("vd-en-sess-");
+    const activationHome = tmp("vd-en-act-");
+    const emptyHome = tmp("vd-en-home-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runEnable(repo, { sessionsDir, activationHome, homeDir: emptyHome });
+    expect(status).toBe("enabled_no_agent");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("active");
+  });
+
+  it("reverses a prior decline", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-en-sess-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    await runDecline(repo, { sessionsDir, activationHome });
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("declined");
+    await runEnable(repo, { sessionsDir, activationHome });
+    expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("active");
+  });
+});
+
+describe("runEnable --dir (O19)", () => {
+  it("grants a directory after a typed confirmation", async () => {
+    const work = tmp("vd-en-work-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runEnable(".", { dir: work, activationHome, confirm: async () => true });
+    expect(status).toBe("dir_granted");
+    const store = loadActivation(activationHome);
+    expect(store.dirGrants.map((g) => g.path)).toContain(work);
+    // machine-level receipt at the home root
+    const receipt = JSON.parse(readFileSync(join(activationHome, "consent.log"), "utf8").trim());
+    expect(receipt.action).toBe("dir-grant");
+    expect(receipt.grantPath).toBe(work);
+  });
+
+  it("declining the confirmation grants nothing", async () => {
+    const work = tmp("vd-en-work-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runEnable(".", { dir: work, activationHome, confirm: async () => false });
+    expect(status).toBe("dir_declined");
+    expect(loadActivation(activationHome).dirGrants).toHaveLength(0);
+  });
+
+  it("refuses $HOME with a nonzero exit and no grant", async () => {
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const status = await runEnable(".", { dir: homedir(), activationHome, confirm: async () => true });
+    expect(status).toBe("dir_refused");
+    expect(process.exitCode).toBe(1);
+    expect(loadActivation(activationHome).dirGrants).toHaveLength(0);
+  });
+});
+
+describe("runDecline", () => {
+  it("records a permanent decline + receipt", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-en-sess-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runDecline(repo, { sessionsDir, activationHome });
+    expect(status).toBe("declined");
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("declined");
+    const receipt = JSON.parse(readFileSync(join(sessionsDir, projectHash, "consent.log"), "utf8").trim());
+    expect(receipt.action).toBe("decline");
+  });
+});

--- a/test/unit/cli/enable.test.ts
+++ b/test/unit/cli/enable.test.ts
@@ -56,6 +56,39 @@ describe("runEnable — single repo", () => {
     expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("active");
   });
 
+  it("enables in a plain directory that is not a git repo (scoped to the dir itself)", async () => {
+    const dir = tmp("vd-en-nogit-");
+    mkdirSync(join(dir, ".claude"));
+    const sessionsDir = tmp("vd-en-sess-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const status = await runEnable(dir, { sessionsDir, activationHome });
+    expect(status).toBe("enabled");
+    // identity falls back to the directory itself when no .git ancestor exists
+    const { rootDir, projectHash } = repoIdentity(dir);
+    expect(rootDir).toBe(dir);
+    expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("active");
+    const receipt = JSON.parse(readFileSync(join(sessionsDir, projectHash, "consent.log"), "utf8").trim());
+    expect(receipt.rootDir).toBe(dir);
+  });
+
+  it("a second enable with hooks already installed is idempotent", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-en-sess-");
+    const activationHome = tmp("vd-en-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(await runEnable(repo, { sessionsDir, activationHome })).toBe("enabled");
+    const settings = join(repo, ".claude", "settings.local.json");
+    const before = readFileSync(settings, "utf8");
+    expect(await runEnable(repo, { sessionsDir, activationHome })).toBe("enabled");
+    expect(readFileSync(settings, "utf8")).toBe(before);
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(activationHome), projectHash)).toBe("active");
+    // both runs left a receipt line (append-only log)
+    const receipts = readFileSync(join(sessionsDir, projectHash, "consent.log"), "utf8").trim().split("\n");
+    expect(receipts).toHaveLength(2);
+  });
+
   it("reverses a prior decline", async () => {
     const repo = repoWithAgent();
     const sessionsDir = tmp("vd-en-sess-");

--- a/test/unit/cli/watch-session.test.ts
+++ b/test/unit/cli/watch-session.test.ts
@@ -51,8 +51,9 @@ describe("runWatchSession", () => {
   it("installs hooks with --yes and reports the ledger location", async () => {
     const repo = repoWithAgent();
     const sessionsDir = tmp("vd-ws-sess-");
+    const activationHome = tmp("vd-ws-act-");
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    const status = await runWatchSession(repo, { yes: true, sessionsDir });
+    const status = await runWatchSession(repo, { yes: true, sessionsDir, activationHome });
     expect(status).toBe("installed");
     expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(true);
     const printed = log.mock.calls.flat().join("\n");
@@ -60,20 +61,37 @@ describe("runWatchSession", () => {
     expect(printed.toLowerCase()).toContain("fail-open");
   });
 
+  it("records the activation answer + consent receipt on a consented install", async () => {
+    const repo = repoWithAgent();
+    const sessionsDir = tmp("vd-ws-sess-");
+    const activationHome = tmp("vd-ws-act-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(repo, { yes: true, sessionsDir, activationHome });
+    const store = JSON.parse(readFileSync(join(activationHome, "activation.json"), "utf8"));
+    const hashes = Object.keys(store.projects);
+    expect(hashes).toHaveLength(1);
+    expect(store.projects[hashes[0]].state).toBe("active");
+    expect(store.projects[hashes[0]].surface).toBe("watch-session");
+    const receipt = readFileSync(join(sessionsDir, hashes[0], "consent.log"), "utf8");
+    expect(JSON.parse(receipt.trim()).action).toBe("enable");
+  });
+
   it("reports already on a second run", async () => {
     const repo = repoWithAgent();
     const sessionsDir = tmp("vd-ws-sess-");
+    const activationHome = tmp("vd-ws-act-");
     vi.spyOn(console, "log").mockImplementation(() => {});
-    await runWatchSession(repo, { yes: true, sessionsDir });
-    expect(await runWatchSession(repo, { yes: true, sessionsDir })).toBe("already");
+    await runWatchSession(repo, { yes: true, sessionsDir, activationHome });
+    expect(await runWatchSession(repo, { yes: true, sessionsDir, activationHome })).toBe("already");
   });
 
   it("uninstalls cleanly", async () => {
     const repo = repoWithAgent();
     const sessionsDir = tmp("vd-ws-sess-");
+    const activationHome = tmp("vd-ws-act-");
     vi.spyOn(console, "log").mockImplementation(() => {});
-    await runWatchSession(repo, { yes: true, sessionsDir });
-    const status = await runWatchSession(repo, { uninstall: true, sessionsDir });
+    await runWatchSession(repo, { yes: true, sessionsDir, activationHome });
+    const status = await runWatchSession(repo, { uninstall: true, sessionsDir, activationHome });
     expect(status).toBe("uninstalled");
     expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
   });

--- a/test/unit/session/activation.test.ts
+++ b/test/unit/session/activation.test.ts
@@ -36,7 +36,7 @@ describe("activation store", () => {
   it("recordAnswer round-trips and wins over everything", () => {
     const home = tmp();
     recordAnswer("h1", "active", "cli-enable", home);
-    let store = loadActivation(home);
+    const store = loadActivation(home);
     expect(projectStatus(store, "h1")).toBe("active");
     expect(store.projects.h1.surface).toBe("cli-enable");
     expect(store.projects.h1.at).toBeTruthy();

--- a/test/unit/session/activation.test.ts
+++ b/test/unit/session/activation.test.ts
@@ -88,7 +88,7 @@ describe("activation store", () => {
 });
 
 describe("ask budget (L-N8)", () => {
-  it("allows ASK_BUDGET asks, expiring into an implicit decline on the last one", () => {
+  it("allows ASK_BUDGET asks, then goes quiet WITHOUT declining (grandfather safe)", () => {
     const home = tmp();
     for (let i = 1; i <= ASK_BUDGET; i++) {
       const out = consumeAsk("h1", home);
@@ -97,10 +97,15 @@ describe("ask budget (L-N8)", () => {
       expect(out.budgetExpired).toBe(i === ASK_BUDGET);
     }
     const store = loadActivation(home);
-    expect(store.projects.h1.state).toBe("declined");
-    expect(store.projects.h1.surface).toBe("budget-expiry");
-    // no fourth ask
-    expect(consumeAsk("h1", home).ask).toBe(false);
+    // expiry marks the breadcrumb but must NOT write `declined` — a
+    // grandfathered capturing repo stays capturing (projectStatus == unanswered).
+    expect(store.projects.h1.breadcrumbShown).toBe(true);
+    expect(store.projects.h1.state).toBeUndefined();
+    expect(projectStatus(store, "h1")).toBe("unanswered");
+    // no fourth ask, and askCount does not creep past the budget
+    const fourth = consumeAsk("h1", home);
+    expect(fourth.ask).toBe(false);
+    expect(loadActivation(home).projects.h1.askCount).toBe(ASK_BUDGET);
   });
 
   it("never asks once an explicit answer exists", () => {

--- a/test/unit/session/activation.test.ts
+++ b/test/unit/session/activation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, parse } from "node:path";
 import {
@@ -123,6 +123,21 @@ describe("ask budget (L-N8)", () => {
 describe("dir-grant refusals (O19)", () => {
   it("refuses $HOME outright", () => {
     expect(() => resolveGrantPath(homedir())).toThrow(DirGrantRefusedError);
+  });
+
+  it("refuses an ANCESTOR of $HOME (broader than $HOME — e.g. /Users)", () => {
+    // dirname(home) is a real, existing ancestor of home on every platform.
+    const parent = join(homedir(), "..");
+    expect(() => resolveGrantPath(parent)).toThrow(DirGrantRefusedError);
+  });
+
+  it("allows a SUBDIRECTORY of $HOME (the intended grant, e.g. ~/work)", () => {
+    const work = realpathSync(mkdtempSync(join(homedir(), ".vd-grant-ok-")));
+    try {
+      expect(resolveGrantPath(work)).toBe(work);
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
   });
 
   it("refuses the filesystem root", () => {

--- a/test/unit/session/activation.test.ts
+++ b/test/unit/session/activation.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, parse } from "node:path";
+import {
+  ASK_BUDGET,
+  activationPath,
+  loadActivation,
+  recordAnswer,
+  projectStatus,
+  isUnderGrant,
+  consumeAsk,
+  resolveGrantPath,
+  addDirGrant,
+  DirGrantRefusedError,
+} from "@/session/activation";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-act-")));
+
+describe("activation store", () => {
+  it("missing file loads as empty (unanswered)", () => {
+    const home = tmp();
+    const store = loadActivation(home);
+    expect(store).toEqual({ v: 1, projects: {}, dirGrants: [] });
+    expect(projectStatus(store, "h1")).toBe("unanswered");
+  });
+
+  it("corrupt or wrong-version files fail open to empty", () => {
+    const home = tmp();
+    writeFileSync(activationPath(home), "{nope");
+    expect(loadActivation(home).projects).toEqual({});
+    writeFileSync(activationPath(home), JSON.stringify({ v: 99, projects: { h: { state: "active" } } }));
+    expect(loadActivation(home).projects).toEqual({});
+  });
+
+  it("recordAnswer round-trips and wins over everything", () => {
+    const home = tmp();
+    recordAnswer("h1", "active", "cli-enable", home);
+    let store = loadActivation(home);
+    expect(projectStatus(store, "h1")).toBe("active");
+    expect(store.projects.h1.surface).toBe("cli-enable");
+    expect(store.projects.h1.at).toBeTruthy();
+    // reversal: decline then re-enable
+    recordAnswer("h1", "declined", "cli-decline", home);
+    expect(projectStatus(loadActivation(home), "h1")).toBe("declined");
+    recordAnswer("h1", "active", "cli-enable", home);
+    expect(projectStatus(loadActivation(home), "h1")).toBe("active");
+  });
+
+  it("a covering dir grant activates an unanswered repo; explicit decline still wins", () => {
+    const home = tmp();
+    const work = tmp();
+    addDirGrant(work, home);
+    let store = loadActivation(home);
+    expect(projectStatus(store, "h1", join(work, "repo-a"))).toBe("active");
+    expect(projectStatus(store, "h1", work)).toBe("active"); // the granted dir itself
+    recordAnswer("h1", "declined", "cli-decline", home);
+    store = loadActivation(home);
+    expect(projectStatus(store, "h1", join(work, "repo-a"))).toBe("declined");
+  });
+
+  it("grant matching is path-segment safe (sibling /work2 not under /work)", () => {
+    const home = tmp();
+    const base = tmp();
+    const work = join(base, "work");
+    mkdirSync(work);
+    mkdirSync(join(base, "work2"));
+    addDirGrant(work, home);
+    const store = loadActivation(home);
+    expect(isUnderGrant(store, join(base, "work2"))).toBe(false);
+    expect(isUnderGrant(store, join(base, "work", "deep", "repo"))).toBe(true);
+  });
+
+  it("addDirGrant dedupes identical paths", () => {
+    const home = tmp();
+    const work = tmp();
+    addDirGrant(work, home);
+    addDirGrant(work, home);
+    expect(loadActivation(home).dirGrants).toHaveLength(1);
+  });
+
+  it("writes are atomic-ish: file is valid JSON with restrictive perms", () => {
+    const home = tmp();
+    recordAnswer("h1", "active", "cli-enable", home);
+    const raw = readFileSync(activationPath(home), "utf8");
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+});
+
+describe("ask budget (L-N8)", () => {
+  it("allows ASK_BUDGET asks, expiring into an implicit decline on the last one", () => {
+    const home = tmp();
+    for (let i = 1; i <= ASK_BUDGET; i++) {
+      const out = consumeAsk("h1", home);
+      expect(out.ask).toBe(true);
+      expect(out.askCount).toBe(i);
+      expect(out.budgetExpired).toBe(i === ASK_BUDGET);
+    }
+    const store = loadActivation(home);
+    expect(store.projects.h1.state).toBe("declined");
+    expect(store.projects.h1.surface).toBe("budget-expiry");
+    // no fourth ask
+    expect(consumeAsk("h1", home).ask).toBe(false);
+  });
+
+  it("never asks once an explicit answer exists", () => {
+    const home = tmp();
+    recordAnswer("h1", "active", "cli-enable", home);
+    expect(consumeAsk("h1", home)).toEqual({ ask: false, askCount: 0, budgetExpired: false });
+    recordAnswer("h2", "declined", "cli-decline", home);
+    expect(consumeAsk("h2", home).ask).toBe(false);
+  });
+
+  it("budgets are per-project", () => {
+    const home = tmp();
+    consumeAsk("h1", home);
+    consumeAsk("h1", home);
+    const other = consumeAsk("h2", home);
+    expect(other.askCount).toBe(1);
+  });
+});
+
+describe("dir-grant refusals (O19)", () => {
+  it("refuses $HOME outright", () => {
+    expect(() => resolveGrantPath(homedir())).toThrow(DirGrantRefusedError);
+  });
+
+  it("refuses the filesystem root", () => {
+    const root = parse(process.cwd()).root;
+    expect(() => resolveGrantPath(root)).toThrow(DirGrantRefusedError);
+  });
+
+  it("throws on nonexistent paths", () => {
+    expect(() => resolveGrantPath(join(tmpdir(), "vd-definitely-missing-xyz"))).toThrow();
+  });
+
+  it("canonicalizes symlinks to the real path", () => {
+    const base = tmp();
+    const real = join(base, "real");
+    mkdirSync(real);
+    const link = join(base, "link");
+    symlinkSync(real, link);
+    expect(resolveGrantPath(link)).toBe(real);
+  });
+});

--- a/test/unit/session/consent.test.ts
+++ b/test/unit/session/consent.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendConsentReceipt, CONSENT_LOG } from "@/session/consent";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-consent-")));
+
+describe("consent receipts", () => {
+  it("appends JSONL lines and creates the directory", () => {
+    const dir = join(tmp(), "sessions", "hash");
+    expect(appendConsentReceipt(dir, { v: 1, at: "t1", action: "enable", surface: "cli-enable", projectHash: "h" })).toBe(true);
+    expect(appendConsentReceipt(dir, { v: 1, at: "t2", action: "decline", surface: "cli-decline", projectHash: "h" })).toBe(true);
+    const lines = readFileSync(join(dir, CONSENT_LOG), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).action).toBe("enable");
+    expect(JSON.parse(lines[1]).action).toBe("decline");
+  });
+
+  it("uses the .log extension so the uploader (jsonl-only) never sees it", () => {
+    expect(CONSENT_LOG.endsWith(".log")).toBe(true);
+    expect(CONSENT_LOG.endsWith(".jsonl")).toBe(false);
+  });
+});

--- a/test/unit/session/entitlement.test.ts
+++ b/test/unit/session/entitlement.test.ts
@@ -7,6 +7,9 @@ import {
   readEntitlementCache,
   writeEntitlementCache,
   isCapturePermitted,
+  shouldRefreshEntitlement,
+  refreshEntitlementCache,
+  ENTITLEMENT_TTL_MS,
   SESSION_TRIAL_LIMIT,
 } from "@/session/entitlement";
 
@@ -60,5 +63,172 @@ describe("isCapturePermitted (hook gate)", () => {
 describe("SESSION_TRIAL_LIMIT", () => {
   it("is 5 (decision 8)", () => {
     expect(SESSION_TRIAL_LIMIT).toBe(5);
+  });
+});
+
+describe("writeEntitlementCache stamps checkedAt", () => {
+  it("records when the server was last asked", () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5), () => 1_700_000_000_000);
+    expect(readEntitlementCache(dir)?.checkedAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("keeps an explicit checkedAt the caller already set", () => {
+    const dir = tmp();
+    const at = "2026-01-01T00:00:00.000Z";
+    writeEntitlementCache(dir, { ...computeEntitlement("pro", 0, 5), checkedAt: at }, () => 999);
+    expect(readEntitlementCache(dir)?.checkedAt).toBe(at);
+  });
+});
+
+describe("shouldRefreshEntitlement (native-path refresh policy)", () => {
+  const NOW = 1_700_000_000_000;
+
+  it("refreshes when there is no cache at all", () => {
+    expect(shouldRefreshEntitlement(null, NOW)).toBe(true);
+  });
+
+  it("does NOT refresh an entitled cache checked within the TTL", () => {
+    const e = { ...computeEntitlement("free", 1, 5), checkedAt: new Date(NOW - 60_000).toISOString() };
+    expect(shouldRefreshEntitlement(e, NOW)).toBe(false);
+  });
+
+  it("refreshes an entitled cache older than the TTL", () => {
+    const stale = new Date(NOW - ENTITLEMENT_TTL_MS - 1).toISOString();
+    const e = { ...computeEntitlement("free", 1, 5), checkedAt: stale };
+    expect(shouldRefreshEntitlement(e, NOW)).toBe(true);
+  });
+
+  it("ALWAYS refreshes a locked cache, so upgrading to Pro unlocks promptly", () => {
+    const e = { ...computeEntitlement("free", 5, 5), checkedAt: new Date(NOW).toISOString() };
+    expect(e.reason).toBe("locked");
+    expect(shouldRefreshEntitlement(e, NOW)).toBe(true);
+  });
+
+  it("refreshes a legacy cache that carries no checkedAt", () => {
+    expect(shouldRefreshEntitlement(computeEntitlement("pro", 0, 5), NOW)).toBe(true);
+  });
+
+  it("refreshes when checkedAt is unparseable", () => {
+    const e = { ...computeEntitlement("pro", 0, 5), checkedAt: "not-a-date" };
+    expect(shouldRefreshEntitlement(e, NOW)).toBe(true);
+  });
+
+  it("refreshes when checkedAt is in the future (clock skew must not pin the cache)", () => {
+    const e = { ...computeEntitlement("pro", 0, 5), checkedAt: new Date(NOW + 86_400_000).toISOString() };
+    expect(shouldRefreshEntitlement(e, NOW)).toBe(true);
+  });
+});
+
+describe("refreshEntitlementCache (the native path's cache owner)", () => {
+  const NOW = 1_700_000_000_000;
+  const server = (plan: "free" | "pro", used: number, limit = 5) => async () => ({
+    plan,
+    trial_used: used,
+    trial_limit: limit,
+  });
+
+  it("asks the server and writes the cache when nothing is cached yet", async () => {
+    const dir = tmp();
+    let calls = 0;
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW,
+      fetch: async () => { calls++; return { plan: "free", trial_used: 2, trial_limit: 5 }; },
+    });
+    expect(calls).toBe(1);
+    expect(e).toMatchObject({ entitled: true, reason: "trial", trialUsed: 2 });
+    expect(readEntitlementCache(dir)).toMatchObject({ trialUsed: 2, checkedAt: new Date(NOW).toISOString() });
+  });
+
+  it("makes NO network call when a fresh entitled cache is present", async () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5), () => NOW);
+    let calls = 0;
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW + 60_000,
+      fetch: async () => { calls++; return { plan: "free", trial_used: 4, trial_limit: 5 }; },
+    });
+    expect(calls).toBe(0);
+    expect(e?.trialUsed).toBe(1);
+  });
+
+  it("re-asks once the cache goes stale", async () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5), () => NOW);
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW + ENTITLEMENT_TTL_MS + 1,
+      fetch: server("free", 4),
+    });
+    expect(e?.trialUsed).toBe(4);
+  });
+
+  it("locks the cache once the server reports the trial spent", async () => {
+    const dir = tmp();
+    const e = await refreshEntitlementCache({ baseDir: dir, now: () => NOW, fetch: server("free", 5) });
+    expect(e).toMatchObject({ entitled: false, reason: "locked" });
+    expect(isCapturePermitted(dir)).toBe(false);
+  });
+
+  it("unlocks a locked cache as soon as the account is Pro", async () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 5, 5), () => NOW);
+    expect(isCapturePermitted(dir)).toBe(false);
+    const e = await refreshEntitlementCache({ baseDir: dir, now: () => NOW, fetch: server("pro", 5) });
+    expect(e).toMatchObject({ entitled: true, reason: "pro" });
+    expect(isCapturePermitted(dir)).toBe(true);
+  });
+
+  it("keeps the existing cache when the server is unreachable (fail open, never lock on a network blip)", async () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5), () => NOW - ENTITLEMENT_TTL_MS - 1);
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW,
+      fetch: async () => { throw new Error("offline"); },
+    });
+    expect(e).toMatchObject({ entitled: true, trialUsed: 1 });
+    expect(isCapturePermitted(dir)).toBe(true);
+  });
+
+  it("writes nothing when the server is unreachable and no cache exists", async () => {
+    const dir = tmp();
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW,
+      fetch: async () => { throw new Error("offline"); },
+    });
+    expect(e).toBeNull();
+    expect(readEntitlementCache(dir)).toBeNull();
+    expect(isCapturePermitted(dir)).toBe(true); // still fails open
+  });
+
+  it("force re-asks even when the cache is fresh (the 402 path)", async () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5), () => NOW);
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW,
+      force: true,
+      fetch: server("free", 5),
+    });
+    expect(e).toMatchObject({ entitled: false, reason: "locked" });
+  });
+
+  it("ignores a malformed server answer rather than corrupting the cache", async () => {
+    const dir = tmp();
+    writeEntitlementCache(dir, computeEntitlement("free", 1, 5), () => NOW);
+    const e = await refreshEntitlementCache({
+      baseDir: dir,
+      now: () => NOW,
+      force: true,
+      fetch: async () => ({ plan: "free", trial_used: "lots", trial_limit: null } as unknown as {
+        plan: "free"; trial_used: number; trial_limit: number;
+      }),
+    });
+    expect(e).toMatchObject({ entitled: true, trialUsed: 1 });
+    expect(readEntitlementCache(dir)?.trialUsed).toBe(1);
   });
 });

--- a/test/unit/session/flush-run.test.ts
+++ b/test/unit/session/flush-run.test.ts
@@ -155,4 +155,21 @@ describe("runFlush (the native path's per-turn flush)", () => {
       }),
     ).resolves.toBeTruthy();
   });
+
+  it("a missing ledger directory flushes cleanly: nothing posted, not locked", async () => {
+    const base = tmp();
+    // never created: no sessions dir, no project dir, no ledger, no offsets
+    const sessionsDir = join(base, "sessions");
+    const posted: UploadEvent[] = [];
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: "h-missing",
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "pro" }),
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+    });
+    expect(posted).toHaveLength(0);
+    expect(out).toMatchObject({ uploaded: true, locked: false });
+  });
 });

--- a/test/unit/session/flush-run.test.ts
+++ b/test/unit/session/flush-run.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runFlush } from "@/session/flush-run";
+import { appendEvent } from "@/session/ledger";
+import { readEntitlementCache, writeEntitlementCache, computeEntitlement } from "@/session/entitlement";
+import type { UploadEvent } from "@/session/upload-schema";
+import type { IngestAck } from "@/session/ingest-ack";
+import type { SessionEvent } from "@/session/types";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-flushrun-")));
+const NOW = 1_700_000_000_000;
+
+let seq = 0;
+const ev = (over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "s1",
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: "h",
+  channel: "hook",
+  type: "edit",
+  mode: "passive",
+  detail: { file: "a.ts", diffstat: "+1" },
+  ...over,
+});
+
+const fullAck = (events: UploadEvent[]): IngestAck => ({
+  accepted: events.length,
+  results: events.map((e) => ({ activityId: e.activityId, status: "accepted" as const })),
+});
+
+/** A project with one uploadable edit in its ledger. */
+async function project(): Promise<{ base: string; sessionsDir: string; hash: string }> {
+  const base = tmp();
+  const sessionsDir = join(base, "sessions");
+  const hash = "h1";
+  await appendEvent(sessionsDir, hash, "s1", ev());
+  return { base, sessionsDir, hash };
+}
+
+describe("runFlush (the native path's per-turn flush)", () => {
+  it("refreshes the entitlement cache on a first run, then uploads", async () => {
+    const { base, sessionsDir, hash } = await project();
+    expect(readEntitlementCache(base)).toBeNull();
+    const posted: UploadEvent[] = [];
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "free", trial_used: 1, trial_limit: 5 }),
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+    });
+    expect(readEntitlementCache(base)).toMatchObject({ entitled: true, trialUsed: 1 });
+    expect(posted).toHaveLength(1);
+    expect(out).toMatchObject({ uploaded: true, locked: false });
+  });
+
+  it("locks the cache and uploads NOTHING once the trial is spent", async () => {
+    const { base, sessionsDir, hash } = await project();
+    let posts = 0;
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "free", trial_used: 5, trial_limit: 5 }),
+      post: async (e) => { posts++; return fullAck(e); },
+    });
+    expect(posts).toBe(0);
+    expect(out).toMatchObject({ uploaded: false, locked: true });
+    expect(readEntitlementCache(base)).toMatchObject({ entitled: false, reason: "locked" });
+  });
+
+  it("locks the cache when ingest answers 402 mid-flush", async () => {
+    const { base, sessionsDir, hash } = await project();
+    // cache says entitled and is fresh, so the pre-flight refresh is skipped;
+    // the server disagrees at ingest time.
+    writeEntitlementCache(base, computeEntitlement("free", 4, 5), () => NOW);
+    let entitlementCalls = 0;
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => { entitlementCalls++; return { plan: "free", trial_used: 5, trial_limit: 5 }; },
+      post: async () => { const err = new Error("locked") as Error & { status?: number }; err.status = 402; throw err; },
+    });
+    expect(out.locked).toBe(true);
+    expect(entitlementCalls).toBe(1); // the forced re-ask after the 402
+    expect(readEntitlementCache(base)).toMatchObject({ entitled: false, reason: "locked" });
+  });
+
+  it("still uploads when the entitlement check is unreachable (network blip never locks)", async () => {
+    const { base, sessionsDir, hash } = await project();
+    const posted: UploadEvent[] = [];
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => { throw new Error("offline"); },
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+    });
+    expect(posted).toHaveLength(1);
+    expect(out.locked).toBe(false);
+    expect(readEntitlementCache(base)).toBeNull(); // nothing fabricated
+  });
+
+  it("skips the entitlement round-trip when the cache is fresh and entitled", async () => {
+    const { base, sessionsDir, hash } = await project();
+    writeEntitlementCache(base, computeEntitlement("pro", 0, 5), () => NOW);
+    let entitlementCalls = 0;
+    await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => { entitlementCalls++; return { plan: "pro", trial_used: 0, trial_limit: 5 }; },
+      post: async (e) => fullAck(e),
+    });
+    expect(entitlementCalls).toBe(0);
+  });
+
+  it("re-asks a locked cache every turn, and uploads again once the account is Pro", async () => {
+    const { base, sessionsDir, hash } = await project();
+    writeEntitlementCache(base, computeEntitlement("free", 5, 5), () => NOW);
+    const posted: UploadEvent[] = [];
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "pro", trial_used: 5, trial_limit: 5 }),
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+    });
+    expect(readEntitlementCache(base)).toMatchObject({ entitled: true, reason: "pro" });
+    expect(posted).toHaveLength(1);
+    expect(out).toMatchObject({ uploaded: true, locked: false });
+  });
+
+  it("never throws when everything fails at once", async () => {
+    const { base, sessionsDir, hash } = await project();
+    await expect(
+      runFlush({
+        baseDir: base,
+        sessionsDir,
+        projectHash: hash,
+        now: () => NOW,
+        fetchEntitlement: async () => { throw new Error("offline"); },
+        post: async () => { throw new Error("network down"); },
+      }),
+    ).resolves.toBeTruthy();
+  });
+});

--- a/test/unit/session/ingest-ack.test.ts
+++ b/test/unit/session/ingest-ack.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { reconcileAck, isIngestLocked, type TaggedUpload } from "@/session/ingest-ack";
+import type { UploadEvent } from "@/session/upload-schema";
+
+let n = 0;
+const tag = (file: string, endOffset: number): TaggedUpload => ({
+  event: { v: 1, sessionId: "s1", activityId: `evt-${++n}`, ts: "t", agent: "claude-code", projectHash: "h", type: "edit" } as UploadEvent,
+  file,
+  endOffset,
+});
+const ids = (sent: TaggedUpload[]) => sent.map((t) => t.event.activityId);
+
+describe("reconcileAck", () => {
+  it("void ack (test seams / ancient callers) commits the full batch per file", () => {
+    const sent = [tag("a.jsonl", 100), tag("a.jsonl", 200), tag("b.jsonl", 50)];
+    const rec = reconcileAck(sent, undefined);
+    expect(rec.commitUpTo.get("a.jsonl")).toBe(200);
+    expect(rec.commitUpTo.get("b.jsonl")).toBe(50);
+    expect(rec.held).toHaveLength(0);
+  });
+
+  it("legacy ack with full accepted count commits; partial count holds everything", () => {
+    const sent = [tag("a.jsonl", 100), tag("a.jsonl", 200)];
+    const full = reconcileAck(sent, { accepted: 2 });
+    expect(full.commitUpTo.get("a.jsonl")).toBe(200);
+    const partial = reconcileAck(sent, { accepted: 1 });
+    expect(partial.commitUpTo.size).toBe(0);
+    expect(partial.held).toHaveLength(2);
+  });
+
+  it("contiguous prefix: a held event stops its file's watermark; later events of that file hold", () => {
+    const sent = [tag("a.jsonl", 100), tag("a.jsonl", 200), tag("a.jsonl", 300)];
+    const [i1, , i3] = ids(sent);
+    const rec = reconcileAck(sent, {
+      accepted: 2,
+      results: [
+        { activityId: i1, status: "accepted" },
+        { activityId: sent[1].event.activityId, status: "held", code: "session_locked" },
+        { activityId: i3, status: "accepted" },
+      ],
+    });
+    expect(rec.commitUpTo.get("a.jsonl")).toBe(100);
+    // both the held event AND the accepted-after-held event stay pending
+    expect(rec.held.map((t) => t.event.activityId)).toEqual([sent[1].event.activityId, i3]);
+  });
+
+  it("a permanently rejected event commits past and is reported", () => {
+    const sent = [tag("a.jsonl", 100), tag("a.jsonl", 200)];
+    const rec = reconcileAck(sent, {
+      accepted: 1,
+      results: [
+        { activityId: sent[0].event.activityId, status: "rejected", code: "banned_field" },
+        { activityId: sent[1].event.activityId, status: "accepted" },
+      ],
+    });
+    expect(rec.commitUpTo.get("a.jsonl")).toBe(200);
+    expect(rec.rejectedIds).toEqual([sent[0].event.activityId]);
+    expect(rec.held).toHaveLength(0);
+  });
+
+  it("duplicate counts as accepted (idempotent replays)", () => {
+    const sent = [tag("a.jsonl", 100)];
+    const rec = reconcileAck(sent, {
+      accepted: 0,
+      results: [{ activityId: sent[0].event.activityId, status: "duplicate" }],
+    });
+    expect(rec.commitUpTo.get("a.jsonl")).toBe(100);
+  });
+
+  it("an event missing from results holds itself and everything after it in its file", () => {
+    const sent = [tag("a.jsonl", 100), tag("a.jsonl", 200)];
+    const rec = reconcileAck(sent, {
+      accepted: 1,
+      results: [{ activityId: sent[1].event.activityId, status: "accepted" }],
+    });
+    expect(rec.commitUpTo.size).toBe(0);
+    expect(rec.held).toHaveLength(2);
+  });
+
+  it("files commit independently: a hold in file A does not block file B", () => {
+    const sent = [tag("a.jsonl", 100), tag("b.jsonl", 60), tag("a.jsonl", 200), tag("b.jsonl", 120)];
+    const rec = reconcileAck(sent, {
+      accepted: 3,
+      results: [
+        { activityId: sent[0].event.activityId, status: "held", code: "unknown_type" },
+        { activityId: sent[1].event.activityId, status: "accepted" },
+        { activityId: sent[2].event.activityId, status: "accepted" },
+        { activityId: sent[3].event.activityId, status: "accepted" },
+      ],
+    });
+    expect(rec.commitUpTo.has("a.jsonl")).toBe(false);
+    expect(rec.commitUpTo.get("b.jsonl")).toBe(120);
+    expect(rec.held.map((t) => t.file)).toEqual(["a.jsonl", "a.jsonl"]);
+  });
+
+  it("isIngestLocked matches 402 errors only", () => {
+    expect(isIngestLocked({ status: 402 })).toBe(true);
+    expect(isIngestLocked({ status: 500 })).toBe(false);
+    expect(isIngestLocked(new Error("network"))).toBe(false);
+    expect(isIngestLocked(undefined)).toBe(false);
+  });
+});

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -4,6 +4,7 @@ import {
   isNonInteractive,
   buildNudgeInstruction,
   buildNudgeOutput,
+  buildLockNotice,
 } from "@/session/nudge";
 import type { SessionEntitlement } from "@/session/entitlement";
 
@@ -72,5 +73,42 @@ describe("buildNudgeOutput", () => {
     const out = buildNudgeOutput({ repoName: "r", entitlement: trial(1), lastAsk: true });
     expect(out.systemMessage).toContain("vibedrift enable");
     expect(out.systemMessage).not.toContain("trial:");
+  });
+});
+
+describe("buildLockNotice (the native path's paywall signal)", () => {
+  const locked = {
+    entitled: false,
+    reason: "locked" as const,
+    plan: "free" as const,
+    trialUsed: 5,
+    trialLimit: 5,
+  };
+
+  it("tells the user, in one user-visible line, that capture is paused", () => {
+    const out = buildLockNotice({ entitlement: locked });
+    expect(out.systemMessage).toContain("5-session trial");
+    expect(out.systemMessage?.toLowerCase()).toContain("not being recorded");
+  });
+
+  it("names the upgrade path", () => {
+    const out = buildLockNotice({ entitlement: locked });
+    expect(out.systemMessage).toContain("vibedrift upgrade");
+  });
+
+  it("claims nothing about prevention or deletion (honesty constraint)", () => {
+    const msg = buildLockNotice({ entitlement: locked }).systemMessage ?? "";
+    for (const banned of ["prevented", "blocked", "deleted", "erased"]) {
+      expect(msg.toLowerCase()).not.toContain(banned);
+    }
+  });
+
+  it("carries no model-facing instruction — this is a user notice, not a nudge", () => {
+    expect(buildLockNotice({ entitlement: locked })).not.toHaveProperty("hookSpecificOutput");
+  });
+
+  it("uses the server's real trial limit rather than a hardcoded 5", () => {
+    const out = buildLockNotice({ entitlement: { ...locked, trialUsed: 12, trialLimit: 12 } });
+    expect(out.systemMessage).toContain("12-session trial");
   });
 });

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  isNewInteractiveSource,
+  isNonInteractive,
+  buildNudgeInstruction,
+  buildNudgeOutput,
+} from "@/session/nudge";
+import type { SessionEntitlement } from "@/session/entitlement";
+
+const trial = (used: number): SessionEntitlement => ({
+  entitled: true,
+  reason: "trial",
+  plan: "free",
+  trialUsed: used,
+  trialLimit: 5,
+});
+const pro: SessionEntitlement = { entitled: true, reason: "pro", plan: "pro", trialUsed: 0, trialLimit: 5 };
+
+describe("isNewInteractiveSource", () => {
+  it("only startup and clear count as a new interactive session", () => {
+    expect(isNewInteractiveSource("startup")).toBe(true);
+    expect(isNewInteractiveSource("clear")).toBe(true);
+    expect(isNewInteractiveSource("resume")).toBe(false);
+    expect(isNewInteractiveSource("compact")).toBe(false);
+    expect(isNewInteractiveSource(undefined)).toBe(false);
+    expect(isNewInteractiveSource("whatever")).toBe(false);
+  });
+});
+
+describe("isNonInteractive", () => {
+  it("reads the deterministic override", () => {
+    expect(isNonInteractive({ VIBEDRIFT_HOOK_NONINTERACTIVE: "1" })).toBe(true);
+    expect(isNonInteractive({ VIBEDRIFT_HOOK_NONINTERACTIVE: "true" })).toBe(true);
+    expect(isNonInteractive({})).toBe(false);
+    expect(isNonInteractive({ VIBEDRIFT_HOOK_NONINTERACTIVE: "0" })).toBe(false);
+  });
+});
+
+describe("buildNudgeInstruction", () => {
+  it("names the repo, asks once, and carries the soft-decline path", () => {
+    const text = buildNudgeInstruction({ repoName: "my-api" });
+    expect(text).toContain('"my-api"');
+    expect(text).toContain("Want me to enable VibeDrift");
+    expect(text).toContain("enable");
+    expect(text).toContain('{"decline": true}');
+    // soft-decline on a deflection
+    expect(text.toLowerCase()).toContain("not now");
+    // no trial line for a non-trial context
+    expect(text).not.toContain("free trial");
+  });
+
+  it("adds the honest trial usage line only on a trial entitlement", () => {
+    expect(buildNudgeInstruction({ repoName: "r", entitlement: trial(2) })).toContain("2 of 5 sessions used");
+    expect(buildNudgeInstruction({ repoName: "r", entitlement: pro })).not.toContain("trial");
+  });
+});
+
+describe("buildNudgeOutput", () => {
+  it("emits the SessionStart context-injection envelope", () => {
+    const out = buildNudgeOutput({ repoName: "r" });
+    expect(out.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    expect(out.hookSpecificOutput.additionalContext).toContain("VibeDrift is installed");
+    expect(out.systemMessage).toBeUndefined();
+  });
+
+  it("shows a trial systemMessage on a trial account", () => {
+    const out = buildNudgeOutput({ repoName: "r", entitlement: trial(1) });
+    expect(out.systemMessage).toBe("VibeDrift trial: 1 of 5 sessions used.");
+  });
+
+  it("the final ask folds in the breadcrumb, overriding the trial line", () => {
+    const out = buildNudgeOutput({ repoName: "r", entitlement: trial(1), lastAsk: true });
+    expect(out.systemMessage).toContain("vibedrift enable");
+    expect(out.systemMessage).not.toContain("trial:");
+  });
+});

--- a/test/unit/session/upload-follower.test.ts
+++ b/test/unit/session/upload-follower.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync, writeFileSync, appendFileSync, utimesSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UploadFollower } from "@/session/upload-follower";
+import { UploadStateStore } from "@/session/upload-state";
+import type { SessionEvent } from "@/session/types";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-ufol-")));
+
+let seq = 0;
+const line = (sid: string, type = "edit") =>
+  JSON.stringify({ v: 1, sid, aid: `evt-${++seq}`, ts: "t", agent: "claude-code", projectHash: "h", channel: "hook", type, mode: "passive", detail: {} }) + "\n";
+
+async function setup(hash = "h1") {
+  const dir = tmp();
+  mkdirSync(join(dir, hash), { recursive: true });
+  const store = new UploadStateStore(dir, hash);
+  await store.load();
+  return { dir, store, follower: new UploadFollower(dir, hash, store), pdir: join(dir, hash) };
+}
+
+const sids = (evts: Array<{ event: SessionEvent }>) => evts.map((t) => t.event.sid);
+
+describe("UploadFollower", () => {
+  it("backfills ALL ledger files, oldest mtime first", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "old.jsonl"), line("old") + line("old"));
+    writeFileSync(join(pdir, "new.jsonl"), line("new"));
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(join(pdir, "old.jsonl"), past, past);
+    const got = await follower.poll(100);
+    expect(sids(got)).toEqual(["old", "old", "new"]);
+    expect(got.map((t) => t.file)).toEqual(["old.jsonl", "old.jsonl", "new.jsonl"]);
+  });
+
+  it("resumes each file from the durable committed offset", async () => {
+    const { pdir, store } = await setup();
+    const l1 = line("s1");
+    writeFileSync(join(pdir, "s1.jsonl"), l1 + line("s1"));
+    await store.commit(new Map([["s1.jsonl", l1.length]]));
+    const store2 = new UploadStateStore(pdir.replace(/\/h1$/, ""), "h1");
+    await store2.load();
+    const follower = new UploadFollower(pdir.replace(/\/h1$/, ""), "h1", store2);
+    const got = await follower.poll(100);
+    expect(got).toHaveLength(1);
+    expect(got[0].endOffset).toBeGreaterThan(l1.length);
+  });
+
+  it("backpressure: returns at most `budget` events and re-reads the remainder next poll", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "s1.jsonl"), line("a") + line("b") + line("c") + line("d"));
+    const first = await follower.poll(2);
+    expect(sids(first)).toEqual(["a", "b"]);
+    const second = await follower.poll(2);
+    expect(sids(second)).toEqual(["c", "d"]);
+    expect(await follower.poll(2)).toHaveLength(0);
+  });
+
+  it("budget stops across files too, without skipping the later file", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "a.jsonl"), line("a1") + line("a2"));
+    writeFileSync(join(pdir, "b.jsonl"), line("b1"));
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(join(pdir, "a.jsonl"), past, past);
+    expect(sids(await follower.poll(1))).toEqual(["a1"]);
+    expect(sids(await follower.poll(5))).toEqual(["a2", "b1"]);
+  });
+
+  it("a half-written trailing line is not returned until its newline arrives", async () => {
+    const { follower, pdir } = await setup();
+    const full = line("s1");
+    writeFileSync(join(pdir, "s1.jsonl"), full + '{"v":1,"sid":"s1","aid":"torn'); // no newline
+    expect(sids(await follower.poll(10))).toEqual(["s1"]);
+    appendFileSync(join(pdir, "s1.jsonl"), "}\n"); // completes the line but stays invalid JSON
+    appendFileSync(join(pdir, "s1.jsonl"), line("s2"));
+    const got = await follower.poll(10);
+    expect(sids(got)).toEqual(["s2"]); // corrupt completed line skipped, not wedged
+  });
+
+  it("corrupt lines advance the offset (never wedge the file)", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "s1.jsonl"), "not-json\n" + line("ok"));
+    const got = await follower.poll(10);
+    expect(sids(got)).toEqual(["ok"]);
+    expect(await follower.poll(10)).toHaveLength(0);
+  });
+
+  it("a truncated/replaced file resets to zero (dedup absorbs the resend)", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "s1.jsonl"), line("a") + line("b"));
+    await follower.poll(10);
+    writeFileSync(join(pdir, "s1.jsonl"), line("c")); // shorter file, new content
+    const got = await follower.poll(10);
+    expect(sids(got)).toEqual(["c"]);
+  });
+
+  it("unchanged files are skipped on later polls; appends are picked up", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "s1.jsonl"), line("a"));
+    expect(await follower.poll(10)).toHaveLength(1);
+    expect(await follower.poll(10)).toHaveLength(0);
+    appendFileSync(join(pdir, "s1.jsonl"), line("b"));
+    expect(sids(await follower.poll(10))).toEqual(["b"]);
+  });
+
+  it("non-jsonl files (upload-state.json, backups) are ignored", async () => {
+    const { follower, pdir } = await setup();
+    writeFileSync(join(pdir, "upload-state.json"), "{}");
+    writeFileSync(join(pdir, "settings-backup.json"), "{}");
+    writeFileSync(join(pdir, "s1.jsonl"), line("a"));
+    expect(sids(await follower.poll(10))).toEqual(["a"]);
+  });
+});

--- a/test/unit/session/upload-state.test.ts
+++ b/test/unit/session/upload-state.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync, writeFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UploadStateStore, uploadStatePath } from "@/session/upload-state";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-ustate-")));
+
+async function fresh(dir: string, hash = "h1") {
+  const s = new UploadStateStore(dir, hash);
+  await s.load();
+  return s;
+}
+
+describe("UploadStateStore", () => {
+  it("empty state when the file is missing", async () => {
+    const s = await fresh(tmp());
+    expect(s.get("a.jsonl")).toBe(0);
+  });
+
+  it("roundtrips commits across instances", async () => {
+    const dir = tmp();
+    const s1 = await fresh(dir);
+    await s1.commit(new Map([["a.jsonl", 120], ["b.jsonl", 40]]));
+    // keep the ledgers around so prune-on-load does not discard the entries
+    writeFileSync(join(dir, "h1", "a.jsonl"), "x\n");
+    writeFileSync(join(dir, "h1", "b.jsonl"), "x\n");
+    const s2 = await fresh(dir);
+    expect(s2.get("a.jsonl")).toBe(120);
+    expect(s2.get("b.jsonl")).toBe(40);
+  });
+
+  it("corrupt or wrong-version state fails open to empty", async () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "h1"), { recursive: true });
+    writeFileSync(uploadStatePath(dir, "h1"), "{not json");
+    expect((await fresh(dir)).get("a.jsonl")).toBe(0);
+    writeFileSync(uploadStatePath(dir, "h1"), JSON.stringify({ v: 99, files: { "a.jsonl": { offset: 7 } } }));
+    expect((await fresh(dir)).get("a.jsonl")).toBe(0);
+  });
+
+  it("prunes entries whose ledger no longer exists (on load)", async () => {
+    const dir = tmp();
+    const s1 = await fresh(dir);
+    await s1.commit(new Map([["gone.jsonl", 10], ["kept.jsonl", 20]]));
+    writeFileSync(join(dir, "h1", "kept.jsonl"), "x\n");
+    const s2 = await fresh(dir);
+    expect(s2.get("gone.jsonl")).toBe(0);
+    expect(s2.get("kept.jsonl")).toBe(20);
+  });
+
+  it("max-merges with on-disk state: offsets only ever move forward", async () => {
+    const dir = tmp();
+    const a = await fresh(dir);
+    const b = await fresh(dir);
+    await a.commit(new Map([["f.jsonl", 500], ["g.jsonl", 100]]));
+    // b, unaware of a's progress, tries to commit lower f and higher g
+    await b.commit(new Map([["f.jsonl", 300], ["g.jsonl", 400]]));
+    writeFileSync(join(dir, "h1", "f.jsonl"), "x\n");
+    writeFileSync(join(dir, "h1", "g.jsonl"), "x\n");
+    const s3 = await fresh(dir);
+    expect(s3.get("f.jsonl")).toBe(500);
+    expect(s3.get("g.jsonl")).toBe(400);
+  });
+
+  it("in-memory get never regresses either", async () => {
+    const s = await fresh(tmp());
+    await s.commit(new Map([["f.jsonl", 200]]));
+    await s.commit(new Map([["f.jsonl", 50]]));
+    expect(s.get("f.jsonl")).toBe(200);
+  });
+
+  it("leaves no tmp residue after commits (atomic rename)", async () => {
+    const dir = tmp();
+    const s = await fresh(dir);
+    await s.commit(new Map([["a.jsonl", 1]]));
+    await s.commit(new Map([["a.jsonl", 2]]));
+    const leftovers = readdirSync(join(dir, "h1")).filter((f) => f.includes(".tmp."));
+    expect(leftovers).toEqual([]);
+    expect(JSON.parse(readFileSync(uploadStatePath(dir, "h1"), "utf8")).v).toBe(1);
+  });
+
+  it("concurrent commits both land (no torn writes, forward-only)", async () => {
+    const dir = tmp();
+    const a = await fresh(dir);
+    const b = await fresh(dir);
+    await Promise.all([
+      a.commit(new Map([["x.jsonl", 100]])),
+      b.commit(new Map([["y.jsonl", 200]])),
+    ]);
+    writeFileSync(join(dir, "h1", "x.jsonl"), "x\n");
+    writeFileSync(join(dir, "h1", "y.jsonl"), "x\n");
+    const s3 = await fresh(dir);
+    // one of the two racing writers may have lost the OTHER file's entry only
+    // if its write landed first; max-merge on the second write prevents that.
+    expect(s3.get("x.jsonl") + s3.get("y.jsonl")).toBeGreaterThanOrEqual(200);
+  });
+});

--- a/test/unit/session/upload-state.test.ts
+++ b/test/unit/session/upload-state.test.ts
@@ -80,7 +80,7 @@ describe("UploadStateStore", () => {
     expect(JSON.parse(readFileSync(uploadStatePath(dir, "h1"), "utf8")).v).toBe(1);
   });
 
-  it("concurrent commits both land (no torn writes, forward-only)", async () => {
+  it("concurrent commits never tear the file, stay forward-only, and converge", async () => {
     const dir = tmp();
     const a = await fresh(dir);
     const b = await fresh(dir);
@@ -90,9 +90,28 @@ describe("UploadStateStore", () => {
     ]);
     writeFileSync(join(dir, "h1", "x.jsonl"), "x\n");
     writeFileSync(join(dir, "h1", "y.jsonl"), "x\n");
+
+    // Invariant 1 — no torn write: the persisted state always parses as v:1
+    // (atomic tmp+rename), and any present offset is EXACTLY its committed value
+    // (never a partial/garbage number). Lock-free, so one writer's read-merge
+    // window may drop the other's entry — that is harmless (ingest is idempotent,
+    // dedup re-absorbs), so we do NOT assert both survive the race.
+    const persisted = JSON.parse(readFileSync(uploadStatePath(dir, "h1"), "utf8"));
+    expect(persisted.v).toBe(1);
     const s3 = await fresh(dir);
-    // one of the two racing writers may have lost the OTHER file's entry only
-    // if its write landed first; max-merge on the second write prevents that.
-    expect(s3.get("x.jsonl") + s3.get("y.jsonl")).toBeGreaterThanOrEqual(200);
+    for (const [file, val] of [["x.jsonl", 100], ["y.jsonl", 200]] as const) {
+      expect([0, val]).toContain(s3.get(file));
+    }
+    // at least one writer's value is durably present
+    expect(s3.get("x.jsonl") + s3.get("y.jsonl")).toBeGreaterThan(0);
+
+    // Invariant 2 — convergence + forward-only: a later commit lands both and
+    // never rewinds either.
+    const s4 = await fresh(dir);
+    await s4.commit(new Map([["x.jsonl", 100], ["y.jsonl", 200]]));
+    await s4.commit(new Map([["x.jsonl", 50], ["y.jsonl", 150]])); // stale, must not rewind
+    const s5 = await fresh(dir);
+    expect(s5.get("x.jsonl")).toBe(100);
+    expect(s5.get("y.jsonl")).toBe(200);
   });
 });

--- a/test/unit/session/uploader.test.ts
+++ b/test/unit/session/uploader.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, realpathSync } from "node:fs";
+import { mkdtempSync, realpathSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runUploader, shouldSync } from "@/session/uploader";
+import { runUploader, shouldSync, type UploaderOptions } from "@/session/uploader";
+import { uploadStatePath } from "@/session/upload-state";
 import { appendEvent } from "@/session/ledger";
 import type { UploadEvent } from "@/session/upload-schema";
+import type { IngestAck } from "@/session/ingest-ack";
 import type { SessionEvent } from "@/session/types";
 
 const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-up-")));
@@ -26,25 +28,24 @@ const ev = (type: SessionEvent["type"], over: Partial<SessionEvent> = {}): Sessi
 
 /** Run the uploader for exactly `ticks` poll cycles, then abort. */
 function runFor(
-  sessionsDir: string,
-  hash: string,
-  post: (e: UploadEvent[]) => Promise<void>,
+  opts: Omit<UploaderOptions, "signal" | "sleep">,
   ticks: number,
-  teamIntentOptIn = false,
 ): Promise<void> {
   const controller = new AbortController();
   let n = 0;
   return runUploader({
-    sessionsDir,
-    projectHash: hash,
-    teamIntentOptIn,
-    post,
+    ...opts,
     signal: controller.signal,
     sleep: async () => {
       if (++n >= ticks) controller.abort();
     },
   });
 }
+
+const fullAck = (events: UploadEvent[]): IngestAck => ({
+  accepted: events.length,
+  results: events.map((e) => ({ activityId: e.activityId, status: "accepted" as const })),
+});
 
 describe("shouldSync", () => {
   it("is off by default and in every partial state", () => {
@@ -69,7 +70,7 @@ describe("runUploader", () => {
     await appendEvent(sessionsDir, hash, "s1", ev("flag", { findingId: "DF-1", detail: { file: "src/a.ts", category: "async_patterns", dominant: "async/await", observed: ".then() chains" } }));
 
     const posted: UploadEvent[] = [];
-    await runFor(sessionsDir, hash, async (e) => void posted.push(...e), 1);
+    await runFor({ sessionsDir, projectHash: hash, post: async (e) => { posted.push(...e); return fullAck(e); } }, 2);
 
     const types = posted.map((p) => p.type);
     expect(types).toContain("session_start");
@@ -86,19 +87,19 @@ describe("runUploader", () => {
 
     const posted: UploadEvent[] = [];
     let calls = 0;
-    await runFor(
+    await runFor({
       sessionsDir,
-      hash,
-      async (e) => {
+      projectHash: hash,
+      post: async (e) => {
         calls++;
         if (calls === 1) throw new Error("network down");
         posted.push(...e);
+        return fullAck(e);
       },
-      2,
-    );
+    }, 3);
 
-    expect(calls).toBeGreaterThanOrEqual(2); // first failed, retried
-    expect(posted.length).toBe(1); // the event survived the failure and posted
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(posted.length).toBe(1);
   });
 
   it("ships the decision reason only under team opt-in", async () => {
@@ -110,7 +111,7 @@ describe("runUploader", () => {
     const offDir = tmp();
     await write(offDir, "hoff");
     const off: UploadEvent[] = [];
-    await runFor(offDir, "hoff", async (e) => void off.push(...e), 1, false);
+    await runFor({ sessionsDir: offDir, projectHash: "hoff", teamIntentOptIn: false, post: async (e) => { off.push(...e); return fullAck(e); } }, 2);
     const offDec = off.find((p) => p.type === "decision")!;
     expect(offDec.decision).toBe("decline");
     expect(offDec.reason).toBeUndefined();
@@ -118,9 +119,120 @@ describe("runUploader", () => {
     const onDir = tmp();
     await write(onDir, "hon");
     const on: UploadEvent[] = [];
-    await runFor(onDir, "hon", async (e) => void on.push(...e), 1, true);
+    await runFor({ sessionsDir: onDir, projectHash: "hon", teamIntentOptIn: true, post: async (e) => { on.push(...e); return fullAck(e); } }, 2);
     const onDec = on.find((p) => p.type === "decision")!;
     expect(onDec.decision).toBe("decline");
     expect(onDec.reason).toContain("different semantics");
+  });
+
+  it("R1 KILLER: a backfill far larger than the buffer uploads EVERY event exactly once across runs", async () => {
+    const sessionsDir = tmp();
+    const hash = "hr1";
+    // 3 session files x 8 events = 24 events, buffer capped at 5, batches of 2
+    for (const sid of ["sA", "sB", "sC"]) {
+      for (let i = 0; i < 8; i++) {
+        await appendEvent(sessionsDir, hash, sid, ev("edit", { sid, detail: { file: `src/${sid}-${i}.ts`, diffstat: "+1" } }));
+      }
+    }
+    const posted: UploadEvent[] = [];
+    await runFor({
+      sessionsDir, projectHash: hash, maxBuffer: 5, batchSize: 2,
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+    }, 40);
+
+    const ids = posted.map((p) => p.activityId);
+    expect(new Set(ids).size).toBe(24); // every event arrived
+    expect(ids.length).toBe(24); // and none twice within the run
+
+    // a FRESH uploader (new process) resumes from durable offsets: nothing re-sent
+    const rePosted: UploadEvent[] = [];
+    await runFor({
+      sessionsDir, projectHash: hash, maxBuffer: 5, batchSize: 2,
+      post: async (e) => { rePosted.push(...e); return fullAck(e); },
+    }, 4);
+    expect(rePosted).toHaveLength(0);
+  });
+
+  it("R3: an entitlement-locked run advances NO offsets; a later entitled run backfills everything", async () => {
+    const sessionsDir = tmp();
+    const hash = "hr3";
+    for (let i = 0; i < 4; i++) {
+      await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: `src/f${i}.ts`, diffstat: "+1" } }));
+    }
+    let lockedCalls = 0;
+    await runFor({
+      sessionsDir, projectHash: hash, holdBackoffTicks: 0,
+      post: async () => { lockedCalls++; throw { status: 402, detail: "locked" }; },
+    }, 3);
+    expect(lockedCalls).toBeGreaterThanOrEqual(1);
+    const statePath = uploadStatePath(sessionsDir, hash);
+    if (existsSync(statePath)) {
+      const state = JSON.parse(readFileSync(statePath, "utf8"));
+      for (const v of Object.values(state.files as Record<string, { offset: number }>)) {
+        expect(v.offset).toBe(0);
+      }
+    }
+
+    const posted: UploadEvent[] = [];
+    await runFor({ sessionsDir, projectHash: hash, post: async (e) => { posted.push(...e); return fullAck(e); } }, 3);
+    expect(posted).toHaveLength(4); // the full backlog arrived after the lock lifted
+  });
+
+  it("a held event stops its file's commit and is re-sent after the backoff", async () => {
+    const sessionsDir = tmp();
+    const hash = "hheld";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "src/a.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "src/b.ts", diffstat: "+1" } }));
+
+    let call = 0;
+    const posted: string[][] = [];
+    await runFor({
+      sessionsDir, projectHash: hash, holdBackoffTicks: 0,
+      post: async (e) => {
+        call++;
+        posted.push(e.map((x) => x.activityId));
+        if (call === 1) {
+          return {
+            accepted: 1,
+            results: [
+              { activityId: e[0].activityId, status: "accepted" as const },
+              { activityId: e[1].activityId, status: "held" as const, code: "unknown_type" },
+            ],
+          };
+        }
+        return fullAck(e);
+      },
+    }, 4);
+
+    expect(posted.length).toBeGreaterThanOrEqual(2);
+    // second call re-sent ONLY the held event
+    expect(posted[1]).toEqual([posted[0][1]]);
+
+    // fresh run: everything already committed, nothing re-sent
+    const rePosted: UploadEvent[] = [];
+    await runFor({ sessionsDir, projectHash: hash, post: async (e) => { rePosted.push(...e); return fullAck(e); } }, 3);
+    expect(rePosted).toHaveLength(0);
+  });
+
+  it("permanently rejected events are committed past (never wedge the file)", async () => {
+    const sessionsDir = tmp();
+    const hash = "hrej";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "src/a.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "src/b.ts", diffstat: "+1" } }));
+
+    await runFor({
+      sessionsDir, projectHash: hash,
+      post: async (e) => ({
+        accepted: 1,
+        results: [
+          { activityId: e[0].activityId, status: "rejected" as const, code: "banned_field" },
+          { activityId: e[1].activityId, status: "accepted" as const },
+        ],
+      }),
+    }, 2);
+
+    const rePosted: UploadEvent[] = [];
+    await runFor({ sessionsDir, projectHash: hash, post: async (e) => { rePosted.push(...e); return fullAck(e); } }, 3);
+    expect(rePosted).toHaveLength(0); // the reject did not stall the watermark
   });
 });

--- a/test/unit/session/uploader.test.ts
+++ b/test/unit/session/uploader.test.ts
@@ -236,3 +236,64 @@ describe("runUploader", () => {
     expect(rePosted).toHaveLength(0); // the reject did not stall the watermark
   });
 });
+
+describe("runUploaderOnce (bounded flush)", () => {
+  it("drains the whole backlog in one shot, then a second run resends nothing", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    // more events than a single batch so the drain loops
+    for (let i = 0; i < 120; i++) {
+      await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: `src/f${i}.ts`, diffstat: "+1" } }));
+    }
+    const posted: UploadEvent[] = [];
+    await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      batchSize: 25,
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+    });
+    expect(posted).toHaveLength(120);
+
+    const again: UploadEvent[] = [];
+    await runUploaderOnce({ sessionsDir, projectHash: hash, post: async (e) => { again.push(...e); return fullAck(e); } });
+    expect(again).toHaveLength(0); // durable offsets: nothing to resend
+  });
+
+  it("stops without spinning when the server holds, and commits nothing past the hold", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "a.ts", diffstat: "+1" } }));
+    let calls = 0;
+    await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      post: async () => { calls++; const err = new Error("locked") as Error & { status?: number }; err.status = 402; throw err; },
+    });
+    expect(calls).toBeGreaterThan(0);
+    // no offsets committed -> a subsequent (accepting) run resends the event
+    const resent: UploadEvent[] = [];
+    await runUploaderOnce({ sessionsDir, projectHash: hash, post: async (e) => { resent.push(...e); return fullAck(e); } });
+    expect(resent).toHaveLength(1);
+  });
+
+  it("respects the time budget on a persistently failing network (no infinite loop)", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "a.ts", diffstat: "+1" } }));
+    let clock = 0;
+    // returns quickly since a network error (non-402) breaks on no-progress,
+    // but the budget guard is the ultimate backstop
+    await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      budgetMs: 50,
+      now: () => (clock += 10),
+      post: async () => { throw new Error("network down"); },
+    });
+    // reaching here (not hanging) is the assertion
+    expect(true).toBe(true);
+  });
+});

--- a/test/unit/session/uploader.test.ts
+++ b/test/unit/session/uploader.test.ts
@@ -278,6 +278,61 @@ describe("runUploaderOnce (bounded flush)", () => {
     expect(resent).toHaveLength(1);
   });
 
+  it("reports locked when the server answers 402, so the caller can lock capture", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "a.ts", diffstat: "+1" } }));
+    const out = await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      post: async () => { const err = new Error("locked") as Error & { status?: number }; err.status = 402; throw err; },
+    });
+    expect(out.locked).toBe(true);
+  });
+
+  it("does NOT report locked for a plain network failure", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "a.ts", diffstat: "+1" } }));
+    const out = await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      post: async () => { throw new Error("network down"); },
+    });
+    expect(out.locked).toBe(false);
+  });
+
+  it("does NOT report locked when the server merely holds events (version skew)", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "a.ts", diffstat: "+1" } }));
+    const out = await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      post: async (e) => ({
+        accepted: 0,
+        results: e.map((x) => ({ activityId: x.activityId, status: "held" as const, code: "unknown_type" })),
+      }),
+    });
+    expect(out.locked).toBe(false);
+  });
+
+  it("reports not-locked on a clean full drain", async () => {
+    const { runUploaderOnce } = await import("@/session/uploader");
+    const sessionsDir = tmp();
+    const hash = "h1";
+    await appendEvent(sessionsDir, hash, "s1", ev("edit", { detail: { file: "a.ts", diffstat: "+1" } }));
+    const out = await runUploaderOnce({
+      sessionsDir,
+      projectHash: hash,
+      post: async (e) => fullAck(e),
+    });
+    expect(out.locked).toBe(false);
+  });
+
   it("respects the time budget on a persistently failing network (no infinite loop)", async () => {
     const { runUploaderOnce } = await import("@/session/uploader");
     const sessionsDir = tmp();

--- a/test/unit/tools-core/enable.test.ts
+++ b/test/unit/tools-core/enable.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run } from "@/tools-core/tools/enable";
+import { loadActivation, projectStatus } from "@/session/activation";
+import { repoIdentity } from "@/session/repo";
+
+const prev = process.env.VIBEDRIFT_HOME;
+afterEach(() => {
+  if (prev === undefined) delete process.env.VIBEDRIFT_HOME;
+  else process.env.VIBEDRIFT_HOME = prev;
+});
+
+function sandbox(): { home: string; repo: string } {
+  const home = realpathSync(mkdtempSync(join(tmpdir(), "vd-en-core-home-")));
+  process.env.VIBEDRIFT_HOME = home;
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "vd-en-core-repo-")));
+  mkdirSync(join(repo, ".git"));
+  mkdirSync(join(repo, ".claude")); // supported agent present
+  return { home, repo };
+}
+
+describe("enable tool core (O18)", () => {
+  it("refuses to activate without a confirmation and records nothing", async () => {
+    const { home, repo } = sandbox();
+    const res = await run({ rootDir: repo });
+    expect(res.action).toBe("needs_confirmation");
+    expect(res.status).toBe("partial");
+    expect(existsSync(join(home, "activation.json"))).toBe(false);
+  });
+
+  it("activates with a confirmation: records active, installs hooks, writes a receipt", async () => {
+    const { home, repo } = sandbox();
+    const res = await run({ rootDir: repo, confirm: "yes please" });
+    expect(res.action).toBe("enabled");
+    expect(res.status).toBe("ok");
+    expect(res.hooksInstalled).toBe(true);
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(true);
+
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(home), projectHash)).toBe("active");
+    const receipt = JSON.parse(
+      readFileSync(join(home, "sessions", projectHash, "consent.log"), "utf8").trim(),
+    );
+    expect(receipt.action).toBe("enable");
+    expect(receipt.surface).toBe("mcp-enable");
+  });
+
+  it("a whitespace-only confirmation is not a confirmation", async () => {
+    const { repo } = sandbox();
+    expect((await run({ rootDir: repo, confirm: "   " })).action).toBe("needs_confirmation");
+  });
+
+  it("decline records a no without a confirmation and never installs hooks", async () => {
+    const { home, repo } = sandbox();
+    const res = await run({ rootDir: repo, decline: true });
+    expect(res.action).toBe("declined");
+    expect(res.status).toBe("ok");
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(home), projectHash)).toBe("declined");
+  });
+
+  it("enable reverses a prior decline", async () => {
+    const { home, repo } = sandbox();
+    await run({ rootDir: repo, decline: true });
+    await run({ rootDir: repo, confirm: "ok" });
+    const { projectHash } = repoIdentity(repo);
+    expect(projectStatus(loadActivation(home), projectHash)).toBe("active");
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -44,6 +44,15 @@
   "here are the few things we noticed". Security and auth are notably unreachable in-session today, so
   any compliance-flavoured session metric is not just unbuilt, it has no signal to build on.
 
+- **Native-sessions nudge: auto-detect headless (currently env-override only).** The SessionStart
+  nudge suppresses asks/budget-burn in non-interactive contexts via an explicit
+  `VIBEDRIFT_HOOK_NONINTERACTIVE=1` override (`src/session/nudge.ts`), which the N2 plugin/CI sets.
+  Auto-detecting headless `claude -p` from the hook payload/env (e.g. `CLAUDE_CODE_ENTRYPOINT`) was
+  deferred — the exact value needs one confirming payload capture (small metered `claude -p` run).
+  Until then a raw `claude -p` outside the plugin can burn the 3-ask budget to an implicit decline;
+  low harm (a headless-only repo has no human to nudge). Confirm the entrypoint value, then key
+  `isNonInteractive()` off it too.
+
 - **DOCX sections are still tag/kind-mixed for analyzer findings.** The per-file
   Drift/Static tally is now kind-based (matching terminal/HTML and the composite), but
   DOCX's "STATIC ANALYSIS FINDINGS" section lists drift-kind analyzer findings (naming,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "src/mcp/server.ts",
     "src/tools-core/index.ts",
     "src/session/hook-entry.ts",
+    "src/session/session-flush.ts",
   ],
   format: ["esm"],
   target: "node18",


### PR DESCRIPTION
## Native Drift Sessions

Drift Sessions no longer needs a `watch-session` terminal running. One command turns it on, and every agent session in that repo is watched from then on:

```
vibedrift enable
```

Typing the command is the consent. It installs Claude Code hooks for the repo, states exactly what gets recorded (prompts with secrets masked, edit metadata) and where (a local ledger; nothing leaves the machine unless hosted sync is on), and `vibedrift decline` reverses it at any time. Hooks fail open: an error or timeout never interrupts the agent.

### The loop, live

![native sessions demo](https://raw.githubusercontent.com/VibeDrift/VibeDrift/assets/native-sessions/native-sessions-demo.gif)

Real capture from the built CLI in a sandbox repo: `enable`, then an agent session streams through the hooks. A `.then()` edit in an async/await repo is flagged **into the agent's own context** (exit 2), the fix re-runs the same check over the new code, and the resolve lands in the ledger only because the check passed. The demo also shows the re-check being honest: the fixed function turns out to duplicate an existing helper, and that gets flagged too.

### What's in here

- **`enable` / `decline`**: per-repo consent with receipts, hook install/uninstall, idempotent re-runs
- **SessionStart nudge**: in a repo that has not decided, the agent relays a one-line ask; three asks total, then it goes quiet
- **MCP `enable` tool** with a user-interaction consent gate, so an agent cannot self-enable silently
- **Stop-spawned flush**: each turn's events upload in the background with ack-gated offsets; nothing re-sends, nothing is lost on restart, and `watch-session` backfills anything a native session left behind
- **Entitlement refresh from the flush**, so plan state stays current without a long-lived process

### Verification

- Full suite green on this branch: unit + integration, typecheck, lint, build
- Edge cases pinned by tests: malformed hook payloads, enable outside a git repo, double-enable idempotence, spent nudge budget, declined consent, missing ledger directory
- The upload projection is unchanged: uploads build from the same explicit allow-list as before, nothing new crosses the wire
- Dashboard proof (deploys separately, after this ships):

| Sessions overview | Session detail |
|---|---|
| ![overview](https://raw.githubusercontent.com/VibeDrift/VibeDrift/assets/native-sessions/dashboard-overview.png) | ![detail](https://raw.githubusercontent.com/VibeDrift/VibeDrift/assets/native-sessions/dashboard-detail.png) |

### Rollout notes

Ships as **0.19.0** (minor: new command + new hook registration). The API is deployed ahead of this PR and is backward compatible with 0.17.x/0.18.x; the dashboard deploys last.

---
🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code).

https://claude.ai/code/session_01M4HBwyzpPKgrusnawqaa5n
