### PR TITLE
refactor: dedup identical security-AST helpers

### DIFF
--- a/src/drift/security-ast-common.ts
+++ b/src/drift/security-ast-common.ts
@@ -1,0 +1,48 @@
+/**
+ * Helpers shared verbatim by the per-language security-AST analyzers
+ * (`security-ast-{go,rust,python}.ts`). Each was a byte-identical copy in two or
+ * three of those files; extracting them here means they cannot silently diverge
+ * — a real hazard in the NEVER-FALSE-BLESS layer. Language-specific helpers
+ * (node-type skip lists, function-def node kinds, string-literal decoding)
+ * deliberately stay in their own files.
+ */
+
+import type { SyntaxNode } from "../core/types.js";
+
+/**
+ * Lowercase segments of an identifier, split on underscore/non-alphanumeric AND
+ * CamelCase boundaries (digits stay attached to their run):
+ *   "get_author_stats" → [get, author, stats]; "JWTBearer" → [jwt, bearer];
+ *   "OAuth2PasswordBearer" → [o, auth2, password, bearer].
+ * Whole-segment matching makes substring blessing structurally impossible.
+ */
+export function nameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * True when `node` or any ancestor BELOW `source_file` carries a parse error — a
+ * per-construct surgical skip, never a whole-file fallback. Error recovery can
+ * swallow a later valid registration into a broken call's argument list as a
+ * clean-looking nested node; extracting from that garbage context could
+ * attribute a route to the wrong receiver/scope. Stopping below `source_file`
+ * means a file-level error in a SIBLING construct does not suppress clean ones.
+ */
+export function inErroredContext(node: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = node;
+  while (cur && cur.type !== "source_file") {
+    if (cur.hasError) return true;
+    cur = cur.parent;
+  }
+  return false;
+}
+
+/** Non-null named children of a node (or [] when the node is absent). */
+export function namedChildrenOf(n: SyntaxNode | null | undefined): SyntaxNode[] {
+  return n ? n.namedChildren.filter((c): c is SyntaxNode => c !== null) : [];
+}

--- a/src/drift/security-ast-go.ts
+++ b/src/drift/security-ast-go.ts
@@ -139,6 +139,7 @@
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
+import { nameSegments, inErroredContext, namedChildrenOf } from "./security-ast-common.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 import { resolveGoMiddlewareBody } from "./security-xfile-index.js";
 import type { CrossFileIndex } from "./security-xfile-index.js";
@@ -282,22 +283,6 @@ function goReceiverName(operand: SyntaxNode | null): string | null {
     }
   }
   return null;
-}
-
-/** True when node or any ancestor BELOW source_file carries a parse error.
- *  Probe-verified hazard: error recovery swallows a later, syntactically valid
- *  registration into a broken call's argument_list as a clean-looking nested
- *  call_expression; extracting from that garbage context could attribute the
- *  route to the wrong receiver/scope. The walk stops below source_file so a
- *  file-level error in a SIBLING function does not suppress clean functions
- *  (per-construct surgical skip; the whole-file dispatch gate is separate). */
-function inErroredContext(node: SyntaxNode): boolean {
-  let cur: SyntaxNode | null = node;
-  while (cur && cur.type !== "source_file") {
-    if (cur.hasError) return true;
-    cur = cur.parent;
-  }
-  return false;
 }
 
 /** Identifiers assigned in-file from a router constructor (gin.Default(),
@@ -585,23 +570,6 @@ const CALL_EXPR_T = new Set(["call_expression"]);
 const RETURN_T = new Set(["return_statement"]);
 const IF_T = new Set(["if_statement"]);
 
-/** Non-null named children of a node. */
-function goNamed(n: SyntaxNode | null | undefined): SyntaxNode[] {
-  return n ? n.namedChildren.filter((c): c is SyntaxNode => c !== null) : [];
-}
-
-/** Lowercase segments of an identifier, split on non-alphanumeric AND CamelCase
- *  boundaries. Copied VERBATIM from security-ast-python.ts:628 (whole-segment
- *  matching makes substring blessing structurally impossible). */
-function nameSegments(name: string): string[] {
-  return name
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((s) => s.length > 0);
-}
-
 /** "401"|"403"|"404"|"500"|"other"|null. An int_literal OR the http.StatusXxx
  *  selector; NEVER guesses a bare local const (returns null so the caller treats
  *  it as unreadable/opaque). */
