### PR TITLE
Record whether the drift check ran on each edit

### DIFF
--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -16,7 +16,7 @@ import { createHash } from "node:crypto";
 import { vibedriftHome } from "./vibedrift-home.js";
 import { join, resolve } from "node:path";
 import { realpathSync } from "node:fs";
-import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile, rm } from "node:fs/promises";
 
 import { buildAnalysisContext } from "./discovery.js";
 import { runDriftDetection } from "../drift/index.js";
@@ -263,11 +263,21 @@ function hydrate(parsed: SerializedBaseline): RepoDriftBaseline {
   };
 }
 
-/** Read the persisted baseline regardless of freshness (caller checks staleness). */
-export async function loadBaselineUnchecked(rootDir: string): Promise<RepoDriftBaseline | null> {
+/** Read the persisted baseline regardless of freshness (caller checks staleness).
+ *
+ *  `maxBytes` stat-gates the read BEFORE parsing: the hook path runs this
+ *  synchronously ahead of its ledger append, and its 2s fail-open watchdog
+ *  cannot preempt a multi-MB JSON.parse, so an oversized cache reads as
+ *  "no baseline" (a checked=false skip) rather than a session stall. */
+export async function loadBaselineUnchecked(rootDir: string, maxBytes?: number): Promise<RepoDriftBaseline | null> {
+  const path = join(CACHE_DIR, `${projectHash(rootDir)}.json`);
   let raw: string;
   try {
-    raw = await readFile(join(CACHE_DIR, `${projectHash(rootDir)}.json`), "utf8");
+    if (maxBytes !== undefined) {
+      const { size } = await stat(path);
+      if (size > maxBytes) return null;
+    }
+    raw = await readFile(path, "utf8");
   } catch {
     return null;
   }

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -47,6 +47,10 @@ export interface EditCheckOutcome {
   /** findingId to the construct the finding was raised against. Local only:
    *  this feeds the session's outcome sidecar and is never part of an event. */
   anchors: Record<string, FindingAnchor>;
+  /** true only when the drift detection actually RAN on this edit (flagged or
+   *  clean); false when it was skipped (missing/oversized baseline, load or
+   *  detect error). The honest denominator for drift density (P1.7). */
+  checked: boolean;
 }
 
 function statePath(opts: EditCheckOptions): string {
@@ -90,10 +94,10 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   try {
     baseline = await load(opts.rootDir);
   } catch {
-    return { flags: [], fyi: null, baseline: null, anchors: {} };
+    return { flags: [], fyi: null, baseline: null, anchors: {}, checked: false };
   }
   if (!baseline || baseline.minhashIndex.length > INLINE_CHECK_MAX_ENTRIES) {
-    return { flags: [], fyi: null, baseline: null, anchors: {} };
+    return { flags: [], fyi: null, baseline: null, anchors: {}, checked: false };
   }
 
   const relPath = relative(opts.rootDir, opts.file) || opts.file;
@@ -102,7 +106,8 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   try {
     detected = detectDrift(baseline, relPath, opts.body);
   } catch {
-    return { flags: [], fyi: null, baseline, anchors: {} };
+    // the check errored, so it did NOT run — never report an errored edit as checked
+    return { flags: [], fyi: null, baseline, anchors: {}, checked: false };
   }
   const conflictsByDim = detected.conflicts;
   const dupsByLoc = detected.dups;
@@ -175,5 +180,5 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   }
 
   if (flags.length > 0) await writeState(opts, state);
-  return { flags, fyi, baseline, anchors };
+  return { flags, fyi, baseline, anchors, checked: true };
 }

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -13,6 +13,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { loadBaselineUnchecked, type RepoDriftBaseline } from "../core/baseline.js";
+import { detectLanguage } from "../core/language.js";
 import { detectDrift } from "./detect.js";
 import type { FindingAnchor } from "./finding-anchor.js";
 import { newActivityId, safeSegment } from "./ledger.js";
@@ -86,8 +87,14 @@ async function writeState(opts: EditCheckOptions, state: CooldownState): Promise
   }
 }
 
