### PR TITLE
fix: stop reporting an ORM that isn't there

### DIFF
--- a/src/codedna/pattern-classifier.ts
+++ b/src/codedna/pattern-classifier.ts
@@ -48,7 +48,25 @@ const SIGNAL_DEFS: SignalDef[] = [
   { pattern: "raw_sql", regex: /\.query\s*\(\s*[`'"]/i, label: "inline SQL query string" },
 
   // ORM
-  { pattern: "orm", regex: /(?:gorm|prisma|sequelize|typeorm|sqlalchemy|django\.db|ent\.)\.?/i, label: "ORM import/usage" },
+  { pattern: "orm", regex: /(?:gorm|prisma|sequelize|typeorm|sqlalchemy|django\.db)\.?/i, label: "ORM import/usage" },
+  // Ent (entgo.io) is split out of the alternation above, anchored AND case-sensitive.
+  // A bare `ent\.` had no left boundary, so it matched every identifier ending in the
+  // letters "ent" followed by a dot: content., fullContent., client., component.,
+  // current., event., document., agent., environment., argument., management. That
+  // single alternative produced 125 of 125 "ORM import/usage" signals across five
+  // repos that declare no ORM at all.
+  //
+  // A left \b alone is NOT sufficient: it still fires on a local variable named `ent`
+  // (ent.ty, ent.entitled, ent.capture_types). Real Ent usage is a package selector
+  // followed by an exported Go identifier (ent.Client, ent.NewClient, ent.Open,
+  // ent.Tx, ent.IsNotFound, []*ent.User), whereas a local `ent` is followed by a
+  // lowercase field. The [A-Z] discriminator separates them.
+  //
+  // The /i flag is deliberately omitted: with it, [A-Z] also matches lowercase and
+  // the discriminator becomes a no-op. Known and accepted recall gap: a package
+  // alias (myent.Client, some_ent.Client) is not recognised. The generated Ent
+  // package is named `ent` by default.
+  { pattern: "orm", regex: /\bent\.[A-Z]/, label: "Ent ORM usage" },
   { pattern: "orm", regex: /\.Find\(\s*&|\.Create\(\s*&|\.Save\(\s*&|\.Where\(/i, label: "ORM method call (Go)" },
   { pattern: "orm", regex: /\.findOne\(|\.findAll\(|\.create\(.*{|\.update\(.*{|\.destroy\(/i, label: "ORM method call (JS)" },
   { pattern: "orm", regex: /objects\.(?:filter|get|create|all)\(/i, label: "Django ORM call" },

--- a/src/codedna/pattern-classifier.ts
+++ b/src/codedna/pattern-classifier.ts
@@ -80,9 +80,23 @@ const SIGNAL_DEFS: SignalDef[] = [
   { pattern: "http_client", regex: /fetch\(|axios\.|requests\.(?:get|post)/i, label: "HTTP fetch/axios/requests" },
 ];
 
-// Files that are likely "handler" or "service" files (where pattern drift matters)
+// Files that are likely "handler" or "service" files (where pattern drift matters).
+//
+// SEGMENT match, not substring. Unanchored, "route" admitted router.go,
+// autorouter.ts, itty-router.js and this repo's own src/drift/route-extractors/,
+// and "api" admitted therapist.ts, capital.ts and rapid.ts. Across seven repos,
+// 344 of 499 gated files entered on a substring rather than a path segment, and
+// a file that enters the classifier gets labelled by whatever signal fires first.
+//
+// `routers?` is included deliberately: a directory or file named `router`/
+// `routers` is real routing code and holds real data access (trpc's Prisma
+// usage lives in src/server/routers/). Only the SUBSTRING matches are dropped,
+// so autorouter.ts, itty-router.js and route-extractors/ no longer qualify
+// while routers/post.ts still does.
+//
+// This mirrors the anchored form CONTEXT_PRIORS already uses just below.
 function isHandlerOrServiceFile(path: string): boolean {
-  return /(?:handler|controller|service|route|endpoint|api|resource)/i.test(path);
+  return /(?:^|\/)(?:handlers?|controllers?|services?|routes?|routers?|endpoints?|api|resources?)(?:[/.]|$)/i.test(path);
 }
 
 // ─── Bayesian context priors ─────────────────────────────────────────

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -31,7 +31,7 @@ import type { IntentHint } from "../intent/types.js";
 
 const CACHE_DIR = join(vibedriftHome(), "baseline-cache");
 /** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
-export const BASELINE_VERSION = 3;
+export const BASELINE_VERSION = 4;
 
 export interface CategoryVote {
   driftCategory: DriftCategory;

--- a/src/drift/architectural-contradiction.ts
+++ b/src/drift/architectural-contradiction.ts
@@ -55,8 +55,23 @@ function detectDataAccess(file: DriftFile): { pattern: DataAccessPattern; eviden
     results.push({ pattern: "raw_sql", evidence: sqlEvidence });
   }
 
-  // ORM
-  const ormPatterns = /\.(?:Where|Find|Create|Save|Delete|First|Preload|findOne|findMany|findAll|objects\.filter)\s*\(/g;
+  // ORM. Route registrations share these verb names with ORM CRUD calls:
+  // router.Create("/users", h), r.Delete("/orders/{id}", h.Del),
+  // app.Delete("/users/:id", deleteUser). The discriminator is the FIRST
+  // ARGUMENT: a route path is a string literal beginning with "/", and no ORM
+  // idiom measured here (gorm, prisma, sequelize, typeorm, django, ent,
+  // mongoose) passes one in that position.
+  //
+  // A receiver or import gate would be stronger, but this module has no ORM
+  // vocabulary and no manifest access — classifyDataAccessLabel and
+  // hasDataAccessPattern take only (content, path) and are the MCP
+  // validate_change and session-resolve contracts. Measured alternatives:
+  // requiring a known ORM token keeps 2 of 8 real ORM idioms, requiring an
+  // ORM-ish chain root keeps 4 of 8. Argument shape keeps 10 of 10.
+  //
+  // The lookahead is zero-width, so extractEvidence still advances and still
+  // records line numbers from match.index.
+  const ormPatterns = /\.(?:Where|Find|Create|Save|Delete|First|Preload|findOne|findMany|findAll|objects\.filter)\s*\(\s*(?!['"`]\/)/g;
   const ormEvidence = extractEvidence(c, ormPatterns);
   if (ormEvidence.length > 0) results.push({ pattern: "orm", evidence: ormEvidence });
 

--- a/test/fixtures/classifier-bodies.txt
+++ b/test/fixtures/classifier-bodies.txt
@@ -391,3 +391,42 @@ export async function loadProfile(userId: string) {
   await repo.put(userId, res);
   return { ...res, extra };
 }
+=== mountChiRoutes synthetic ===
+func mountOrderRoutes(r chi.Router, h *OrderHandler) {
+  r.Get("/orders", h.List)
+  r.Create("/orders", h.New)
+  r.Delete("/orders/{id}", h.Del)
+}
+=== mountFiberRoutes synthetic ===
+func mountUserRoutes(app *fiber.App) {
+  app.Get("/users", listUsers)
+  app.Delete("/users/:id", deleteUser)
+}
+=== mountCustomRouter synthetic ===
+export function mount(router: Router) {
+  router.Create("/users", handleCreateUser);
+  router.Delete("/users/:id", handleDeleteUser);
+}
+=== loadUserViaGorm synthetic ===
+func (s *Store) loadUser(id string) (*User, error) {
+  var u User
+  if err := s.db.Where("id = ?", id).First(&u).Error; err != nil {
+    return nil, err
+  }
+  return &u, nil
+}
+=== listSeatsViaSequelize synthetic ===
+export async function listSeats(orgId: string) {
+  const rows = await Seat.findAll({ where: { orgId, active: true } });
+  return rows.map((r) => r.get({ plain: true }));
+}
+=== filterUsersViaDjango synthetic ===
+def active_users(org_id):
+    qs = User.objects.filter(org_id=org_id, active=True)
+    return list(qs)
+=== lookupRouteTable synthetic ===
+export function resolveRoute(pattern: string) {
+  const hit = routes.findOne(pattern);
+  if (!hit) return null;
+  return hit.handler;
+}

--- a/test/unit/codedna/pattern-classifier.test.ts
+++ b/test/unit/codedna/pattern-classifier.test.ts
@@ -168,6 +168,55 @@ describe("pattern-classifier ORM signal (issue #87)", () => {
     });
   });
 
