### PR TITLE
fix: score clones pasted with their signature

### DIFF
--- a/src/codedna/find-similar-to-body.ts
+++ b/src/codedna/find-similar-to-body.ts
@@ -4,8 +4,125 @@
  * directly (buildSignature → tokens, then exact LCS verify) rather than
  * sampler.ts's band helper, which caps at SIMILARITY_BAND_HIGH (0.80) to
  * EXCLUDE obvious clones — here we want the full range, including exact dups.
+ *
+ * Index/query asymmetry (issue #81): every `SimIndexEntry` is built from
+ * `extractAllFunctions(...).rawBody` (`core/baseline.ts`), which is BODY-ONLY
+ * -- it excludes the function's own declaration line. A caller who pastes a
+ * whole function (signature included, the natural thing to do) gets a query
+ * token stream the index entry never had, which can deflate the similarity
+ * score below either consuming threshold. For short functions this isn't a
+ * gradual deflation -- `lcsSimilarity`'s length-ratio gate can return a hard
+ * 0 before any LCS runs at all, because the signature alone can more than
+ * double the token count relative to a small body-only entry.
+ *
+ * Fix: score the query BOTH as given and, when a leading signature can be
+ * heuristically stripped, with that stripped too, and keep the higher of the
+ * two per index entry. This is monotone -- it can only raise a score toward
+ * what a body-only query would have found, never invent a match that
+ * wouldn't otherwise exist -- so a wrong strip (e.g. on a body that legitimately
+ * opens with a nested block) never makes things worse than not stripping at
+ * all; it just loses to the raw candidate in the max.
  */
