### PR TITLE
Opt in to sharing file names, per repo

### DIFF
--- a/src/auth/api.ts
+++ b/src/auth/api.ts
@@ -1,5 +1,6 @@
 import { resolveApiUrl } from "./resolver.js";
 import type { UploadEvent } from "../session/upload-schema.js";
+import type { FileNameEntry } from "../session/file-names.js";
 
 /**
  * Typed HTTP client for the VibeDrift Auth + Account API.
@@ -247,6 +248,63 @@ export async function postSessionIngest(
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
       body: JSON.stringify({ events }),
+    },
+    opts?.timeoutMs ?? 15_000,
+  );
+}
+
+export interface SessionNamesResponse {
+  ok: boolean;
+  /** Entries stored (upserted) by the server. */
+  stored: number;
+  /** Entries the server refused (bad hash or path); the batch still succeeds. */
+  rejected: number;
+}
+
+export interface SessionNamesDeleteResponse {
+  ok: boolean;
+  deleted: number;
+}
+
+/**
+ * Upload the opt-in file-name manifest for ONE project: `fileHash -> repo-relative
+ * path`, so the user's own dashboard can name files instead of showing the
+ * pseudonym. Only invoked when that repo's `--names on` flag is set and hosted
+ * sync is on. Paths only, never file contents. Batches are capped at 500
+ * entries by the caller (see session/file-names.ts). Short timeout: this rides
+ * behind the event flush and must never hold it up.
+ */
+export async function postSessionNames(
+  token: string,
+  projectHash: string,
+  names: FileNameEntry[],
+  opts?: { apiUrl?: string; timeoutMs?: number },
+): Promise<SessionNamesResponse> {
+  const base = await resolveApiUrl(opts?.apiUrl);
+  return jsonFetch<SessionNamesResponse>(
+    `${base}/v1/sessions/names`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ projectHash, names }),
+    },
+    opts?.timeoutMs ?? 15_000,
+  );
+}
+
+/** Delete every uploaded file name for one project — the reversal half of the
+ *  opt-in (`watch-session --names off`). */
+export async function deleteSessionNames(
+  token: string,
+  projectHash: string,
+  opts?: { apiUrl?: string; timeoutMs?: number },
+): Promise<SessionNamesDeleteResponse> {
+  const base = await resolveApiUrl(opts?.apiUrl);
+  return jsonFetch<SessionNamesDeleteResponse>(
+    `${base}/v1/sessions/names?project_hash=${encodeURIComponent(projectHash)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
     },
     opts?.timeoutMs ?? 15_000,
   );

--- a/src/auth/api.ts
+++ b/src/auth/api.ts
@@ -254,11 +254,19 @@ export async function postSessionIngest(
 }
 
 export interface SessionNamesResponse {
+  /** false when the server took the request but did NOT store it (its write
+   *  failed): the entries come back `held` and the caller must re-send them. */
   ok: boolean;
   /** Entries stored (upserted) by the server. */
   stored: number;
   /** Entries the server refused (bad hash or path); the batch still succeeds. */
   rejected: number;
+  /** Per-entry acknowledgments, mirroring ingest. Absent on legacy servers. */
+  results?: Array<{
+    fileHash?: string;
+    status: "stored" | "duplicate" | "rejected" | "held";
+    code?: string;
+  }>;
 }
 
 export interface SessionNamesDeleteResponse {

--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -307,12 +307,17 @@ export async function runWatchSession(
  * it opted in under against an identity that survives the repo moving.
  *
  * OFF deletes what was already uploaded and then clears the flag. The delete is
- * scoped to a project hash, and a repo that moved on disk has uploaded under
- * more than one, so every hash this machine recorded for THIS repo is deleted,
- * not just the current one. The flag ends up off locally either way — but the
- * report is strictly what happened: a deletion that did not land is never
- * printed as one, the current hash's failure is queued for the next flush, and
- * an older hash's failure says plainly that it is still out there.
+ * scoped to a project hash, and one repo can have uploaded under more than one
+ * (it moved on disk, or a second clone or git worktree of it hashes differently
+ * while sharing the same repo identity), so every hash this machine recorded for
+ * THIS repo is deleted, not just the current one. The local opt-in is cleared
+ * for every one of those hashes for the same reason: an opt-out that deleted a
+ * second working copy's uploads while leaving that copy ARMED would have it
+ * re-upload them on its next flush, after the user was told sharing was off.
+ * The flag ends up off locally either way — but the report is strictly what
+ * happened: a deletion that did not land is never printed as one, the current
+ * hash's failure is queued for the next flush, and an older hash's failure says
+ * plainly that it is still out there.
  */
 async function toggleFileNames(
   on: boolean,
@@ -348,7 +353,8 @@ async function toggleFileNames(
   }
 
   // Every hash this repo has shared names under: the current one plus anything
-  // recorded before the repo moved (a moved repo hashes to something new).
+  // recorded from another path for the same repo (it moved, or a second clone
+  // or worktree of it opted in and hashes differently).
   const hashes = [...new Set([projectHash, ...nameShareHashes(loadActivation(activationHome), key)])];
   let removed = 0;
   let counted = true;
@@ -369,7 +375,10 @@ async function toggleFileNames(
       else earlierFailed++;
     }
   }
-  setShareFileNames(projectHash, false, activationHome);
+  // Disarm every hash the opt-out covered, not only the current one: another
+  // working copy of this repo would otherwise still be opted in and re-upload
+  // on its next flush the names this command just deleted.
+  for (const hash of hashes) setShareFileNames(hash, false, activationHome);
   if (currentFailed) setNamesDeletePending(projectHash, true, activationHome);
 
   if (!currentFailed && earlierFailed === 0) {

--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -14,7 +14,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import chalk from "chalk";
-import { repoIdentity, defaultSessionsDir } from "../../session/repo.js";
+import { repoIdentity, repoKey, defaultSessionsDir } from "../../session/repo.js";
 import {
   installHooks,
   uninstallHooks,
@@ -22,7 +22,15 @@ import {
   resolveHookCommand,
   detectClaudeCode,
 } from "../../session/install.js";
-import { recordAnswer, setShareFileNames, setNamesDeletePending } from "../../session/activation.js";
+import {
+  recordAnswer,
+  setShareFileNames,
+  setNamesDeletePending,
+  loadActivation,
+  recordNameShare,
+  nameShareHashes,
+  forgetNameShare,
+} from "../../session/activation.js";
 import { clearUploadedNames } from "../../session/file-names.js";
 import { appendConsentReceipt } from "../../session/consent.js";
 import { vibedriftHome } from "../../core/vibedrift-home.js";
@@ -63,8 +71,9 @@ export interface WatchSessionOptions {
    *  repo-relative paths (never contents) so the dashboard can name files,
    *  "off" deletes what was uploaded and stops future uploads. */
   names?: "on" | "off";
-  /** Test seam: perform the server-side name deletion (default: the API). */
-  deleteNames?: () => Promise<{ deleted?: number }>;
+  /** Test seam: perform the server-side name deletion for ONE project hash
+   *  (default: the API). Called once per hash this repo has uploaded under. */
+  deleteNames?: (projectHash: string) => Promise<{ deleted?: number }>;
   /** Force hosted sync off for THIS run regardless of the saved setting. */
   localOnly?: boolean;
   /** Test seam: inject config instead of reading ~/.vibedrift (bypasses network). */
@@ -175,6 +184,7 @@ export async function runWatchSession(
   if (options.names) {
     await toggleFileNames(options.names === "on", {
       projectHash,
+      rootDir,
       sessionsDir,
       activationHome: options.activationHome ?? vibedriftHome(),
       deleteNames: options.deleteNames,
@@ -293,21 +303,29 @@ export async function runWatchSession(
  * `--names on|off`: the per-repo file-name opt-in.
  *
  * ON prints the full disclosure BEFORE the flag is written, so the state on
- * disk never runs ahead of what the user was told. OFF deletes what was already
- * uploaded and then clears the flag; if that DELETE cannot reach the server the
- * flag still ends up off and the deletion is queued for the next flush, so
- * "off" always means off locally, immediately.
+ * disk never runs ahead of what the user was told, and records the project hash
+ * it opted in under against an identity that survives the repo moving.
+ *
+ * OFF deletes what was already uploaded and then clears the flag. The delete is
+ * scoped to a project hash, and a repo that moved on disk has uploaded under
+ * more than one, so every hash this machine recorded for THIS repo is deleted,
+ * not just the current one. The flag ends up off locally either way — but the
+ * report is strictly what happened: a deletion that did not land is never
+ * printed as one, the current hash's failure is queued for the next flush, and
+ * an older hash's failure says plainly that it is still out there.
  */
 async function toggleFileNames(
   on: boolean,
   ctx: {
     projectHash: string;
+    rootDir: string;
     sessionsDir: string;
     activationHome: string;
-    deleteNames?: () => Promise<{ deleted?: number }>;
+    deleteNames?: (projectHash: string) => Promise<{ deleted?: number }>;
   },
 ): Promise<void> {
-  const { projectHash, sessionsDir, activationHome } = ctx;
+  const { projectHash, rootDir, sessionsDir, activationHome } = ctx;
+  const key = repoKey(rootDir);
 
   if (on) {
     console.log(chalk.bold("Drift Sessions file names for this repo"));
@@ -324,39 +342,66 @@ async function toggleFileNames(
       ),
     );
     setShareFileNames(projectHash, true, activationHome);
+    recordNameShare(projectHash, key, activationHome);
     console.log(`${chalk.green("✓")} File names are ON for this repo.`);
     return;
   }
 
-  let deleted: number | undefined;
-  let failed = false;
-  try {
-    const res = ctx.deleteNames ? await ctx.deleteNames() : await deleteNamesViaNetwork(projectHash);
-    deleted = typeof res?.deleted === "number" ? res.deleted : undefined;
-  } catch {
-    failed = true;
+  // Every hash this repo has shared names under: the current one plus anything
+  // recorded before the repo moved (a moved repo hashes to something new).
+  const hashes = [...new Set([projectHash, ...nameShareHashes(loadActivation(activationHome), key)])];
+  let removed = 0;
+  let counted = true;
+  let currentFailed = false;
+  let earlierFailed = 0;
+  for (const hash of hashes) {
+    try {
+      const res = ctx.deleteNames ? await ctx.deleteNames(hash) : await deleteNamesViaNetwork(hash);
+      if (typeof res?.deleted === "number") removed += res.deleted;
+      else counted = false;
+      forgetNameShare(hash, key, activationHome);
+      setNamesDeletePending(hash, false, activationHome);
+      await clearUploadedNames(sessionsDir, hash);
+    } catch {
+      // keep the record: it is what a re-run (or, for this repo's current hash,
+      // the next flush) retries from.
+      if (hash === projectHash) currentFailed = true;
+      else earlierFailed++;
+    }
   }
   setShareFileNames(projectHash, false, activationHome);
-  if (failed) {
-    setNamesDeletePending(projectHash, true, activationHome);
-    console.log(`${chalk.green("✓")} File names are OFF for this repo; nothing more will be uploaded.`);
+  if (currentFailed) setNamesDeletePending(projectHash, true, activationHome);
+
+  if (!currentFailed && earlierFailed === 0) {
+    console.log(
+      `${chalk.green("✓")} File names are OFF for this repo${counted ? ` (${removed} removed from your dashboard)` : ""}.`,
+    );
+    console.log(chalk.dim('  The dashboard shows per-repo pseudonyms again, like "file ab12cd34".'));
+    return;
+  }
+
+  console.log(`${chalk.green("✓")} File names are OFF for this repo; nothing more will be uploaded.`);
+  if (counted && removed > 0) {
+    console.log(chalk.dim(`  Removed ${removed} uploaded name${removed === 1 ? "" : "s"} from your dashboard.`));
+  }
+  if (currentFailed) {
     console.log(
       chalk.dim("  The delete request did not reach the server. It will be retried on the next session flush."),
     );
-    return;
   }
-  setNamesDeletePending(projectHash, false, activationHome);
-  await clearUploadedNames(sessionsDir, projectHash);
-  console.log(
-    `${chalk.green("✓")} File names are OFF for this repo${
-      deleted !== undefined ? ` (${deleted} removed from your dashboard)` : ""
-    }.`,
-  );
-  console.log(chalk.dim('  The dashboard shows per-repo pseudonyms again, like "file ab12cd34".'));
+  if (earlierFailed > 0) {
+    console.log(
+      chalk.dim(
+        `  ${earlierFailed} earlier upload${earlierFailed === 1 ? "" : "s"} for this repo (from a previous path) could not be removed. Re-run this command to try again.`,
+      ),
+    );
+  }
 }
 
-/** Delete this repo's uploaded names server-side. Throws when there is no
- *  account or the request fails, which queues the deletion for the next flush. */
+/** Delete one project hash's uploaded names server-side. Throws when there is
+ *  no account or the request fails; the caller decides what that means (the
+ *  current hash is queued for the next flush, an older one is kept for a
+ *  re-run) and reports only what actually happened. */
 async function deleteNamesViaNetwork(projectHash: string): Promise<{ deleted?: number }> {
   const cfg = await readConfig();
   if (!cfg.token) throw new Error("not logged in");

--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -22,7 +22,8 @@ import {
   resolveHookCommand,
   detectClaudeCode,
 } from "../../session/install.js";
-import { recordAnswer } from "../../session/activation.js";
+import { recordAnswer, setShareFileNames, setNamesDeletePending } from "../../session/activation.js";
+import { clearUploadedNames } from "../../session/file-names.js";
 import { appendConsentReceipt } from "../../session/consent.js";
 import { vibedriftHome } from "../../core/vibedrift-home.js";
 import { runLiveTape } from "../../session/live.js";
@@ -58,6 +59,12 @@ export interface WatchSessionOptions {
   /** Toggle hosted sync (Phase 5): "on" opts into derived-only upload, "off"
    *  disables it. A standalone control — sets config and returns. */
   sync?: "on" | "off";
+  /** Toggle the opt-in file-name manifest for THIS repo: "on" shares
+   *  repo-relative paths (never contents) so the dashboard can name files,
+   *  "off" deletes what was uploaded and stops future uploads. */
+  names?: "on" | "off";
+  /** Test seam: perform the server-side name deletion (default: the API). */
+  deleteNames?: () => Promise<{ deleted?: number }>;
   /** Force hosted sync off for THIS run regardless of the saved setting. */
   localOnly?: boolean;
   /** Test seam: inject config instead of reading ~/.vibedrift (bypasses network). */
@@ -89,6 +96,7 @@ export type WatchSessionStatus =
   | "locked"
   | "login_required"
   | "sync_updated"
+  | "names_updated"
   | "aborted_unparseable";
 
 async function askConsent(question: string): Promise<boolean> {
@@ -160,6 +168,18 @@ export async function runWatchSession(
       console.log(`${chalk.green("✓")} Drift Sessions hosted sync is OFF — sessions stay entirely on this machine.`);
     }
     return "sync_updated";
+  }
+
+  // File-name sharing toggle: per repo, default off, fully reversible. Also a
+  // standalone control, so it never installs hooks or starts a watch.
+  if (options.names) {
+    await toggleFileNames(options.names === "on", {
+      projectHash,
+      sessionsDir,
+      activationHome: options.activationHome ?? vibedriftHome(),
+      deleteNames: options.deleteNames,
+    });
+    return "names_updated";
   }
 
   // Entitlement gate (decision 8): sessions are Pro-only with a one-time
@@ -267,6 +287,81 @@ export async function runWatchSession(
     console.log(chalk.dim("  next Claude Code session in this repo will be recorded; run with --status to check."));
   }
   return installed;
+}
+
+/**
+ * `--names on|off`: the per-repo file-name opt-in.
+ *
+ * ON prints the full disclosure BEFORE the flag is written, so the state on
+ * disk never runs ahead of what the user was told. OFF deletes what was already
+ * uploaded and then clears the flag; if that DELETE cannot reach the server the
+ * flag still ends up off and the deletion is queued for the next flush, so
+ * "off" always means off locally, immediately.
+ */
+async function toggleFileNames(
+  on: boolean,
+  ctx: {
+    projectHash: string;
+    sessionsDir: string;
+    activationHome: string;
+    deleteNames?: () => Promise<{ deleted?: number }>;
+  },
+): Promise<void> {
+  const { projectHash, sessionsDir, activationHome } = ctx;
+
+  if (on) {
+    console.log(chalk.bold("Drift Sessions file names for this repo"));
+    console.log(
+      chalk.dim(
+        [
+          '  What gets shared: repo-relative file paths, for example src/payments/refund.ts,',
+          '  so your dashboard can name files instead of showing "file ab12cd34".',
+          "  What never gets shared: file contents, absolute paths, or anything outside this repo.",
+          "  Scope: this repo only, and only while hosted sync is on (vibedrift watch-session --sync on).",
+          "  Reversible: vibedrift watch-session --names off deletes the names already uploaded",
+          "  for this repo and stops future uploads.",
+        ].join("\n"),
+      ),
+    );
+    setShareFileNames(projectHash, true, activationHome);
+    console.log(`${chalk.green("✓")} File names are ON for this repo.`);
+    return;
+  }
+
+  let deleted: number | undefined;
+  let failed = false;
+  try {
+    const res = ctx.deleteNames ? await ctx.deleteNames() : await deleteNamesViaNetwork(projectHash);
+    deleted = typeof res?.deleted === "number" ? res.deleted : undefined;
+  } catch {
+    failed = true;
+  }
+  setShareFileNames(projectHash, false, activationHome);
+  if (failed) {
+    setNamesDeletePending(projectHash, true, activationHome);
+    console.log(`${chalk.green("✓")} File names are OFF for this repo; nothing more will be uploaded.`);
+    console.log(
+      chalk.dim("  The delete request did not reach the server. It will be retried on the next session flush."),
+    );
+    return;
+  }
+  setNamesDeletePending(projectHash, false, activationHome);
+  await clearUploadedNames(sessionsDir, projectHash);
+  console.log(
+    `${chalk.green("✓")} File names are OFF for this repo${
+      deleted !== undefined ? ` (${deleted} removed from your dashboard)` : ""
+    }.`,
+  );
+  console.log(chalk.dim('  The dashboard shows per-repo pseudonyms again, like "file ab12cd34".'));
+}
+
+/** Delete this repo's uploaded names server-side. Throws when there is no
+ *  account or the request fails, which queues the deletion for the next flush. */
+async function deleteNamesViaNetwork(projectHash: string): Promise<{ deleted?: number }> {
+  const cfg = await readConfig();
+  if (!cfg.token) throw new Error("not logged in");
+  const { deleteSessionNames } = await import("../../auth/api.js");
+  return deleteSessionNames(cfg.token, projectHash, { apiUrl: cfg.apiUrl });
 }
 
 /** Resolve entitlement from the server, tolerating offline via the local cache.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -276,16 +276,22 @@ program
   .option("--yes", "skip the consent prompt (you have read what it records)")
   .option("--no-watch", "install only; do not follow the live event tape")
   .option("--sync <state>", "hosted sync (Pro): 'on' opts into derived-only upload, 'off' disables it")
+  .option(
+    "--names <state>",
+    "share this repo's file NAMES with your dashboard: 'on' uploads repo-relative paths (never file contents), 'off' deletes them",
+  )
   .option("--local-only", "force hosted sync off for this run")
   .action(async (path: string, options) => {
     const sync = options.sync === "on" ? "on" : options.sync === "off" ? "off" : undefined;
+    const names = options.names === "on" ? "on" : options.names === "off" ? "off" : undefined;
     await runWatchSession(path, {
       uninstall: options.uninstall,
       status: options.status,
       yes: options.yes,
       sync,
+      names,
       localOnly: options.localOnly === true,
-      watch: options.watch !== false && !options.uninstall && !options.status && !sync,
+      watch: options.watch !== false && !options.uninstall && !options.status && !sync && !names,
     });
   });
 

--- a/src/session/activation.ts
+++ b/src/session/activation.ts
@@ -56,6 +56,14 @@ export interface ProjectActivation {
   askCount?: number;
   /** The one-time "run `vibedrift enable`" breadcrumb was already shown. */
   breadcrumbShown?: boolean;
+  /** Opt-in (default OFF): upload this repo's REPO-RELATIVE file paths with the
+   *  derived events, so the dashboard can name files instead of showing a
+   *  pseudonym. Paths only, never file contents. Set by
+   *  `watch-session --names on`, cleared by `--names off`. */
+  shareFileNames?: boolean;
+  /** A `--names off` DELETE that never reached the server. The next flush
+   *  retries it; sharing is already off either way. */
+  namesDeletePending?: boolean;
 }
 
 export interface ActivationStore {
@@ -124,6 +132,48 @@ export function recordAnswer(
   const store = loadActivation(home);
   const prev = store.projects[projectHash] ?? {};
   store.projects[projectHash] = { ...prev, state, at: new Date().toISOString(), surface };
+  saveActivation(store, home);
+}
+
+/** Is the opt-in file-name manifest on for this repo? Strictly `true` counts,
+ *  so a missing store, a missing entry, or any other value reads as OFF. */
+export function shareFileNamesEnabled(store: ActivationStore, projectHash: string): boolean {
+  return store.projects[projectHash]?.shareFileNames === true;
+}
+
+/** Does this repo still owe the server a `--names off` deletion? */
+export function namesDeleteIsPending(store: ActivationStore, projectHash: string): boolean {
+  return store.projects[projectHash]?.namesDeletePending === true;
+}
+
+/** Flip the per-repo file-name opt-in. Off deletes the key rather than storing
+ *  `false`, so the store never grows a record for a repo that opted out. */
+export function setShareFileNames(projectHash: string, on: boolean, home: string = vibedriftHome()): void {
+  patchProject(projectHash, (rec) => {
+    if (on) rec.shareFileNames = true;
+    else delete rec.shareFileNames;
+  }, home);
+}
+
+/** Record (or clear) the owed opt-out deletion the next flush retries. */
+export function setNamesDeletePending(projectHash: string, pending: boolean, home: string = vibedriftHome()): void {
+  patchProject(projectHash, (rec) => {
+    if (pending) rec.namesDeletePending = true;
+    else delete rec.namesDeletePending;
+  }, home);
+}
+
+/** Read-modify-write one project record, preserving every other field (an
+ *  activation answer must survive a names toggle, and vice versa). */
+function patchProject(
+  projectHash: string,
+  mutate: (rec: ProjectActivation) => void,
+  home: string = vibedriftHome(),
+): void {
+  const store = loadActivation(home);
+  const rec = { ...(store.projects[projectHash] ?? {}) };
+  mutate(rec);
+  store.projects[projectHash] = rec;
   saveActivation(store, home);
 }
 

--- a/src/session/activation.ts
+++ b/src/session/activation.ts
@@ -18,6 +18,10 @@
  * Only an explicit `vibedrift enable`/`decline` sets `state`; the ask itself
  * self-limits via `askCount`.
  *
+ * Name shares: which project hashes each repo turned the file-name manifest on
+ * under, keyed on an identity that survives the repo moving on disk, so opting
+ * out can delete every upload it made rather than only the current hash's.
+ *
  * Dir grants (O19): stored canonicalized; `$HOME` and filesystem roots are
  * REFUSED outright — a grant that broad is indistinguishable from the
  * auto-capture-everything design that was explicitly rejected.
@@ -66,13 +70,29 @@ export interface ProjectActivation {
   namesDeletePending?: boolean;
 }
 
+/**
+ * One repo turned file-name sharing ON under one project hash.
+ *
+ * The project hash is derived from the repo's PATH, so a repo that moves gets a
+ * new one and its earlier uploads become unreachable from the new location.
+ * This record keys them on `repoKey` (see session/repo.ts), which survives a
+ * move, so `--names off` can delete every hash this machine uploaded names
+ * under for the repo rather than only the current one.
+ */
+export interface NameShareRecord {
+  repoKey: string;
+  projectHash: string;
+  at: string;
+}
+
 export interface ActivationStore {
   v: 1;
   projects: Record<string, ProjectActivation>;
   dirGrants: Array<{ path: string; at: string }>;
+  nameShares: NameShareRecord[];
 }
 
-const EMPTY: ActivationStore = { v: 1, projects: {}, dirGrants: [] };
+const EMPTY: ActivationStore = { v: 1, projects: {}, dirGrants: [], nameShares: [] };
 
 export function activationPath(home: string = vibedriftHome()): string {
   return join(home, "activation.json");
@@ -87,6 +107,7 @@ export function loadActivation(home: string = vibedriftHome()): ActivationStore 
       v: 1,
       projects: typeof parsed.projects === "object" && parsed.projects !== null ? parsed.projects : {},
       dirGrants: Array.isArray(parsed.dirGrants) ? parsed.dirGrants : [],
+      nameShares: Array.isArray(parsed.nameShares) ? parsed.nameShares : [],
     };
   } catch {
     return structuredClone(EMPTY);
@@ -153,6 +174,33 @@ export function setShareFileNames(projectHash: string, on: boolean, home: string
     if (on) rec.shareFileNames = true;
     else delete rec.shareFileNames;
   }, home);
+}
+
+/** Remember that this repo shared names under this project hash, so a later
+ *  `--names off` can still reach the upload after the repo (and therefore the
+ *  hash) has moved. Idempotent per (repoKey, projectHash). */
+export function recordNameShare(projectHash: string, repoKey: string, home: string = vibedriftHome()): void {
+  const store = loadActivation(home);
+  if (store.nameShares.some((s) => s.repoKey === repoKey && s.projectHash === projectHash)) return;
+  store.nameShares.push({ repoKey, projectHash, at: new Date().toISOString() });
+  saveActivation(store, home);
+}
+
+/** Every project hash this machine shared names under for one repo, newest last.
+ *  The caller adds the CURRENT hash: a repo that opted in before this record
+ *  existed has no entry here. */
+export function nameShareHashes(store: ActivationStore, repoKey: string): string[] {
+  return store.nameShares.filter((s) => s.repoKey === repoKey).map((s) => s.projectHash);
+}
+
+/** Drop one record, once its server-side names are confirmed deleted. A record
+ *  whose deletion FAILED is kept on purpose: it is the retry list. */
+export function forgetNameShare(projectHash: string, repoKey: string, home: string = vibedriftHome()): void {
+  const store = loadActivation(home);
+  const kept = store.nameShares.filter((s) => !(s.repoKey === repoKey && s.projectHash === projectHash));
+  if (kept.length === store.nameShares.length) return;
+  store.nameShares = kept;
+  saveActivation(store, home);
 }
 
 /** Record (or clear) the owed opt-out deletion the next flush retries. */

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -134,7 +134,11 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
     return { flags: [], fyi: null, baseline: null, anchors: {}, checked: false };
   }
 
-  const relPath = relative(opts.rootDir, opts.file) || opts.file;
+  // Forward slashes on every platform: the baseline stores its relative paths
+  // that way (core/discovery.ts) and so does the edit event the hook records,
+  // so a Windows separator here would both miss the baseline and hash a flag to
+  // a different file pseudonym than its own edit.
+  const relPath = relative(opts.rootDir, opts.file).replace(/\\/g, "/") || opts.file;
 
   // Non-code is a skip class (P1 contract): prose and config bodies would
   // dilute the checked-edit denominator, and a code snippet quoted inside

--- a/src/session/file-names.ts
+++ b/src/session/file-names.ts
@@ -30,6 +30,7 @@
 
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { debug } from "../core/debug.js";
 import { safeSegment } from "./ledger.js";
 import { UploadStateStore } from "./upload-state.js";
 import { toUploadEvent } from "./upload-schema.js";
@@ -43,6 +44,15 @@ import type { SessionEvent } from "./types.js";
 
 /** Server batch cap; a request never carries more than this many entries. */
 export const NAMES_BATCH_MAX = 500;
+/**
+ * Byte cap per request, comfortably under the endpoint's 256KB body limit.
+ * The entry cap alone is NOT enough: 500 entries of long multi-byte paths
+ * measure several hundred KB, and because names upload fail-open a 413 would be
+ * SILENT — the names would simply never appear on the dashboard.
+ */
+export const NAMES_BATCH_MAX_BYTES = 180 * 1024;
+/** Room for the `{"projectHash":"...","names":[]}` envelope in that budget. */
+const ENVELOPE_BYTES = 128;
 /** Server path cap, mirrored client-side. */
 export const MAX_REL_PATH_LEN = 300;
 
@@ -127,10 +137,44 @@ export async function collectFileNames(sessionsDir: string, projectHash: string)
       // The hash comes from the upload schema itself: never re-derived here.
       const hash = toUploadEvent(ev)?.fileHash;
       if (!isFileHash(hash)) continue;
-      if (!byHash.has(hash)) byHash.set(hash, rel);
+      byHash.set(hash, rel); // last occurrence wins; position stays ledger order
     }
   }
   return [...byHash].map(([fileHash, path]) => ({ fileHash, path }));
+}
+
+/**
+ * Split a manifest into the requests that may actually be sent. The last gate
+ * before the wire, so it re-applies every rule rather than trusting its input:
+ *  - drops anything whose hash or path fails validation,
+ *  - collapses a repeated fileHash (last occurrence wins) so no request can
+ *    carry the same conflict target twice,
+ *  - caps each request at NAMES_BATCH_MAX entries AND NAMES_BATCH_MAX_BYTES of
+ *    serialized JSON, whichever binds first.
+ */
+export function planNameBatches(entries: readonly FileNameEntry[]): FileNameEntry[][] {
+  const unique = new Map<string, string>();
+  for (const e of entries) {
+    if (!e || !isFileHash(e.fileHash) || !isSafeRelPath(e.path)) continue;
+    unique.set(e.fileHash, e.path); // last occurrence wins, first position kept
+  }
+
+  const batches: FileNameEntry[][] = [];
+  let current: FileNameEntry[] = [];
+  let bytes = ENVELOPE_BYTES;
+  for (const [fileHash, path] of unique) {
+    const entry: FileNameEntry = { fileHash, path };
+    const size = Buffer.byteLength(JSON.stringify(entry), "utf8") + 1; // +1 comma
+    if (current.length > 0 && (current.length >= NAMES_BATCH_MAX || bytes + size > NAMES_BATCH_MAX_BYTES)) {
+      batches.push(current);
+      current = [];
+      bytes = ENVELOPE_BYTES;
+    }
+    current.push(entry);
+    bytes += size;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
 }
 
 export function namesStatePath(sessionsDir: string, projectHash: string): string {
@@ -177,13 +221,20 @@ export async function clearUploadedNames(sessionsDir: string, projectHash: strin
   }
 }
 
+/** What the server reports per batch. Legacy/void answers count as all-stored. */
+export interface NamesPostAck {
+  stored?: number;
+  /** Entries the server refused (bad hash/path, duplicate in batch). */
+  rejected?: number;
+}
+
 export interface NamesSyncOptions {
   sessionsDir: string;
   projectHash: string;
   /** VibeDrift home: the activation store (the opt-in flag) lives here. */
   home: string;
-  /** POST one batch of at most NAMES_BATCH_MAX entries. Must reject on failure. */
-  postNames?: (entries: FileNameEntry[]) => Promise<unknown>;
+  /** POST one planned batch. Must reject on failure. */
+  postNames?: (entries: FileNameEntry[]) => Promise<NamesPostAck | void>;
   /** DELETE every uploaded name for this project. Must reject on failure. */
   deleteNames?: () => Promise<unknown>;
   /** false when the account is entitlement-locked: an owed deletion is still
@@ -192,10 +243,12 @@ export interface NamesSyncOptions {
 }
 
 export interface NamesSyncResult {
-  /** Entries the server accepted this run. */
+  /** Entries sent in requests the server answered successfully. */
   uploaded: number;
   /** Requests actually made. */
   batches: number;
+  /** Entries the server itself refused (should be 0: we validate first). */
+  rejected: number;
   /** An owed opt-out deletion completed this run. */
   deleted: boolean;
   /** A deletion is still owed to the server (retried on the next flush). */
@@ -209,7 +262,7 @@ export interface NamesSyncResult {
  * a bad server never turns into a request storm. Never throws.
  */
 export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncResult> {
-  const res: NamesSyncResult = { uploaded: 0, batches: 0, deleted: false, deletePending: false };
+  const res: NamesSyncResult = { uploaded: 0, batches: 0, rejected: 0, deleted: false, deletePending: false };
   try {
     const { sessionsDir, projectHash, home } = opts;
     const store = loadActivation(home);
@@ -240,16 +293,22 @@ export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncRe
     const fresh = entries.filter((e) => !known.has(e.fileHash));
     if (fresh.length === 0) return res;
 
-    for (let i = 0; i < fresh.length; i += NAMES_BATCH_MAX) {
-      const batch = fresh.slice(i, i + NAMES_BATCH_MAX);
+    for (const batch of planNameBatches(fresh)) {
+      let ack: NamesPostAck | void;
       try {
-        await opts.postNames(batch);
+        ack = await opts.postNames(batch);
       } catch {
         break; // one attempt per flush run; the rest waits for the next flush
       }
       res.batches++;
       res.uploaded += batch.length;
+      if (ack && typeof ack.rejected === "number") res.rejected += ack.rejected;
       await recordUploadedHashes(sessionsDir, projectHash, batch.map((e) => e.fileHash));
+    }
+    // We validate before sending, so a rejection means the server disagrees with
+    // this client. Say so once, quietly, and never retry it.
+    if (res.rejected > 0) {
+      debug("session-names", `${res.rejected} file-name entr${res.rejected === 1 ? "y" : "ies"} rejected by the server`);
     }
     return res;
   } catch {

--- a/src/session/file-names.ts
+++ b/src/session/file-names.ts
@@ -34,7 +34,10 @@
  * A name counts as uploaded only when the SERVER says it stored it. The endpoint
  * answers HTTP 200 with `ok:false` (entries `held`, code `db_error`) when its
  * write fails, so a 2xx alone is not an acceptance: held entries stay out of the
- * local record and the next flush sends them again.
+ * local record and the next flush sends them again. What the local record tracks
+ * is therefore SETTLED entries, not accepted ones: an entry the server refused
+ * outright is settled too (a rejection will not change on a retry), and
+ * recording it is what keeps it from riding along on every flush forever.
  *
  * Fail-open, always: nothing here throws, and it runs AFTER the event flush has
  * committed its offsets, so a names failure cannot block, delay or corrupt the
@@ -70,7 +73,7 @@ const ENVELOPE_BYTES = 128;
 /** Server path cap, mirrored client-side. */
 export const MAX_REL_PATH_LEN = 300;
 
-const STATE_VERSION = 1 as const;
+const STATE_VERSION = 2 as const;
 const STATE_FILE = "names-state.json";
 
 export interface FileNameEntry {
@@ -197,38 +200,44 @@ export function namesStatePath(sessionsDir: string, projectHash: string): string
   return join(sessionsDir, safeSegment(projectHash), STATE_FILE);
 }
 
-/** Hashes already accepted by the server, so a per-turn flush re-sends nothing.
- *  Fail-open: unreadable state means "send it again", which the server upserts. */
-async function readUploadedHashes(sessionsDir: string, projectHash: string): Promise<Set<string>> {
+/**
+ * Hashes the server has SETTLED — stored, deduplicated onto an existing row, or
+ * refused outright — so a per-turn flush re-sends none of them. A held entry is
+ * never in here: it is the one outcome a retry can still change.
+ *
+ * Fail-open: unreadable state (including a v1 file, which recorded accepted
+ * entries only) means "send it again", which the server upserts.
+ */
+async function readSettledHashes(sessionsDir: string, projectHash: string): Promise<Set<string>> {
   try {
     const parsed = JSON.parse(await readFile(namesStatePath(sessionsDir, projectHash), "utf8")) as {
       v?: number;
-      uploaded?: unknown;
+      settled?: unknown;
     };
-    if (parsed?.v !== STATE_VERSION || !Array.isArray(parsed.uploaded)) return new Set();
-    return new Set(parsed.uploaded.filter(isFileHash));
+    if (parsed?.v !== STATE_VERSION || !Array.isArray(parsed.settled)) return new Set();
+    return new Set(parsed.settled.filter(isFileHash));
   } catch {
     return new Set();
   }
 }
 
-/** Merge newly-accepted hashes into the local record (atomic, never throws). */
-async function recordUploadedHashes(sessionsDir: string, projectHash: string, hashes: string[]): Promise<void> {
+/** Merge newly-settled hashes into the local record (atomic, never throws). */
+async function recordSettledHashes(sessionsDir: string, projectHash: string, hashes: string[]): Promise<void> {
   try {
-    const merged = await readUploadedHashes(sessionsDir, projectHash);
+    const merged = await readSettledHashes(sessionsDir, projectHash);
     for (const h of hashes) merged.add(h);
     const dir = join(sessionsDir, safeSegment(projectHash));
     await mkdir(dir, { recursive: true, mode: 0o700 });
     const path = namesStatePath(sessionsDir, projectHash);
     const tmp = `${path}.tmp.${process.pid}`;
-    await writeFile(tmp, JSON.stringify({ v: STATE_VERSION, uploaded: [...merged] }), { mode: 0o600 });
+    await writeFile(tmp, JSON.stringify({ v: STATE_VERSION, settled: [...merged] }), { mode: 0o600 });
     await rename(tmp, path);
   } catch {
     // fail-open: the next flush re-sends, which the server upserts
   }
 }
 
-/** Forget what was uploaded, so a later opt-in re-uploads from scratch. */
+/** Forget what the server settled, so a later opt-in re-uploads from scratch. */
 export async function clearUploadedNames(sessionsDir: string, projectHash: string): Promise<void> {
   try {
     await rm(namesStatePath(sessionsDir, projectHash), { force: true });
@@ -256,16 +265,20 @@ export interface NamesPostAck {
   results?: Array<{ fileHash?: string | null; status?: string; code?: string }>;
 }
 
-/** Hashes a batch's ack says are actually on the server, or null when the ack
- *  carries no per-entry detail (then the batch is judged as a whole). */
-function persistedHashes(ack: NamesPostAck | void): Set<string> | null {
+/** What a batch's ack says happened per entry, or null when it carries no
+ *  per-entry detail (then the batch is judged as a whole). `stored` is what is
+ *  actually on the server (`duplicate`'s winning entry is); `rejected` is what
+ *  the server refused. Anything else (`held`) is neither, and stays retryable. */
+function perEntryOutcome(ack: NamesPostAck | void): { stored: Set<string>; rejected: Set<string> } | null {
   if (!ack || !Array.isArray(ack.results)) return null;
   const stored = new Set<string>();
+  const rejected = new Set<string>();
   for (const r of ack.results) {
-    if (!r || (r.status !== "stored" && r.status !== "duplicate")) continue;
-    if (isFileHash(r.fileHash)) stored.add(r.fileHash);
+    if (!r || !isFileHash(r.fileHash)) continue;
+    if (r.status === "stored" || r.status === "duplicate") stored.add(r.fileHash);
+    else if (r.status === "rejected") rejected.add(r.fileHash);
   }
-  return stored;
+  return { stored, rejected };
 }
 
 /** Entries this ack reports as accepted-but-unstored. 0 when it says nothing. */
@@ -289,11 +302,12 @@ export interface NamesSyncOptions {
 }
 
 export interface NamesSyncResult {
-  /** Entries the server actually stored (the only ones recorded locally). */
+  /** Entries the server actually stored. */
   uploaded: number;
   /** Requests actually made. */
   batches: number;
-  /** Entries the server itself refused (should be 0: we validate first). */
+  /** Entries the server itself refused (should be 0: we validate first).
+   *  Settled, so they are recorded locally and never sent again. */
   rejected: number;
   /** Entries the server accepted the request for but did NOT store (`ok:false`
    *  or a per-entry `held`). Deliberately left unrecorded: the next flush
@@ -339,7 +353,7 @@ export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncRe
 
     const entries = await collectFileNames(sessionsDir, projectHash);
     if (entries.length === 0) return res;
-    const known = await readUploadedHashes(sessionsDir, projectHash);
+    const known = await readSettledHashes(sessionsDir, projectHash);
     const fresh = entries.filter((e) => !known.has(e.fileHash));
     if (fresh.length === 0) return res;
 
@@ -360,12 +374,20 @@ export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncRe
         res.held += batch.length;
         break; // one attempt per run: the next flush re-sends this batch
       }
-      const persisted = persistedHashes(ack);
-      const stored = persisted ? batch.filter((e) => persisted.has(e.fileHash)) : batch;
+      const outcome = perEntryOutcome(ack);
+      const stored = outcome ? batch.filter((e) => outcome.stored.has(e.fileHash)) : batch;
       res.uploaded += stored.length;
       res.held += heldCount(ack);
-      if (stored.length > 0) {
-        await recordUploadedHashes(sessionsDir, projectHash, stored.map((e) => e.fileHash));
+      // Record everything the server SETTLED, which is more than what it stored:
+      // a rejection is final (we validate before sending, so a server that
+      // refuses this entry will refuse it again), and leaving it out of the
+      // record is what had every later flush carry it again forever. A held
+      // entry is deliberately excluded: that one a retry can still fix.
+      const settled = outcome
+        ? batch.filter((e) => outcome.stored.has(e.fileHash) || outcome.rejected.has(e.fileHash))
+        : batch;
+      if (settled.length > 0) {
+        await recordSettledHashes(sessionsDir, projectHash, settled.map((e) => e.fileHash));
       }
     }
     // Said once, quietly: a held entry is not an error the user can act on, and

--- a/src/session/file-names.ts
+++ b/src/session/file-names.ts
@@ -9,7 +9,7 @@
  * flush. Paths only. Never file contents, never an absolute path, never a path
  * outside the repo.
  *
- * Three rules hold this honest:
+ * Four rules hold this honest:
  *  1. The hash is NEVER re-derived here. Every entry's `fileHash` comes from
  *     `toUploadEvent()` itself, so a manifest entry can only ever describe a
  *     hash the events already carry. If the derivation changes, both move
@@ -17,7 +17,14 @@
  *  2. Only this project's own ledger contributes, and only lines the uploader
  *     already committed (flushed). A line stamped with another project's hash
  *     is skipped, so a stray record can never be relabeled into this repo.
- *  3. Every path is validated client-side with the same rules the ingest
+ *  3. PROVENANCE, not path shape, decides what is in this repo. The hook stamps
+ *     `detail.inRepo` when it resolves the edited file (hook-entry.ts), because
+ *     an out-of-repo edit is recorded by BASENAME and a basename is
+ *     indistinguishable from a file at the repo root. Only lines marked
+ *     `inRepo: true` contribute; an unmarked line (written before the field
+ *     existed) is unknown provenance and contributes nothing. That is what makes
+ *     "nothing outside this repo" a fact rather than a hope.
+ *  4. Every path is ALSO validated client-side with the same rules the ingest
  *     endpoint applies (defense in depth): an absolute path, a drive letter, a
  *     `..` segment, a backslash, a control character or an overlong path never
  *     leaves the machine, even if some future producer wrote one to the ledger.
@@ -135,8 +142,10 @@ export async function collectFileNames(sessionsDir: string, projectHash: string)
       } catch {
         continue; // corrupt line: skip, never wedge the manifest
       }
-      // Only this project's own records, and only paths that pass the wire rules.
+      // Only this project's own records, only files the hook stamped as being
+      // INSIDE this repo, and only paths that pass the wire rules.
       if (!ev || ev.projectHash !== projectHash) continue;
+      if (ev.detail?.inRepo !== true) continue; // unmarked or out-of-repo: never shared
       const rel = ev.detail?.file;
       if (!isSafeRelPath(rel)) continue;
       // The hash comes from the upload schema itself: never re-derived here.

--- a/src/session/file-names.ts
+++ b/src/session/file-names.ts
@@ -18,12 +18,14 @@
  *     already committed (flushed). A line stamped with another project's hash
  *     is skipped, so a stray record can never be relabeled into this repo.
  *  3. PROVENANCE, not path shape, decides what is in this repo. The hook stamps
- *     `detail.inRepo` when it resolves the edited file (hook-entry.ts), because
- *     an out-of-repo edit is recorded by BASENAME and a basename is
- *     indistinguishable from a file at the repo root. Only lines marked
- *     `inRepo: true` contribute; an unmarked line (written before the field
- *     existed) is unknown provenance and contributes nothing. That is what makes
- *     "nothing outside this repo" a fact rather than a hope.
+ *     `detail.inRepo` when it resolves the edited file (hook-entry.ts). Only
+ *     lines marked `inRepo: true` contribute; an unmarked line (written before
+ *     the field existed) is unknown provenance and contributes nothing. That is
+ *     what makes "nothing outside this repo" a fact rather than a hope. The hook
+ *     also records an out-of-repo edit as `../<basename>`, a form no in-repo
+ *     relative path can take, so the two can never be the same string and
+ *     therefore never the same pseudonym: a hash this manifest puts a real name
+ *     on cannot also stand for an edit outside the repo.
  *  4. Every path is ALSO validated client-side with the same rules the ingest
  *     endpoint applies (defense in depth): an absolute path, a drive letter, a
  *     `..` segment, a backslash, a control character or an overlong path never

--- a/src/session/file-names.ts
+++ b/src/session/file-names.ts
@@ -22,6 +22,11 @@
  *     `..` segment, a backslash, a control character or an overlong path never
  *     leaves the machine, even if some future producer wrote one to the ledger.
  *
+ * A name counts as uploaded only when the SERVER says it stored it. The endpoint
+ * answers HTTP 200 with `ok:false` (entries `held`, code `db_error`) when its
+ * write fails, so a 2xx alone is not an acceptance: held entries stay out of the
+ * local record and the next flush sends them again.
+ *
  * Fail-open, always: nothing here throws, and it runs AFTER the event flush has
  * committed its offsets, so a names failure cannot block, delay or corrupt the
  * flush. Turning sharing off deletes what was uploaded; if that DELETE cannot
@@ -223,9 +228,39 @@ export async function clearUploadedNames(sessionsDir: string, projectHash: strin
 
 /** What the server reports per batch. Legacy/void answers count as all-stored. */
 export interface NamesPostAck {
+  /**
+   * `false` when the server answered 200 but did NOT persist the batch (its
+   * write failed, so every entry comes back `held`). Honoring this is what
+   * makes the upload recoverable: a held batch is left out of the local record
+   * so the NEXT flush sends it again. Absent means "stored" (a legacy or void
+   * answer), which is the only safe reading of a server that predates the flag.
+   */
+  ok?: boolean;
   stored?: number;
   /** Entries the server refused (bad hash/path, duplicate in batch). */
   rejected?: number;
+  /** Per-entry outcome, when the server reports one. Only `stored` (and
+   *  `duplicate`, whose winning entry IS stored) means the row exists; `held`
+   *  and `rejected` do not. */
+  results?: Array<{ fileHash?: string | null; status?: string; code?: string }>;
+}
+
+/** Hashes a batch's ack says are actually on the server, or null when the ack
+ *  carries no per-entry detail (then the batch is judged as a whole). */
+function persistedHashes(ack: NamesPostAck | void): Set<string> | null {
+  if (!ack || !Array.isArray(ack.results)) return null;
+  const stored = new Set<string>();
+  for (const r of ack.results) {
+    if (!r || (r.status !== "stored" && r.status !== "duplicate")) continue;
+    if (isFileHash(r.fileHash)) stored.add(r.fileHash);
+  }
+  return stored;
+}
+
+/** Entries this ack reports as accepted-but-unstored. 0 when it says nothing. */
+function heldCount(ack: NamesPostAck | void): number {
+  if (!ack || !Array.isArray(ack.results)) return 0;
+  return ack.results.filter((r) => r?.status === "held").length;
 }
 
 export interface NamesSyncOptions {
@@ -243,12 +278,16 @@ export interface NamesSyncOptions {
 }
 
 export interface NamesSyncResult {
-  /** Entries sent in requests the server answered successfully. */
+  /** Entries the server actually stored (the only ones recorded locally). */
   uploaded: number;
   /** Requests actually made. */
   batches: number;
   /** Entries the server itself refused (should be 0: we validate first). */
   rejected: number;
+  /** Entries the server accepted the request for but did NOT store (`ok:false`
+   *  or a per-entry `held`). Deliberately left unrecorded: the next flush
+   *  re-sends them. */
+  held: number;
   /** An owed opt-out deletion completed this run. */
   deleted: boolean;
   /** A deletion is still owed to the server (retried on the next flush). */
@@ -262,7 +301,7 @@ export interface NamesSyncResult {
  * a bad server never turns into a request storm. Never throws.
  */
 export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncResult> {
-  const res: NamesSyncResult = { uploaded: 0, batches: 0, rejected: 0, deleted: false, deletePending: false };
+  const res: NamesSyncResult = { uploaded: 0, batches: 0, rejected: 0, held: 0, deleted: false, deletePending: false };
   try {
     const { sessionsDir, projectHash, home } = opts;
     const store = loadActivation(home);
@@ -301,9 +340,27 @@ export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncRe
         break; // one attempt per flush run; the rest waits for the next flush
       }
       res.batches++;
-      res.uploaded += batch.length;
       if (ack && typeof ack.rejected === "number") res.rejected += ack.rejected;
-      await recordUploadedHashes(sessionsDir, projectHash, batch.map((e) => e.fileHash));
+
+      // A 200 is NOT an acceptance: the server answers ok:false (every entry
+      // `held`) when its write failed. Recording those hashes would filter them
+      // out of every future flush — the names would be lost for good, silently.
+      if (ack && ack.ok === false) {
+        res.held += batch.length;
+        break; // one attempt per run: the next flush re-sends this batch
+      }
+      const persisted = persistedHashes(ack);
+      const stored = persisted ? batch.filter((e) => persisted.has(e.fileHash)) : batch;
+      res.uploaded += stored.length;
+      res.held += heldCount(ack);
+      if (stored.length > 0) {
+        await recordUploadedHashes(sessionsDir, projectHash, stored.map((e) => e.fileHash));
+      }
+    }
+    // Said once, quietly: a held entry is not an error the user can act on, and
+    // it costs nothing (the next flush re-sends it).
+    if (res.held > 0) {
+      debug("session-names", `${res.held} file-name entr${res.held === 1 ? "y" : "ies"} held by the server; retrying on the next flush`);
     }
     // We validate before sending, so a rejection means the server disagrees with
     // this client. Say so once, quietly, and never retry it.

--- a/src/session/file-names.ts
+++ b/src/session/file-names.ts
@@ -1,0 +1,258 @@
+/**
+ * The opt-in file-name manifest (per repo, default OFF).
+ *
+ * Derived events carry a file only as `fileHash` — a per-repo grouping
+ * pseudonym (see upload-schema.ts) — so the dashboard can group by file but can
+ * only ever say "file ab12cd34". A user who WANTS real names on their own
+ * dashboard turns them on for one repo with `vibedrift watch-session --names on`,
+ * and this module ships the hash -> repo-relative path mapping alongside the
+ * flush. Paths only. Never file contents, never an absolute path, never a path
+ * outside the repo.
+ *
+ * Three rules hold this honest:
+ *  1. The hash is NEVER re-derived here. Every entry's `fileHash` comes from
+ *     `toUploadEvent()` itself, so a manifest entry can only ever describe a
+ *     hash the events already carry. If the derivation changes, both move
+ *     together by construction.
+ *  2. Only this project's own ledger contributes, and only lines the uploader
+ *     already committed (flushed). A line stamped with another project's hash
+ *     is skipped, so a stray record can never be relabeled into this repo.
+ *  3. Every path is validated client-side with the same rules the ingest
+ *     endpoint applies (defense in depth): an absolute path, a drive letter, a
+ *     `..` segment, a backslash, a control character or an overlong path never
+ *     leaves the machine, even if some future producer wrote one to the ledger.
+ *
+ * Fail-open, always: nothing here throws, and it runs AFTER the event flush has
+ * committed its offsets, so a names failure cannot block, delay or corrupt the
+ * flush. Turning sharing off deletes what was uploaded; if that DELETE cannot
+ * reach the server it is recorded as pending and retried on the next flush.
+ */
+
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { safeSegment } from "./ledger.js";
+import { UploadStateStore } from "./upload-state.js";
+import { toUploadEvent } from "./upload-schema.js";
+import {
+  loadActivation,
+  namesDeleteIsPending,
+  setNamesDeletePending,
+  shareFileNamesEnabled,
+} from "./activation.js";
+import type { SessionEvent } from "./types.js";
+
+/** Server batch cap; a request never carries more than this many entries. */
+export const NAMES_BATCH_MAX = 500;
+/** Server path cap, mirrored client-side. */
+export const MAX_REL_PATH_LEN = 300;
+
+const STATE_VERSION = 1 as const;
+const STATE_FILE = "names-state.json";
+
+export interface FileNameEntry {
+  /** 16 lowercase hex — the SAME pseudonym the derived events carry. */
+  fileHash: string;
+  /** Repo-relative path, e.g. `src/payments/refund.ts`. */
+  path: string;
+}
+
+/** The 16-hex pseudonym shape the wire accepts. */
+export function isFileHash(h: unknown): h is string {
+  return typeof h === "string" && /^[0-9a-f]{16}$/.test(h);
+}
+
+/**
+ * Client-side mirror of the ingest validation. A path is shareable only when it
+ * is a plain repo-relative path: non-empty, within the length cap, no leading
+ * "/", no drive letter, no `..` segment, no backslash, no control characters.
+ * This is defense in depth, not a formality: it is the last gate before a path
+ * leaves the machine.
+ */
+export function isSafeRelPath(p: unknown): p is string {
+  if (typeof p !== "string") return false;
+  if (p.trim().length === 0) return false;
+  if (p.length > MAX_REL_PATH_LEN) return false;
+  if (p.startsWith("/")) return false;
+  if (/^[A-Za-z]:/.test(p)) return false; // C:\repo, c:/repo
+  if (p.includes("\\")) return false;
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(p)) return false;
+  return !p.split("/").some((seg) => seg === "..");
+}
+
+/**
+ * Build this project's manifest from its OWN ledger: every distinct file whose
+ * derived event has already been flushed (committed offsets), in ledger order.
+ * Never throws; an unreadable ledger simply contributes nothing.
+ */
+export async function collectFileNames(sessionsDir: string, projectHash: string): Promise<FileNameEntry[]> {
+  const dir = join(sessionsDir, safeSegment(projectHash));
+  let files: string[];
+  try {
+    files = (await readdir(dir)).filter((n) => n.endsWith(".jsonl")).sort();
+  } catch {
+    return [];
+  }
+  if (files.length === 0) return [];
+
+  const store = new UploadStateStore(sessionsDir, projectHash);
+  await store.load();
+
+  const byHash = new Map<string, string>();
+  for (const name of files) {
+    const committed = store.get(name);
+    if (committed <= 0) continue; // nothing from this ledger has shipped yet
+    let raw: string;
+    try {
+      raw = await readFile(join(dir, name), "utf8");
+    } catch {
+      continue;
+    }
+    let cursor = 0;
+    for (const line of raw.split("\n")) {
+      const end = cursor + line.length + 1; // +1 for the newline
+      cursor = end;
+      if (end > committed) break; // past what the uploader acknowledged
+      if (!line.trim()) continue;
+      let ev: SessionEvent;
+      try {
+        ev = JSON.parse(line) as SessionEvent;
+      } catch {
+        continue; // corrupt line: skip, never wedge the manifest
+      }
+      // Only this project's own records, and only paths that pass the wire rules.
+      if (!ev || ev.projectHash !== projectHash) continue;
+      const rel = ev.detail?.file;
+      if (!isSafeRelPath(rel)) continue;
+      // The hash comes from the upload schema itself: never re-derived here.
+      const hash = toUploadEvent(ev)?.fileHash;
+      if (!isFileHash(hash)) continue;
+      if (!byHash.has(hash)) byHash.set(hash, rel);
+    }
+  }
+  return [...byHash].map(([fileHash, path]) => ({ fileHash, path }));
+}
+
+export function namesStatePath(sessionsDir: string, projectHash: string): string {
+  return join(sessionsDir, safeSegment(projectHash), STATE_FILE);
+}
+
+/** Hashes already accepted by the server, so a per-turn flush re-sends nothing.
+ *  Fail-open: unreadable state means "send it again", which the server upserts. */
+async function readUploadedHashes(sessionsDir: string, projectHash: string): Promise<Set<string>> {
+  try {
+    const parsed = JSON.parse(await readFile(namesStatePath(sessionsDir, projectHash), "utf8")) as {
+      v?: number;
+      uploaded?: unknown;
+    };
+    if (parsed?.v !== STATE_VERSION || !Array.isArray(parsed.uploaded)) return new Set();
+    return new Set(parsed.uploaded.filter(isFileHash));
+  } catch {
+    return new Set();
+  }
+}
+
+/** Merge newly-accepted hashes into the local record (atomic, never throws). */
+async function recordUploadedHashes(sessionsDir: string, projectHash: string, hashes: string[]): Promise<void> {
+  try {
+    const merged = await readUploadedHashes(sessionsDir, projectHash);
+    for (const h of hashes) merged.add(h);
+    const dir = join(sessionsDir, safeSegment(projectHash));
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    const path = namesStatePath(sessionsDir, projectHash);
+    const tmp = `${path}.tmp.${process.pid}`;
+    await writeFile(tmp, JSON.stringify({ v: STATE_VERSION, uploaded: [...merged] }), { mode: 0o600 });
+    await rename(tmp, path);
+  } catch {
+    // fail-open: the next flush re-sends, which the server upserts
+  }
+}
+
+/** Forget what was uploaded, so a later opt-in re-uploads from scratch. */
+export async function clearUploadedNames(sessionsDir: string, projectHash: string): Promise<void> {
+  try {
+    await rm(namesStatePath(sessionsDir, projectHash), { force: true });
+  } catch {
+    // best effort
+  }
+}
+
+export interface NamesSyncOptions {
+  sessionsDir: string;
+  projectHash: string;
+  /** VibeDrift home: the activation store (the opt-in flag) lives here. */
+  home: string;
+  /** POST one batch of at most NAMES_BATCH_MAX entries. Must reject on failure. */
+  postNames?: (entries: FileNameEntry[]) => Promise<unknown>;
+  /** DELETE every uploaded name for this project. Must reject on failure. */
+  deleteNames?: () => Promise<unknown>;
+  /** false when the account is entitlement-locked: an owed deletion is still
+   *  honored, but nothing new is uploaded. */
+  canUpload?: boolean;
+}
+
+export interface NamesSyncResult {
+  /** Entries the server accepted this run. */
+  uploaded: number;
+  /** Requests actually made. */
+  batches: number;
+  /** An owed opt-out deletion completed this run. */
+  deleted: boolean;
+  /** A deletion is still owed to the server (retried on the next flush). */
+  deletePending: boolean;
+}
+
+/**
+ * The flush-time names step: settle any owed opt-out deletion, then (only when
+ * the repo opted in) upload the entries the server has not seen yet. One
+ * attempt per flush run: a failed request stops the run instead of retrying, so
+ * a bad server never turns into a request storm. Never throws.
+ */
+export async function syncFileNames(opts: NamesSyncOptions): Promise<NamesSyncResult> {
+  const res: NamesSyncResult = { uploaded: 0, batches: 0, deleted: false, deletePending: false };
+  try {
+    const { sessionsDir, projectHash, home } = opts;
+    const store = loadActivation(home);
+
+    // 1. The user's opt-out outranks everything: settle it first, even when the
+    //    account is locked (it is a deletion, not an upload).
+    if (namesDeleteIsPending(store, projectHash)) {
+      res.deletePending = true;
+      if (opts.deleteNames) {
+        try {
+          await opts.deleteNames();
+          setNamesDeletePending(projectHash, false, home);
+          await clearUploadedNames(sessionsDir, projectHash);
+          res.deleted = true;
+          res.deletePending = false;
+        } catch {
+          // still owed: the next flush tries again
+        }
+      }
+    }
+
+    // 2. Uploads are opt-in, and never happen for a locked account.
+    if (opts.canUpload === false || !opts.postNames || !shareFileNamesEnabled(store, projectHash)) return res;
+
+    const entries = await collectFileNames(sessionsDir, projectHash);
+    if (entries.length === 0) return res;
+    const known = await readUploadedHashes(sessionsDir, projectHash);
+    const fresh = entries.filter((e) => !known.has(e.fileHash));
+    if (fresh.length === 0) return res;
+
+    for (let i = 0; i < fresh.length; i += NAMES_BATCH_MAX) {
+      const batch = fresh.slice(i, i + NAMES_BATCH_MAX);
+      try {
+        await opts.postNames(batch);
+      } catch {
+        break; // one attempt per flush run; the rest waits for the next flush
+      }
+      res.batches++;
+      res.uploaded += batch.length;
+      await recordUploadedHashes(sessionsDir, projectHash, batch.map((e) => e.fileHash));
+    }
+    return res;
+  } catch {
+    return res; // a names fault is never the flush's problem
+  }
+}

--- a/src/session/flush-run.ts
+++ b/src/session/flush-run.ts
@@ -21,11 +21,13 @@
 
 import { refreshEntitlementCache, type EntitlementFetchResult } from "./entitlement.js";
 import { runUploaderOnce } from "./uploader.js";
+import { syncFileNames, type FileNameEntry, type NamesPostAck } from "./file-names.js";
 import type { IngestAck } from "./ingest-ack.js";
 import type { UploadEvent } from "./upload-schema.js";
 
 export interface FlushRunOptions {
-  /** Entitlement-cache dir (the VibeDrift home root). */
+  /** Entitlement-cache dir (the VibeDrift home root) — also where the
+   *  activation store that holds the per-repo file-name opt-in lives. */
   baseDir: string;
   sessionsDir: string;
   projectHash: string;
@@ -33,6 +35,10 @@ export interface FlushRunOptions {
   /** Ask the server for entitlement; must reject on failure. */
   fetchEntitlement: () => Promise<EntitlementFetchResult>;
   post: (events: UploadEvent[]) => Promise<IngestAck | void>;
+  /** Opt-in file-name manifest (off by default, per repo). Both are optional:
+   *  without them the names step is inert. */
+  postNames?: (entries: FileNameEntry[]) => Promise<NamesPostAck | void>;
+  deleteNames?: () => Promise<unknown>;
   budgetMs?: number;
   now?: () => number;
 }
@@ -57,7 +63,12 @@ export async function runFlush(opts: FlushRunOptions): Promise<FlushRunResult> {
 
   // 2. A known-locked account uploads nothing: the server would only 402 it.
   //    A null entitlement means we could not ask, which fails open (upload).
-  if (entitlement && !entitlement.entitled) return { uploaded: false, locked: true };
+  //    An owed `--names off` deletion is still honored: an opt-out must land
+  //    even on an account that can no longer sync.
+  if (entitlement && !entitlement.entitled) {
+    await settleFileNames(opts, false);
+    return { uploaded: false, locked: true };
+  }
 
   const { locked } = await runUploaderOnce({
     sessionsDir: opts.sessionsDir,
@@ -72,8 +83,32 @@ export async function runFlush(opts: FlushRunOptions): Promise<FlushRunResult> {
   //    the hook gate stops capturing on the next event.
   if (locked) {
     await refreshEntitlementCache({ baseDir, now, force: true, fetch: opts.fetchEntitlement });
+    await settleFileNames(opts, false);
     return { uploaded: true, locked: true };
   }
 
+  // 4. Last, and strictly behind the events: the opt-in file-name manifest.
+  //    Offsets are already committed by this point, so a names failure cannot
+  //    block, delay or corrupt the flush — and with the flag off (the default)
+  //    this makes no request at all.
+  await settleFileNames(opts, true);
+
   return { uploaded: true, locked: false };
+}
+
+/** Run the names step without letting it affect the flush in any way. */
+async function settleFileNames(opts: FlushRunOptions, canUpload: boolean): Promise<void> {
+  if (!opts.postNames && !opts.deleteNames) return;
+  try {
+    await syncFileNames({
+      sessionsDir: opts.sessionsDir,
+      projectHash: opts.projectHash,
+      home: opts.baseDir,
+      postNames: opts.postNames,
+      deleteNames: opts.deleteNames,
+      canUpload,
+    });
+  } catch {
+    // syncFileNames already fails open; this is the belt on the braces
+  }
 }

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -231,7 +231,7 @@ async function main(): Promise<number> {
   // Resolve the edited file to a repo-relative path. A relative file_path from
   // the hook is resolved against the repo root; an edit OUTSIDE the repo is not
   // in this repo's baseline, so we record only its basename (never a machine
-  // path) and skip the inline check.
+  // path), under an out-of-repo marker, and skip the inline check.
   //
   // The answer is STAMPED on the event (`detail.inRepo`) rather than inferred
   // downstream: consumers that promise "nothing outside this repo" — the opt-in

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -238,6 +238,14 @@ async function main(): Promise<number> {
   // from a file at the repo root. Downstream consumers that promise "nothing
   // outside this repo" — the opt-in file-name manifest — read this mark rather
   // than guessing from the path's shape.
+  //
+  // The recorded path always uses FORWARD slashes, the same normalization the
+  // scanner applies to its own relative paths (core/discovery.ts). `relative()`
+  // answers "src\payments\refund.ts" on Windows, and a backslash is refused by
+  // the wire rules, so without this the file-name manifest stays permanently
+  // empty on win32 while `--names on` reports success. This is the ledger's own
+  // field and the upload schema hashes exactly this string, so the name and the
+  // pseudonym cannot drift apart.
   let checkAbsFile: string | null = null;
   if (event.detail.file) {
     const abs = isAbsolute(event.detail.file)
@@ -245,7 +253,7 @@ async function main(): Promise<number> {
       : resolve(rootDir, event.detail.file);
     const rel = relative(rootDir, abs);
     if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
-      event.detail.file = rel;
+      event.detail.file = rel.replace(/\\/g, "/");
       event.detail.inRepo = true;
       checkAbsFile = abs;
     } else {

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -232,6 +232,12 @@ async function main(): Promise<number> {
   // the hook is resolved against the repo root; an edit OUTSIDE the repo is not
   // in this repo's baseline, so we record only its basename (never a machine
   // path) and skip the inline check.
+  //
+  // The answer is STAMPED on the event (`detail.inRepo`), because it cannot be
+  // recovered later: an out-of-repo basename ("notes.ts") is indistinguishable
+  // from a file at the repo root. Downstream consumers that promise "nothing
+  // outside this repo" — the opt-in file-name manifest — read this mark rather
+  // than guessing from the path's shape.
   let checkAbsFile: string | null = null;
   if (event.detail.file) {
     const abs = isAbsolute(event.detail.file)
@@ -240,9 +246,11 @@ async function main(): Promise<number> {
     const rel = relative(rootDir, abs);
     if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
       event.detail.file = rel;
+      event.detail.inRepo = true;
       checkAbsFile = abs;
     } else {
       event.detail.file = basename(abs);
+      event.detail.inRepo = false;
     }
   }
 

--- a/src/session/hook-entry.ts
+++ b/src/session/hook-entry.ts
@@ -233,11 +233,9 @@ async function main(): Promise<number> {
   // in this repo's baseline, so we record only its basename (never a machine
   // path) and skip the inline check.
   //
-  // The answer is STAMPED on the event (`detail.inRepo`), because it cannot be
-  // recovered later: an out-of-repo basename ("notes.ts") is indistinguishable
-  // from a file at the repo root. Downstream consumers that promise "nothing
-  // outside this repo" — the opt-in file-name manifest — read this mark rather
-  // than guessing from the path's shape.
+  // The answer is STAMPED on the event (`detail.inRepo`) rather than inferred
+  // downstream: consumers that promise "nothing outside this repo" — the opt-in
+  // file-name manifest — read the mark, never the path's shape.
   //
   // The recorded path always uses FORWARD slashes, the same normalization the
   // scanner applies to its own relative paths (core/discovery.ts). `relative()`
@@ -257,7 +255,15 @@ async function main(): Promise<number> {
       event.detail.inRepo = true;
       checkAbsFile = abs;
     } else {
-      event.detail.file = basename(abs);
+      // Outside the repo: still only the basename (never a machine path), but
+      // marked with a leading "../" so the recorded form CANNOT equal an
+      // in-repo path. An in-repo relative path never starts with ".." — that is
+      // exactly what sends an edit down this branch — so a repo-ROOT file and
+      // an out-of-repo file sharing a basename stay two distinct strings, and
+      // therefore two distinct pseudonyms, everywhere the hash is the identity.
+      // The marker also makes the path unshareable by construction: a ".."
+      // segment is refused by the wire rules on both sides.
+      event.detail.file = `../${basename(abs)}`;
       event.detail.inRepo = false;
     }
   }

--- a/src/session/repo.ts
+++ b/src/session/repo.ts
@@ -4,6 +4,7 @@
  * on the repo root, defined as the nearest ancestor containing `.git`.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { vibedriftHome } from "../core/vibedrift-home.js";
@@ -26,4 +27,39 @@ export function defaultSessionsDir(): string {
 export function repoIdentity(cwd: string): { rootDir: string; projectHash: string } {
   const rootDir = resolveRepoRoot(cwd);
   return { rootDir, projectHash: projectHash(rootDir) };
+}
+
+/**
+ * An identity for a repo that survives a MOVE on disk.
+ *
+ * `projectHash` is sha256 of the canonical root PATH, so moving or re-cloning a
+ * repo mints a new one and anything keyed on the old hash — names already
+ * uploaded, for instance — becomes unreachable from the new location. A repo's
+ * root commit is the same wherever the working copy lives, so that is the key
+ * when git can answer; otherwise we fall back to the canonical path, which is
+ * no worse than the hash it stands in for.
+ *
+ * Never throws, and never used to decide what is captured — only to link this
+ * machine's own records for one repo across its project hashes.
+ */
+export function repoKey(rootDir: string): string {
+  try {
+    const out = execFileSync("git", ["rev-list", "--max-parents=0", "HEAD"], {
+      cwd: rootDir,
+      encoding: "utf8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    // Sorted: several root commits (merged unrelated histories) must still map
+    // to one deterministic key.
+    const roots = out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => /^[0-9a-f]{40,64}$/.test(l))
+      .sort();
+    if (roots.length > 0) return `git:${roots[0]}`;
+  } catch {
+    // not a git repo, no commits yet, or no git on PATH
+  }
+  return `path:${canonicalizeRoot(rootDir)}`;
 }

--- a/src/session/session-flush.ts
+++ b/src/session/session-flush.ts
@@ -47,16 +47,22 @@ async function main(): Promise<void> {
 
   const token = cfg.token;
   const apiUrl = cfg.apiUrl;
-  const { postSessionIngest, fetchSessionEntitlement } = await import("../auth/api.js");
+  const { postSessionIngest, fetchSessionEntitlement, postSessionNames, deleteSessionNames } =
+    await import("../auth/api.js");
   const { vibedriftHome } = await import("../core/vibedrift-home.js");
   const { runFlush } = await import("./flush-run.js");
+  const hash = projectHash;
   await runFlush({
     baseDir: vibedriftHome(),
     sessionsDir,
-    projectHash,
+    projectHash: hash,
     teamIntentOptIn: cfg.sessionsTeamIntentOptIn === true,
     fetchEntitlement: () => fetchSessionEntitlement(token, { apiUrl }),
     post: (events) => postSessionIngest(token, events, { apiUrl }),
+    // Opt-in per repo (default off). runFlush only calls these when this repo's
+    // `--names on` flag is set, or when an opt-out deletion is still owed.
+    postNames: (names) => postSessionNames(token, hash, names, { apiUrl }),
+    deleteNames: () => deleteSessionNames(token, hash, { apiUrl }),
   });
 }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -32,6 +32,14 @@ export interface SessionEventDetail {
    *  baseline, check error). Absent on ledger lines written before this
    *  field existed. */
   checked?: boolean;
+  /** edit events only: PROVENANCE of `file`, stamped by the hook at the moment
+   *  it resolved the path. true = the edit landed inside this repo and `file` is
+   *  repo-relative; false = it landed outside, so `file` is only a basename.
+   *  The two look identical for a root-level file, so the opt-in file-name
+   *  manifest keys on this mark, never on the path's shape. Absent on ledger
+   *  lines written before this field existed: unknown, and treated as
+   *  "not shareable" rather than assumed in-repo. */
+  inRepo?: boolean;
   category?: string;
   dominant?: string;
   observed?: string;

--- a/test/integration/session-hook.test.ts
+++ b/test/integration/session-hook.test.ts
@@ -69,14 +69,14 @@ describe("hook entry (integration)", () => {
     const ev = JSON.parse(lines[0]);
     expect(ev.type).toBe("edit");
     expect(ev.detail.diffstat).toBe("+1");
-    expect(ev.detail.file).toBe(join("src", "a.ts"));
+    expect(ev.detail.file).toBe("src/a.ts");
     expect(lines[0]).not.toContain("UNIQUE_BODY_SENTINEL_9f2");
     expect(ev.body).toBeUndefined();
     // no baseline in this repo, so the inline check was skipped
     expect(ev.detail.checked).toBe(false);
   });
 
-  it("records checked=false (and only the basename) for an out-of-repo edit", () => {
+  it("records checked=false (and only the marked basename) for an out-of-repo edit", () => {
     const home = tmp("vd-home-");
     const repo = tmp("vd-repo-");
     const elsewhere = tmp("vd-outside-");
@@ -91,7 +91,9 @@ describe("hook entry (integration)", () => {
     expect(r.status).toBe(0);
     const ev = JSON.parse(ledgerLines(home, "it-out")[0]);
     expect(ev.type).toBe("edit");
-    expect(ev.detail.file).toBe("notes.ts");
+    // the basename only, marked so it can never be read as a repo-root file
+    expect(ev.detail.file).toBe("../notes.ts");
+    expect(ev.detail.file).not.toContain(elsewhere);
     expect(ev.detail.checked).toBe(false);
     // provenance is stamped at the source: this file was NOT in the repo
     expect(ev.detail.inRepo).toBe(false);
@@ -110,7 +112,7 @@ describe("hook entry (integration)", () => {
       tool_input: { file_path: file, content: "export const x = 1;\n" },
     });
     expect(runHook(home, edit(join(repo, "src", "in.ts"))).status).toBe(0);
-    // an edit outside the repo, recorded by basename — the shape of a root file
+    // an edit outside the repo, recorded by basename under an out-of-repo marker
     expect(runHook(home, edit(join(elsewhere, "secret-notes.ts"))).status).toBe(0);
 
     const sessions = join(home, ".vibedrift", "sessions");
@@ -121,12 +123,53 @@ describe("hook entry (integration)", () => {
     await store.commit(new Map([["it-manifest.jsonl", readFileSync(ledger, "utf8").length]]));
 
     const events = ledgerLines(home, "it-manifest").map((l) => JSON.parse(l));
-    expect(events.map((e) => e.detail.file)).toEqual([join("src", "in.ts"), "secret-notes.ts"]);
+    expect(events.map((e) => e.detail.file)).toEqual(["src/in.ts", "../secret-notes.ts"]);
     expect(events.map((e) => e.detail.inRepo)).toEqual([true, false]);
 
     const entries = await collectFileNames(sessions, hash);
-    expect(entries.map((e) => e.path)).toEqual([join("src", "in.ts")]);
+    expect(entries.map((e) => e.path)).toEqual(["src/in.ts"]);
     expect(JSON.stringify(entries)).not.toContain("secret-notes.ts");
+  });
+
+  it("an out-of-repo edit can never share a file hash with a repo-ROOT file", async () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    const elsewhere = tmp("vd-outside-");
+    mkdirSync(join(repo, ".git"));
+    const edit = (file: string) => ({
+      session_id: "it-collide",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: file, content: "export const x = 1;\n" },
+    });
+    // the same basename, once at the repo root and once outside the repo
+    expect(runHook(home, edit(join(repo, "notes.ts"))).status).toBe(0);
+    expect(runHook(home, edit(join(elsewhere, "notes.ts"))).status).toBe(0);
+
+    const events = ledgerLines(home, "it-collide").map((l) => JSON.parse(l) as SessionEvent);
+    const edits = events.filter((e) => e.type === "edit");
+    expect(edits.map((e) => e.detail.inRepo)).toEqual([true, false]);
+    const [inside, outside] = edits.map((e) => toUploadEvent(e)?.fileHash);
+    expect(inside).toMatch(/^[0-9a-f]{16}$/);
+    // two different files, so nothing else is recorded: identical recorded
+    // paths also had the revert detector read the second edit as the first
+    // file being restored.
+    expect(events.map((e) => e.type)).toEqual(["edit", "edit"]);
+    // The pseudonym the manifest puts a real name on must not ALSO stand for
+    // out-of-repo activity, or the dashboard shows an in-repo path on a row
+    // that is partly someone else's file.
+    expect(outside).not.toBe(inside);
+
+    const sessions = join(home, ".vibedrift", "sessions");
+    const hash = readdirSync(sessions)[0];
+    const ledger = join(sessions, hash, "it-collide.jsonl");
+    const store = new UploadStateStore(sessions, hash);
+    await store.load();
+    await store.commit(new Map([["it-collide.jsonl", readFileSync(ledger, "utf8").length]]));
+
+    const entries = await collectFileNames(sessions, hash);
+    expect(entries).toEqual([{ fileHash: inside, path: "notes.ts" }]);
   });
 
   it("records a Windows-style relative path portably, so the manifest still fills", async () => {

--- a/test/integration/session-hook.test.ts
+++ b/test/integration/session-hook.test.ts
@@ -3,6 +3,8 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { collectFileNames } from "@/session/file-names";
+import { UploadStateStore } from "@/session/upload-state";
 
 const ENTRY = join(process.cwd(), "src", "session", "hook-entry.ts");
 const BUILDER = join(process.cwd(), "test", "helpers", "session-build-baseline.ts");
@@ -89,6 +91,40 @@ describe("hook entry (integration)", () => {
     expect(ev.type).toBe("edit");
     expect(ev.detail.file).toBe("notes.ts");
     expect(ev.detail.checked).toBe(false);
+    // provenance is stamped at the source: this file was NOT in the repo
+    expect(ev.detail.inRepo).toBe(false);
+  });
+
+  it("an out-of-repo edit never becomes a file-name manifest entry", async () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    const elsewhere = tmp("vd-outside-");
+    mkdirSync(join(repo, ".git"));
+    const edit = (file: string) => ({
+      session_id: "it-manifest",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: file, content: "export const x = 1;\n" },
+    });
+    expect(runHook(home, edit(join(repo, "src", "in.ts"))).status).toBe(0);
+    // an edit outside the repo, recorded by basename — the shape of a root file
+    expect(runHook(home, edit(join(elsewhere, "secret-notes.ts"))).status).toBe(0);
+
+    const sessions = join(home, ".vibedrift", "sessions");
+    const hash = readdirSync(sessions)[0];
+    const ledger = join(sessions, hash, "it-manifest.jsonl");
+    const store = new UploadStateStore(sessions, hash);
+    await store.load();
+    await store.commit(new Map([["it-manifest.jsonl", readFileSync(ledger, "utf8").length]]));
+
+    const events = ledgerLines(home, "it-manifest").map((l) => JSON.parse(l));
+    expect(events.map((e) => e.detail.file)).toEqual([join("src", "in.ts"), "secret-notes.ts"]);
+    expect(events.map((e) => e.detail.inRepo)).toEqual([true, false]);
+
+    const entries = await collectFileNames(sessions, hash);
+    expect(entries.map((e) => e.path)).toEqual([join("src", "in.ts")]);
+    expect(JSON.stringify(entries)).not.toContain("secret-notes.ts");
   });
 
   it("captures NOTHING when the entitlement cache says locked", () => {

--- a/test/integration/session-hook.test.ts
+++ b/test/integration/session-hook.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { collectFileNames } from "@/session/file-names";
 import { UploadStateStore } from "@/session/upload-state";
+import { toUploadEvent } from "@/session/upload-schema";
+import type { SessionEvent } from "@/session/types";
 
 const ENTRY = join(process.cwd(), "src", "session", "hook-entry.ts");
 const BUILDER = join(process.cwd(), "test", "helpers", "session-build-baseline.ts");
@@ -125,6 +127,39 @@ describe("hook entry (integration)", () => {
     const entries = await collectFileNames(sessions, hash);
     expect(entries.map((e) => e.path)).toEqual([join("src", "in.ts")]);
     expect(JSON.stringify(entries)).not.toContain("secret-notes.ts");
+  });
+
+  it("records a Windows-style relative path portably, so the manifest still fills", async () => {
+    const home = tmp("vd-home-");
+    const repo = tmp("vd-repo-");
+    mkdirSync(join(repo, ".git"));
+    // Byte for byte what node's relative() returns on win32 for
+    // <repo>\src\payments\refund.ts. A backslash is refused by the wire rules,
+    // so an unnormalized ledger leaves the manifest permanently empty on
+    // Windows while `--names on` still reports success.
+    const r = runHook(home, {
+      session_id: "it-win",
+      cwd: repo,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: "src\\payments\\refund.ts", content: "export const x = 1;\n" },
+    });
+    expect(r.status).toBe(0);
+    const event = JSON.parse(ledgerLines(home, "it-win")[0]) as SessionEvent;
+    expect(event.detail.file).toBe("src/payments/refund.ts");
+    expect(event.detail.inRepo).toBe(true);
+
+    const sessions = join(home, ".vibedrift", "sessions");
+    const hash = readdirSync(sessions)[0];
+    const ledger = join(sessions, hash, "it-win.jsonl");
+    const store = new UploadStateStore(sessions, hash);
+    await store.load();
+    await store.commit(new Map([["it-win.jsonl", readFileSync(ledger, "utf8").length]]));
+
+    const entries = await collectFileNames(sessions, hash);
+    expect(entries.map((e) => e.path)).toEqual(["src/payments/refund.ts"]);
+    // and it names the very hash the uploaded event carries for that file
+    expect(entries[0].fileHash).toBe(toUploadEvent(event)?.fileHash);
   });
 
   it("captures NOTHING when the entitlement cache says locked", () => {

--- a/test/unit/cli/watch-session.test.ts
+++ b/test/unit/cli/watch-session.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runWatchSession } from "@/cli/commands/watch-session";
 import { readConfig } from "@/auth/config";
+import { repoIdentity } from "@/session/repo";
+import { loadActivation, shareFileNamesEnabled, namesDeleteIsPending } from "@/session/activation";
 
 function tmp(prefix: string): string {
   return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
@@ -159,5 +161,93 @@ describe("runWatchSession", () => {
     });
     expect(status).toBe("login_required");
     expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("runWatchSession — file-name sharing toggle (--names)", () => {
+  const hashOf = (repo: string) => repoIdentity(repo).projectHash;
+
+  it("--names on prints the disclosure BEFORE writing the flag, and installs nothing", async () => {
+    const repo = repoWithAgent();
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    const hash = hashOf(repo);
+    const lines: string[] = [];
+    const flagWhenPrinted: boolean[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+      flagWhenPrinted.push(shareFileNamesEnabled(loadActivation(activationHome), hash));
+    });
+    const status = await runWatchSession(repo, { names: "on", activationHome, sessionsDir });
+    expect(status).toBe("names_updated");
+    expect(shareFileNamesEnabled(loadActivation(activationHome), hash)).toBe(true);
+    // the whole disclosure was on screen before the flag existed on disk
+    const confirmIdx = lines.findIndex((l) => /File names are ON/i.test(l));
+    expect(confirmIdx).toBeGreaterThan(0);
+    expect(flagWhenPrinted.slice(0, confirmIdx)).toEqual(flagWhenPrinted.slice(0, confirmIdx).map(() => false));
+    expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+  });
+
+  it("the disclosure says paths only, names the reversal, and uses no em-dashes", async () => {
+    const repo = repoWithAgent();
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(repo, { names: "on", activationHome, sessionsDir });
+    const printed = log.mock.calls.flat().map(String).join("\n");
+    expect(printed).toMatch(/repo-relative/i);
+    expect(printed).toMatch(/never .*file contents/i);
+    expect(printed).toMatch(/never .*absolute path/i);
+    expect(printed).toContain("vibedrift watch-session --names off");
+    expect(printed).toMatch(/delete/i);
+    expect(printed).not.toMatch(/[—–]/);
+  });
+
+  it("--names off deletes the uploaded names, then clears the flag", async () => {
+    const repo = repoWithAgent();
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    const hash = hashOf(repo);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(repo, { names: "on", activationHome, sessionsDir });
+    let deletes = 0;
+    const flagWhenDeleted: boolean[] = [];
+    const status = await runWatchSession(repo, {
+      names: "off",
+      activationHome,
+      sessionsDir,
+      deleteNames: async () => {
+        deletes++;
+        flagWhenDeleted.push(shareFileNamesEnabled(loadActivation(activationHome), hash));
+        return { deleted: 3 };
+      },
+    });
+    expect(status).toBe("names_updated");
+    expect(deletes).toBe(1);
+    expect(flagWhenDeleted).toEqual([true]); // DELETE first, then clear the flag
+    expect(shareFileNamesEnabled(loadActivation(activationHome), hash)).toBe(false);
+    expect(namesDeleteIsPending(loadActivation(activationHome), hash)).toBe(false);
+    const printed = log.mock.calls.flat().map(String).join("\n");
+    expect(printed).toMatch(/File names are OFF/i);
+  });
+
+  it("--names off with an unreachable server still turns sharing off and queues the delete", async () => {
+    const repo = repoWithAgent();
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    const hash = hashOf(repo);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(repo, { names: "on", activationHome, sessionsDir });
+    const status = await runWatchSession(repo, {
+      names: "off",
+      activationHome,
+      sessionsDir,
+      deleteNames: async () => { throw new Error("offline"); },
+    });
+    expect(status).toBe("names_updated");
+    expect(shareFileNamesEnabled(loadActivation(activationHome), hash)).toBe(false);
+    expect(namesDeleteIsPending(loadActivation(activationHome), hash)).toBe(true);
+    const printed = log.mock.calls.flat().map(String).join("\n");
+    expect(printed).toMatch(/retried on the next/i);
   });
 });

--- a/test/unit/cli/watch-session.test.ts
+++ b/test/unit/cli/watch-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, realpathSync, renameSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runWatchSession } from "@/cli/commands/watch-session";
@@ -15,6 +16,26 @@ function repoWithAgent(): string {
   const repo = tmp("vd-ws-");
   mkdirSync(join(repo, ".git"));
   mkdirSync(join(repo, ".claude"));
+  return repo;
+}
+
+/** A REAL git repo (one commit), so its identity survives a move on disk —
+ *  which a path-derived project hash does not. */
+function gitRepoWithAgent(): string {
+  const repo = tmp("vd-ws-git-");
+  mkdirSync(join(repo, ".claude"));
+  execFileSync("git", ["init", "-q"], { cwd: repo, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c", "user.email=test@example.com",
+      "-c", "user.name=Test",
+      "-c", "commit.gpgsign=false",
+      "-c", "core.hooksPath=/dev/null",
+      "commit", "-q", "--allow-empty", "-m", "init",
+    ],
+    { cwd: repo, stdio: "ignore" },
+  );
   return repo;
 }
 
@@ -249,5 +270,78 @@ describe("runWatchSession — file-name sharing toggle (--names)", () => {
     expect(namesDeleteIsPending(loadActivation(activationHome), hash)).toBe(true);
     const printed = log.mock.calls.flat().map(String).join("\n");
     expect(printed).toMatch(/retried on the next/i);
+    // a deletion that did not happen is never reported as one
+    expect(printed).not.toMatch(/removed from your dashboard/i);
+  });
+
+  it("--names off deletes the names uploaded under a PREVIOUS project hash (repo moved)", async () => {
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const before = gitRepoWithAgent();
+    const oldHash = hashOf(before);
+    await runWatchSession(before, { names: "on", activationHome, sessionsDir });
+
+    // the repo moves on disk: same repo, brand new project hash
+    const after = join(before, "..", `moved-${Date.now()}`);
+    renameSync(before, after);
+    const newHash = hashOf(after);
+    expect(newHash).not.toBe(oldHash);
+
+    const deleted: string[] = [];
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(after, {
+      names: "off",
+      activationHome,
+      sessionsDir,
+      deleteNames: async (projectHash: string) => { deleted.push(projectHash); return { deleted: 2 }; },
+    });
+    expect(deleted).toContain(oldHash);
+    expect(deleted).toContain(newHash);
+    const printed = log.mock.calls.flat().map(String).join("\n");
+    expect(printed).toMatch(/File names are OFF/i);
+    rmSync(after, { recursive: true, force: true });
+  });
+
+  it("--names off reports only what it removed when an earlier upload cannot be deleted", async () => {
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const before = gitRepoWithAgent();
+    const oldHash = hashOf(before);
+    await runWatchSession(before, { names: "on", activationHome, sessionsDir });
+    const after = join(before, "..", `moved-${Date.now()}-b`);
+    renameSync(before, after);
+    const newHash = hashOf(after);
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runWatchSession(after, {
+      names: "off",
+      activationHome,
+      sessionsDir,
+      deleteNames: async (projectHash: string) => {
+        if (projectHash === oldHash) throw new Error("offline");
+        return { deleted: 1 };
+      },
+    });
+    const printed = log.mock.calls.flat().map(String).join("\n");
+    // sharing is off locally, and the copy never claims the removal it failed
+    expect(printed).toMatch(/File names are OFF for this repo; nothing more will be uploaded/i);
+    expect(printed).not.toMatch(/removed from your dashboard/i);
+    expect(printed).toMatch(/could not be removed/i);
+    expect(printed).toMatch(/re-run/i);
+    // the current hash succeeded, so it is not queued; the earlier one is kept
+    expect(namesDeleteIsPending(loadActivation(activationHome), newHash)).toBe(false);
+
+    // re-running retries exactly the upload that is still out there
+    const retried: string[] = [];
+    await runWatchSession(after, {
+      names: "off",
+      activationHome,
+      sessionsDir,
+      deleteNames: async (projectHash: string) => { retried.push(projectHash); return { deleted: 2 }; },
+    });
+    expect(retried).toContain(oldHash);
+    rmSync(after, { recursive: true, force: true });
   });
 });

--- a/test/unit/cli/watch-session.test.ts
+++ b/test/unit/cli/watch-session.test.ts
@@ -7,6 +7,10 @@ import { runWatchSession } from "@/cli/commands/watch-session";
 import { readConfig } from "@/auth/config";
 import { repoIdentity } from "@/session/repo";
 import { loadActivation, shareFileNamesEnabled, namesDeleteIsPending } from "@/session/activation";
+import { appendEvent } from "@/session/ledger";
+import { UploadStateStore } from "@/session/upload-state";
+import { syncFileNames, type FileNameEntry } from "@/session/file-names";
+import type { SessionEvent } from "@/session/types";
 
 function tmp(prefix: string): string {
   return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
@@ -37,6 +41,37 @@ function gitRepoWithAgent(): string {
     { cwd: repo, stdio: "ignore" },
   );
   return repo;
+}
+
+/** A second working copy of the SAME repo (a clone or a worktree): one repo
+ *  identity, two paths, therefore two project hashes. */
+function cloneOf(src: string): string {
+  const dest = join(tmp("vd-ws-clone-"), "clone");
+  execFileSync("git", ["clone", "-q", src, dest], { stdio: "ignore" });
+  mkdirSync(join(dest, ".claude"), { recursive: true });
+  return realpathSync(dest);
+}
+
+/** One flushed edit in a project's ledger: the raw material a names flush
+ *  uploads from. */
+async function flushedEdit(sessionsDir: string, projectHash: string, file: string): Promise<void> {
+  const event: SessionEvent = {
+    v: 1,
+    sid: "s1",
+    aid: `evt-${file}`,
+    ts: new Date().toISOString(),
+    agent: "claude-code",
+    projectHash,
+    channel: "hook",
+    type: "edit",
+    mode: "passive",
+    detail: { file, diffstat: "+1", inRepo: true },
+  };
+  await appendEvent(sessionsDir, projectHash, "s1", event);
+  const store = new UploadStateStore(sessionsDir, projectHash);
+  await store.load();
+  const raw = readFileSync(join(sessionsDir, projectHash, "s1.jsonl"), "utf8");
+  await store.commit(new Map([["s1.jsonl", raw.length]]));
 }
 
 afterEach(() => {
@@ -343,5 +378,47 @@ describe("runWatchSession — file-name sharing toggle (--names)", () => {
     });
     expect(retried).toContain(oldHash);
     rmSync(after, { recursive: true, force: true });
+  });
+
+  it("--names off in one clone disarms the OTHER clone too, so nothing re-uploads", async () => {
+    const activationHome = tmp("vd-ws-act-");
+    const sessionsDir = tmp("vd-ws-sess-");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    // Two working copies of ONE repo (a clone or a git worktree): the same repo
+    // identity, two paths, two project hashes.
+    const cloneA = gitRepoWithAgent();
+    const cloneB = cloneOf(cloneA);
+    const hashA = hashOf(cloneA);
+    const hashB = hashOf(cloneB);
+    expect(hashA).not.toBe(hashB);
+
+    await runWatchSession(cloneA, { names: "on", activationHome, sessionsDir });
+    await runWatchSession(cloneB, { names: "on", activationHome, sessionsDir });
+    await flushedEdit(sessionsDir, hashA, "src/a.ts");
+
+    const deleted: string[] = [];
+    await runWatchSession(cloneB, {
+      names: "off",
+      activationHome,
+      sessionsDir,
+      deleteNames: async (projectHash: string) => { deleted.push(projectHash); return { deleted: 1 }; },
+    });
+    // the opt-out deleted BOTH copies' uploads, so it must disarm both: leaving
+    // clone A opted in would silently re-upload what the user just removed.
+    expect(deleted.sort()).toEqual([hashA, hashB].sort());
+    expect(shareFileNamesEnabled(loadActivation(activationHome), hashB)).toBe(false);
+    expect(shareFileNamesEnabled(loadActivation(activationHome), hashA)).toBe(false);
+
+    // end to end: clone A's next flush uploads nothing at all
+    const sent: FileNameEntry[][] = [];
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hashA,
+      home: activationHome,
+      canUpload: true,
+      postNames: async (entries) => { sent.push(entries); },
+    });
+    expect(sent).toEqual([]);
+    rmSync(cloneB, { recursive: true, force: true });
   });
 });

--- a/test/unit/session/activation.test.ts
+++ b/test/unit/session/activation.test.ts
@@ -17,6 +17,9 @@ import {
   setShareFileNames,
   namesDeleteIsPending,
   setNamesDeletePending,
+  recordNameShare,
+  nameShareHashes,
+  forgetNameShare,
 } from "@/session/activation";
 
 const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-act-")));
@@ -25,7 +28,7 @@ describe("activation store", () => {
   it("missing file loads as empty (unanswered)", () => {
     const home = tmp();
     const store = loadActivation(home);
-    expect(store).toEqual({ v: 1, projects: {}, dirGrants: [] });
+    expect(store).toEqual({ v: 1, projects: {}, dirGrants: [], nameShares: [] });
     expect(projectStatus(store, "h1")).toBe("unanswered");
   });
 
@@ -193,6 +196,19 @@ describe("per-repo file-name sharing (opt-in manifest)", () => {
     expect(projectStatus(store, "h1")).toBe("active");
     expect(shareFileNamesEnabled(store, "h1")).toBe(true);
     expect(store.projects.h1.surface).toBe("cli-enable");
+  });
+
+  it("records every project hash one repo shared names under, and forgets one at a time", () => {
+    const home = tmp();
+    expect(nameShareHashes(loadActivation(home), "git:abc")).toEqual([]);
+    recordNameShare("h1", "git:abc", home);
+    recordNameShare("h1", "git:abc", home); // idempotent
+    recordNameShare("h2", "git:abc", home); // the same repo, moved on disk
+    recordNameShare("h3", "git:other", home); // a different repo entirely
+    expect(nameShareHashes(loadActivation(home), "git:abc")).toEqual(["h1", "h2"]);
+    forgetNameShare("h1", "git:abc", home);
+    expect(nameShareHashes(loadActivation(home), "git:abc")).toEqual(["h2"]);
+    expect(nameShareHashes(loadActivation(home), "git:other")).toEqual(["h3"]);
   });
 
   it("a pending opt-out delete round-trips and clears", () => {

--- a/test/unit/session/activation.test.ts
+++ b/test/unit/session/activation.test.ts
@@ -13,6 +13,10 @@ import {
   resolveGrantPath,
   addDirGrant,
   DirGrantRefusedError,
+  shareFileNamesEnabled,
+  setShareFileNames,
+  namesDeleteIsPending,
+  setNamesDeletePending,
 } from "@/session/activation";
 
 const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-act-")));
@@ -161,5 +165,42 @@ describe("dir-grant refusals (O19)", () => {
     const link = join(base, "link");
     symlinkSync(real, link);
     expect(resolveGrantPath(link)).toBe(real);
+  });
+});
+
+describe("per-repo file-name sharing (opt-in manifest)", () => {
+  it("is OFF by default, for a missing store and for an activated repo", () => {
+    const home = tmp();
+    expect(shareFileNamesEnabled(loadActivation(home), "h1")).toBe(false);
+    recordAnswer("h1", "active", "cli-enable", home);
+    expect(shareFileNamesEnabled(loadActivation(home), "h1")).toBe(false);
+  });
+
+  it("setShareFileNames round-trips per repo and never leaks to another repo", () => {
+    const home = tmp();
+    setShareFileNames("h1", true, home);
+    expect(shareFileNamesEnabled(loadActivation(home), "h1")).toBe(true);
+    expect(shareFileNamesEnabled(loadActivation(home), "h2")).toBe(false);
+    setShareFileNames("h1", false, home);
+    expect(shareFileNamesEnabled(loadActivation(home), "h1")).toBe(false);
+  });
+
+  it("keeps the activation answer intact when the flag flips", () => {
+    const home = tmp();
+    recordAnswer("h1", "active", "cli-enable", home);
+    setShareFileNames("h1", true, home);
+    const store = loadActivation(home);
+    expect(projectStatus(store, "h1")).toBe("active");
+    expect(shareFileNamesEnabled(store, "h1")).toBe(true);
+    expect(store.projects.h1.surface).toBe("cli-enable");
+  });
+
+  it("a pending opt-out delete round-trips and clears", () => {
+    const home = tmp();
+    expect(namesDeleteIsPending(loadActivation(home), "h1")).toBe(false);
+    setNamesDeletePending("h1", true, home);
+    expect(namesDeleteIsPending(loadActivation(home), "h1")).toBe(true);
+    setNamesDeletePending("h1", false, home);
+    expect(namesDeleteIsPending(loadActivation(home), "h1")).toBe(false);
   });
 });

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -75,6 +75,15 @@ describe("runEditChecks", () => {
     expect(out.fyi!.toLowerCase()).not.toContain("prevented");
   });
 
+  it("records the flagged file with forward slashes, whatever the separator was", async () => {
+    // What relative() answers on win32 for <repo>\src\winroutes.ts. The flag's
+    // file must land in the same form the edit event records, or the two hash
+    // to different pseudonyms and one file shows up as two on the dashboard.
+    const out = await runEditChecks(opts({ sessionId: "s-winpath", file: join(repo, "src\\winroutes.ts") }));
+    expect(out.flags.length).toBeGreaterThanOrEqual(1);
+    expect(out.flags[0].detail.file).toBe("src/winroutes.ts");
+  });
+
   it("suppresses the FYI (but keeps flags) within the cooldown window", async () => {
     const first = await runEditChecks(opts({ sessionId: "s-cool" }));
     expect(first.fyi).toBeTruthy();

--- a/test/unit/session/file-names.test.ts
+++ b/test/unit/session/file-names.test.ts
@@ -398,6 +398,107 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
     expect(res).toMatchObject({ batches: 1, rejected: 1 });
   });
 
+  it("a held batch (ok:false) records nothing, and the next flush re-sends it", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts", "src/b.ts"]);
+    setShareFileNames(hash, true, base);
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => ({
+        ok: false,
+        stored: 0,
+        rejected: 0,
+        results: entries.map((e) => ({ fileHash: e.fileHash, status: "held" as const, code: "db_error" })),
+      }),
+    });
+    expect(res).toMatchObject({ uploaded: 0, held: 2 });
+    // nothing was written to the local record, so nothing is filtered out later
+    expect(existsSync(namesStatePath(sessionsDir, hash))).toBe(false);
+    const sent: FileNameEntry[][] = [];
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => { sent.push(entries); return { ok: true, stored: entries.length, rejected: 0 }; },
+    });
+    expect(sent.flat().map((e) => e.path).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("a held batch stops the run: the remaining batches wait for the next flush", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    const dir = join(sessionsDir, hash);
+    mkdirSync(dir, { recursive: true });
+    const lines = Array.from({ length: NAMES_BATCH_MAX + 3 }, (_, i) =>
+      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1", inRepo: true } })),
+    );
+    writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
+    await markFlushed(sessionsDir, hash);
+    setShareFileNames(hash, true, base);
+    let posts = 0;
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async () => { posts++; return { ok: false, stored: 0, rejected: 0 }; },
+    });
+    expect(posts).toBe(1);
+    expect(res.uploaded).toBe(0);
+    expect(res.held).toBe(NAMES_BATCH_MAX);
+  });
+
+  it("an ok:true batch IS recorded, so the next flush sends nothing", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    setShareFileNames(hash, true, base);
+    const opts = {
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries: FileNameEntry[]) => ({ ok: true, stored: entries.length, rejected: 0 }),
+    };
+    const first = await syncFileNames(opts);
+    expect(first).toMatchObject({ uploaded: 1, batches: 1, held: 0 });
+    let posts = 0;
+    await syncFileNames({ ...opts, postNames: async (e) => { posts++; return { ok: true, stored: e.length, rejected: 0 }; } });
+    expect(posts).toBe(0);
+  });
+
+  it("per-entry results: only the entries the server stored are recorded", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts", "src/b.ts"]);
+    setShareFileNames(hash, true, base);
+    const first = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => ({
+        ok: true,
+        stored: 1,
+        rejected: 0,
+        results: [
+          { fileHash: entries[0].fileHash, status: "stored" as const },
+          { fileHash: entries[1].fileHash, status: "held" as const, code: "db_error" },
+        ],
+      }),
+    });
+    expect(first).toMatchObject({ uploaded: 1, held: 1 });
+    const sent: FileNameEntry[][] = [];
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => { sent.push(entries); return { ok: true, stored: entries.length, rejected: 0 }; },
+    });
+    expect(sent.flat().map((e) => e.path)).toEqual(["src/b.ts"]);
+  });
+
   it("retries a pending opt-out delete, clears the flag state and the local manifest record", async () => {
     const { base, sessionsDir, hash } = await project(["src/a.ts"]);
     setShareFileNames(hash, true, base);

--- a/test/unit/session/file-names.test.ts
+++ b/test/unit/session/file-names.test.ts
@@ -421,6 +421,35 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
     expect(res).toMatchObject({ batches: 1, rejected: 1 });
   });
 
+  it("sends a REJECTED entry exactly once, while a held one keeps retrying", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts", "src/b.ts"]);
+    setShareFileNames(hash, true, base);
+    const sent: string[][] = [];
+    // The server refuses one entry outright and holds the other: a rejection is
+    // settled (we validated before sending, so it will never be accepted), a
+    // hold is not.
+    const postNames = async (entries: FileNameEntry[]) => {
+      sent.push(entries.map((e) => e.path));
+      return {
+        ok: true,
+        stored: 0,
+        rejected: 1,
+        results: entries.map((e) =>
+          e.path === "src/a.ts"
+            ? { fileHash: e.fileHash, status: "rejected" as const, code: "bad_path" }
+            : { fileHash: e.fileHash, status: "held" as const, code: "db_error" },
+        ),
+      };
+    };
+    const opts = { sessionsDir, projectHash: hash, home: base, canUpload: true, postNames };
+    const first = await syncFileNames(opts);
+    await syncFileNames(opts);
+    await syncFileNames(opts);
+    expect(first).toMatchObject({ uploaded: 0, rejected: 1, held: 1 });
+    expect(sent.flat().filter((p) => p === "src/a.ts")).toHaveLength(1);
+    expect(sent.flat().filter((p) => p === "src/b.ts")).toHaveLength(3);
+  });
+
   it("a held batch (ok:false) records nothing, and the next flush re-sends it", async () => {
     const { base, sessionsDir, hash } = await project(["src/a.ts", "src/b.ts"]);
     setShareFileNames(hash, true, base);

--- a/test/unit/session/file-names.test.ts
+++ b/test/unit/session/file-names.test.ts
@@ -8,7 +8,9 @@ import { toUploadEvent } from "@/session/upload-schema";
 import { loadActivation, setShareFileNames, setNamesDeletePending, namesDeleteIsPending } from "@/session/activation";
 import {
   NAMES_BATCH_MAX,
+  NAMES_BATCH_MAX_BYTES,
   MAX_REL_PATH_LEN,
+  planNameBatches,
   isSafeRelPath,
   collectFileNames,
   syncFileNames,
@@ -168,6 +170,60 @@ describe("collectFileNames (manifest built from this project's own ledger)", () 
   });
 });
 
+const batchBytes = (batch: FileNameEntry[]): number =>
+  Buffer.byteLength(JSON.stringify({ projectHash: "0123456789abcdef", names: batch }), "utf8");
+
+describe("planNameBatches (what one request may carry)", () => {
+  const entry = (i: number, path?: string): FileNameEntry => ({
+    fileHash: i.toString(16).padStart(16, "0"),
+    path: path ?? `src/f${i}.ts`,
+  });
+
+  it("caps a request at 500 entries", () => {
+    const batches = planNameBatches(Array.from({ length: NAMES_BATCH_MAX * 2 + 3 }, (_, i) => entry(i)));
+    expect(batches.map((b) => b.length)).toEqual([NAMES_BATCH_MAX, NAMES_BATCH_MAX, 3]);
+  });
+
+  it("caps a request by BYTES too, so a multi-byte monorepo never nears the server limit", () => {
+    // 500 entries of long multi-byte paths blow past the byte budget well
+    // before the entry cap; a silent 413 would lose the names entirely.
+    const long = `src/${"\u65e5\u672c\u8a9e".repeat(60)}.ts`;
+    expect(long.length).toBeLessThanOrEqual(MAX_REL_PATH_LEN);
+    const batches = planNameBatches(Array.from({ length: NAMES_BATCH_MAX }, (_, i) => entry(i, `${i}/${long}`)));
+    expect(batches.length).toBeGreaterThan(1);
+    for (const b of batches) expect(batchBytes(b)).toBeLessThanOrEqual(NAMES_BATCH_MAX_BYTES);
+    expect(batches.flat()).toHaveLength(NAMES_BATCH_MAX);
+  });
+
+  it("never repeats a fileHash inside a batch: last occurrence wins", () => {
+    const batches = planNameBatches([
+      { fileHash: "a".repeat(16), path: "src/old.ts" },
+      { fileHash: "b".repeat(16), path: "src/other.ts" },
+      { fileHash: "a".repeat(16), path: "src/new.ts" },
+    ]);
+    expect(batches).toEqual([
+      [
+        { fileHash: "a".repeat(16), path: "src/new.ts" },
+        { fileHash: "b".repeat(16), path: "src/other.ts" },
+      ],
+    ]);
+  });
+
+  it("is the last gate: bad hashes and unsafe paths never reach a request", () => {
+    const batches = planNameBatches([
+      { fileHash: "NOTHEX", path: "src/a.ts" },
+      { fileHash: "a".repeat(16), path: "/etc/passwd" },
+      { fileHash: "b".repeat(16), path: "../../.ssh/id_rsa" },
+      { fileHash: "c".repeat(16), path: "src/ok.ts" },
+    ]);
+    expect(batches).toEqual([[{ fileHash: "c".repeat(16), path: "src/ok.ts" }]]);
+  });
+
+  it("returns no batches for nothing to send", () => {
+    expect(planNameBatches([])).toEqual([]);
+  });
+});
+
 describe("syncFileNames (flush-time upload, opt-in gated)", () => {
   it("makes NO request at all when the repo flag is off", async () => {
     const { base, sessionsDir, hash } = await project(["src/a.ts"]);
@@ -295,6 +351,51 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
       postNames: async () => { retried++; },
     });
     expect(retried).toBe(2);
+  });
+
+  it("keeps every request inside the entry AND byte caps", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    const dir = join(sessionsDir, hash);
+    mkdirSync(dir, { recursive: true });
+    const long = `${"\u65e5\u672c\u8a9e".repeat(60)}.ts`;
+    const lines = Array.from({ length: NAMES_BATCH_MAX }, (_, i) =>
+      JSON.stringify(ev({ detail: { file: `src/${i}/${long}`, diffstat: "+1" } })),
+    );
+    writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
+    await markFlushed(sessionsDir, hash);
+    setShareFileNames(hash, true, base);
+    const sent: FileNameEntry[][] = [];
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => { sent.push(entries); },
+    });
+    expect(sent.length).toBeGreaterThan(1);
+    for (const b of sent) {
+      expect(b.length).toBeLessThanOrEqual(NAMES_BATCH_MAX);
+      expect(batchBytes(b)).toBeLessThanOrEqual(NAMES_BATCH_MAX_BYTES);
+      expect(new Set(b.map((e) => e.fileHash)).size).toBe(b.length);
+    }
+    expect(sent.flat()).toHaveLength(NAMES_BATCH_MAX);
+  });
+
+  it("counts server-side rejections without retrying them", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts", "src/b.ts"]);
+    setShareFileNames(hash, true, base);
+    let posts = 0;
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async () => { posts++; return { ok: true, stored: 1, rejected: 1 }; },
+    });
+    expect(posts).toBe(1);
+    expect(res).toMatchObject({ batches: 1, rejected: 1 });
   });
 
   it("retries a pending opt-out delete, clears the flag state and the local manifest record", async () => {

--- a/test/unit/session/file-names.test.ts
+++ b/test/unit/session/file-names.test.ts
@@ -32,7 +32,7 @@ const ev = (over: Partial<SessionEvent> = {}): SessionEvent => ({
   channel: "hook",
   type: "edit",
   mode: "passive",
-  detail: { file: "src/a.ts", diffstat: "+1" },
+  detail: { file: "src/a.ts", diffstat: "+1", inRepo: true },
   ...over,
 });
 
@@ -54,7 +54,7 @@ async function project(files: string[]): Promise<{ base: string; sessionsDir: st
   const base = tmp();
   const sessionsDir = join(base, "sessions");
   const hash = "p1";
-  for (const file of files) await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file, diffstat: "+1" } }));
+  for (const file of files) await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file, diffstat: "+1", inRepo: true } }));
   await markFlushed(sessionsDir, hash);
   return { base, sessionsDir, hash };
 }
@@ -104,7 +104,7 @@ describe("collectFileNames (manifest built from this project's own ledger)", () 
     const base = tmp();
     const sessionsDir = join(base, "sessions");
     const hash = "p1";
-    const e = ev({ detail: { file: "src/payments/refund.ts", diffstat: "+9" } });
+    const e = ev({ detail: { file: "src/payments/refund.ts", diffstat: "+9", inRepo: true } });
     await appendEvent(sessionsDir, hash, "s1", e);
     await markFlushed(sessionsDir, hash);
     const [entry] = await collectFileNames(sessionsDir, hash);
@@ -116,9 +116,9 @@ describe("collectFileNames (manifest built from this project's own ledger)", () 
     const base = tmp();
     const sessionsDir = join(base, "sessions");
     const hash = "p1";
-    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/flushed.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/flushed.ts", diffstat: "+1", inRepo: true } }));
     const firstLineEnd = readFileSync(join(sessionsDir, hash, "s1.jsonl"), "utf8").length;
-    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/pending.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/pending.ts", diffstat: "+1", inRepo: true } }));
     await markFlushed(sessionsDir, hash, firstLineEnd);
     const entries = await collectFileNames(sessionsDir, hash);
     expect(entries.map((e) => e.path)).toEqual(["src/flushed.ts"]);
@@ -128,8 +128,8 @@ describe("collectFileNames (manifest built from this project's own ledger)", () 
     const base = tmp();
     const sessionsDir = join(base, "sessions");
     const hash = "p1";
-    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/mine.ts", diffstat: "+1" } }));
-    await appendEvent(sessionsDir, hash, "s1", ev({ projectHash: "other", detail: { file: "src/theirs.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/mine.ts", diffstat: "+1", inRepo: true } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ projectHash: "other", detail: { file: "src/theirs.ts", diffstat: "+1", inRepo: true } }));
     await markFlushed(sessionsDir, hash);
     const entries = await collectFileNames(sessionsDir, hash);
     expect(entries.map((e) => e.path)).toEqual(["src/mine.ts"]);
@@ -150,11 +150,33 @@ describe("collectFileNames (manifest built from this project's own ledger)", () 
     const sessionsDir = join(base, "sessions");
     const hash = "p1";
     for (const file of ["/etc/passwd", "../../.ssh/id_rsa", "C:\\Users\\me\\secrets.env", "src/ok.ts"]) {
-      await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file, diffstat: "+1" } }));
+      await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file, diffstat: "+1", inRepo: true } }));
     }
     await markFlushed(sessionsDir, hash);
     const entries = await collectFileNames(sessionsDir, hash);
     expect(entries.map((e) => e.path)).toEqual(["src/ok.ts"]);
+  });
+
+  it("never shares a file the hook recorded as OUTSIDE this repo, whatever its path looks like", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    // The hook records an out-of-repo edit by BASENAME, which is shaped exactly
+    // like a file at the repo root: only the provenance mark tells them apart.
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "secrets.env", diffstat: "+1", inRepo: false } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "README.md", diffstat: "+1", inRepo: true } }));
+    await markFlushed(sessionsDir, hash);
+    const entries = await collectFileNames(sessionsDir, hash);
+    expect(entries.map((e) => e.path)).toEqual(["README.md"]);
+  });
+
+  it("fails closed: a line with no provenance mark is never shared", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/legacy.ts", diffstat: "+1" } }));
+    await markFlushed(sessionsDir, hash);
+    expect(await collectFileNames(sessionsDir, hash)).toEqual([]);
   });
 
   it("tolerates a corrupt line and a missing project dir", async () => {
@@ -164,7 +186,7 @@ describe("collectFileNames (manifest built from this project's own ledger)", () 
     expect(await collectFileNames(sessionsDir, hash)).toEqual([]);
     mkdirSync(join(sessionsDir, hash), { recursive: true });
     writeFileSync(join(sessionsDir, hash, "s1.jsonl"), "{not json\n");
-    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/a.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/a.ts", diffstat: "+1", inRepo: true } }));
     await markFlushed(sessionsDir, hash);
     expect((await collectFileNames(sessionsDir, hash)).map((e) => e.path)).toEqual(["src/a.ts"]);
   });
@@ -280,7 +302,7 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
     const dir = join(sessionsDir, hash);
     mkdirSync(dir, { recursive: true });
     const lines = Array.from({ length: NAMES_BATCH_MAX + 7 }, (_, i) =>
-      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1" } })),
+      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1", inRepo: true } })),
     );
     writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
     await markFlushed(sessionsDir, hash);
@@ -312,7 +334,7 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
     await syncFileNames(opts);
     expect(posts).toBe(1);
     // a newly edited file is the only thing the next flush sends
-    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/new.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/new.ts", diffstat: "+1", inRepo: true } }));
     await markFlushed(sessionsDir, hash);
     const sent: FileNameEntry[][] = [];
     await syncFileNames({ ...opts, postNames: async (e) => { sent.push(e); } });
@@ -326,7 +348,7 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
     const dir = join(sessionsDir, hash);
     mkdirSync(dir, { recursive: true });
     const lines = Array.from({ length: NAMES_BATCH_MAX + 3 }, (_, i) =>
-      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1" } })),
+      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1", inRepo: true } })),
     );
     writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
     await markFlushed(sessionsDir, hash);
@@ -361,7 +383,7 @@ describe("syncFileNames (flush-time upload, opt-in gated)", () => {
     mkdirSync(dir, { recursive: true });
     const long = `${"\u65e5\u672c\u8a9e".repeat(60)}.ts`;
     const lines = Array.from({ length: NAMES_BATCH_MAX }, (_, i) =>
-      JSON.stringify(ev({ detail: { file: `src/${i}/${long}`, diffstat: "+1" } })),
+      JSON.stringify(ev({ detail: { file: `src/${i}/${long}`, diffstat: "+1", inRepo: true } })),
     );
     writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
     await markFlushed(sessionsDir, hash);

--- a/test/unit/session/file-names.test.ts
+++ b/test/unit/session/file-names.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent } from "@/session/ledger";
+import { UploadStateStore } from "@/session/upload-state";
+import { toUploadEvent } from "@/session/upload-schema";
+import { loadActivation, setShareFileNames, setNamesDeletePending, namesDeleteIsPending } from "@/session/activation";
+import {
+  NAMES_BATCH_MAX,
+  MAX_REL_PATH_LEN,
+  isSafeRelPath,
+  collectFileNames,
+  syncFileNames,
+  namesStatePath,
+  type FileNameEntry,
+} from "@/session/file-names";
+import type { SessionEvent } from "@/session/types";
+
+const tmp = () => realpathSync(mkdtempSync(join(tmpdir(), "vd-names-")));
+
+let seq = 0;
+const ev = (over: Partial<SessionEvent> = {}): SessionEvent => ({
+  v: 1,
+  sid: "s1",
+  aid: `evt-${seq++}`,
+  ts: new Date().toISOString(),
+  agent: "claude-code",
+  projectHash: "p1",
+  channel: "hook",
+  type: "edit",
+  mode: "passive",
+  detail: { file: "src/a.ts", diffstat: "+1" },
+  ...over,
+});
+
+/** Mark every byte of every ledger file as positively acknowledged, which is
+ *  what "already flushed for this project" means on disk. */
+async function markFlushed(sessionsDir: string, hash: string, upTo?: number): Promise<void> {
+  const dir = join(sessionsDir, hash);
+  const store = new UploadStateStore(sessionsDir, hash);
+  await store.load();
+  const offsets = new Map<string, number>();
+  for (const f of readdirSync(dir).filter((n) => n.endsWith(".jsonl"))) {
+    const raw = readFileSync(join(dir, f), "utf8");
+    offsets.set(f, upTo ?? raw.length);
+  }
+  await store.commit(offsets);
+}
+
+async function project(files: string[]): Promise<{ base: string; sessionsDir: string; hash: string }> {
+  const base = tmp();
+  const sessionsDir = join(base, "sessions");
+  const hash = "p1";
+  for (const file of files) await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file, diffstat: "+1" } }));
+  await markFlushed(sessionsDir, hash);
+  return { base, sessionsDir, hash };
+}
+
+describe("isSafeRelPath (client-side mirror of the ingest validation)", () => {
+  it("accepts ordinary repo-relative paths", () => {
+    expect(isSafeRelPath("src/a.ts")).toBe(true);
+    expect(isSafeRelPath("a.ts")).toBe(true);
+    expect(isSafeRelPath("packages/api/src/routes/v1/names.py")).toBe(true);
+    expect(isSafeRelPath("weird name (1).ts")).toBe(true);
+  });
+
+  it("refuses absolute paths, drive letters, traversal, backslashes and control chars", () => {
+    expect(isSafeRelPath("/etc/passwd")).toBe(false);
+    expect(isSafeRelPath("C:\\repo\\a.ts")).toBe(false);
+    expect(isSafeRelPath("c:/repo/a.ts")).toBe(false);
+    expect(isSafeRelPath("../../.ssh/id_rsa")).toBe(false);
+    expect(isSafeRelPath("src/../../secrets.env")).toBe(false);
+    expect(isSafeRelPath("..")).toBe(false);
+    expect(isSafeRelPath("src\\a.ts")).toBe(false);
+    expect(isSafeRelPath("src/a\n.ts")).toBe(false);
+    expect(isSafeRelPath("src/a\u0000.ts")).toBe(false);
+  });
+
+  it("refuses empty and overlong paths", () => {
+    expect(isSafeRelPath("")).toBe(false);
+    expect(isSafeRelPath("   ")).toBe(false);
+    expect(isSafeRelPath("a".repeat(MAX_REL_PATH_LEN))).toBe(true);
+    expect(isSafeRelPath("a".repeat(MAX_REL_PATH_LEN + 1))).toBe(false);
+  });
+
+  it("refuses non-strings", () => {
+    expect(isSafeRelPath(undefined)).toBe(false);
+    expect(isSafeRelPath(42)).toBe(false);
+  });
+});
+
+describe("collectFileNames (manifest built from this project's own ledger)", () => {
+  it("returns one entry per distinct flushed file, in ledger order", async () => {
+    const { sessionsDir, hash } = await project(["src/a.ts", "src/b.ts", "src/a.ts"]);
+    const entries = await collectFileNames(sessionsDir, hash);
+    expect(entries.map((e) => e.path)).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(new Set(entries.map((e) => e.fileHash)).size).toBe(2);
+  });
+
+  it("hash parity: every entry carries the upload schema's OWN fileHash", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    const e = ev({ detail: { file: "src/payments/refund.ts", diffstat: "+9" } });
+    await appendEvent(sessionsDir, hash, "s1", e);
+    await markFlushed(sessionsDir, hash);
+    const [entry] = await collectFileNames(sessionsDir, hash);
+    expect(entry.fileHash).toBe(toUploadEvent(e)?.fileHash);
+    expect(entry.fileHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("omits events that have not been flushed yet (past the committed offset)", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/flushed.ts", diffstat: "+1" } }));
+    const firstLineEnd = readFileSync(join(sessionsDir, hash, "s1.jsonl"), "utf8").length;
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/pending.ts", diffstat: "+1" } }));
+    await markFlushed(sessionsDir, hash, firstLineEnd);
+    const entries = await collectFileNames(sessionsDir, hash);
+    expect(entries.map((e) => e.path)).toEqual(["src/flushed.ts"]);
+  });
+
+  it("ignores a ledger line stamped with ANOTHER project's hash", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/mine.ts", diffstat: "+1" } }));
+    await appendEvent(sessionsDir, hash, "s1", ev({ projectHash: "other", detail: { file: "src/theirs.ts", diffstat: "+1" } }));
+    await markFlushed(sessionsDir, hash);
+    const entries = await collectFileNames(sessionsDir, hash);
+    expect(entries.map((e) => e.path)).toEqual(["src/mine.ts"]);
+  });
+
+  it("ignores event kinds whose upload projection carries no fileHash", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    // `command` is never uploaded at all; it must not contribute a name.
+    await appendEvent(sessionsDir, hash, "s1", ev({ type: "command", detail: { file: "scripts/deploy.sh" } }));
+    await markFlushed(sessionsDir, hash);
+    expect(await collectFileNames(sessionsDir, hash)).toEqual([]);
+  });
+
+  it("defense in depth: an absolute or traversal path in the ledger never becomes an entry", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    for (const file of ["/etc/passwd", "../../.ssh/id_rsa", "C:\\Users\\me\\secrets.env", "src/ok.ts"]) {
+      await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file, diffstat: "+1" } }));
+    }
+    await markFlushed(sessionsDir, hash);
+    const entries = await collectFileNames(sessionsDir, hash);
+    expect(entries.map((e) => e.path)).toEqual(["src/ok.ts"]);
+  });
+
+  it("tolerates a corrupt line and a missing project dir", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    expect(await collectFileNames(sessionsDir, hash)).toEqual([]);
+    mkdirSync(join(sessionsDir, hash), { recursive: true });
+    writeFileSync(join(sessionsDir, hash, "s1.jsonl"), "{not json\n");
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/a.ts", diffstat: "+1" } }));
+    await markFlushed(sessionsDir, hash);
+    expect((await collectFileNames(sessionsDir, hash)).map((e) => e.path)).toEqual(["src/a.ts"]);
+  });
+});
+
+describe("syncFileNames (flush-time upload, opt-in gated)", () => {
+  it("makes NO request at all when the repo flag is off", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    let posts = 0;
+    let deletes = 0;
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async () => { posts++; },
+      deleteNames: async () => { deletes++; },
+    });
+    expect(posts).toBe(0);
+    expect(deletes).toBe(0);
+    expect(res).toMatchObject({ uploaded: 0, batches: 0 });
+    expect(existsSync(namesStatePath(sessionsDir, hash))).toBe(false);
+  });
+
+  it("uploads the manifest when the flag is on", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts", "src/b.ts"]);
+    setShareFileNames(hash, true, base);
+    const sent: FileNameEntry[][] = [];
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => { sent.push(entries); },
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].map((e) => e.path).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(res).toMatchObject({ uploaded: 2, batches: 1 });
+  });
+
+  it("uploads nothing when the account is entitlement-locked", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    setShareFileNames(hash, true, base);
+    let posts = 0;
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: false,
+      postNames: async () => { posts++; },
+    });
+    expect(posts).toBe(0);
+  });
+
+  it("batches at 500 entries per request", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    const dir = join(sessionsDir, hash);
+    mkdirSync(dir, { recursive: true });
+    const lines = Array.from({ length: NAMES_BATCH_MAX + 7 }, (_, i) =>
+      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1" } })),
+    );
+    writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
+    await markFlushed(sessionsDir, hash);
+    setShareFileNames(hash, true, base);
+    const sizes: number[] = [];
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async (entries) => { sizes.push(entries.length); },
+    });
+    expect(sizes).toEqual([NAMES_BATCH_MAX, 7]);
+    expect(res.uploaded).toBe(NAMES_BATCH_MAX + 7);
+  });
+
+  it("remembers what it uploaded: a second flush with nothing new posts nothing", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    setShareFileNames(hash, true, base);
+    let posts = 0;
+    const opts = {
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async () => { posts++; },
+    };
+    await syncFileNames(opts);
+    await syncFileNames(opts);
+    expect(posts).toBe(1);
+    // a newly edited file is the only thing the next flush sends
+    await appendEvent(sessionsDir, hash, "s1", ev({ detail: { file: "src/new.ts", diffstat: "+1" } }));
+    await markFlushed(sessionsDir, hash);
+    const sent: FileNameEntry[][] = [];
+    await syncFileNames({ ...opts, postNames: async (e) => { sent.push(e); } });
+    expect(sent).toEqual([[expect.objectContaining({ path: "src/new.ts" })]]);
+  });
+
+  it("one attempt per flush run: a failed batch never retries and never throws", async () => {
+    const base = tmp();
+    const sessionsDir = join(base, "sessions");
+    const hash = "p1";
+    const dir = join(sessionsDir, hash);
+    mkdirSync(dir, { recursive: true });
+    const lines = Array.from({ length: NAMES_BATCH_MAX + 3 }, (_, i) =>
+      JSON.stringify(ev({ detail: { file: `src/f${i}.ts`, diffstat: "+1" } })),
+    );
+    writeFileSync(join(dir, "s1.jsonl"), `${lines.join("\n")}\n`);
+    await markFlushed(sessionsDir, hash);
+    setShareFileNames(hash, true, base);
+    let posts = 0;
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async () => { posts++; throw new Error("names endpoint down"); },
+    });
+    expect(posts).toBe(1);
+    expect(res).toMatchObject({ uploaded: 0, batches: 0 });
+    // nothing was recorded as uploaded, so the next flush tries again
+    let retried = 0;
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      postNames: async () => { retried++; },
+    });
+    expect(retried).toBe(2);
+  });
+
+  it("retries a pending opt-out delete, clears the flag state and the local manifest record", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    setShareFileNames(hash, true, base);
+    await syncFileNames({ sessionsDir, projectHash: hash, home: base, canUpload: true, postNames: async () => {} });
+    expect(existsSync(namesStatePath(sessionsDir, hash))).toBe(true);
+    // the user turned names off but the DELETE never reached the server
+    setShareFileNames(hash, false, base);
+    setNamesDeletePending(hash, true, base);
+    let deletes = 0;
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      deleteNames: async () => { deletes++; },
+      postNames: async () => { throw new Error("must not upload while off"); },
+    });
+    expect(deletes).toBe(1);
+    expect(res).toMatchObject({ deleted: true, deletePending: false });
+    expect(namesDeleteIsPending(loadActivation(base), hash)).toBe(false);
+    expect(existsSync(namesStatePath(sessionsDir, hash))).toBe(false);
+  });
+
+  it("a delete that fails again stays pending for the next flush", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    setNamesDeletePending(hash, true, base);
+    const res = await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: true,
+      deleteNames: async () => { throw new Error("still offline"); },
+    });
+    expect(res).toMatchObject({ deleted: false, deletePending: true });
+    expect(namesDeleteIsPending(loadActivation(base), hash)).toBe(true);
+  });
+
+  it("honors a pending delete even when the account is locked", async () => {
+    const { base, sessionsDir, hash } = await project(["src/a.ts"]);
+    setNamesDeletePending(hash, true, base);
+    let deletes = 0;
+    await syncFileNames({
+      sessionsDir,
+      projectHash: hash,
+      home: base,
+      canUpload: false,
+      deleteNames: async () => { deletes++; },
+    });
+    expect(deletes).toBe(1);
+    expect(namesDeleteIsPending(loadActivation(base), hash)).toBe(false);
+  });
+});

--- a/test/unit/session/file-names.test.ts
+++ b/test/unit/session/file-names.test.ts
@@ -72,6 +72,7 @@ describe("isSafeRelPath (client-side mirror of the ingest validation)", () => {
     expect(isSafeRelPath("C:\\repo\\a.ts")).toBe(false);
     expect(isSafeRelPath("c:/repo/a.ts")).toBe(false);
     expect(isSafeRelPath("../../.ssh/id_rsa")).toBe(false);
+    expect(isSafeRelPath("../notes.ts")).toBe(false); // the hook's out-of-repo marker
     expect(isSafeRelPath("src/../../secrets.env")).toBe(false);
     expect(isSafeRelPath("..")).toBe(false);
     expect(isSafeRelPath("src\\a.ts")).toBe(false);

--- a/test/unit/session/flush-run.test.ts
+++ b/test/unit/session/flush-run.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runFlush } from "@/session/flush-run";
 import { appendEvent } from "@/session/ledger";
+import { readFileSync } from "node:fs";
 import { readEntitlementCache, writeEntitlementCache, computeEntitlement } from "@/session/entitlement";
+import { setShareFileNames, setNamesDeletePending, namesDeleteIsPending, loadActivation } from "@/session/activation";
+import type { FileNameEntry } from "@/session/file-names";
 import type { UploadEvent } from "@/session/upload-schema";
 import type { IngestAck } from "@/session/ingest-ack";
 import type { SessionEvent } from "@/session/types";
@@ -19,7 +22,8 @@ const ev = (over: Partial<SessionEvent> = {}): SessionEvent => ({
   aid: `evt-${seq++}`,
   ts: new Date().toISOString(),
   agent: "claude-code",
-  projectHash: "h",
+  // the hook stamps every event with the SAME hash it uses for the ledger dir
+  projectHash: "h1",
   channel: "hook",
   type: "edit",
   mode: "passive",
@@ -171,5 +175,78 @@ describe("runFlush (the native path's per-turn flush)", () => {
     });
     expect(posted).toHaveLength(0);
     expect(out).toMatchObject({ uploaded: true, locked: false });
+  });
+});
+
+describe("runFlush — opt-in file-name manifest", () => {
+  const uploadedOffsets = (sessionsDir: string, hash: string): Record<string, { offset: number }> =>
+    JSON.parse(readFileSync(join(sessionsDir, hash, "upload-state.json"), "utf8")).files;
+
+  it("makes NO names request when the repo never opted in (the default)", async () => {
+    const { base, sessionsDir, hash } = await project();
+    let nameCalls = 0;
+    await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "pro" }),
+      post: async (e) => fullAck(e),
+      postNames: async () => { nameCalls++; },
+      deleteNames: async () => { nameCalls++; },
+    });
+    expect(nameCalls).toBe(0);
+  });
+
+  it("posts the manifest for the flushed events once the repo opted in", async () => {
+    const { base, sessionsDir, hash } = await project();
+    setShareFileNames(hash, true, base);
+    const sent: FileNameEntry[] = [];
+    await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "pro" }),
+      post: async (e) => fullAck(e),
+      postNames: async (entries) => { sent.push(...entries); },
+    });
+    expect(sent).toEqual([{ fileHash: expect.stringMatching(/^[0-9a-f]{16}$/), path: "a.ts" }]);
+  });
+
+  it("a names failure never blocks the flush: events still commit their offsets", async () => {
+    const { base, sessionsDir, hash } = await project();
+    setShareFileNames(hash, true, base);
+    const posted: UploadEvent[] = [];
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "pro" }),
+      post: async (e) => { posted.push(...e); return fullAck(e); },
+      postNames: async () => { throw new Error("names endpoint down"); },
+    });
+    expect(posted).toHaveLength(1);
+    expect(out).toMatchObject({ uploaded: true, locked: false });
+    expect(Object.values(uploadedOffsets(sessionsDir, hash))[0].offset).toBeGreaterThan(0);
+  });
+
+  it("honors a pending opt-out delete even when the account is locked", async () => {
+    const { base, sessionsDir, hash } = await project();
+    setNamesDeletePending(hash, true, base);
+    let deletes = 0;
+    const out = await runFlush({
+      baseDir: base,
+      sessionsDir,
+      projectHash: hash,
+      now: () => NOW,
+      fetchEntitlement: async () => ({ plan: "free", trial_used: 5, trial_limit: 5 }),
+      post: async (e) => fullAck(e),
+      deleteNames: async () => { deletes++; },
+    });
+    expect(out).toMatchObject({ uploaded: false, locked: true });
+    expect(deletes).toBe(1);
+    expect(namesDeleteIsPending(loadActivation(base), hash)).toBe(false);
   });
 });

--- a/test/unit/session/flush-run.test.ts
+++ b/test/unit/session/flush-run.test.ts
@@ -27,7 +27,9 @@ const ev = (over: Partial<SessionEvent> = {}): SessionEvent => ({
   channel: "hook",
   type: "edit",
   mode: "passive",
-  detail: { file: "a.ts", diffstat: "+1" },
+  // inRepo is the hook's provenance stamp: this edit landed inside the repo,
+  // which is what makes "a.ts" shareable as a name at all.
+  detail: { file: "a.ts", diffstat: "+1", inRepo: true },
   ...over,
 });
 

--- a/test/unit/session/repo.test.ts
+++ b/test/unit/session/repo.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, renameSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveRepoRoot, repoIdentity, defaultSessionsDir } from "@/session/repo";
+import { resolveRepoRoot, repoIdentity, repoKey, defaultSessionsDir } from "@/session/repo";
 import { projectHash } from "@/core/baseline";
 
 const tmp = (prefix: string) => realpathSync(mkdtempSync(join(tmpdir(), prefix)));
@@ -35,6 +36,36 @@ describe("repoIdentity", () => {
     const id = repoIdentity(d);
     expect(id.rootDir).toBe(d);
     expect(id.projectHash).toBe(projectHash(d));
+  });
+});
+
+describe("repoKey", () => {
+  it("is the root commit for a git repo, so it survives a move on disk", () => {
+    const a = tmp("vd-key-");
+    execFileSync("git", ["init", "-q"], { cwd: a, stdio: "ignore" });
+    execFileSync(
+      "git",
+      [
+        "-c", "user.email=test@example.com",
+        "-c", "user.name=Test",
+        "-c", "commit.gpgsign=false",
+        "-c", "core.hooksPath=/dev/null",
+        "commit", "-q", "--allow-empty", "-m", "init",
+      ],
+      { cwd: a, stdio: "ignore" },
+    );
+    const before = repoKey(a);
+    expect(before).toMatch(/^git:[0-9a-f]{40,64}$/);
+    const moved = join(a, "..", `vd-key-moved-${Date.now()}`);
+    renameSync(a, moved);
+    expect(repoKey(moved)).toBe(before);
+    expect(repoIdentity(moved).projectHash).not.toBe(repoIdentity(a).projectHash);
+    rmSync(moved, { recursive: true, force: true });
+  });
+
+  it("falls back to the canonical path when git cannot answer", () => {
+    const d = tmp("vd-nogit-");
+    expect(repoKey(d)).toBe(`path:${d}`);
   });
 });
 


### PR DESCRIPTION
Your dashboard shows `file 77aa11bb` where a file was flagged, because only a salted pseudonym ever leaves your machine. This adds a per-repo opt-in so it can show `payments/refund.ts` instead, for the repos you choose.

```
vibedrift watch-session --names on     # this repo only
vibedrift watch-session --names off    # deletes what was uploaded, stops future uploads
```

- **Paths only.** Never file contents, never absolute paths, never anything outside the repo. The check that decides "inside the repo" happens when the edit is recorded, not by guessing from how a path looks, and anything unmarked is excluded rather than assumed safe.
- **Off by default**, and the disclosure prints before the setting is written.
- **Genuinely reversible.** Turning it off deletes the names already uploaded, including for repos that have moved on disk since, and it disarms every working copy of the repo rather than just the one you ran it in. If a delete cannot reach the server, nothing claims success and it retries.
- **Never interferes with your session.** Names upload after the session record has already been committed, and a failure there can never block, delay, or corrupt it.

Also fixed along the way: file paths recorded on Windows now use forward slashes, so they work everywhere.

2,516 tests, lint and typecheck clean. The API side is already deployed.

---
🤖 This PR was written by Claude (AI), operating the VibeDrift release process on Sami's behalf.