### PR TITLE
Show trial usage at session start, with an honest recap at the wall

### DIFF
--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -149,6 +149,28 @@ async function main(): Promise<number> {
     }
   }
 
+  // Trial meter (P0.3): the activated-repo counterpart of the nudge path's
+  // trial line, same systemMessage channel, same new-interactive-only budget.
+  // Cached entitlement only; an unknown cache emits nothing (never a fabricated
+  // count) and Pro never sees a meter (buildTrialLine owns both rules). Guarded
+  // so a failure here changes nothing about how the rest of the event is
+  // processed (hooks fail open).
+  if (normalized.type === "session_start" && status === "active" && capturePermitted) {
+    try {
+      const source =
+        typeof (payload as Record<string, unknown>).source === "string"
+          ? ((payload as Record<string, unknown>).source as string)
+          : undefined;
+      const { isNewInteractiveSource, isNonInteractive, buildTrialLine } = await import("./nudge.js");
+      if (isNewInteractiveSource(source) && !isNonInteractive()) {
+        const line = buildTrialLine(readEntitlementCache());
+        if (line) process.stdout.write(JSON.stringify({ systemMessage: line }) + "\n");
+      }
+    } catch {
+      // fail-open: no meter, capture proceeds untouched
+    }
+  }
+
   if (!capturePermitted) {
     // Locked account: capture nothing, but do two things so the paywall is
     // neither invisible nor a one-way door.

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -23,6 +23,7 @@
 import { relative, resolve, isAbsolute, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import type { TrialRecapTotals } from "./trial-recap.js";
 
 const SELF_TIMEOUT_MS = 2000;
@@ -89,7 +90,7 @@ async function main(): Promise<number> {
   }
 
   const [
-    { appendEvent, newActivityId },
+    { appendEvent, newActivityId, sessionFilePath },
     { normalizeHookPayload },
     { repoIdentity, defaultSessionsDir },
     { runEditChecks },
@@ -117,7 +118,24 @@ async function main(): Promise<number> {
   // reads a local cache written by `watch-session` — no network on this path.
   // Fail-open: a missing/unreadable cache permits capture.
   const { isCapturePermitted, readEntitlementCache } = await import("./entitlement.js");
-  const capturePermitted = isCapturePermitted();
+  let capturePermitted = isCapturePermitted();
+
+  // Sticky session grant (P0.3): the server burns the final trial fuse on this
+  // session's first ingested edit, so a mid-session entitlement refresh can
+  // flip the cache to locked while the session it promised is still running.
+  // Ledger evidence of THIS session id means capture started under an entitled
+  // (or fail-open) read; that session keeps recording to its end. The next
+  // session id has no ledger yet and locks normally. An error here means no
+  // grant, never an unlock.
+  if (!capturePermitted) {
+    try {
+      if (existsSync(sessionFilePath(defaultSessionsDir(), projectHash, normalized.sid))) {
+        capturePermitted = true;
+      }
+    } catch {
+      // stay locked
+    }
+  }
 
   // Activation gate (L-N3): an explicit `decline` stops capture entirely; an
   // un-activated (unanswered) repo emits the SessionStart nudge but otherwise

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -23,6 +23,7 @@
 import { relative, resolve, isAbsolute, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
+import type { TrialRecapTotals } from "./trial-recap.js";
 
 const SELF_TIMEOUT_MS = 2000;
 
@@ -186,7 +187,17 @@ async function main(): Promise<number> {
       const { isNewInteractiveSource, isNonInteractive, buildLockNotice } = await import("./nudge.js");
       const ent = readEntitlementCache();
       if (ent && !ent.entitled && isNewInteractiveSource(source) && !isNonInteractive()) {
-        process.stdout.write(JSON.stringify(buildLockNotice({ entitlement: ent })) + "\n");
+        // Recap what the trial really caught (P0.3). Real ledger sums only;
+        // null falls back to number-free copy inside buildLockNotice. Guarded
+        // so a summing failure still delivers the paused notice.
+        let totals: TrialRecapTotals | null = null;
+        try {
+          const { sumLocalLedgerTotals } = await import("./trial-recap.js");
+          totals = sumLocalLedgerTotals(defaultSessionsDir());
+        } catch {
+          // fail-open: recap without numbers
+        }
+        process.stdout.write(JSON.stringify(buildLockNotice({ entitlement: ent, totals })) + "\n");
       }
     }
     if (normalized.type === "session_end") {

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -109,10 +109,13 @@ export interface NoticeOutput {
  * one `systemMessage` line on SessionStart.
  *
  * Honesty constraints (§6): state that recording is paused, then recap only
- * what the trial's REAL local ledgers show (`totals`, summed by trial-recap).
- * With no readable ledgers, or a clean trial, the copy carries no numbers at
- * all. Never claim anything was prevented, blocked, or deleted: the trial's
- * local ledgers are untouched and still the user's.
+ * what the REAL local ledgers show (`totals`, summed by trial-recap). The copy
+ * is machine-scoped, never trial-scoped: local ledgers can hold more or fewer
+ * sessions than the trial consumed (fail-open captures, other machines).
+ * Three tiers: real numbers when drift was caught; "ran clean" only when every
+ * ledger was read in full; otherwise no claim at all (a partial or absent read
+ * can support neither story). Never claim anything was prevented, blocked, or
+ * deleted: the local ledgers are untouched and still the user's.
  */
 export function buildLockNotice(ctx: {
   entitlement: SessionEntitlement;
@@ -120,12 +123,19 @@ export function buildLockNotice(ctx: {
 }): NoticeOutput {
   const limit = ctx.entitlement.trialLimit;
   const t = ctx.totals;
-  const recap =
-    t && t.flagged > 0
-      ? `Across your ${limit} free sessions, VibeDrift flagged ${t.flagged} drifts; ` +
-        `your agent fixed ${t.resolved} on the spot, re-verified. ` +
-        `Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing`
-      : `You ran your ${limit} free sessions clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing`;
+  let recap: string;
+  if (t && t.flagged > 0) {
+    const drifts = t.flagged === 1 ? "1 drift" : `${t.flagged} drifts`;
+    const fixed =
+      t.resolved === 0
+        ? "none were fixed in-session."
+        : `your agent fixed ${t.resolved} on the spot, re-verified.`;
+    recap = `On this machine, VibeDrift flagged ${drifts}; ${fixed} Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing`;
+  } else if (t && t.complete) {
+    recap = `Your watched sessions on this machine ran clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing`;
+  } else {
+    recap = `Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing`;
+  }
   return {
     systemMessage:
       `VibeDrift: your ${limit}-session trial is used up, so this session is not being recorded. ` + recap,

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -75,6 +75,9 @@ const BREADCRUMB =
  */
 export function buildTrialLine(e: SessionEntitlement | null | undefined): string | null {
   if (!e || !e.entitled || e.reason !== "trial") return null;
+  // A spent (or corrupt, "6 of 5") count never renders: the lock notice owns
+  // the spent state, and a grandfathered in-flight cache must not show a meter.
+  if (e.trialUsed >= e.trialLimit) return null;
   const line = `VibeDrift trial: ${e.trialUsed} of ${e.trialLimit} sessions used.`;
   return e.trialUsed === e.trialLimit - 1 ? `${line} This is your last free session.` : line;
 }

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -61,6 +61,17 @@ export interface NudgeContext {
 const BREADCRUMB =
   "VibeDrift won't ask again in this repo — run `vibedrift enable` or `vibedrift decline` to set it explicitly.";
 
+/**
+ * The one-line trial meter, shared by the nudge path (un-activated repos) and
+ * the activated-repo SessionStart notice. Null unless the CACHED entitlement
+ * explicitly says trial: an unknown or unreadable cache emits nothing (a
+ * fabricated count is worse than silence), and Pro never sees a meter.
+ */
+export function buildTrialLine(e: SessionEntitlement | null | undefined): string | null {
+  if (!e || !e.entitled || e.reason !== "trial") return null;
+  return `VibeDrift trial: ${e.trialUsed} of ${e.trialLimit} sessions used.`;
+}
+
 /** The model-facing relay instruction. Imperative (relays reliably in testing)
  *  and carries the soft-decline path (N1: the concierge skill formalizes it in
  *  N2; until then it rides here). */
@@ -112,9 +123,8 @@ export function buildNudgeOutput(ctx: NudgeContext): NudgeOutput {
       additionalContext: buildNudgeInstruction(ctx),
     },
   };
+  const trialLine = buildTrialLine(ctx.entitlement);
   if (ctx.lastAsk) out.systemMessage = BREADCRUMB;
-  else if (ctx.entitlement && ctx.entitlement.reason === "trial") {
-    out.systemMessage = `VibeDrift trial: ${ctx.entitlement.trialUsed} of ${ctx.entitlement.trialLimit} sessions used.`;
-  }
+  else if (trialLine) out.systemMessage = trialLine;
   return out;
 }

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -24,6 +24,7 @@
  */
 
 import type { SessionEntitlement } from "./entitlement.js";
+import type { TrialRecapTotals } from "./trial-recap.js";
 
 /** The four documented Claude Code SessionStart `source` values. */
 export type StartSource = "startup" | "resume" | "clear" | "compact";
@@ -107,17 +108,27 @@ export interface NoticeOutput {
  * screen; the native flow has no terminal we own, so the honest equivalent is
  * one `systemMessage` line on SessionStart.
  *
- * Honesty constraints (§6): state only that recording is paused. Never claim
- * anything was prevented, blocked, or deleted — the trial's local ledgers are
- * untouched and still the user's.
+ * Honesty constraints (§6): state that recording is paused, then recap only
+ * what the trial's REAL local ledgers show (`totals`, summed by trial-recap).
+ * With no readable ledgers, or a clean trial, the copy carries no numbers at
+ * all. Never claim anything was prevented, blocked, or deleted: the trial's
+ * local ledgers are untouched and still the user's.
  */
-export function buildLockNotice(ctx: { entitlement: SessionEntitlement }): NoticeOutput {
+export function buildLockNotice(ctx: {
+  entitlement: SessionEntitlement;
+  totals?: TrialRecapTotals | null;
+}): NoticeOutput {
   const limit = ctx.entitlement.trialLimit;
+  const t = ctx.totals;
+  const recap =
+    t && t.flagged > 0
+      ? `Across your ${limit} free sessions, VibeDrift flagged ${t.flagged} drifts; ` +
+        `your agent fixed ${t.resolved} on the spot, re-verified. ` +
+        `Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing`
+      : `You ran your ${limit} free sessions clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing`;
   return {
     systemMessage:
-      `VibeDrift: your ${limit}-session trial is used up, so this session is not being recorded. ` +
-      `Run \`vibedrift upgrade\` to keep Drift Sessions watching. ` +
-      `Your existing local session history stays on this machine.`,
+      `VibeDrift: your ${limit}-session trial is used up, so this session is not being recorded. ` + recap,
   };
 }
 

--- a/src/session/nudge.ts
+++ b/src/session/nudge.ts
@@ -66,10 +66,16 @@ const BREADCRUMB =
  * the activated-repo SessionStart notice. Null unless the CACHED entitlement
  * explicitly says trial: an unknown or unreadable cache emits nothing (a
  * fabricated count is worse than silence), and Pro never sees a meter.
+ *
+ * Boundary notice: the metrics-surface plan asked for an end-of-session-4
+ * banner, but Claude Code has no reliable session-end signal (B6: Stop fires
+ * per response, and SessionEnd is unobserved on /resume), so the START of the
+ * final session (trialUsed at limit - 1) is the honest boundary.
  */
 export function buildTrialLine(e: SessionEntitlement | null | undefined): string | null {
   if (!e || !e.entitled || e.reason !== "trial") return null;
-  return `VibeDrift trial: ${e.trialUsed} of ${e.trialLimit} sessions used.`;
+  const line = `VibeDrift trial: ${e.trialUsed} of ${e.trialLimit} sessions used.`;
+  return e.trialUsed === e.trialLimit - 1 ? `${line} This is your last free session.` : line;
 }
 
 /** The model-facing relay instruction. Imperative (relays reliably in testing)

--- a/src/session/trial-recap.ts
+++ b/src/session/trial-recap.ts
@@ -1,0 +1,57 @@
+/**
+ * Trial recap totals for the locked-attempt prompt (P0.3): sum what the trial
+ * ACTUALLY caught, from the real local session ledgers, across every project on
+ * this machine (the trial is account-wide, not per-repo).
+ *
+ * Honesty constraints: only files that exist and read cleanly contribute; an
+ * unreadable file is skipped, and when nothing was readable the answer is null
+ * so the caller falls back to copy with no numbers in it. Synchronous and
+ * bounded by the local ledger count; runs once per locked SessionStart, never
+ * on the capture path.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseJsonlLines } from "./ledger.js";
+import { summarize } from "./summary.js";
+
+export interface TrialRecapTotals {
+  /** confirmed (non-experimental) flags, as `summarize` counts them */
+  flagged: number;
+  /** verified re-checked fixes, never the agent's stated intent */
+  resolved: number;
+}
+
+export function sumLocalLedgerTotals(sessionsDir: string): TrialRecapTotals | null {
+  let flagged = 0;
+  let resolved = 0;
+  let filesRead = 0;
+  let projectDirs: string[];
+  try {
+    projectDirs = readdirSync(sessionsDir);
+  } catch {
+    return null;
+  }
+  for (const project of projectDirs) {
+    let names: string[];
+    try {
+      names = readdirSync(join(sessionsDir, project));
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      // sidecars (.outcomes.json/.intent.json) and consent.log live beside the
+      // ledgers; only the per-session .jsonl tapes are session evidence.
+      if (!name.endsWith(".jsonl")) continue;
+      try {
+        const s = summarize(parseJsonlLines(readFileSync(join(sessionsDir, project, name), "utf8")));
+        flagged += s.flagged;
+        resolved += s.resolved;
+        filesRead++;
+      } catch {
+        // unreadable ledger: skip it rather than guess
+      }
+    }
+  }
+  return filesRead > 0 ? { flagged, resolved } : null;
+}

--- a/src/session/trial-recap.ts
+++ b/src/session/trial-recap.ts
@@ -1,31 +1,59 @@
 /**
- * Trial recap totals for the locked-attempt prompt (P0.3): sum what the trial
+ * Trial recap totals for the locked-attempt prompt (P0.3): sum what the watch
  * ACTUALLY caught, from the real local session ledgers, across every project on
  * this machine (the trial is account-wide, not per-repo).
  *
  * Honesty constraints: only files that exist and read cleanly contribute; an
- * unreadable file is skipped, and when nothing was readable the answer is null
- * so the caller falls back to copy with no numbers in it. Synchronous and
- * bounded by the local ledger count; runs once per locked SessionStart, never
+ * unreadable or oversized file is skipped and marks the read `complete: false`
+ * (a partial read can support "flagged at least this" but never "ran clean"),
+ * and when nothing was readable the answer is null so the caller falls back to
+ * copy with no claims in it.
+ *
+ * Budget: the walk is synchronous, and the hook's 2s self-timeout cannot
+ * preempt sync I/O (a setTimeout only fires once the event loop is free), so
+ * the walk carries its own hard caps: per-file size, total bytes, and file
+ * count. Exceeding the count/byte budget aborts to null rather than reporting
+ * a truncated sum as the whole story. Runs once per locked SessionStart, never
  * on the capture path.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parseJsonlLines } from "./ledger.js";
 import { summarize } from "./summary.js";
+
+export const RECAP_MAX_FILES = 200;
+export const RECAP_MAX_FILE_BYTES = 5 * 1024 * 1024;
+export const RECAP_MAX_TOTAL_BYTES = 20 * 1024 * 1024;
 
 export interface TrialRecapTotals {
   /** confirmed (non-experimental) flags, as `summarize` counts them */
   flagged: number;
   /** verified re-checked fixes, never the agent's stated intent */
   resolved: number;
+  /** false when any ledger was skipped (size cap or read error): the sums are
+   *  then a floor, and "ran clean" can no longer be claimed from them */
+  complete: boolean;
 }
 
-export function sumLocalLedgerTotals(sessionsDir: string): TrialRecapTotals | null {
+export interface RecapReadBudget {
+  maxFiles?: number;
+  maxFileBytes?: number;
+  maxTotalBytes?: number;
+}
+
+export function sumLocalLedgerTotals(
+  sessionsDir: string,
+  budget: RecapReadBudget = {},
+): TrialRecapTotals | null {
+  const maxFiles = budget.maxFiles ?? RECAP_MAX_FILES;
+  const maxFileBytes = budget.maxFileBytes ?? RECAP_MAX_FILE_BYTES;
+  const maxTotalBytes = budget.maxTotalBytes ?? RECAP_MAX_TOTAL_BYTES;
   let flagged = 0;
   let resolved = 0;
   let filesRead = 0;
+  let bytesRead = 0;
+  let complete = true;
   let projectDirs: string[];
   try {
     projectDirs = readdirSync(sessionsDir);
@@ -43,15 +71,32 @@ export function sumLocalLedgerTotals(sessionsDir: string): TrialRecapTotals | nu
       // sidecars (.outcomes.json/.intent.json) and consent.log live beside the
       // ledgers; only the per-session .jsonl tapes are session evidence.
       if (!name.endsWith(".jsonl")) continue;
+      const path = join(sessionsDir, project, name);
+      let size: number;
       try {
-        const s = summarize(parseJsonlLines(readFileSync(join(sessionsDir, project, name), "utf8")));
+        size = statSync(path).size;
+      } catch {
+        complete = false;
+        continue;
+      }
+      if (size > maxFileBytes) {
+        complete = false;
+        continue;
+      }
+      // Count/byte budget exceeded: a truncated corpus cannot honestly be
+      // summed as "what the trial caught", so abort to the no-claims fallback.
+      if (filesRead >= maxFiles || bytesRead + size > maxTotalBytes) return null;
+      try {
+        const s = summarize(parseJsonlLines(readFileSync(path, "utf8")));
         flagged += s.flagged;
         resolved += s.resolved;
         filesRead++;
+        bytesRead += size;
       } catch {
         // unreadable ledger: skip it rather than guess
+        complete = false;
       }
     }
   }
-  return filesRead > 0 ? { flagged, resolved } : null;
+  return filesRead > 0 ? { flagged, resolved, complete } : null;
 }

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -333,9 +333,9 @@ describe("entitlement lock in the native path (integration)", () => {
     expect(r.status).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.systemMessage).toContain("trial is used up");
-    // clean trial (the only local ledger holds no flags): the no-numbers fallback
+    // clean read (the only local ledger holds no flags): the machine-scoped clean copy
     expect(out.systemMessage).toContain(
-      "You ran your 5 free sessions clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing",
+      "Your watched sessions on this machine ran clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing",
     );
   });
 
@@ -359,7 +359,7 @@ describe("entitlement lock in the native path (integration)", () => {
     entitlement(home, LOCKED);
     const out = JSON.parse(runStart(home, repo, "startup", "s2").stdout.trim());
     expect(out.systemMessage).toContain(
-      "Across your 5 free sessions, VibeDrift flagged 2 drifts; your agent fixed 1 on the spot, re-verified. Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
+      "On this machine, VibeDrift flagged 2 drifts; your agent fixed 1 on the spot, re-verified. Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
     );
     // a user notice only, out of the agent's way
     expect(out).not.toHaveProperty("hookSpecificOutput");

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -333,7 +333,46 @@ describe("entitlement lock in the native path (integration)", () => {
     expect(r.status).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.systemMessage).toContain("trial is used up");
-    expect(out.systemMessage).toContain("vibedrift upgrade");
+    // clean trial (the only local ledger holds no flags): the no-numbers fallback
+    expect(out.systemMessage).toContain(
+      "You ran your 5 free sessions clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing",
+    );
+  });
+
+  it("recaps the trial's real numbers on the locked attempt", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    const hash = activateRepo(home, repo);
+    const ev = (over: Record<string, unknown>): string =>
+      JSON.stringify({
+        v: 1, sid: "t1", aid: "a1", ts: "2026-07-30T00:00:00.000Z", agent: "claude-code",
+        projectHash: hash, channel: "hook", mode: "passive", detail: { file: "x.ts", category: "naming" }, ...over,
+      });
+    writeFileSync(
+      join(home, ".vibedrift", "sessions", hash, "t1.jsonl"),
+      [
+        ev({ type: "flag", findingId: "DF-1" }),
+        ev({ type: "flag", findingId: "DF-2" }),
+        ev({ type: "resolve", findingId: "DF-1" }),
+      ].join("\n") + "\n",
+    );
+    entitlement(home, LOCKED);
+    const out = JSON.parse(runStart(home, repo, "startup", "s2").stdout.trim());
+    expect(out.systemMessage).toContain(
+      "Across your 5 free sessions, VibeDrift flagged 2 drifts; your agent fixed 1 on the spot, re-verified. Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
+    );
+    // a user notice only, out of the agent's way
+    expect(out).not.toHaveProperty("hookSpecificOutput");
+  });
+
+  it("emits the recap only at SessionStart, never on Stop", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    activate(home, repo);
+    entitlement(home, LOCKED);
+    const r = stopHook(home, repo);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("");
   });
 
   it("captures nothing while locked", () => {

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -365,6 +365,36 @@ describe("entitlement lock in the native path (integration)", () => {
     expect(out).not.toHaveProperty("hookSpecificOutput");
   });
 
+  it("keeps capturing a session granted before the cache flipped to locked", () => {
+    const home = tmp("vd-lock-home-");
+    const repo = repoDir();
+    const hash = activateRepo(home, repo);
+    // session 5 starts entitled and gets captured
+    entitlement(home, { entitled: true, reason: "trial", plan: "free", trialUsed: 4, trialLimit: 5 });
+    runStart(home, repo, "startup", "s5");
+    // mid-session the refresh burns the fuse and the cache flips to locked
+    entitlement(home, LOCKED);
+    // ...but the promised session keeps recording to its end
+    spawnSync(TSX, [ENTRY], {
+      input: JSON.stringify({
+        session_id: "s5",
+        cwd: repo,
+        hook_event_name: "PostToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: join(repo, "x.ts"), content: "export const x = 1;\n" },
+      }),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home, VIBEDRIFT_HOOK_DEBUG: "" },
+      timeout: 30_000,
+    });
+    const captured = readFileSync(join(home, ".vibedrift", "sessions", hash, "s5.jsonl"), "utf8");
+    expect(captured).toContain('"type":"edit"');
+    // the NEXT session locks normally
+    const r = runStart(home, repo, "startup", "s6");
+    expect(r.stdout).toContain("trial is used up");
+    expect(existsSync(join(home, ".vibedrift", "sessions", hash, "s6.jsonl"))).toBe(false);
+  });
+
   it("emits the recap only at SessionStart, never on Stop", () => {
     const home = tmp("vd-lock-home-");
     const repo = repoDir();

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -270,6 +270,17 @@ describe("trial meter on activated repos (integration)", () => {
     expect(runStart(home, repo, "compact", "s3").stdout.trim()).toBe("");
   });
 
+  it("warns at the start of the last free session", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    entitlement(home, { ...TRIAL, trialUsed: 4 });
+    const out = JSON.parse(runStart(home, repo, "startup", "s2").stdout.trim());
+    expect(out.systemMessage).toBe(
+      "VibeDrift trial: 4 of 5 sessions used. This is your last free session.",
+    );
+  });
+
   it("still records the session (the meter is a notice, not a gate)", () => {
     const home = tmp("vd-meter-home-");
     const repo = repoDir();

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -270,6 +270,24 @@ describe("trial meter on activated repos (integration)", () => {
     expect(runStart(home, repo, "compact", "s3").stdout.trim()).toBe("");
   });
 
+  it("stays silent in a non-interactive/headless context", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    entitlement(home, TRIAL);
+    const r = runStart(home, repo, "startup", "s2", { VIBEDRIFT_HOOK_NONINTERACTIVE: "1" });
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("shows the meter on /clear (a genuinely new interactive session)", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    entitlement(home, TRIAL);
+    const out = JSON.parse(runStart(home, repo, "clear", "s2").stdout.trim());
+    expect(out.systemMessage).toBe("VibeDrift trial: 2 of 5 sessions used.");
+  });
+
   it("warns at the start of the last free session", () => {
     const home = tmp("vd-meter-home-");
     const repo = repoDir();

--- a/test/integration/session-nudge.test.ts
+++ b/test/integration/session-nudge.test.ts
@@ -214,15 +214,77 @@ describe("Stop-hook session-flush spawn (integration)", () => {
   });
 });
 
+function entitlement(home: string, e: Record<string, unknown>): void {
+  mkdirSync(join(home, ".vibedrift"), { recursive: true });
+  writeFileSync(join(home, ".vibedrift", "sessions-entitlement.json"), JSON.stringify(e));
+}
+
+/** Capture a projectHash by running one startup, then mark the repo active. */
+function activateRepo(home: string, repo: string): string {
+  runStart(home, repo, "startup");
+  const path = join(home, ".vibedrift", "activation.json");
+  const store = JSON.parse(readFileSync(path, "utf8"));
+  const hash = Object.keys(store.projects)[0];
+  store.projects[hash] = { state: "active", surface: "cli-enable" };
+  writeFileSync(path, JSON.stringify(store));
+  return hash;
+}
+
+describe("trial meter on activated repos (integration)", () => {
+  const TRIAL = { entitled: true, reason: "trial", plan: "free", trialUsed: 2, trialLimit: 5 };
+
+  it("shows the trial count at SessionStart on an activated trial repo", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    entitlement(home, TRIAL);
+    const r = runStart(home, repo, "startup", "s2");
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    // a user notice only: no model-facing instruction on an activated repo
+    expect(out).not.toHaveProperty("hookSpecificOutput");
+    expect(out.systemMessage).toBe("VibeDrift trial: 2 of 5 sessions used.");
+  });
+
+  it("stays silent for a pro account", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    entitlement(home, { entitled: true, reason: "pro", plan: "pro", trialUsed: 0, trialLimit: 5 });
+    expect(runStart(home, repo, "startup", "s2").stdout.trim()).toBe("");
+  });
+
+  it("stays silent when the entitlement cache is missing", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    expect(runStart(home, repo, "startup", "s2").stdout.trim()).toBe("");
+  });
+
+  it("stays silent on resume/compact (continuation, not a new session)", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    activateRepo(home, repo);
+    entitlement(home, TRIAL);
+    expect(runStart(home, repo, "resume", "s2").stdout.trim()).toBe("");
+    expect(runStart(home, repo, "compact", "s3").stdout.trim()).toBe("");
+  });
+
+  it("still records the session (the meter is a notice, not a gate)", () => {
+    const home = tmp("vd-meter-home-");
+    const repo = repoDir();
+    const hash = activateRepo(home, repo);
+    entitlement(home, TRIAL);
+    runStart(home, repo, "startup", "s2");
+    const captured = readFileSync(join(home, ".vibedrift", "sessions", hash, "s2.jsonl"), "utf8");
+    expect(captured).toContain('"type":"session_start"');
+  });
+});
+
 describe("entitlement lock in the native path (integration)", () => {
   function config(home: string, cfg: Record<string, unknown>): void {
     mkdirSync(join(home, ".vibedrift"), { recursive: true });
     writeFileSync(join(home, ".vibedrift", "config.json"), JSON.stringify(cfg));
-  }
-
-  function entitlement(home: string, e: Record<string, unknown>): void {
-    mkdirSync(join(home, ".vibedrift"), { recursive: true });
-    writeFileSync(join(home, ".vibedrift", "sessions-entitlement.json"), JSON.stringify(e));
   }
 
   const LOCKED = {

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -137,29 +137,65 @@ describe("buildLockNotice (the native path's paywall signal)", () => {
     expect(out.systemMessage).toContain("vibedrift.ai/dashboard/billing");
   });
 
-  it("recaps real totals when the trial caught drift", () => {
-    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 14, resolved: 9 } });
+  it("recaps real totals, machine-scoped, when the watch caught drift", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 14, resolved: 9, complete: true } });
     expect(out.systemMessage).toContain(
-      "Across your 5 free sessions, VibeDrift flagged 14 drifts; your agent fixed 9 on the spot, re-verified. Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
+      "On this machine, VibeDrift flagged 14 drifts; your agent fixed 9 on the spot, re-verified. Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
     );
-  });
-
-  it("falls back to the clean line when the trial flagged nothing", () => {
-    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 0, resolved: 0 } });
-    expect(out.systemMessage).toContain(
-      "You ran your 5 free sessions clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing",
-    );
+    // local ledgers are not the trial ledger: never attribute the sums to it
     expect(out.systemMessage).not.toContain("Across your");
   });
 
-  it("falls back when no ledgers were readable (never invented numbers)", () => {
-    const out = buildLockNotice({ entitlement: locked, totals: null });
-    expect(out.systemMessage).toContain("free sessions clean");
+  it("pluralizes a single caught drift", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 1, resolved: 1, complete: true } });
+    expect(out.systemMessage).toContain("VibeDrift flagged 1 drift; your agent fixed 1 on the spot");
+    expect(out.systemMessage).not.toContain("1 drifts");
+  });
+
+  it("says none were fixed instead of fixed 0", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 3, resolved: 0, complete: true } });
+    expect(out.systemMessage).toContain(
+      "VibeDrift flagged 3 drifts; none were fixed in-session. Keep it in the loop:",
+    );
+    expect(out.systemMessage).not.toContain("fixed 0");
+  });
+
+  it("recaps totals at a non-default server limit", () => {
+    const out = buildLockNotice({
+      entitlement: { ...locked, trialUsed: 12, trialLimit: 12 },
+      totals: { flagged: 3, resolved: 2, complete: true },
+    });
+    expect(out.systemMessage).toContain("12-session trial is used up");
+    expect(out.systemMessage).toContain(
+      "On this machine, VibeDrift flagged 3 drifts; your agent fixed 2 on the spot, re-verified.",
+    );
+  });
+
+  it("claims a clean run only when every ledger was read in full", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 0, resolved: 0, complete: true } });
+    expect(out.systemMessage).toContain(
+      "Your watched sessions on this machine ran clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing",
+    );
+    expect(out.systemMessage).not.toContain("On this machine, VibeDrift flagged");
+  });
+
+  it("claims nothing when a partial read found no drift", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 0, resolved: 0, complete: false } });
+    expect(out.systemMessage).not.toContain("ran clean");
     expect(out.systemMessage).not.toContain("flagged");
