### PR TITLE
fix: watch-session toggles compose with install

### DIFF
--- a/src/cli/commands/watch-session.ts
+++ b/src/cli/commands/watch-session.ts
@@ -65,12 +65,21 @@ export interface WatchSessionOptions {
    *  The CLI sets this true by default; omit it (as tests do) to just install. */
   watch?: boolean;
   /** Toggle hosted sync (Phase 5): "on" opts into derived-only upload, "off"
-   *  disables it. A standalone control — sets config and returns. */
+   *  disables it. Composes with `names`, and with the install flow when
+   *  `install` is set; a bare toggle sets config and returns. */
   sync?: "on" | "off";
   /** Toggle the opt-in file-name manifest for THIS repo: "on" shares
    *  repo-relative paths (never contents) so the dashboard can name files,
-   *  "off" deletes what was uploaded and stops future uploads. */
+   *  "off" deletes what was uploaded and stops future uploads. Same
+   *  composition rules as `sync`. */
   names?: "on" | "off";
+  /** Continue into the normal install/watch flow AFTER applying `sync`/`names`.
+   *  The CLI sets this when the invocation carried an install-intent flag
+   *  (--yes or --no-watch), so `--yes --no-watch --sync on --names on`
+   *  configures and installs in one command instead of silently dropping
+   *  everything after the first toggle. Without it, a toggle invocation stays
+   *  the documented standalone control (`vibedrift watch-session --sync off`). */
+  install?: boolean;
   /** Test seam: perform the server-side name deletion for ONE project hash
    *  (default: the API). Called once per hash this repo has uploaded under. */
   deleteNames?: (projectHash: string) => Promise<{ deleted?: number }>;
@@ -130,10 +139,16 @@ export async function runWatchSession(
         : `${chalk.dim("○")} Drift Sessions hooks not installed`,
     );
     console.log(chalk.dim(`  session ledger: ${ledgerDir}`));
+    if (options.sync || options.names) {
+      console.log(chalk.dim("  (--sync/--names not applied with --status; run them without --status)"));
+    }
     return "status";
   }
 
   if (options.uninstall) {
+    if (options.sync || options.names) {
+      console.log(chalk.dim("(--sync/--names not applied with --uninstall; run them without --uninstall)"));
+    }
     const res = await uninstallHooks(rootDir, installOpts);
     if (res.status === "not_installed") {
       console.log("Drift Sessions hooks were not installed; nothing to remove.");
@@ -149,31 +164,16 @@ export async function runWatchSession(
     return "uninstalled";
   }
 
-  // Hosted sync toggle (Phase 5): a standalone control — set the flag and return.
+  // Hosted sync + file-name toggles: configuration controls that COMPOSE —
+  // with each other (both apply, sync first), and with the install/watch flow
+  // below when `install` is set (--yes / --no-watch on the CLI). A bare toggle
+  // invocation applies its state and returns, which is the documented
+  // standalone usage (`vibedrift watch-session --sync off`). Before this
+  // composed, `--sync` won and everything after it was silently dropped: no
+  // hooks, no `--names`, while the sync confirmation read as success.
   if (options.sync) {
-    const on = options.sync === "on";
-    await patchConfig({ sessionsSyncEnabled: on, ...(on ? { sessionsSyncNoticeShown: true } : {}) });
-    if (on) {
-      console.log(`${chalk.green("✓")} Drift Sessions hosted sync is ON.`);
-      console.log(
-        chalk.dim(
-          [
-            "  Only a DERIVED projection leaves this machine — findings, scores, outcomes,",
-            "  and metadata. Your prompts and code never do. File paths ship only as",
-            "  per-repo grouping hashes, never the paths themselves. The agent's decision",
-            "  reasoning + intent label stay local unless a team explicitly opts in.",
-            "  Turn off anytime: vibedrift watch-session --sync off",
-          ].join("\n"),
-        ),
-      );
-    } else {
-      console.log(`${chalk.green("✓")} Drift Sessions hosted sync is OFF — sessions stay entirely on this machine.`);
-    }
-    return "sync_updated";
+    await toggleHostedSync(options.sync === "on");
   }
-
-  // File-name sharing toggle: per repo, default off, fully reversible. Also a
-  // standalone control, so it never installs hooks or starts a watch.
   if (options.names) {
     await toggleFileNames(options.names === "on", {
       projectHash,
@@ -182,7 +182,11 @@ export async function runWatchSession(
       activationHome: options.activationHome ?? vibedriftHome(),
       deleteNames: options.deleteNames,
     });
-    return "names_updated";
+  }
+  if ((options.sync || options.names) && !options.install) {
+    // Both toggles may have applied; `sync` wins the return value by
+    // precedence, mirroring its position in the flow.
+    return options.sync ? "sync_updated" : "names_updated";
   }
 
   // Agent detection comes FIRST: a machine that cannot run sessions at all
@@ -294,6 +298,28 @@ export async function runWatchSession(
     console.log(chalk.dim("  next Claude Code session in this repo will be recorded; run with --status to check."));
   }
   return installed;
+}
+
+/** `--sync on|off`: flip the hosted-sync flag and print the disclosure. The
+ *  ON path also marks the one-time notice as shown, since this IS the notice. */
+async function toggleHostedSync(on: boolean): Promise<void> {
+  await patchConfig({ sessionsSyncEnabled: on, ...(on ? { sessionsSyncNoticeShown: true } : {}) });
+  if (on) {
+    console.log(`${chalk.green("✓")} Drift Sessions hosted sync is ON.`);
+    console.log(
+      chalk.dim(
+        [
+          "  Only a DERIVED projection leaves this machine — findings, scores, outcomes,",
+          "  and metadata. Your prompts and code never do. File paths ship only as",
+          "  per-repo grouping hashes, never the paths themselves. The agent's decision",
+          "  reasoning + intent label stay local unless a team explicitly opts in.",
+          "  Turn off anytime: vibedrift watch-session --sync off",
+        ].join("\n"),
+      ),
+    );
+  } else {
+    console.log(`${chalk.green("✓")} Drift Sessions hosted sync is OFF — sessions stay entirely on this machine.`);
+  }
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -275,23 +275,33 @@ program
   .option("--status", "report whether hooks are installed")
   .option("--yes", "skip the consent prompt (you have read what it records)")
   .option("--no-watch", "install only; do not follow the live event tape")
-  .option("--sync <state>", "hosted sync (Pro): 'on' opts into derived-only upload, 'off' disables it")
+  .option(
+    "--sync <state>",
+    "hosted sync (Pro): 'on' opts into derived-only upload, 'off' disables it; add --yes/--no-watch to also install",
+  )
   .option(
     "--names <state>",
-    "share this repo's file NAMES with your dashboard: 'on' uploads repo-relative paths (never file contents), 'off' deletes them",
+    "share this repo's file NAMES with your dashboard: 'on' uploads repo-relative paths (never file contents), 'off' deletes them; add --yes/--no-watch to also install",
   )
   .option("--local-only", "force hosted sync off for this run")
   .action(async (path: string, options) => {
     const sync = options.sync === "on" ? "on" : options.sync === "off" ? "off" : undefined;
     const names = options.names === "on" ? "on" : options.names === "off" ? "off" : undefined;
+    // --yes / --no-watch alongside a toggle means "configure and install in
+    // one command"; a bare toggle stays the documented standalone control
+    // (`vibedrift watch-session --sync off`), which neither installs nor
+    // watches.
+    const installRequested = options.yes === true || options.watch === false;
+    const toggleOnly = (sync !== undefined || names !== undefined) && !installRequested;
     await runWatchSession(path, {
       uninstall: options.uninstall,
       status: options.status,
       yes: options.yes,
       sync,
       names,
+      install: installRequested,
       localOnly: options.localOnly === true,
-      watch: options.watch !== false && !options.uninstall && !options.status && !sync && !names,
+      watch: options.watch !== false && !options.uninstall && !options.status && !toggleOnly,
     });
   });
 

--- a/test/unit/cli/watch-session.test.ts
+++ b/test/unit/cli/watch-session.test.ts
@@ -103,6 +103,64 @@ describe("runWatchSession — hosted sync toggle", () => {
       process.env.USERPROFILE = prevProfile;
     }
   });
+
+  it("--sync on --names on applies BOTH toggles and still installs nothing", async () => {
+    const home = tmp("vd-ws-home-");
+    const prevHome = process.env.HOME;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const repo = repoWithAgent();
+      const sessionsDir = tmp("vd-ws-sess-");
+      const activationHome = tmp("vd-ws-act-");
+      const status = await runWatchSession(repo, { sync: "on", names: "on", activationHome, sessionsDir });
+      // sync wins the return value by precedence; the observable effects are
+      // BOTH applied (before the fix, --names was silently dropped here)
+      expect(status).toBe("sync_updated");
+      expect((await readConfig()).sessionsSyncEnabled).toBe(true);
+      const { projectHash } = repoIdentity(repo);
+      expect(shareFileNamesEnabled(loadActivation(activationHome), projectHash)).toBe(true);
+      // without install intent, a toggle invocation still never installs hooks
+      expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(false);
+    } finally {
+      process.env.HOME = prevHome;
+      process.env.USERPROFILE = prevProfile;
+    }
+  });
+
+  it("install:true continues past the toggles into a real install (one-command flow)", async () => {
+    const home = tmp("vd-ws-home-");
+    const prevHome = process.env.HOME;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const repo = repoWithAgent();
+      const sessionsDir = tmp("vd-ws-sess-");
+      const activationHome = tmp("vd-ws-act-");
+      // the CLI maps `--yes --no-watch --sync on --names on` to exactly this
+      // call; before the fix it returned "sync_updated" with no hooks written
+      const status = await runWatchSession(repo, {
+        yes: true,
+        install: true,
+        sync: "on",
+        names: "on",
+        activationHome,
+        sessionsDir,
+      });
+      expect(status).toBe("installed");
+      expect(existsSync(join(repo, ".claude", "settings.local.json"))).toBe(true);
+      expect((await readConfig()).sessionsSyncEnabled).toBe(true);
+      const { projectHash } = repoIdentity(repo);
+      expect(shareFileNamesEnabled(loadActivation(activationHome), projectHash)).toBe(true);
+    } finally {
+      process.env.HOME = prevHome;
+      process.env.USERPROFILE = prevProfile;
+    }
+  });
 });
 
 describe("runWatchSession", () => {

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,55 @@
 # CLI backlog
 
+- **[TUNING] Hook scope-check false positive on working documents.** The experimental
+  "looks unrelated to this task" advisory flagged a `.lavish/*.html` artifact edit during a session
+  whose task WAS building that artifact (2026-08-14, Vibestack workspace). Working-document paths
+  (`.lavish/`, scratch/plan artifacts) probably deserve an allowlist or lower confidence, and the
+  task-inference should weigh the conversation topic, not just source-tree adjacency.
+
+- **[REFACTOR, from PR #98 review] Centralized error codes + handling.** Sami: "start using a
+  centralized class for all VibeDrift exception codes and error handling." Today `VibeDriftApiError`
+  (src/auth/api.ts) carries only status+message; command-level catches are ad-hoc per call site.
+  Shape: one error module with typed codes (auth, entitlement, schema, network, rate-limit), every
+  API call path throwing/classifying through it, commands switching on code instead of string
+  matching. Touches every command — its own focused PR, not a rider.
+
+- **[BUG] dependencies analyzer adds `pkg.name` to the declared-deps set** (`declared.add(pkg.name)`
+  before `detectPhantomDeps`), so "phantom dependencies (declared but unused): <own package name>"
+  fires on ~every JS/TS repo that doesn't self-import (reproduced with controls: tracks the name
+  field verbatim; fires even with no dependency blocks at all). A fabricated "declared" claim —
+  keep the self-name for missing-dep suppression if that was the intent, but exclude it from the
+  phantom set.
+
+- **[BUG] return-shape declared-divergence fires when the dominant pattern MATCHES the declaration**
+  and the message prints the dominant, yielding "Team declared throws on error … but src/analyzers/
+  uses throws on error (2/4 files)". Should not fire when dominant == declared (or should name the
+  deviating minority pattern instead). Seen on 0.19.6 self-scan.
+
+- **[BUG, sessions] Intent anchors from absolute paths never match edits.** A prompt naming
+  `/abs/path/to/repo/src/x.ts` locks an anchor that `fileMatchesAnchors` (exact-or-suffix rule)
+  can never match against repo-relative edit paths → "0/N task files touched" even when the named
+  file was edited, and the scope tier degrades. Normalize prompt-extracted file anchors to
+  repo-relative before locking. Observed live on 0.19.6.
+
+- **[TRIAGE, sessions] `watch-session` "session summary" counters accumulate across all sessions
+  one watch run has seen** (observed 3 → 4 → 7 edits across four consecutive sessions) while the
+  label reads per-session. Decide intended semantics; if per-session, reset the fold per
+  `session_start`; if watch-lifetime, relabel.
+
+- **[POLISH batch, all verified on 0.19.6]** `usage` header "Recent scans (20)" vs hard
+  `slice(0, 10)` (show real row count or "10 of 20"); fix-plan projection rounds to nearest 5
+  ("~100/100" from a real 98.0 — print the recomputed value it already has) and the HTML "fix all"
+  projection can go BELOW the current score on small repos (empty-category `NO_FINDING_PRIOR=0.8`
+  beats the observed prior — floor it at current); MCP `serverInfo.version` hardcoded "0.1.0";
+  unknown subcommand falls through to the scan `[path]` arg (typo matching a real dir silently
+  scans and then blocks on the report server — consider rejecting non-path-looking barewords or
+  did-you-mean); `--fail-on-score` exits 1 with zero explanation (print one line naming score vs
+  threshold); watch-session help tagline "(local-only, consent-gated)" is stale once `--sync on`
+  persists ("local by default, sync opt-in"); scan html path prints no hint that `--format
+  terminal` avoids the blocking report server; declared-conventions extractor ignores negation —
+  AGENTS.md:71 "no `.then()` chains in new code" surfaces ".then() chains" in the scan banner's
+  "Declared conventions" list as if it were the declared style.
+
 - **[DESIGN-READY, GATED] Multi-host native sessions — Phase 0 contract freeze + adapter program.**
   Full narrative in workspace LOGBOOK 2026-08-03. Six hosts verified to have Claude-style hook
   surfaces (Cursor 21 events / Codex 11 stable-default-on / Gemini 11 GA / Copilot 14 / Windsurf-Devin


### PR DESCRIPTION
## Summary

`--sync` and `--names` were standalone early-returns inside `watch-session`. Combined with other flags, the sync toggle won and everything after it was silently dropped: `vibedrift watch-session <path> --yes --no-watch --sync on --names on` printed the sync confirmation and exited with **no hooks installed and `--names` ignored**, while the output read as success. The help text presents these as combinable options of one command.

Found while dogfooding repo setup on 0.19.6.

**New semantics:**
- `--sync` and `--names` compose with each other: both always apply, sync first.
- With install intent (`--yes` or `--no-watch`), the command continues into the normal install/watch flow after applying the toggles, so configure-and-install works in one command.
- A bare toggle (`vibedrift watch-session --sync off`) stays the documented standalone control and never installs hooks.
- `--status` / `--uninstall` combined with toggles now print an explicit "not applied" note instead of silently eating the flags.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed — not needed: README's documented usages (standalone toggles, `--no-watch`, `--status`) are unchanged; only the previously-broken combination changed
- [x] This change improves how accurately or confidently VibeDrift measures drift (or is neutral infra) — neutral infra; also removes a silent-failure path in session enablement
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Measurement

End-to-end repro of the failing invocation, isolated `HOME`/`VIBEDRIFT_HOME`, run from source on this branch:

```
$ npx tsx src/cli/index.ts watch-session <repo> --yes --no-watch --sync on --names on
✓ Drift Sessions hosted sync is ON.
✓ File names are ON for this repo.
✓ Drift Sessions hooks installed for this repo (<repo>/.claude/settings.local.json).
```

Before this branch, the same invocation printed only the sync block and `--status` confirmed no hooks. Standalone behavior preserved (verified in the same run): `--sync off` alone flips config and writes no `.claude/settings.local.json`.

## Regression proof

The two new tests bind: with the src changes stashed, exactly those 2 fail (`--names` dropped, no hooks installed) and the 20 pre-existing tests still pass. Full suite: 2639 passing.

## Blast radius

```
$ command grep -rn "runWatchSession\|sync_updated\|names_updated" src/ --include="*.ts" | grep -v "commands/watch-session.ts"
src/cli/index.ts:25:import { runWatchSession } from "./commands/watch-session.js";
src/cli/index.ts:296:    await runWatchSession(path, {
```

One caller (the CLI registration, updated in this PR); no other consumer of the `sync_updated` / `names_updated` statuses. The `install` option is new and read only when a toggle is present.

---
🤖 This PR was authored by Claude (AI assistant) on behalf of @skhan75.
🤖 Generated with [Claude Code](https://claude.com/claude-code)