@@ -679,7 +647,7 @@ function goCallCorroborated(call: SyntaxNode): boolean {
   while (stmt.parent && stmt.parent.type !== "block") stmt = stmt.parent;
   const block = stmt.parent;
   if (!block) return false;
-  const sibs = goNamed(block);
+  const sibs = namedChildrenOf(block);
   const idx = sibs.findIndex((s) => s.equals(stmt));
   if (idx < 0) return false;
   for (let i = idx + 1; i < sibs.length; i++) {
@@ -706,7 +674,7 @@ function goCompositeIs401Error(composite: SyntaxNode): boolean {
     else typeText = c.text;
   }
   if (!/HTTPError$/.test(typeText) || !lv) return false;
-  for (const ke of goNamed(lv)) {
+  for (const ke of namedChildrenOf(lv)) {
     if (ke.type !== "keyed_element") continue;
     const key = ke.namedChild(0);
     const valEl = ke.namedChild(1);
@@ -740,8 +708,8 @@ function goCredentialBoundLocals(body: SyntaxNode): Set<string> {
     const left = decl.childForFieldName("left");
     const right = decl.childForFieldName("right");
     if (left?.type !== "expression_list" || right?.type !== "expression_list") continue;
-    const lc = goNamed(left);
-    const rc = goNamed(right);
+    const lc = namedChildrenOf(left);
+    const rc = namedChildrenOf(right);
     for (let i = 0; i < lc.length && i < rc.length; i++) {
       if (lc[i].type === "identifier" && rc[i].type === "call_expression" && goIsCredentialReadCall(rc[i])) {
         bound.add(lc[i].text);
@@ -810,7 +778,7 @@ function scanGoBody(body: SyntaxNode, defs: Map<string, SyntaxNode | null>, hop:
         continue;
       }
       if (field === "Error" && fn.childForFieldName("operand")?.text === "http") {
-        const named = goNamed(args);
+        const named = namedChildrenOf(args);
         if (goRejectStatus(named[named.length - 1] ?? null) === "401" && goCallCorroborated(call)) out.reject401 = true;
         continue;
       }
@@ -896,14 +864,14 @@ export function collectGoFunctionDefs(root: SyntaxNode): Map<string, SyntaxNode 
 export function resolveEffectiveBody(fnNode: SyntaxNode, defs: Map<string, SyntaxNode | null>): SyntaxNode | null {
   const body = fnNode.childForFieldName("body");
   if (!body) return null;
-  const stmts = goNamed(body);
+  const stmts = namedChildrenOf(body);
   if (stmts.length === 1 && stmts[0].type === "return_statement") {
     const exprList = stmts[0].namedChild(0);
     const val = exprList?.type === "expression_list" ? exprList.namedChild(0) : null;
     if (val) {
       if (val.type === "func_literal") return val.childForFieldName("body") ?? body;
       if (val.type === "call_expression") {
-        const cargs = goNamed(val.childForFieldName("arguments"));
+        const cargs = namedChildrenOf(val.childForFieldName("arguments"));
         if (cargs.length === 1 && cargs[0].type === "func_literal") {
           return cargs[0].childForFieldName("body") ?? body;
         }
@@ -983,7 +951,7 @@ function isPureSelectorTarget(arg: SyntaxNode): boolean {
   if (arg.type === "call_expression") {
     const fn = arg.childForFieldName("function");
     if (!fn || fn.type !== "selector_expression" || !isPureSelectorChain(fn)) return false;
-    return goNamed(arg.childForFieldName("arguments")).length <= 1;
+    return namedChildrenOf(arg.childForFieldName("arguments")).length <= 1;
   }
   return false;
 }
@@ -1057,7 +1025,7 @@ function classifyGoMiddlewareArg(
   }
   // Wrap recursion: single-arg call, through a transparent/unnamed outer only.
   if (arg.type === "call_expression" && (name === null || goNameIsTransparentWrap(name))) {
-    const inner = goNamed(arg.childForFieldName("arguments"));
+    const inner = namedChildrenOf(arg.childForFieldName("arguments"));
     if (inner.length === 1) return classifyGoMiddlewareArg(inner[0], defs, depth + 1, importerRel, index);
   }
   return { outcome: "not-auth", name };
@@ -1071,7 +1039,7 @@ function collectWithArgs(operand: SyntaxNode | null): SyntaxNode[] {
   for (let hops = 0; cur && cur.type === "call_expression" && hops < 16; hops++) {
     const fn = cur.childForFieldName("function");
     if (fn?.type !== "selector_expression") break;
-    if (fn.childForFieldName("field")?.text === "With") args.push(...goNamed(cur.childForFieldName("arguments")));
+    if (fn.childForFieldName("field")?.text === "With") args.push(...namedChildrenOf(cur.childForFieldName("arguments")));
     cur = fn.childForFieldName("operand");
   }
   return args;
@@ -1236,7 +1204,7 @@ function collectGoMiddleware(
       if (!gated(receiver)) continue;
       const scope = enclosingScope(call, root);
       if (hasConditionalRegistrationAncestor(call, scope)) continue;
-      const named = goNamed(call.childForFieldName("arguments"));
+      const named = namedChildrenOf(call.childForFieldName("arguments"));
       const { lanes, unsureHook } = lanesFromArgs(named, defs, importerRel, index);
       marks.push({ receiver, scope, row: call.startPosition.row, lanes, unsureHook });
       continue;
@@ -1248,7 +1216,7 @@ function collectGoMiddleware(
     // are a single structural binding and never poison.
     if (CLOSURE_ROUTE_FIELDS.has(field)) {
       if (!gated(receiver)) continue;
-      const lit = goNamed(call.childForFieldName("arguments")).find((n) => n.type === "func_literal");
+      const lit = namedChildrenOf(call.childForFieldName("arguments")).find((n) => n.type === "func_literal");
       if (!lit) continue;
       const param = lit.childForFieldName("parameters")?.descendantsOfType("parameter_declaration")[0];
       const pname = param?.childForFieldName("name");
@@ -1277,7 +1245,7 @@ function collectGoMiddleware(
       if (parent === null) return;
       // On a Group creation call every arg AFTER the path is a middleware
       // candidate INCLUDING the last (no handler position).
-      const inlineArgs = goNamed(valueNode.childForFieldName("arguments")).slice(1);
+      const inlineArgs = namedChildrenOf(valueNode.childForFieldName("arguments")).slice(1);
       const { lanes, unsureHook } = lanesFromArgs(inlineArgs, defs, importerRel, index);
       derivations.push({
         child: nameNode.text, childScope: scope,
@@ -1301,8 +1269,8 @@ function collectGoMiddleware(
     const left = decl.childForFieldName("left");
     const right = decl.childForFieldName("right");
     if (left?.type !== "expression_list" || right?.type !== "expression_list") continue;
-    const lc = goNamed(left);
-    const rc = goNamed(right);
+    const lc = namedChildrenOf(left);
+    const rc = namedChildrenOf(right);
     for (let i = 0; i < lc.length && i < rc.length; i++) recordDecl(lc[i], rc[i]);
   }
   for (const spec of root.descendantsOfType("var_spec")) {

--- a/src/drift/security-ast-python.ts
+++ b/src/drift/security-ast-python.ts
@@ -72,6 +72,7 @@
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
+import { nameSegments } from "./security-ast-common.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 import type { CrossFileIndex } from "./security-xfile-index.js";
 import { resolvePyHookBody } from "./security-xfile-index.js";
@@ -621,20 +622,6 @@ function decoratorName(expr: SyntaxNode): string | null {
   if (expr.type === "identifier") return expr.text;
   if (expr.type === "attribute") return expr.childForFieldName("attribute")?.text ?? null;
   return null;
-}
-
-/** Lowercase segments of an identifier, split on underscore/non-alphanumeric AND
- *  CamelCase boundaries (digits stay attached to their run):
- *  "get_author_stats" -> [get, author, stats]; "JWTBearer" -> [jwt, bearer];
- *  "OAuth2PasswordBearer" -> [o, auth2, password, bearer]. Whole-segment matching
- *  makes substring blessing structurally impossible. */
-function nameSegments(name: string): string[] {
-  return name
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((s) => s.length > 0);
 }
 
 /** Two-tier segment auth check for hook handler names (see the constants block):

--- a/src/drift/security-ast-rust.ts
+++ b/src/drift/security-ast-rust.ts
@@ -114,6 +114,7 @@
  */
 
 import type { Tree, SyntaxNode } from "../core/types.js";
+import { nameSegments, inErroredContext, namedChildrenOf } from "./security-ast-common.js";
 import type { RouteInfo, FileMiddleware } from "./security-consistency.js";
 
 // Field name for Axum's fluent builder registration (`Router::new().route(...)`).
@@ -271,18 +272,6 @@ const LET_DECL_T = new Set(["let_declaration"]);
 const RETURN_EXPR_T = new Set(["return_expression"]);
 const TRY_EXPR_T = new Set(["try_expression"]);
 
-/** Lowercase segments of an identifier, split on non-alphanumeric AND CamelCase
- *  boundaries. Copied VERBATIM from security-ast-go.ts:603 (whole-segment
- *  matching makes substring blessing structurally impossible). */
-function nameSegments(name: string): string[] {
-  return name
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((s) => s.length > 0);
-}
-
 /** Path/verb text of a Rust string literal. string_literal is a LEAF in the pinned
  *  grammar (slice off the two quote chars). raw_string_literal has an r + variable-#
  *  prefix, so strip r#*"…"#* by regex; a mismatch → null (skip, a miss is safe). Anything
@@ -295,24 +284,6 @@ function rustStringText(node: SyntaxNode): string | null {
     return m ? m[2] : null;
   }
   return null;
-}
-
-/** Non-null named children. */
-function rustNamed(n: SyntaxNode | null | undefined): SyntaxNode[] {
-  return n ? n.namedChildren.filter((c): c is SyntaxNode => c !== null) : [];
-}
-
-/** True when node or any ancestor BELOW source_file carries a parse error (per-construct
- *  surgical skip; there is no whole-file fallback for Rust — see the module header).
- *  Mirror inErroredContext, security-ast-go.ts: Rust error recovery can swallow a later
- *  valid registration into a broken call's arguments. */
-function inErroredContext(node: SyntaxNode): boolean {
-  let cur: SyntaxNode | null = node;
-  while (cur && cur.type !== "source_file") {
-    if (cur.hasError) return true;
-    cur = cur.parent;
-  }
-  return false;
 }
 
 interface RustRoute {
@@ -419,7 +390,7 @@ function asBuilderRoute(call: SyntaxNode): RustRoute | null {
   if (fn?.type !== "field_expression") return null;
   const field = fn.childForFieldName("field");
   if (field?.text !== ROUTE_FIELD) return null;
-  const named = rustNamed(call.childForFieldName("arguments"));
+  const named = namedChildrenOf(call.childForFieldName("arguments"));
   if (named.length !== 2) return null;
   const path = rustStringText(named[0]);
   if (path === null || !path.startsWith("/")) return null; // leading-slash gate
@@ -434,7 +405,7 @@ function asBuilderRoute(call: SyntaxNode): RustRoute | null {
  *  value. A non-string value (a bare identifier / const) is not readable and
  *  is skipped, so an empty result means "no readable method=". */
 function readRouteMacroMethods(tokenTree: SyntaxNode): string[] {
-  const kids = rustNamed(tokenTree);
+  const kids = namedChildrenOf(tokenTree);
   const out: string[] = [];
   for (let i = 0; i < kids.length; i++) {
     if (kids[i].type !== "identifier" || kids[i].text !== "method") continue;
@@ -466,7 +437,7 @@ function attrMacroMethod(macro: string, tokenTree: SyntaxNode | null): string | 
 
 /** Attribute-macro route on the function_item that FOLLOWS the attribute_item sibling. */
 function asAttributeRoute(attrItem: SyntaxNode): RustRoute | null {
-  const attr = rustNamed(attrItem).find((n) => n.type === "attribute");
+  const attr = namedChildrenOf(attrItem).find((n) => n.type === "attribute");
   if (!attr) return null;
   const callee = attr.namedChild(0);
   const macro = callee?.type === "identifier" ? callee.text
@@ -474,7 +445,7 @@ function asAttributeRoute(attrItem: SyntaxNode): RustRoute | null {
   if (!ATTR_ROUTE_METHODS.has(macro) && macro !== ROUTE_MACRO) return null;
   const tokenTree = attr.childForFieldName("arguments") ?? null;
   const pathNode = tokenTree
-    ? rustNamed(tokenTree).find((n) => n.type === "string_literal" || n.type === "raw_string_literal")
+    ? namedChildrenOf(tokenTree).find((n) => n.type === "string_literal" || n.type === "raw_string_literal")
     : null;
   const path = pathNode ? rustStringText(pathNode) : null;
   if (path === null || !path.startsWith("/")) return null;
@@ -836,7 +807,7 @@ function classifyRustLayerArg(
     const fn = arg.childForFieldName("function");
     const calleeName = fn ? rustCalleeName(fn) : null;
     if (calleeName && FROM_FN_CALLEES.has(calleeName)) {
-      const args = rustNamed(arg.childForFieldName("arguments"));
+      const args = namedChildrenOf(arg.childForFieldName("arguments"));
       const handler = args.length ? args[args.length - 1] : null; // from_fn: only arg; with_state: LAST arg
       if (handler?.type === "identifier") {
         const hname = handler.text;
@@ -884,7 +855,7 @@ function coveringLayerArgs(routeCall: SyntaxNode): SyntaxNode[] {
     if (!grand || grand.type !== "call_expression") break;
     if (!(grand.childForFieldName("function")?.equals(parent) ?? false)) break;
     if (LAYER_FIELDS.has(parent.childForFieldName("field")?.text ?? "")) {
-      for (const a of rustNamed(grand.childForFieldName("arguments"))) out.push(a);
+      for (const a of namedChildrenOf(grand.childForFieldName("arguments"))) out.push(a);
     }
     cur = grand; // climb past this chain link (layer collected above, route/other skipped)
   }
@@ -915,7 +886,7 @@ function extractorTypeUnsure(handler: string | null, defs: Map<string, SyntaxNod
   const def = defs.get(handler) ?? null;
   const params = def?.childForFieldName("parameters");
   if (!params) return null;
-  for (const p of rustNamed(params)) {
+  for (const p of namedChildrenOf(params)) {
     if (p.type !== "parameter") continue;
     const tname = rustTypeName(p.childForFieldName("type"));
     if (!tname) continue;


### PR DESCRIPTION
## Summary

Putting this up as a **gander, not a strong recommendation** cause the comments made me think the modularization here was on purpose for separation of concerns. 

While auditing duplication I noticed the per-language security-AST analyzers (`security-ast-{go,rust,python}.ts`) carry a few byte-identical helpers, and I thought it might make sense to share them. The three verified-identical ones are:

- **`nameSegments`** — the identifier → lowercase-segments splitter. In **all three** files, byte-identical.
- **`inErroredContext`** — the parent-walk parse-error guard. In **go + rust**, byte-identical.
- **`namedChildrenOf`** — non-null named children. Was `goNamed`/`rustNamed` (identical bodies); unified under a neutral name (`namedChildrenOf`, not `named`, to avoid shadowing go's local `const named` variables).

This lifts them into `src/drift/security-ast-common.ts` and imports them from the three analyzers.

## What I deliberately did NOT touch

Two pairs *look* like duplicates (same token structure) but differ in the literals that matter, the per-language grammar node types. So unifying them blindly would break one language:

- `goPrunedDescendants` skips `func_literal`; `rustPrunedDescendants` skips `closure_expression` + `function_item`.
- `collectFunctionDefs` scans `function_definition` (python); `collectRustFunctionDefs` scans `function_item` (rust).

Those stay in their own files. So does everything genuinely language-specific (string-literal decoding, router-name collection, etc.).

## Type of change

- [x] Refactor (no behavior change)

## The measurement

Found by grouping every function in `src/**/*.ts` by exact normalized token stream and reporting cross-file groups. Then I read each candidate's full body to confirm byte-identity before lifting, which is how the two divergent pairs above got caught (they group as "same structure" but their node-type literals differ).

## The regression / identity proof

Behavior-preserving by construction (the extracted bodies are character-identical to the copies they replace; only `goNamed`/`rustNamed` were renamed). Verified:

- `npm run typecheck`, `npm run lint`, `npm run build` — clean; no leftover `goNamed`/`rustNamed`.
- **Security suites: 1018/1018 pass** across 17 files.
- **`npm run calibrate`** (required for security-touching changes): the enforced **`security-floor` precision gate holds at 1.000 ≥ 0.95**, and every posture row is unchanged — `security_posture` and `security_posture_{go,py,rust}` all report `prec 1.00 / recall 1.00 / F1 1.00`. Behavior is identical.
- Full suite: failing set unchanged versus clean `main` (all pre-existing environment tests; the ±1 count is a known flaky env test). No failures in `drift/` or `security`.

## The blast radius

- New `security-ast-common.ts` imported by exactly the three security-AST analyzers. `SyntaxNode` comes from `../core/types.js` (same as its consumers).
- Call-site renames confined to `goNamed`→`namedChildrenOf` (go, 15) and `rustNamed`→`namedChildrenOf` (rust, 7). No other file references these symbols.
- **No version bump needed.** This changes only *where* helpers live, not what they compute — vote logic, the detector set, and the anchor/signature format are untouched, and the calibration confirms identical detection output, so warm `BASELINE_VERSION` caches stay valid. `SCORING_VERSION` is likewise untouched.

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm run build` pass; security suites 1018/1018; calibration security-floor gate 1.000 ≥ 0.95
- [x] No new behavior (pure refactor) — covered by the existing security suites + calibration
- [ ] `README.md` updated — n/a
- [x] Improves how confidently VibeDrift measures drift — the Go/Rust/Python copies of these security helpers can no longer silently diverge
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" — n/a, no score-facing copy touched