+    expect(out.systemMessage).toContain("Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing");
+  });
+
+  it("claims nothing when no ledgers were readable (never invented copy)", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: null });
+    expect(out.systemMessage).toBe(
+      "VibeDrift: your 5-session trial is used up, so this session is not being recorded. " +
+        "Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
+    );
   });
 
   it("claims nothing about prevention or deletion (honesty constraint)", () => {
-    for (const totals of [null, { flagged: 3, resolved: 2 }]) {
+    for (const totals of [null, { flagged: 3, resolved: 2, complete: true }, { flagged: 0, resolved: 0, complete: false }]) {
       const msg = buildLockNotice({ entitlement: locked, totals }).systemMessage ?? "";
       for (const banned of ["prevented", "blocked", "deleted", "erased"]) {
         expect(msg.toLowerCase()).not.toContain(banned);

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -132,13 +132,38 @@ describe("buildLockNotice (the native path's paywall signal)", () => {
 
   it("names the upgrade path", () => {
     const out = buildLockNotice({ entitlement: locked });
-    expect(out.systemMessage).toContain("vibedrift upgrade");
+    expect(out.systemMessage).toContain("Pro");
+    expect(out.systemMessage).toContain("$15/mo");
+    expect(out.systemMessage).toContain("vibedrift.ai/dashboard/billing");
+  });
+
+  it("recaps real totals when the trial caught drift", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 14, resolved: 9 } });
+    expect(out.systemMessage).toContain(
+      "Across your 5 free sessions, VibeDrift flagged 14 drifts; your agent fixed 9 on the spot, re-verified. Keep it in the loop: Pro, $15/mo. vibedrift.ai/dashboard/billing",
+    );
+  });
+
+  it("falls back to the clean line when the trial flagged nothing", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: { flagged: 0, resolved: 0 } });
+    expect(out.systemMessage).toContain(
+      "You ran your 5 free sessions clean. Pro keeps the watch on: $15/mo. vibedrift.ai/dashboard/billing",
+    );
+    expect(out.systemMessage).not.toContain("Across your");
+  });
+
+  it("falls back when no ledgers were readable (never invented numbers)", () => {
+    const out = buildLockNotice({ entitlement: locked, totals: null });
+    expect(out.systemMessage).toContain("free sessions clean");
+    expect(out.systemMessage).not.toContain("flagged");
   });
 
   it("claims nothing about prevention or deletion (honesty constraint)", () => {
-    const msg = buildLockNotice({ entitlement: locked }).systemMessage ?? "";
-    for (const banned of ["prevented", "blocked", "deleted", "erased"]) {
-      expect(msg.toLowerCase()).not.toContain(banned);
+    for (const totals of [null, { flagged: 3, resolved: 2 }]) {
+      const msg = buildLockNotice({ entitlement: locked, totals }).systemMessage ?? "";
+      for (const banned of ["prevented", "blocked", "deleted", "erased"]) {
+        expect(msg.toLowerCase()).not.toContain(banned);
+      }
     }
   });
 

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -5,6 +5,7 @@ import {
   buildNudgeInstruction,
   buildNudgeOutput,
   buildLockNotice,
+  buildTrialLine,
 } from "@/session/nudge";
 import type { SessionEntitlement } from "@/session/entitlement";
 
@@ -53,6 +54,27 @@ describe("buildNudgeInstruction", () => {
   it("adds the honest trial usage line only on a trial entitlement", () => {
     expect(buildNudgeInstruction({ repoName: "r", entitlement: trial(2) })).toContain("2 of 5 sessions used");
     expect(buildNudgeInstruction({ repoName: "r", entitlement: pro })).not.toContain("trial");
+  });
+});
+
+describe("buildTrialLine", () => {
+  it("renders the trial count for a trial entitlement", () => {
+    expect(buildTrialLine(trial(2))).toBe("VibeDrift trial: 2 of 5 sessions used.");
+  });
+
+  it("returns null for a pro account (the meter is trial-only)", () => {
+    expect(buildTrialLine(pro)).toBeNull();
+  });
+
+  it("returns null when the entitlement is unknown (never a fabricated count)", () => {
+    expect(buildTrialLine(null)).toBeNull();
+    expect(buildTrialLine(undefined)).toBeNull();
+  });
+
+  it("returns null when locked (the lock notice owns that path)", () => {
+    expect(
+      buildTrialLine({ entitled: false, reason: "locked", plan: "free", trialUsed: 5, trialLimit: 5 }),
+    ).toBeNull();
   });
 });
 

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -76,6 +76,18 @@ describe("buildTrialLine", () => {
       buildTrialLine({ entitled: false, reason: "locked", plan: "free", trialUsed: 5, trialLimit: 5 }),
     ).toBeNull();
   });