+  describe("handler/service path gate matches segments, not substrings", () => {
+    // Every input carries one unambiguous signal, so classification depends
+    // only on the gate.
+    const BODY = "await fetch(url);";
+    const classified = (path: string): boolean => classifyPatterns([file(path, BODY)]).length > 0;
+
+    const rejected = [
+      ["autorouter.ts", "src/autorouter.ts"],
+      ["AutoRouter.ts", "src/AutoRouter.ts"],
+      ["itty-router.js", "benchmarks/webapp/itty-router.js"],
+      ["route-extractors", "src/drift/route-extractors/go.ts"],
+      ["therapist.ts (api substring)", "src/therapist.ts"],
+      ["capital.ts (api substring)", "src/capital.ts"],
+      ["rapid.ts (api substring)", "src/rapid.ts"],
+      ["serviceable.ts", "src/serviceable.ts"],
+    ] as const;
+
+    for (const [name, path] of rejected) {
+      it(`rejects ${name}`, () => {
+        expect(classified(path)).toBe(false);
+      });
+    }
+
+    const admitted = [
+      ["api segment", "src/auth/api.ts"],
+      ["nested api route", "src/app/api/auth/cli/route.ts"],
+      ["handlers dir", "src/handlers/carts.ts"],
+      ["go api dir", "internal/api/router.go"],
+      ["python api dir", "app/api/views.py"],
+      ["services dir", "src/services/thing.ts"],
+      ["rust handlers file", "crates/vibe_lsp/src/handlers.rs"],
+      // `routers` is a real routing directory, not a substring accident.
+      // trpc keeps its Prisma data access here, so excluding it would be a
+      // recall regression rather than a false-positive fix.
+      ["routers dir", "examples/next-prisma-starter/src/server/routers/post.ts"],
+      ["router.go as a full segment", "internal/router.go"],
+    ] as const;
+
+    for (const [name, path] of admitted) {
+      it(`admits ${name}`, () => {
+        expect(classified(path)).toBe(true);
+      });
+    }
+
+    it("still rejects an ordinary source file", () => {
+      expect(classified("src/scoring/engine.ts")).toBe(false);
+    });
+  });
+
   describe("finding level: the reported symptom", () => {
     it("does not invent an ORM majority from `content.` substrings", () => {
       // Five files whose only data-access-looking line is a string split, plus one

--- a/test/unit/codedna/pattern-classifier.test.ts
+++ b/test/unit/codedna/pattern-classifier.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import { classifyPatterns, patternFindings } from "../../../src/codedna/pattern-classifier.js";
+import type { SourceFile, SupportedLanguage } from "../../../src/core/types.js";
+
+/**
+ * Regression tests for issue #87 — the data-access pattern classifier labelling
+ * files "orm" when no ORM is present.
+ *
+ * Two independent defects are covered here:
+ *
+ *   1. The ORM signal regex carried a bare `ent\.` alternative with no left
+ *      boundary, so any identifier ending in the letters "ent" plus a dot was
+ *      read as an Ent ORM usage. `file.content.split(...)` was enough.
+ *   2. `isHandlerOrServiceFile` matched its tokens as unanchored substrings, so
+ *      "route" inside "router"/"autorouter"/"route-extractors" and "api" inside
+ *      "therapist"/"capital" admitted files that are not handlers.
+ *
+ * Before the fix, scanning this repository against itself reported
+ * "Pattern drift: src/auth/api.ts uses http_client while 5/6 files use orm"
+ * at confidence 1.0, with no ORM in package.json.
+ */
+
+const file = (relativePath: string, content: string, language: SupportedLanguage = "typescript"): SourceFile => ({
+  path: `/repo/${relativePath}`,
+  relativePath,
+  language,
+  content,
+  lineCount: content.split("\n").length,
+});
+
+/** Classify a single body at a path that clears the handler/service gate. */
+function patternsFor(content: string, language: SupportedLanguage = "typescript", path = "src/handlers/data.ts"): string[] {
+  const dists = classifyPatterns([file(path, content, language)]);
+  return dists.length === 0 ? [] : Object.keys(dists[0].patterns);
+}
+
+const hasOrm = (content: string, language: SupportedLanguage = "typescript", path?: string): boolean =>
+  patternsFor(content, language, path).includes("orm");
+
+describe("pattern-classifier ORM signal (issue #87)", () => {
+  describe("true positives: real ORM usage must still be detected", () => {
+    const cases: Array<[string, string, SupportedLanguage]> = [
+      ["gorm package selector", 'db := gorm.Open(postgres.Open(dsn))', "go"],
+      ["prisma lowercase client", "const items = await prisma.post.findMany({ where: { published: true } });", "typescript"],
+      ["prisma capitalized namespace import", "import type { Prisma } from '@prisma/client';", "typescript"],
+      ["prisma type position", "} satisfies Prisma.PostSelect;", "typescript"],
+      ["sequelize require", 'const Sequelize = require("sequelize");', "javascript"],
+      ["typeorm import", 'import { getRepository } from "typeorm";', "typescript"],
+      ["sqlalchemy import", "from sqlalchemy.orm import Session", "python"],
+      ["django.db import", "from django.db import models", "python"],
+      ["Ent client type", "var client *ent.Client", "go"],
+      ["Ent constructor", "client := ent.NewClient(ent.Driver(drv))", "go"],
+      ["Ent open", 'c, err := ent.Open("postgres", dsn)', "go"],
+      ["Ent error helper", "if ent.IsNotFound(err) { return nil }", "go"],
+      ["Ent generated entity slice", "func all(ctx context.Context) ([]*ent.User, error) {", "go"],
+      ["Ent generated entity pointer", "func one(ctx context.Context) (*ent.User, error) {", "go"],
+      ["Ent transaction type", "var t *ent.Tx", "go"],
+    ];
+
+    for (const [name, line, language] of cases) {
+      it(`keeps ${name}`, () => {
+        expect(hasOrm(line, language)).toBe(true);
+      });
+    }
+  });
+
+  describe("true negatives: identifiers merely ending in 'ent' are not an ORM", () => {
+    const cases: Array<[string, string]> = [
+      ["content.", 'const lines = file.content.split("\\n");'],
+      ["fullContent.", "const idx = fullContent.indexOf(routePath);"],
+      ["client.", "const res = client.send(req);"],
+      ["httpClient.", "httpClient.get(url)"],
+      ["component.", "component.render()"],
+      ["current.", "current.next = null"],
+      ["agent.", "agent.run()"],
+      ["environment.", "environment.NODE_ENV"],
+      ["argument.", "argument.value"],
+      ["management.", "management.list()"],
+      ["document.", 'const doc = document.getElementById("x");'],
+      ["event.", "switch (event.type) {"],
+      ["parent.", "parent.appendChild(node)"],
+    ];
+
+    for (const [name, line] of cases) {
+      it(`does not read ${name} as an ORM`, () => {
+        expect(hasOrm(line)).toBe(false);
+      });
+    }
+  });
+
+  describe("Ent boundary cases", () => {
+    it("matches ent. at the start of a line", () => {
+      expect(hasOrm("ent.Client{}", "go")).toBe(true);
+    });
+
+    it("does not match a snake_case alias", () => {
+      // `_` is a word character, so there is no \b between "some_" and "ent".
+      expect(hasOrm("x := some_ent.Client{}", "go")).toBe(false);
+    });
+
+    it("does not match a camelCase alias (documented recall gap)", () => {
+      // Accepted limitation: the generated Ent package is named `ent` by default,
+      // so an aliased import is not recognised. Widening this needs an import table.
+      expect(hasOrm("var c *myent.Client = newClient()", "go")).toBe(false);
+    });
+
+    it("does not match a lowercase field after ent (Rust local variable)", () => {
+      expect(hasOrm("return ent.ty.clone();", "rust")).toBe(false);
+    });
+
+    it("does not match a lowercase field after ent (TS local variable)", () => {
+      expect(hasOrm("if (ent && !ent.entitled) {")).toBe(false);
+    });
+
+    it("does not match uppercase ENT.", () => {
+      // The Ent definition is case-sensitive on purpose; the /i alternation above
+      // it no longer contains "ent" at all.
+      expect(hasOrm("ENT.Client", "go")).toBe(false);
+    });
+
+    it("does not match entity.", () => {
+      expect(hasOrm("entity.save()")).toBe(false);
+    });
+
+    it("does not match the entgo.io import path", () => {
+      // Pre-existing behaviour, pinned so that changing it is a deliberate act.
+      expect(hasOrm('import "entgo.io/ent"', "go")).toBe(false);
+    });
+
+    it("still matches inside a string literal (line regex, not AST)", () => {
+      // Accepted behaviour: the classifier is line-based, so it cannot tell code
+      // from a string. Pinned so the limitation is visible rather than surprising.
+      expect(hasOrm('const s = "ent.Client";')).toBe(true);
+    });
+
+    it("still matches inside a comment (line regex, not AST)", () => {
+      expect(hasOrm("// use ent.Client here")).toBe(true);
+    });
+
+    it("leaves the untouched alternation alone (gorm2 still matches)", () => {
+      // Proves the fix is scoped to the Ent alternative only.
+      expect(hasOrm("gorm2.Open()", "go")).toBe(true);
+    });
+  });
+
+  describe("production-shaped file", () => {
+    it("classifies an HTTP handler that merely reads file.content as http_client, not orm", () => {
+      const body = [
+        'import { readFileSync } from "node:fs";',
+        'import { logger } from "../logger.js";',
+        "",
+        "export async function loadOrder(id: string): Promise<Order> {",
+        "  logger.info(`loading order ${id}`);",
+        "  const res = await fetch(`https://api.example.com/orders/${id}`);",
+        "  if (!res.ok) throw new Error(`order ${id} failed: ${res.status}`);",
+        "  return (await res.json()) as Order;",
+        "}",
+        "",
+        "export function summarize(file: { content: string }): string[] {",
+        '  const lines = file.content.split("\\n");',
+        "  return lines.filter((l) => l.trim().length > 0);",
+        "}",
+      ].join("\n");
+
+      const patterns = patternsFor(body);
+      expect(patterns).toContain("http_client");
+      expect(patterns).not.toContain("orm");
+    });
+  });
+
+  describe("finding level: the reported symptom", () => {
+    it("does not invent an ORM majority from `content.` substrings", () => {
+      // Five files whose only data-access-looking line is a string split, plus one
+      // real HTTP client. Before the fix this produced exactly:
+      //   "Pattern drift: src/handlers/f5.ts uses http_client while 5/6 files use orm"
+      const files: SourceFile[] = [];
+      for (let i = 0; i < 5; i++) {
+        files.push(file(`src/handlers/f${i}.ts`, 'const lines = file.content.split("\\n");'));
+      }
+      files.push(file("src/handlers/f5.ts", "await fetch(url);"));
+
+      const findings = patternFindings(classifyPatterns(files));
+      expect(findings.filter((f) => /\borm\b/.test(f.message))).toEqual([]);
+    });
+
+    it("still reports drift when a real ORM majority exists", () => {
+      // Guards the opposite direction: the detector must not go silent.
+      const files: SourceFile[] = [];
+      for (let i = 0; i < 5; i++) {
+        files.push(file(`src/handlers/f${i}.ts`, "const rows = await prisma.user.findMany({ where: { id } });"));
+      }
+      files.push(file("src/handlers/f5.ts", "await fetch(url);"));
+
+      const findings = patternFindings(classifyPatterns(files));
+      expect(findings.some((f) => /uses http_client while 5\/6 files use orm/.test(f.message))).toBe(true);
+    });
+  });
+});

--- a/test/unit/drift/classifier-golden.test.ts
+++ b/test/unit/drift/classifier-golden.test.ts
@@ -73,6 +73,22 @@ const GOLDEN: [string, string | null, string | null, string | null][] = [
   ["decodeTokenShapeTie", null, null, "tuple returns (value, error)"],
   ["readCursorShapeTie", null, null, "error-object returns"],
   ["loadProfileAccessTie", "async_await", "inline HTTP client calls", null],
+
+  // Issue #87: route registrations share verb names with ORM CRUD calls.
+  // The first three must classify as null (they are routers, not data access);
+  // the next three are real ORM idioms that must keep classifying as ORM.
+  ["mountChiRoutes", null, null, null],
+  ["mountFiberRoutes", null, null, null],
+  ["mountCustomRouter", null, null, null],
+  ["loadUserViaGorm", null, "ORM methods", "tuple returns (value, error)"],
+  ["listSeatsViaSequelize", null, "ORM methods", null],
+  ["filterUsersViaDjango", null, "ORM methods", null],
+  // KNOWN REMAINING FALSE POSITIVE, deliberately pinned rather than fixed.
+  // `routes.findOne(pattern)` passes an identifier, not a route-path literal,
+  // so it is indistinguishable from `Model.findOne(id)` without receiver or
+  // import knowledge. Both gates that would provide that knowledge cost 4 to 6
+  // of 8 real ORM idioms, so the recall trade was refused. Tracked in todo.md.
+  ["lookupRouteTable", null, "ORM methods", "null/undefined sentinels"],
 ];
 
 describe("shared single-body classifiers (characterization golden)", () => {


### PR DESCRIPTION
## Summary

Three regex defects made VibeDrift report an ORM in codebases that have none. Scanning this repository against itself said `src/auth/api.ts uses http_client while 5/6 files use orm` at confidence 1.0, with no ORM in `package.json`. The label was inverted: the one file that genuinely is an HTTP client was reported as the deviation from a majority that does not exist.

Three commits, each independently measured and reviewable on its own:

**1. `fix(codedna): anchor the Ent ORM signal`** — the ORM regex carried a bare `ent\.` alternative with no left boundary, so any identifier ending in the letters "ent" plus a dot was read as Ent ORM usage. `file.content.split(...)` and `fullContent.indexOf(...)` were enough. That one alternative produced **125 of 125** "ORM import/usage" signals across five repos that declare no ORM at all.

A left `\b` alone is not sufficient: it still fires on a local variable named `ent` (`ent.ty`, `ent.entitled`). Real Ent usage is a package selector followed by an exported Go identifier, so the Ent alternative is split out as `/\bent\.[A-Z]/`, case-sensitive because the `/i` flag would make the `[A-Z]` discriminator a no-op.

**2. `fix(codedna): match handler paths by segment, not substring`** — `isHandlerOrServiceFile` matched unanchored substrings, so "route" inside `autorouter.ts`, `itty-router.js` and this repo's own `src/drift/route-extractors/` admitted files that are not handlers, and "api" admitted `therapist.ts` and `capital.ts`. A file that enters the classifier gets labelled by whatever signal fires first, so a parser was being given a data-access architecture label.

**3. `fix(drift): stop reading route registrations as ORM calls`** — the data-access detector matched bare CRUD verb names with no receiver and no import corroboration, so `router.Create("/users", h)` and `r.Delete("/orders/{id}", h.Del)` were evidence of an ORM. 7 of 8 realistic router bodies were labelled "ORM methods". This one is not confined to a scan report: `classifyDataAccessLabel` is the MCP `validate_change` contract and `hasDataAccessPattern` is on the session resolve path, so an agent editing a router mid-session could be told its change conflicts with an ORM the repo does not have.

## Before / after

![before and after](https://raw.githubusercontent.com/VibeDrift/VibeDrift/assets/i87-orm-demo/docs/media/issue-87/i87-before-after.gif)

A 7-file TypeScript service with no ORM in `package.json`, where five files contain `const lines = file.content.split("\n")`:

```
── BEFORE (main)
  Pattern drift: src/handlers/payments.ts uses http_client while 5/6 files use orm   [confidence 1]

── AFTER (fix/orm-mislabel-87)
  no codedna-pattern findings
```

## The measurement

Population: 11 repositories, 4 language mixes, roughly 4,000 discovered files. Four Vibestack repos plus seven third-party OSS repos already vendored under `eval/discrimination/.cache/`. Run with the cache disabled:

```bash
VIBEDRIFT_DISABLE_CACHE=1 npx tsx src/cli/index.ts "$R" --local-only --no-cache --format json
```

| repo | composite | `codedna-pattern` | of which name `orm` | `drift-architectural_consistency` |
| --- | --- | --- | --- | --- |
| TanStack-query | 82.5 → 82.5 | 14 → **0** | 14 → **0** | 10 → 10 |
| trpc-trpc | 94.8 → 95.1 | 33 → 19 | 33 → **10** | 1 → 1 |
| honojs-hono | 70.8 → 70.9 | 5 → **0** | 5 → **0** | 0 → 0 |
| fastify-fastify | 88.0 → 88.2 | 5 → **0** | 4 → **0** | 0 → 0 |
| vibedrift-public | 87.0 → 86.8 | 1 → **0** | 1 → **0** | 6 → 6 |
| vibedrift-landing-page | 90.1 → 90.1 | 3 → 3 | 3 → 2 | 8 → 8 |
| vibe-drift-api | 75.0 → 75.0 | 1 → 1 | 1 → 1 | 3 → 3 |
| vibelang | 74.6 → 74.6 | 0 → 0 | 0 → 0 | 1 → 1 |
| expressjs-express, sindresorhus-ky, vuejs-core | unchanged | 0 → 0 | 0 → 0 | 0 → 0 |
| **total** | | **62 → 23** | **61 → 13** | **29 → 29** |

Three things worth reading off that table.

**Recall is preserved where an ORM genuinely exists.** trpc really does use Prisma. Counting signals rather than findings, it keeps exactly **20 of 20** `ORM import/usage` signals after the fix, and 0 Ent false positives. An earlier draft of commit 2 dropped all 20, because `src/server/routers/` is a `routers` directory and my first anchored pattern only accepted `routes`. That is why `routers?` is in the alternation, and why there is a test pinning it.

**No collateral findings were lost.** `drift-architectural_consistency` totals are identical at 29 before and after. Commit 3 can in principle shrink a directory group below `minGroupSize` and silently delete unrelated data-access findings, so this column is the check for that, and it did not happen.

**The composite barely moves, and that is the point.** The largest change is +0.3 on trpc; `vibedrift-public` moves −0.2. The case for this fix is the precision of a user-visible sentence, not the number.

## What this deliberately does not fix

The remaining 13 ORM-naming findings come from two *other* ORM regexes in the same file (`/\.Where\(/i` matching numpy's `np.where(`, `/\.create\(.*{/` matching `stripe.customers.create({`). That is a separate false-positive class with a different fix, and folding it in would have made this measurement uninterpretable. Same for the one surviving Path B case: `routes.findOne(pattern)` passes an identifier rather than a route-path literal, so it is indistinguishable from `Model.findOne(id)` without receiver or import knowledge. It is pinned in the golden corpus with a comment saying so.

I measured the two gates that *would* provide that knowledge before rejecting them: requiring a known ORM token keeps 2 of 8 real ORM idioms, requiring an ORM-ish chain root keeps 4 of 8. The first-argument discriminator shipped here keeps 10 of 10. A manifest gate is not expressible at all, because both entry points take only `(content, path)`.

## Regression proof

I inverted each change and watched the tests fail:

- Restore `|ent\.` in the alternation → **20 of 60** fail in `pattern-classifier.test.ts`
- Restore the unanchored path gate → **8 of 60** fail (exactly the eight rejection cases)
- Remove the `(?!['"\`]\/)` lookahead → **3 fail** in `classifier-golden.test.ts` (`mountChiRoutes`, `mountFiberRoutes`, `mountCustomRouter`)

`test/unit/codedna/pattern-classifier.test.ts` is new; there were previously **zero** tests anywhere referencing this module. It adds 60 tests: 15 true positives across six ORM libraries, 13 identifiers that must no longer match, boundary cases for aliases, string literals, comments and casing, 18 path-gate cases in both directions, and a finding-level test reproducing the reported symptom.

## Blast radius

```
$ command grep -rn "classifyPatterns|patternFindings|isHandlerOrServiceFile" src/
src/codedna/index.ts
src/codedna/pattern-classifier.ts

$ command grep -rn "classifyDataAccessLabel|hasDataAccessPattern" src/
src/drift/architectural-contradiction.ts
src/session/finding-anchor.ts
src/tools-core/tools/validate-change.ts
```

Commit 3 touches all three of its consumers at once by editing the shared regex, which preserves the `classifyDataAccessLabel` ↔ `hasDataAccessPattern` symmetry the module docstring calls load-bearing.

## Version bumps

`BASELINE_VERSION` 3 → 4 in commit 3. The `data_access` vote is persisted in the MCP baseline and read by `validate_change` and the session inline check, so a warm `~/.vibedrift/baseline-cache` would otherwise keep serving the old label and the fix would not reproduce for existing users.

No `Analyzer.version` bump: this touches Code DNA and a drift detector, neither of which is keyed by the findings cache. No `SCORING_VERSION` bump: no scoring math, constant, factor or gate threshold changed. Flagging one judgment call for you rather than deciding it myself — the fix does move stored composites by up to 0.3, which makes historical scores marginally non-comparable in the way a scoring change would. Say the word if you want it bumped.

## Calibration

`npm run calibrate` run before and after. The measured rows are **byte-identical**, and the one enforced gate holds:

```
✓ security floor precision gate: 1.000 >= 0.95
```

The `architectural_consistency` row sits at recall 0.00, which pre-dates this branch: the saved baseline I diffed against is dated 2026-07-16. `npm run calibrate:monotonic` is not required here (no scoring or weight change) and is red on `main` for unrelated reasons.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed — n/a, no flag, command or feature changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra)
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

Suite: 191 files, 2583 tests, all passing.

## Related issues

Closes #87

---

Investigated and implemented by an AI assistant following `docs/AI_CONTRIBUTOR_GUIDE.md`, including the investigator/refuter passes. The refuter overturned several numbers from the first pass, notably that a bare `\bent\.` boundary is not a sufficient fix.