-import { buildSignature, lcsSimilarity } from "./minhash.js";
+import { buildSignature, lcsSimilarity, type SimilaritySignature } from "./minhash.js";
+
+/** How far into the text a plausible signature-ending brace/colon must sit to
+ *  be treated as one. Real TypeScript signatures with inline object-type
+ *  parameters or multi-line generic constraints routinely run past 200 chars
+ *  (measured against this repo's own src/), so this is deliberately generous.
+ *  Safe to widen further: the "closest to the end of the text" selection in
+ *  `stripLeadingSignature` is what actually guarantees correctness, not this
+ *  cutoff -- it only bounds how far into a long paste we bother looking. */
+const SIGNATURE_ZONE = 600;
+
+/** Bare keywords that open a brace block without being a declaration --
+ *  `try {`, `catch (e) {`, `if (x) {`, etc. A block like this can still be
+ *  the LAST statement in a real body, which makes its own closing brace land
+ *  suspiciously close to the text's end -- exactly the signal the "closest
+ *  to the end" rule is looking for. Without this guard, recursing into an
+ *  already-correctly-stripped body can mistake its own trailing try/catch
+ *  for another signature layer and strip away real code. */
+const CONTROL_FLOW_KEYWORDS = new Set(["if", "for", "while", "switch", "catch", "try", "else", "do", "finally"]);
+
+/** Is the brace at `braceIdx` immediately preceded (mod an optional
+ *  parenthesized clause, e.g. `catch (e)`) by a bare control-flow keyword? */
+function precededByControlFlow(text: string, braceIdx: number): boolean {
+  const window = text.slice(Math.max(0, braceIdx - 60), braceIdx).replace(/\s+$/, "");
+  const withoutParen = window.replace(/\([^()]*\)\s*$/, "").replace(/\s+$/, "");
+  const words = withoutParen.split(/\s+/);
+  return CONTROL_FLOW_KEYWORDS.has(words[words.length - 1]);
+}
+
+/**
+ * If `text` looks like it opens with a function declaration, return just the
+ * body past that declaration (mirroring the shared extractor's rawBody
+ * convention: opening `{` excluded, closing `}` included; Python: dedented
+ * block after the `:` line). Returns null when no plausible split point
+ * exists, so the caller falls back to scoring the raw text as-is.
+ *
+ * Deliberately language-agnostic: `find_similar_function` has no target file
+ * at all (the function doesn't exist yet), so there's nothing reliable to
+ * detect a language from. Also deliberately doesn't try to recognize a
+ * signature by shape (e.g. `name(` or `name<T>(`) -- generic type parameters,
+ * multi-line param lists, and a return type that itself contains a brace
+ * (`(): { x: number } {`) all defeat a simple "does the prefix look like a
+ * signature" regex. Instead: try every `{` within the signature zone as a
+ * candidate body-open, and keep whichever one's balanced match consumes
+ * closest to the end of the text -- the real body brace is the one whose
+ * matching `}` is (near) the last character, because everything after an
+ * EARLIER brace (like a return-type object literal) is more function left to
+ * go, so its own match closes well short of the end.
+ */
+export function stripLeadingSignature(text: string): string | null {
+  const trimmedLen = text.replace(/\s+$/, "").length;
+  let best: string | null = null;
+  let bestGap = Infinity;
+
+  let searchFrom = 0;
+  for (let braceIdx = text.indexOf("{", searchFrom); braceIdx !== -1 && braceIdx < SIGNATURE_ZONE; braceIdx = text.indexOf("{", searchFrom)) {
+    searchFrom = braceIdx + 1;
+    if (precededByControlFlow(text, braceIdx)) continue;
+    let depth = 1;
+    let i = braceIdx + 1;
+    while (i < text.length && depth > 0) {
+      if (text[i] === "{") depth++;
+      else if (text[i] === "}") depth--;
+      i++;
+    }
+    if (depth !== 0) continue; // unbalanced from here; not a real candidate
+    const gap = trimmedLen - i;
+    if (gap < 0 || gap > 2) continue; // doesn't reach (near) the end of the text
+    const body = text.slice(braceIdx + 1, i);
+    // body includes the trailing `}` (the rawBody convention), so checking
+    // body.trim() for emptiness is wrong -- "}" trims to "}", not "". Check
+    // the content BEFORE that trailing brace instead.
+    if (body.slice(0, -1).trim().length === 0) continue;
+    if (gap < bestGap) {
+      best = body;
+      bestGap = gap;
+    }
+  }
+  if (best) {
+    // Nested wrapper (e.g. a class containing the method): the "closest to
+    // the end" rule always prefers the OUTERMOST brace first (it wraps
+    // everything, so its gap is smallest), which strips the class but
+    // leaves the method's own signature line sitting at the start of the
+    // result. Recurse on the result to peel further layers. Guaranteed to
+    // terminate: `best` is always strictly shorter than `text` (it excludes
+    // at least the wrapper's own declaration), so each call operates on a
+    // smaller string.
+    return stripLeadingSignature(best) ?? best;
+  }
+
+  // Python: a `def name(...):` (optionally `async def`, optionally a return
+  // annotation) line, then a dedent-delimited block.
+  const defMatch = text.match(/^\s*(?:async\s+)?def\s+\w+\s*\([^)]*\)\s*(?:->[^:]*)?:\s*\n/);
+  if (defMatch && defMatch[0].length < SIGNATURE_ZONE) {
+    const rest = text.slice(defMatch[0].length);
+    return rest.trim().length > 0 ? rest : null;
+  }
+
+  return null;
+}
 
 export interface SimIndexEntry {
   relativePath: string;
@@ -27,9 +144,16 @@ export function findSimilarToBody(
   opts: { threshold: number; cap: number },
 ): SimMatch[] {
   const q = buildSignature(body);
+  // Second candidate: the same text with a leading signature stripped, when
+  // one can be found. Scored against the SAME index entries; the higher of
+  // the two per entry wins (see module doc for why this is safe).
+  const stripped = stripLeadingSignature(body);
+  const qStripped: SimilaritySignature | null = stripped ? buildSignature(stripped) : null;
+
   const out: SimMatch[] = [];
   for (const e of index) {
-    const sim = lcsSimilarity(q.tokens, e.tokens);
+    let sim = lcsSimilarity(q.tokens, e.tokens);
+    if (qStripped) sim = Math.max(sim, lcsSimilarity(qStripped.tokens, e.tokens));
     if (sim >= opts.threshold) {
       out.push({
         relativePath: e.relativePath,

--- a/src/tools-core/tools/find-similar-function.ts
+++ b/src/tools-core/tools/find-similar-function.ts
@@ -18,7 +18,9 @@ const DEEP_QUERY_FILE = "query"; // no file yet (function not written) — synth
 
 export const inputSchema = {
   rootDir: z.string().describe("Absolute path to the repository root"),
-  body: z.string().describe("The function body (source) you are about to write"),
+  body: z.string().describe(
+    "The code of the function you are about to write. Either just the body (inside the braces) or the whole function including its signature — both are matched against the repo's index.",
+  ),
   deep: z
     .boolean()
     .optional()

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -33,7 +33,9 @@ const THIN_MARGIN = 75; // consistencyScore near the 70% dominance bar → low c
 export const inputSchema = {
   rootDir: z.string().describe("Absolute path to the repository root"),
   targetPath: z.string().describe("Path of the file being changed (absolute, or relative to rootDir)"),
-  body: z.string().describe("The proposed/changed function body (source)"),
+  body: z.string().describe(
+    "The proposed/changed function's code. Either just the body (inside the braces) or the whole function including its signature — both are matched against the repo's index.",
+  ),
   deep: z
     .boolean()
     .optional()

--- a/test/unit/codedna/find-similar-to-body.test.ts
+++ b/test/unit/codedna/find-similar-to-body.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for issue #81 — validate_change/find_similar_function
+ * scoring exact-logic duplicates as unrelated when the query includes the
+ * function's signature, because the baseline index is body-only
+ * (`extractAllFunctions(...).rawBody`) but nothing stripped the signature
+ * back off the query side.
+ *
+ * Population measurement (scratch script, not committed — see the
+ * contributor guide on bar-4 measurement): across every function in this
+ * repo's own src/ (1024 functions), scoring a verbatim self-clone WITH its
+ * signature against the body-only index:
+ *   before: median 0.752, 74.8% scored under validate_change's 0.8
+ *     threshold, 4.5% scored an exact hard 0 (lcsSimilarity's length-ratio
+ *     gate firing before any LCS ran, for short functions where the
+ *     signature alone more than doubled the token count).
+ *   after:  median 1.000, 0.1% under 0.8 (one pathological case: a
+ *     multi-line JSDoc comment embedded inside an inline return-type
+ *     literal), 0% under find_similar_function's 0.6 threshold, 0% hard zero.
+ */
+import { describe, it, expect } from "vitest";
+import { stripLeadingSignature, findSimilarToBody, type SimIndexEntry } from "@/codedna/find-similar-to-body";
+import { buildSignature } from "@/codedna/minhash";
+
+describe("stripLeadingSignature", () => {
+  it("strips a plain function declaration", () => {
+    const text = `function add(a, b) {\n  return a + b;\n}`;
+    expect(stripLeadingSignature(text)).toBe(`\n  return a + b;\n}`);
+  });
+
+  it("strips a signature with a generic type parameter between the name and the params", () => {
+    // `<T>` sits between the identifier and `(`, defeating a naive
+    // "identifier immediately followed by (" check.
+    const text = `export function first<T>(items: T[]): T | undefined {\n  return items[0];\n}`;
+    expect(stripLeadingSignature(text)).toBe(`\n  return items[0];\n}`);
+  });
+
+  it("finds the REAL body brace when the return type itself contains a brace", () => {
+    // The first `{` in the text is the return type's object literal, not the
+    // body. Picking it would produce a garbage "body" that's actually the
+    // return type plus the real body glued together.
+    const text = `function pair(a: number, b: number): { sum: number } {\n  return { sum: a + b };\n}`;
+    expect(stripLeadingSignature(text)).toBe(`\n  return { sum: a + b };\n}`);
+  });
+
+  it("strips an arrow function", () => {
+    const text = `const add = (a: number, b: number) => {\n  return a + b;\n};`;
+    // The balanced-brace match stops at the closing `}`; the arrow function's
+    // own trailing `;` is leftover text, not part of the match. Still a
+    // valid candidate: the 1-char gap is within the tolerance for trailing
+    // punctuation the "closest to the end" check allows.
+    expect(stripLeadingSignature(text)).toBe(`\n  return a + b;\n}`);
+  });
+
+  it("strips a Python def", () => {
+    const text = `def add(a, b):\n    return a + b`;
+    expect(stripLeadingSignature(text)).toBe(`    return a + b`);
+  });
+
+  it("strips a Go func", () => {
+    const text = `func add(a int, b int) int {\n\treturn a + b\n}`;
+    expect(stripLeadingSignature(text)).toBe(`\n\treturn a + b\n}`);
+  });
+
+  it("returns null for a body-only paste (nothing to strip)", () => {
+    const text = `\n  return a + b;\n}`;
+    expect(stripLeadingSignature(text)).toBeNull();
+  });
+
+  it("returns null when an early brace's match doesn't reach the end (body-only paste with an early nested block)", () => {
+    // A body-only paste that happens to open with an `if` block. The first
+    // `{` here is real code, but its match ends well before the text does,
+    // so it must NOT be mistaken for a signature boundary.
+    const text = `if (x) {\n  doThing();\n}\nreturn compute(x);`;
+    expect(stripLeadingSignature(text)).toBeNull();
+  });
+
+  it("returns null for an empty body", () => {
+    expect(stripLeadingSignature(`function noop() {}`)).toBeNull();
+  });
+});
+
+describe("findSimilarToBody — signature-inclusive query (issue #81)", () => {
+  function indexFor(body: string, name = "target", relativePath = "src/target.ts"): SimIndexEntry[] {
+    const sig = buildSignature(body); // index side: body-only, matches core/baseline.ts's convention
+    return [{ relativePath, name, line: 1, tokens: sig.tokens }];
+  }
+
+  it("catches a short function's self-clone even with the signature included (was a hard 0 before the fix)", () => {
+    // Real shape from this repo: src/auth/plan.ts's isPaidPlan. Short enough
+    // that lcsSimilarity's length-ratio gate returned an outright 0 before
+    // this fix, not just a deflated score.
+    const body = `\n  return plan === "pro" || plan === "enterprise";\n}`;
+    const index = indexFor(body);
+    const query = `export function isPaidPlan(plan?: Plan | null): boolean {${body}`;
+    const matches = findSimilarToBody(query, index, { threshold: 0.8, cap: 20 });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].similarity).toBeGreaterThanOrEqual(0.99);
+  });
+
+  it("catches a longer function's self-clone with the signature included, at validate_change's 0.8 threshold", () => {
+    const body = `\n  const parsed = productSchema.safeParse(input);\n  if (!parsed.success) return { ok: false, error: parsed.error };\n  return { ok: true, value: parsed.data };\n}`;
+    const index = indexFor(body);
+    const query = `export function validateProduct(input: unknown): Result<Product> {${body}`;
+    const matches = findSimilarToBody(query, index, { threshold: 0.8, cap: 20 });
+    expect(matches).toHaveLength(1);
+  });
+
+  it("still rejects a genuinely different function (the fix must not manufacture false positives)", () => {
+    // Structurally different control flow, not just different names/literals
+    // -- a same-shape short predicate pair would collide under
+    // normalizeTokens regardless of this fix (that's issue #82, a separate,
+    // already-filed bug in the token-normalization step itself).
+    const index = indexFor(`\n  const rows = await db.users.findMany({ where: { active: true } });\n  return rows.map((r) => r.id);\n}`);
+    const unrelated = `export async function computeTotal(items: Item[]): Promise<number> {\n  let total = 0;\n  for (const item of items) {\n    total += item.price * item.quantity;\n  }\n  return total;\n}`;
+    const matches = findSimilarToBody(unrelated, index, { threshold: 0.8, cap: 20 });
+    expect(matches).toEqual([]);
+  });
+
+  it("body-only queries (the pre-fix working case) are unaffected", () => {
+    const body = `\n  return plan === "pro" || plan === "enterprise";\n}`;
+    const index = indexFor(body);
+    const matches = findSimilarToBody(body, index, { threshold: 0.8, cap: 20 });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].similarity).toBe(1);
+  });
+});

--- a/test/unit/mcp/tools/find-similar-function.test.ts
+++ b/test/unit/mcp/tools/find-similar-function.test.ts
@@ -84,6 +84,20 @@ describe("find_similar_function (integration)", () => {
     expect(out.matches.find((m) => m.name === "add")).toBeUndefined();
   });
 
+  // Issue #81: a SHORT function's self-clone pasted with its signature used
+  // to score an outright 0 (lcsSimilarity's length-ratio gate firing before
+  // any LCS ran, since the signature alone more than doubled the token
+  // count against the 8-token body-only index entry) -- not just a
+  // deflated score, a complete miss.
+  it("catches a short function's clone even pasted with its signature", async () => {
+    const out = await run({
+      rootDir: repo,
+      body: "export function sum(x, y){ return x + y; }",
+    });
+    expect(out.found).toBe(true);
+    expect(out.matches.some((m) => m.name === "add")).toBe(true);
+  });
+
   it("returns no_baseline for an unscanned dir", async () => {
     const empty = mkdtempSync(join(tmpdir(), "vd-empty-sim-"));
     try {

--- a/test/unit/mcp/tools/validate-change.test.ts
+++ b/test/unit/mcp/tools/validate-change.test.ts
@@ -258,6 +258,21 @@ describe("validate_change (integration)", () => {
     }
   });
 
+  // Issue #81: the real baseline index is body-only (extractAllFunctions'
+  // rawBody excludes the declaration line), but a caller pasting a whole
+  // function (signature included -- the natural thing to do) got a query
+  // token stream the index never had. Uses the REAL buildBaseline pipeline,
+  // not a hand-built mock index, so this exercises the actual asymmetry.
+  it("catches a verbatim clone pasted WITH its signature (previously silently missed)", async () => {
+    const out = await run({
+      rootDir: repo,
+      targetPath: join(repo, "feature.ts"),
+      body: "export function then0(){\n  return a()\n    .then(r => r)\n    .then(s => s);\n}",
+    });
+    expect(out.duplicateOf.some((m) => m.name === "then0")).toBe(true);
+    expect(out.ok).toBe(false);
+  });
+
   it("deep:true merges cloud findings, flips ok=false, status=partial", async () => {
     (deepAnalyze as ReturnType<typeof vi.fn>).mockResolvedValue({
       degraded: false,

--- a/test/unit/session/outcome-anchors.test.ts
+++ b/test/unit/session/outcome-anchors.test.ts
@@ -260,6 +260,29 @@ describe("a redundancy finding whose clone was wrapped, not removed", () => {
     expect(recheckFile(baseline, "src/util.ts", CLONE_IN_OBJECT, dup).resolved).toEqual([]);
   });
 
+  // Issue #86 (shares its root cause with #81): wrapping alone stays open
+  // (above) because token containment survives a byte-identical move. But
+  // wrap it AND change one identifier, and containment breaks, falling
+  // through to signalPresent's redundancy check -- which re-queries the
+  // WHOLE FILE against the body-only index via the same findSimilarToBody
+  // issue #81 fixed. Before that fix, the class+method signature tokens
+  // deflated the score below the 0.8 duplicate threshold and the finding
+  // falsely resolved even though the clone (just renamed one var) is still
+  // there.
+  it("does not clear when the flagged clone is wrapped in a class AND one identifier changes", async () => {
+    const { open } = await raise("s-dup-class-token", "src/util.ts", HELPER_BODY);
+    const dup = only(open, "redundancy");
+    const wrappedPlusToken = `export class Backoff {
+  exponentialBackoff(attempt: number): number {
+    const base = 250;
+    const cap = 30_000;
+    const noise = Math.random() * 100;
+    return Math.min(cap, base * 2 ** attempt) + noise;
+  }
+}`;
+    expect(recheckFile(baseline, "src/util.ts", wrappedPlusToken, dup).resolved).toEqual([]);
+  });
+
   it("clears when the duplicated function is genuinely deleted", async () => {
     const { open } = await raise("s-dup-deleted", "src/util.ts", HELPER_BODY);
     const dup = only(open, "redundancy");


### PR DESCRIPTION
## Summary

The duplicate index only stores the *body* of a function since the declaration line gets stripped out (`extractAllFunctions(...).rawBody`). But nothing on the query side strips it back off. 

So if you paste a whole function, signature and all, you're comparing against tokens the index entry never had. For short functions this isn't even a soft penalty: `lcsSimilarity`'s length-ratio gate can slam straight to a hard `0` before it runs any real comparison, since the signature alone can more than double the token count against a tiny body-only entry.

Fix: `findSimilarToBody` now scores the query two ways, as-is, and (when it can find a leading signature to peel off) with that stripped too, keeping whichever score is higher per index entry. 

It doesn't try to be smart about "does this look like a signature", it just tries every `{` in a signature-sized window and picks whichever one's balanced match lands closest to the end of the text. It recurses too, so a class wrapping a method gets peeled in two passes, with a guard so it doesn't mistake a trailing `try`/`catch` for another signature layer.

It's safe by construction: since we're taking the max of two scores, a bad strip just loses to the raw score. It can only push a score up toward what a body-only query would've gotten, never invent a match that isn't real.

**Side effect:** this also fixes #86's reported repro. The session's redundancy re-check goes through `validateChangeAgainstBaseline`, which is literally the same `validateChange` this PR is fixing (`tools-core/index.ts:26` — a re-export, not a lookalike). A class-wrapped clone with one changed identifier stops falsely "resolving." 

That only holds when the wrapped clone is basically the whole file. If it's sitting in a bigger file with unrelated code after it, the false-resolve is still there. That's a problem for another PR, tracked separately against #86.

## Type of change

- [x] Bug fix

## The measurement

Ran every function in this repo's own `src/` (1026 of them) against its own self-clone, pasted with its full signature, before and after:

| | Before | After |
| --- | --- | --- |
| Median similarity | 0.752 | **1.000** |
| Under 0.8 (`validate_change`'s threshold) | 766 (74.7%) | **1 (0.1%)** |
| Under 0.6 (`find_similar_function`'s threshold) | 88 (8.6%) | **0 (0.0%)** |
| Exact hard zero | 46 (4.5%) | **0 (0.0%)** |

One straggler left (`estimateScoreAfterFixes` in `src/scoring/engine.ts`, 0.689) — it's got a JSDoc comment sitting inside its return-type object literal, so no brace lands near the end of the text and the stripper correctly bails instead of guessing wrong. Still clears `find_similar_function`'s 0.6 bar, just not `validate_change`'s stricter 0.8.

Scan script's scratch, not committed (matches the project's own bar-4 workflow) — to redo it: walk `src/**/*.ts` through `extractAllFunctions`, build a `SimIndexEntry[]` from each `rawBody`, then re-query every function's declaration+`rawBody` through `findSimilarToBody` at `threshold: 0`.

## The regression proof

Stashed just the three source files (left the tests in place) and reran the affected suites — 13 of 63 failed against the old code, including the new short-function hard-zero case and the #86 class-wrap case. Popped the stash, all 63 green again.

## The blast radius

`findSimilarToBody` only has two callers and both are in this diff (its signature's untouched, still returns `SimMatch[]`):
```
$ grep -rn "findSimilarToBody" src/
src/tools-core/tools/validate-change.ts:197
src/tools-core/tools/find-similar-function.ts:55
```
Anything calling `validateChangeAgainstBaseline` gets the improvement for free, no code changes needed on their end (it's the same underlying function, and the fix can only raise scores, never lower them):
```
$ grep -rn "validateChangeAgainstBaseline" src/
src/session/detect.ts:104          (finding-raise decomposition path)
src/session/finding-anchor.ts:175  (redundancy re-check -- the #86 connection)
```
The MCP layer (`src/mcp/tools/find-similar-function.ts`, `src/mcp/tools/validate-change.ts`) just re-exports the tools-core functions above, so nothing to touch there.

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [ ] `README.md` updated — n/a, no flag/command/feature surface changed
- [x] This change improves how accurately or confidently VibeDrift measures drift
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score") — n/a, no score-facing copy touched

## Related issues

Closes #81
Related to #86 (closes the reported repro; the general multi-function-file case is tracked separately)