+
+  it("flags the last free session at 4 of 5", () => {
+    expect(buildTrialLine(trial(4))).toBe(
+      "VibeDrift trial: 4 of 5 sessions used. This is your last free session.",
+    );
+  });
+
+  it("keys the boundary on the real limit, not a hardcoded 4", () => {
+    expect(buildTrialLine({ ...trial(4), trialLimit: 10 })).toBe(
+      "VibeDrift trial: 4 of 10 sessions used.",
+    );
+  });
 });
 
 describe("buildNudgeOutput", () => {
@@ -89,6 +101,11 @@ describe("buildNudgeOutput", () => {
   it("shows a trial systemMessage on a trial account", () => {
     const out = buildNudgeOutput({ repoName: "r", entitlement: trial(1) });
     expect(out.systemMessage).toBe("VibeDrift trial: 1 of 5 sessions used.");
+  });
+
+  it("carries the last-free-session notice at the boundary", () => {
+    const out = buildNudgeOutput({ repoName: "r", entitlement: trial(4) });
+    expect(out.systemMessage).toContain("This is your last free session.");
   });
 
   it("the final ask folds in the breadcrumb, overriding the trial line", () => {

--- a/test/unit/session/nudge.test.ts
+++ b/test/unit/session/nudge.test.ts
@@ -77,6 +77,14 @@ describe("buildTrialLine", () => {
     ).toBeNull();
   });
 
+  it("returns null once the count reaches the limit (the lock notice owns spent)", () => {
+    expect(buildTrialLine(trial(5))).toBeNull();
+  });
+
+  it("returns null on an absurd over-limit count from a corrupt cache", () => {
+    expect(buildTrialLine(trial(6))).toBeNull();
+  });
+
   it("flags the last free session at 4 of 5", () => {
     expect(buildTrialLine(trial(4))).toBe(
       "VibeDrift trial: 4 of 5 sessions used. This is your last free session.",

--- a/test/unit/session/trial-recap.test.ts
+++ b/test/unit/session/trial-recap.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sumLocalLedgerTotals } from "@/session/trial-recap";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "vd-recap-"));
+}
+
+/** One serialized ledger event with the boilerplate fields filled in. */
+function ev(over: Record<string, unknown>): string {
+  return JSON.stringify({
+    v: 1,
+    sid: "s1",
+    aid: "a1",
+    ts: "2026-07-30T00:00:00.000Z",
+    agent: "claude-code",
+    projectHash: "p",
+    channel: "hook",
+    mode: "passive",
+    detail: {},
+    ...over,
+  });
+}
+
+const flag = (id: string): string => ev({ type: "flag", findingId: id, detail: { file: "x.ts", category: "naming" } });
+const resolve = (id: string): string => ev({ type: "resolve", findingId: id, detail: { file: "x.ts", category: "naming" } });
+
+describe("sumLocalLedgerTotals", () => {
+  it("sums flagged and resolved across every project's ledgers", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    mkdirSync(join(dir, "bbbb"), { recursive: true });
+    writeFileSync(join(dir, "aaaa", "s1.jsonl"), [flag("DF-1"), flag("DF-2"), resolve("DF-1")].join("\n") + "\n");
+    writeFileSync(join(dir, "bbbb", "s1.jsonl"), flag("DF-1") + "\n");
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 3, resolved: 1 });
+  });
+
+  it("returns null when the sessions dir does not exist", () => {
+    expect(sumLocalLedgerTotals(join(tmp(), "never-written"))).toBeNull();
+  });
+
+  it("returns null when no ledger files exist", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    expect(sumLocalLedgerTotals(dir)).toBeNull();
+  });
+
+  it("returns null when the only ledger is unreadable (never a guessed count)", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    const file = join(dir, "aaaa", "s1.jsonl");
+    writeFileSync(file, flag("DF-1") + "\n");
+    chmodSync(file, 0o000);
+    expect(sumLocalLedgerTotals(dir)).toBeNull();
+  });
+
+  it("counts only session ledgers, never sidecar or consent files", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    writeFileSync(join(dir, "aaaa", "s1.jsonl"), flag("DF-1") + "\n");
+    writeFileSync(join(dir, "aaaa", "consent.log"), ev({ type: "flag", findingId: "DF-9" }) + "\n");
+    writeFileSync(join(dir, "aaaa", "s1.outcomes.json"), "{}");
+    writeFileSync(join(dir, "aaaa", "s1.intent.json"), "{}");
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0 });
+  });
+
+  it("skips a corrupt line without losing the rest of the ledger", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    writeFileSync(join(dir, "aaaa", "s1.jsonl"), ["{not json", flag("DF-1")].join("\n") + "\n");
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0 });
+  });
+});