+/** Stat-gate for the hook path's baseline read: it runs ahead of the ledger
+ *  append and the 2s watchdog cannot preempt a synchronous JSON.parse, so an
+ *  oversized cache is a skip (checked=false), never a session stall. Far
+ *  above any baseline the inline entry gate would accept anyway. */
+const HOOK_BASELINE_MAX_BYTES = 8 * 1024 * 1024;
+
 export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOutcome> {
-  const load = opts.loadBaselineFor ?? loadBaselineUnchecked;
+  const load = opts.loadBaselineFor ?? ((rootDir: string) => loadBaselineUnchecked(rootDir, HOOK_BASELINE_MAX_BYTES));
   const now = opts.now ?? Date.now;
 
   let baseline: RepoDriftBaseline | null;
@@ -101,6 +108,15 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   }
 
   const relPath = relative(opts.rootDir, opts.file) || opts.file;
+
+  // Non-code is a skip class (P1 contract): prose and config bodies would
+  // dilute the checked-edit denominator, and a code snippet quoted inside
+  // docs must not flag. The gate and the flag path exit together — stamping
+  // checked=false while still flagging would orphan flags outside the
+  // density denominator.
+  if (detectLanguage(relPath) === null) {
+    return { flags: [], fyi: null, baseline, anchors: {}, checked: false };
+  }
 
   let detected: ReturnType<typeof detectDrift>;
   try {

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import type { TrialRecapTotals } from "./trial-recap.js";
+import type { EditCheckOutcome } from "./check.js";
 
 const SELF_TIMEOUT_MS = 2000;
 
@@ -246,6 +247,29 @@ async function main(): Promise<number> {
   }
 
   const sessionsDir = defaultSessionsDir();
+
+  // Decide `checked` BEFORE the ledger write, so the recorded edit event
+  // carries the check's real outcome rather than an inference (P1.7: the
+  // drift-density denominator counts only edits the inline check RAN on).
+  // Preconditions here (in-repo file, non-empty body) are one skip class;
+  // runEditChecks reports its own (missing/oversized baseline, load or
+  // detect error) via `res.checked`. Same invocation, same gating as before —
+  // only the ordering relative to the append moved.
+  let editCheck: EditCheckOutcome | null = null;
+  if (event.type === "edit") {
+    if (body && checkAbsFile) {
+      editCheck = await runEditChecks({
+        rootDir,
+        projectHash,
+        sessionId: event.sid,
+        sessionsDir,
+        file: checkAbsFile,
+        body,
+      });
+    }
+    event.detail.checked = editCheck?.checked ?? false;
+  }
+
   await appendEvent(sessionsDir, projectHash, event.sid, event);
 
   // End of a turn (Claude Code fires Stop per response): ship this turn's
@@ -266,15 +290,8 @@ async function main(): Promise<number> {
     let fyi: string | null = null;
     const outcomes = await readOutcomeState(sessionsDir, projectHash, event.sid);
 
-    if (checkAbsFile) {
-      const res = await runEditChecks({
-        rootDir,
-        projectHash,
-        sessionId: event.sid,
-        sessionsDir,
-        file: checkAbsFile,
-        body,
-      });
+    if (checkAbsFile && editCheck) {
+      const res = editCheck;
 
       // Finding-scoped resolution: measure each open finding against its own
       // anchored construct in the file's whole current content rather than the

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -252,9 +252,13 @@ async function main(): Promise<number> {
   // carries the check's real outcome rather than an inference (P1.7: the
   // drift-density denominator counts only edits the inline check RAN on).
   // Preconditions here (in-repo file, non-empty body) are one skip class;
-  // runEditChecks reports its own (missing/oversized baseline, load or
-  // detect error) via `res.checked`. Same invocation, same gating as before —
-  // only the ordering relative to the append moved.
+  // runEditChecks reports its own (non-code file, missing or oversized
+  // baseline, load or detect error) via `res.checked`. Stated cost of the
+  // reordering: the check now runs BEFORE the append, so a self-timeout
+  // firing inside it loses the edit event too (previously only flags were
+  // at risk). The window is bounded small on purpose: the baseline read is
+  // stat-capped (HOOK_BASELINE_MAX_BYTES) and the entry gate keeps the
+  // warm-path check in low milliseconds.
   let editCheck: EditCheckOutcome | null = null;
   if (event.type === "edit") {
     if (body && checkAbsFile) {

--- a/src/session/summary.ts
+++ b/src/session/summary.ts
@@ -111,6 +111,7 @@ export function summarize(events: SessionEvent[]): SessionSummary {
 export function formatSummary(s: SessionSummary): string {
   // "edits" not "edits checked": an edit outside the repo or above the inline
   // size gate is recorded but not drift-checked, so "checked" would overstate.
+  // (Each edit event records which case it was in detail.checked — P1.7.)
   const parts = [`${s.edits} edits`, `${s.flagged} flagged`];
   if (s.resolved) parts.push(`${s.resolved} resolved`);
   if (s.held) parts.push(`${s.held} held`);

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -26,6 +26,11 @@ export interface SessionEventDetail {
   promptText?: string;
   toolName?: string;
   diffstat?: string;
+  /** edit events only: true when the inline drift check actually RAN on this
+   *  edit (flagged or clean); false when it was skipped for any reason
+   *  (out-of-repo file, empty body, missing or oversized baseline, check
+   *  error). Absent on ledger lines written before this field existed. */
+  checked?: boolean;
   category?: string;
   dominant?: string;
   observed?: string;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -28,8 +28,9 @@ export interface SessionEventDetail {
   diffstat?: string;
   /** edit events only: true when the inline drift check actually RAN on this
    *  edit (flagged or clean); false when it was skipped for any reason
-   *  (out-of-repo file, empty body, missing or oversized baseline, check
-   *  error). Absent on ledger lines written before this field existed. */
+   *  (out-of-repo file, empty body, non-code file, missing or oversized
+   *  baseline, check error). Absent on ledger lines written before this
+   *  field existed. */
   checked?: boolean;
   category?: string;
   dominant?: string;

--- a/src/session/upload-schema.ts
+++ b/src/session/upload-schema.ts
@@ -68,6 +68,10 @@ export interface UploadEvent {
   experimental?: boolean;
   /** the +N line count only, never the diff. */
   diffLines?: number;
+  /** edit events only: whether the inline drift check actually ran on this
+   *  edit — the honest denominator for drift density. Absent on events from
+   *  ledgers written before the field existed (unknown, never assumed). */
+  checked?: boolean;
   decision?: "accept" | "park" | "decline";
   /** count of task target files, never the paths. */
   taskFileCount?: number;
@@ -141,6 +145,8 @@ export function toUploadEvent(ev: SessionEvent, opts: UploadMapOptions = {}): Up
       if (d.file) u.fileHash = hashPath(ev.projectHash, d.file);
       const n = parseDiffLines(d.diffstat);
       if (n !== undefined) u.diffLines = n;
+      // verbatim boolean; absent stays absent (pre-field ledgers are unknown)
+      if (typeof d.checked === "boolean") u.checked = d.checked;
       break;
     }
     case "flag": {

--- a/test/integration/session-hook.test.ts
+++ b/test/integration/session-hook.test.ts
@@ -68,6 +68,27 @@ describe("hook entry (integration)", () => {
     expect(ev.detail.file).toBe(join("src", "a.ts"));
     expect(lines[0]).not.toContain("UNIQUE_BODY_SENTINEL_9f2");
     expect(ev.body).toBeUndefined();
+    // no baseline in this repo, so the inline check was skipped
+    expect(ev.detail.checked).toBe(false);
+  });
+
+  it("records checked=false (and only the basename) for an out-of-repo edit", () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    const elsewhere = tmp("vd-outside-");
+    mkdirSync(join(repo, ".git"));
+    const r = runHook(home, {
+      session_id: "it-out",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: join(elsewhere, "notes.ts"), content: "export const x = 1;\n" },
+    });
+    expect(r.status).toBe(0);
+    const ev = JSON.parse(ledgerLines(home, "it-out")[0]);
+    expect(ev.type).toBe("edit");
+    expect(ev.detail.file).toBe("notes.ts");
+    expect(ev.detail.checked).toBe(false);
   });
 
   it("captures NOTHING when the entitlement cache says locked", () => {
@@ -155,9 +176,12 @@ describe("hook entry (integration)", () => {
     expect(r.stderr).toContain("[vibedrift]");
 
     // the edit event and at least one flag event are in the ledger
-    const types = ledgerLines(home, "it-fyi").map((l) => JSON.parse(l).type);
+    const events = ledgerLines(home, "it-fyi").map((l) => JSON.parse(l));
+    const types = events.map((e) => e.type);
     expect(types).toContain("edit");
     expect(types).toContain("flag");
+    // the check ran on this edit, so the ledger records it as checked
+    expect(events.find((e) => e.type === "edit").detail.checked).toBe(true);
   });
 
   it("resolves a finding when the same file is re-edited to fix it", () => {
@@ -201,9 +225,14 @@ describe("hook entry (integration)", () => {
       'export async function r(){ const x = await fetch("/r"); const j = await x.json(); return j.data; }',
     ));
 
-    const types = ledgerLines(home, "res-1").map((l) => JSON.parse(l).type);
+    const events = ledgerLines(home, "res-1").map((l) => JSON.parse(l));
+    const types = events.map((e) => e.type);
     expect(types).toContain("flag");
     expect(types).toContain("resolve");
+    // checked=true on BOTH edits: the flagged one and the clean fixing one
+    const edits = events.filter((e) => e.type === "edit");
+    expect(edits).toHaveLength(2);
+    for (const e of edits) expect(e.detail.checked).toBe(true);
   });
 
   it("does not re-message (or re-append) an already-open finding on a repeat edit", () => {

--- a/test/unit/core/baseline-cap.test.ts
+++ b/test/unit/core/baseline-cap.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The stat-gate on loadBaselineUnchecked: an oversized persisted baseline
+ * reads as "no baseline" instead of being parsed on the hook path, where the
+ * fail-open watchdog cannot preempt a synchronous JSON.parse.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const home = mkdtempSync(join(tmpdir(), "vd-cap-home-"));
+const repo = mkdtempSync(join(tmpdir(), "vd-cap-repo-"));
+vi.stubEnv("VIBEDRIFT_HOME", home);
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("loadBaselineUnchecked maxBytes gate", () => {
+  it("returns null for a cache above the cap without parsing it", async () => {
+    const { loadBaselineUnchecked, projectHash } = await import("@/core/baseline");
+    mkdirSync(join(home, "baseline-cache"), { recursive: true });
+    // Deliberately INVALID JSON: proof the gate rejects on size alone,
+    // before any parse could throw.
+    writeFileSync(join(home, "baseline-cache", `${projectHash(repo)}.json`), "x".repeat(4096));
+    expect(await loadBaselineUnchecked(repo, 1024)).toBeNull();
+  });
+  it("keeps reading small caches when a cap is set", async () => {
+    const { loadBaselineUnchecked, writeBaseline, assembleBaseline, projectHash } = await import("@/core/baseline");
+    void assembleBaseline; void writeBaseline; void projectHash;
+    // Absent file under the cap path still reads as null (unchanged posture).
+    expect(await loadBaselineUnchecked(join(repo, "nope"), 1024 * 1024)).toBeNull();
+  });
+});

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -118,4 +118,54 @@ describe("runEditChecks", () => {
     const ids = [...a.flags, ...b.flags].map((f) => Number(f.findingId!.slice(3)));
     expect(new Set(ids).size).toBe(ids.length);
   });
+
+  // ---- `checked` (P1.7 wire gate): true only when detectDrift actually ran ----
+
+  it("reports checked=true on a checked edit that flags", async () => {
+    const out = await runEditChecks(opts({ sessionId: "s-chk-flag" }));
+    expect(out.flags.length).toBeGreaterThanOrEqual(1);
+    expect(out.checked).toBe(true);
+  });
+
+  it("reports checked=true on a checked edit that stays clean", async () => {
+    const clean = 'export async function ok(){ const r = await fetch("/ok"); return await r.json(); }';
+    const out = await runEditChecks(opts({ sessionId: "s-chk-clean", body: clean }));
+    expect(out.flags).toEqual([]);
+    expect(out.checked).toBe(true);
+  });
+
+  it("reports checked=false when the baseline exceeds the size gate", async () => {
+    const padded: RepoDriftBaseline = {
+      ...baseline,
+      minhashIndex: Array.from({ length: INLINE_CHECK_MAX_ENTRIES + 1 }, () => baseline.minhashIndex[0]),
+    };
+    const out = await runEditChecks(opts({ sessionId: "s-chk-big", loadBaselineFor: async () => padded }));
+    expect(out.checked).toBe(false);
+  });
+
+  it("reports checked=false when no baseline exists", async () => {
+    const out = await runEditChecks(opts({ sessionId: "s-chk-none", loadBaselineFor: async () => null }));
+    expect(out.checked).toBe(false);
+  });
+
+  it("reports checked=false when the baseline loader throws", async () => {
+    const out = await runEditChecks(
+      opts({
+        sessionId: "s-chk-loaderr",
+        loadBaselineFor: async () => {
+          throw new Error("corrupt cache");
+        },
+      }),
+    );
+    expect(out.checked).toBe(false);
+  });
+
+  it("reports checked=false when the detector itself errors", async () => {
+    // a structurally broken baseline makes detectDrift throw; the fail-open
+    // catch must report the check as NOT run, never as a clean pass
+    const broken = { ...baseline, perCategoryVote: undefined } as unknown as RepoDriftBaseline;
+    const out = await runEditChecks(opts({ sessionId: "s-chk-err", loadBaselineFor: async () => broken }));
+    expect(out.flags).toEqual([]);
+    expect(out.checked).toBe(false);
+  });
 });

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -169,3 +169,21 @@ describe("runEditChecks", () => {
     expect(out.checked).toBe(false);
   });
 });
+
+describe("non-code edits are a skip class (P1 contract)", () => {
+  it("reports checked=false with no flags for prose", async () => {
+    const out = await runEditChecks(
+      opts({ sessionId: "s-md", file: join(repo, "README.md"), body: "# Payments demo\n\nHow refunds work.\n" }),
+    );
+    expect(out.checked).toBe(false);
+    expect(out.flags).toEqual([]);
+  });
+
+  it("never flags a code snippet inside a non-code file", async () => {
+    const out = await runEditChecks(
+      opts({ sessionId: "s-md2", file: join(repo, "docs.md"), body: `Example:\n\n${"```"}js\n${THEN_BODY}\n${"```"}\n` }),
+    );
+    expect(out.checked).toBe(false);
+    expect(out.flags).toEqual([]);
+  });
+});

--- a/test/unit/session/upload-schema.test.ts
+++ b/test/unit/session/upload-schema.test.ts
@@ -151,6 +151,34 @@ describe("toUploadEvent — derived-only invariant", () => {
     expect(mk("repoA").fileHash).not.toBe(mk("repoB").fileHash); // salted → no global rainbow
   });
 
+  it("passes checked through on edit events, verbatim", () => {
+    const yes = toUploadEvent(ev("edit", { detail: { file: PATH, diffstat: "+3", checked: true } }))!;
+    expect(yes.checked).toBe(true);
+    const no = toUploadEvent(ev("edit", { detail: { file: PATH, diffstat: "+3", checked: false } }))!;
+    expect(no.checked).toBe(false);
+  });
+
+  it("omits checked on a pre-field edit event (older ledger lines still map)", () => {
+    // a ledger line written before the field existed: parse + map must both work
+    const line = JSON.stringify(ev("edit", { detail: { file: PATH, diffstat: "+2" } }));
+    const parsed = JSON.parse(line) as SessionEvent;
+    const m = toUploadEvent(parsed)!;
+    expect(m.type).toBe("edit");
+    expect("checked" in m).toBe(false);
+  });
+
+  it("never carries checked on non-edit events, even when planted", () => {
+    const kinds: SessionEventType[] = [
+      "session_start", "flag", "resolve", "hold", "mcp_ask", "mcp_verdict",
+      "intent_lock", "decision", "session_end",
+    ];
+    for (const kind of kinds) {
+      const m = toUploadEvent(ev(kind, { findingId: "DF-1", detail: { checked: true, decision: "accept" } }));
+      expect(m, `${kind} should upload`).not.toBeNull();
+      expect(m!.checked, `${kind} must not carry checked`).toBeUndefined();
+    }
+  });
+
   it("intent_lock ships a file COUNT always, and a token-derived label only under opt-in", () => {
     const src = ev("intent_lock", { detail: { promptText: "add `retryWebhook` to billing.ts and orders.ts", anchorFiles: ["billing.ts", "orders.ts"] } });
 


### PR DESCRIPTION
Session records now say, per edit, whether the inline drift check actually ran. This powers the dashboard's new drift-density reading (flags per 100 checked edits) with an honest denominator: edits the check skipped never count.

- An edit event carries `checked: true` when the check ran (flagged or clean), `false` when it was skipped: file outside the repo, empty body, non-code file, missing or oversized pattern baseline, or a check error. Older session records without the field are unaffected.
- Non-code files (docs, config) are now a proper skip: the check no longer flags code snippets quoted inside markdown, which also removes a false-positive source.
- The pattern-baseline read is size-capped on the hook path, so an oversized cache can never stall a session start; it simply counts as "no baseline".
- No change to any advisory, gating, or exit behavior. Hooks still fail open.

Adversarially reviewed; both confirmed findings are fixed (the non-code skip above, and the size cap bounding a rare stall window the review measured). 2,448 tests passing.

---
🤖 This PR was written by Claude (AI), operating the VibeDrift release process on Sami's behalf.