--- a/test/unit/session/trial-recap.test.ts
+++ b/test/unit/session/trial-recap.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { sumLocalLedgerTotals } from "@/session/trial-recap";
+import {
+  sumLocalLedgerTotals,
+  RECAP_MAX_FILES,
+  RECAP_MAX_FILE_BYTES,
+  RECAP_MAX_TOTAL_BYTES,
+} from "@/session/trial-recap";
 
 function tmp(): string {
   return mkdtempSync(join(tmpdir(), "vd-recap-"));
@@ -34,7 +39,7 @@ describe("sumLocalLedgerTotals", () => {
     mkdirSync(join(dir, "bbbb"), { recursive: true });
     writeFileSync(join(dir, "aaaa", "s1.jsonl"), [flag("DF-1"), flag("DF-2"), resolve("DF-1")].join("\n") + "\n");
     writeFileSync(join(dir, "bbbb", "s1.jsonl"), flag("DF-1") + "\n");
-    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 3, resolved: 1 });
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 3, resolved: 1, complete: true });
   });
 
   it("returns null when the sessions dir does not exist", () => {
@@ -63,13 +68,63 @@ describe("sumLocalLedgerTotals", () => {
     writeFileSync(join(dir, "aaaa", "consent.log"), ev({ type: "flag", findingId: "DF-9" }) + "\n");
     writeFileSync(join(dir, "aaaa", "s1.outcomes.json"), "{}");
     writeFileSync(join(dir, "aaaa", "s1.intent.json"), "{}");
-    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0 });
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0, complete: true });
   });
 
   it("skips a corrupt line without losing the rest of the ledger", () => {
     const dir = tmp();
     mkdirSync(join(dir, "aaaa"), { recursive: true });
     writeFileSync(join(dir, "aaaa", "s1.jsonl"), ["{not json", flag("DF-1")].join("\n") + "\n");
-    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0 });
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0, complete: true });
+  });
+
+  it("excludes experimental signals from the totals", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    writeFileSync(
+      join(dir, "aaaa", "s1.jsonl"),
+      ev({ type: "flag", findingId: "DF-1", detail: { file: "x.ts", category: "scope", experimental: true } }) + "\n",
+    );
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 0, resolved: 0, complete: true });
+  });
+
+  it("returns null once the file budget is exceeded (sync walk stays bounded)", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    for (let i = 0; i < 4; i++) writeFileSync(join(dir, "aaaa", `s${i}.jsonl`), flag("DF-1") + "\n");
+    expect(sumLocalLedgerTotals(dir, { maxFiles: 3 })).toBeNull();
+  });
+
+  it("returns null once the total byte budget is exceeded", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    writeFileSync(join(dir, "aaaa", "s1.jsonl"), flag("DF-1") + "\n");
+    writeFileSync(join(dir, "aaaa", "s2.jsonl"), flag("DF-1") + "\n");
+    expect(sumLocalLedgerTotals(dir, { maxTotalBytes: 200 })).toBeNull();
+  });
+
+  it("skips an oversized ledger and reports the read as partial", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    // ten flag lines put big.jsonl well over the tiny test cap
+    writeFileSync(join(dir, "aaaa", "big.jsonl"), Array(10).fill(flag("DF-1")).join("\n") + "\n");
+    writeFileSync(join(dir, "aaaa", "s1.jsonl"), ev({ type: "flag", findingId: "DF-2", detail: { file: "y.ts", category: "naming" } }) + "\n");
+    expect(sumLocalLedgerTotals(dir, { maxFileBytes: 500 })).toEqual({ flagged: 1, resolved: 0, complete: false });
+  });
+
+  it("marks a per-file read error as a partial read", () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "aaaa"), { recursive: true });
+    writeFileSync(join(dir, "aaaa", "s1.jsonl"), flag("DF-1") + "\n");
+    const broken = join(dir, "aaaa", "s2.jsonl");
+    writeFileSync(broken, flag("DF-2") + "\n");
+    chmodSync(broken, 0o000);
+    expect(sumLocalLedgerTotals(dir)).toEqual({ flagged: 1, resolved: 0, complete: false });
+  });
+
+  it("pins the default budgets", () => {
+    expect(RECAP_MAX_FILES).toBe(200);
+    expect(RECAP_MAX_FILE_BYTES).toBe(5 * 1024 * 1024);
+    expect(RECAP_MAX_TOTAL_BYTES).toBe(20 * 1024 * 1024);
   });
 });


### PR DESCRIPTION
Free accounts get 5 watched sessions. Before this change, you could not see where you stood: the count only appeared while a repo was still un-activated, and the sixth session hit the wall with a generic notice.

## What changes

- **Every new session on the free trial shows where you stand**: `VibeDrift trial: 2 of 5 sessions used.` It appears once at session start and never interrupts your work.
- **The last free session says so**: `This is your last free session.`
- **When the trial is spent, the notice recaps what VibeDrift actually did for you**, from the session records on your machine: `On this machine, VibeDrift flagged 2 drifts; your agent fixed 1 on the spot, re-verified.` If your local records show nothing, or there are none on this machine, the notice makes no claim at all. Nothing is ever estimated or invented.
- **Your last free session can't be cut short**: once a session starts recording, it finishes recording, even if the trial runs out mid-session. The next session locks normally.

## Safety

This code runs inside your agent's session hooks, so it is built to stay out of the way: the recap read is capped (file count and size budgets), everything is wrapped so a failure changes nothing about your session, headless and CI runs stay silent, and the meter never shows for paid accounts.

## Demo

Real runs of the hook, sandboxed:

![trial prompts demo](https://raw.githubusercontent.com/VibeDrift/VibeDrift/assets/native-sessions/metrics-p0/trial-prompts-demo.gif)

---
🤖 This PR was written by Claude (AI), operating the VibeDrift release process on Sami's behalf.