### PR TITLE
In-loop precision: directory-scoped conventions, extractor and normalizer accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ PLAN-*.md
 
 # Claude Code local hook installs (vibedrift enable) — never committed
 .claude/settings.local.json
-.measure/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ PLAN-*.md
 
 # Claude Code local hook installs (vibedrift enable) — never committed
 .claude/settings.local.json
+.measure/

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -35,12 +35,24 @@ export function detectDomainCategory(name: string, body: string): string {
 }
 
 // Tokenize body for comparison (strip comments, normalize strings)
+//
+// ORDER IS LOAD-BEARING: string literals are neutralized BEFORE comments.
+// A `//` inside a literal — `'https://example.invalid'` — would otherwise be
+// read as a comment start, deleting the closing quote and desynchronizing
+// quote pairing for the remainder of the body. Measured on the audited session
+// population: that leaked 45 distinct English words out of test-name literals
+// into one stored anchor, and swallowed 43% of another file's tokens.
+//
+// Block comments are stripped before line comments for the same reason in the
+// other direction: a `//` inside a block comment must not terminate scanning
+// early.
 export function tokenizeBody(body: string): string[] {
-  let cleaned = body.replace(/\/\/.*$/gm, "").replace(/#.*$/gm, "");
+  let cleaned = body
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``");
   cleaned = cleaned.replace(/\/\*[\s\S]*?\*\//g, "");
-  cleaned = cleaned.replace(/"(?:[^"\\]|\\.)*"/g, '""');
-  cleaned = cleaned.replace(/'(?:[^'\\]|\\.)*'/g, "''");
-  cleaned = cleaned.replace(/`(?:[^`\\]|\\.)*`/g, "``");
+  cleaned = cleaned.replace(/\/\/.*$/gm, "").replace(/#.*$/gm, "");
   return cleaned.match(/[a-zA-Z_]\w*|[0-9]+|[{}()[\];,.:=<>!+\-*/%&|^~?]/g) ?? [];
 }
 

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -280,6 +280,29 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
   return [];
 }
 
+/**
+ * A body whose only statement is a `throw` — a not-implemented stub.
+ *
+ * Stubs carry no reusable logic but are byte-identical everywhere they appear,
+ * so indexing them manufactures duplicate findings and tells a developer to
+ * "extract" something that does nothing. Measured on one provider-client
+ * codebase, `throw new Error("Method not implemented.")` appeared as three
+ * different method names across nine files and dominated a 7.1-point composite
+ * drop.
+ *
+ * Deliberately narrow: a throw that follows any other statement, or sits behind
+ * a guard, is real logic and stays indexed.
+ */
+function isStubBody(tokens: string[]): boolean {
+  if (tokens[0] !== "throw") return false;
+  // The captured body carries the closing brace(s), so trim trailing `}` and
+  // `;` before deciding. What remains after the throw's terminating `;` must be
+  // nothing: any further statement means the throw is part of real control flow.
+  let end = tokens.length;
+  while (end > 0 && (tokens[end - 1] === "}" || tokens[end - 1] === ";")) end--;
+  return !tokens.slice(1, end).includes(";");
+}
+
 // Extract all functions from a single source file
 export function extractFunctionsFromFile(file: SourceFile): ExtractedFunction[] {
   const functions: ExtractedFunction[] = [];
@@ -311,6 +334,7 @@ export function extractFunctionsFromFile(file: SourceFile): ExtractedFunction[] 
       const declarationCode = (file.content.split("\n")[line - 1] ?? "").trim();
       const tokens = tokenizeBody(body);
       if (tokens.length < 5) continue;
+      if (isStubBody(tokens)) continue;
 
       functions.push({
         name,

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -210,8 +210,40 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
     return [
       // Match up to the parameter `)`; findBodyOpenBrace locates the body brace
       // past any return-type annotation (which may contain `{`, `<>`, `=>`).
-      { re: /(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)/g, bodyAfterMatch: false, isArrow: false },
-      { re: /(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?(?:<[^>]*>\s*)?\(([^)]*)\)/g, bodyAfterMatch: false, isArrow: true },
+      // `\*?` admits generator declarations (`function* walk()`).
+      {
+        re: /(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s*\*?\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)/g,
+        bodyAfterMatch: false,
+        isArrow: false,
+      },
+      // `let`/`var` alongside `const`: an arrow bound to any of them is a
+      // function, and only `const` was indexed before.
+      {
+        re: /(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:<[^>]*>\s*)?\(([^)]*)\)/g,
+        bodyAfterMatch: false,
+        isArrow: true,
+      },
+      // Method shorthand: class methods, object-literal methods, generators,
+      // getters and setters. None of these were indexed before, which is why a
+      // class-heavy file contributed far fewer entries than it has functions.
+      //
+      // Three guards keep this from over-matching, in order of importance:
+      //  1. `^[ \t]*` anchors to a line start, so a mid-line call expression
+      //     can never match.
+      //  2. The negative lookahead excludes the keywords that share the shape
+      //     `name (args) { ... }` — if, for, while, switch, catch, and the
+      //     declaration forms already covered by the patterns above.
+      //  3. The body brace must follow the parameter list directly, separated
+      //     only by whitespace or a TS return-type annotation containing
+      //     neither `;` nor `{`. This is what rejects `describe("x", () => {`,
+      //     whose block belongs to the arrow rather than to `describe`, and
+      //     interface or type-literal members, which end in `;` and have no
+      //     body at all.
+      {
+        re: /^[ \t]*(?:(?:public|private|protected|static|readonly|abstract|override|async|get|set)\s+)*\*?\s*(?!(?:if|for|while|switch|catch|do|else|return|typeof|new|function|const|let|var|class|interface|type|import|export|await|yield)\b)(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?::[^;{]*?)?\s*\{/gm,
+        bodyAfterMatch: true,
+        isArrow: false,
+      },
     ];
   }
   if (language === "python") {

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -96,6 +96,8 @@ function extractBody(content: string, startAfterBrace: number, language: string)
 
 interface FnPattern {
   re: RegExp;
+  /** Verify the captured params are a real parameter list (method shorthand only). */
+  realParamList?: boolean;
   /**
    * true  → the regex match already ends at the start of the body, so the
    *         body begins at `match.index + match[0].length` (Go/Rust end at
@@ -262,6 +264,7 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
         re: /^[ \t]*(?:(?:public|private|protected|static|readonly|abstract|override|async|get|set)\s+)*\*?\s*(?!(?:if|for|while|switch|catch|do|else|return|typeof|new|function|const|let|var|class|interface|type|import|export|await|yield|constructor)\b)(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?::[^;{\n]*?)?\s*\{/gm,
         bodyAfterMatch: true,
         isArrow: false,
+        realParamList: true,
       },
     ];
   }
@@ -308,6 +311,54 @@ function isStubBody(tokens: string[]): boolean {
   return !tokens.slice(1, end).includes(";");
 }
 
+/**
+ * Whether a method-shorthand match's parameter list is really a parameter list.
+ *
+ * The pattern captures parameters with `[^)]*`, which stops at the FIRST `)`.
+ * For a call expression taking a callback — `test('name', function (assert) {` —
+ * that first `)` is the CALLBACK's parameter close, so the body-brace guard sees
+ * the callback's own brace and the match succeeds, indexing an entry named after
+ * the CALLEE. Measured on a callback-heavy repo, this inflated the function index
+ * from 2190 to 5114 entries, every one of them a phantom named `test`, `it`,
+ * `describe` or a DSL registration helper.
+ *
+ * That is worse than a normal false positive: function count is the DENOMINATOR
+ * the duplicate scorer divides by, so the inflation moved the composite in the
+ * OPTIMISTIC direction while the honest duplicate fraction had gone up.
+ *
+ * Rejecting any match whose captured params contain `(` would also discard
+ * genuine methods with function-typed parameters (`mapAll(fn: (x: number) => number)`).
+ * So when the capture is unbalanced we walk the real parens: find the true
+ * matching close, then require the body brace to follow it, allowing a
+ * single-line return-type annotation. A callback call fails that test because its
+ * matching close sits after the callback body, followed by `)` or `;`.
+ */
+function hasRealParamList(content: string, matchStart: number, matched: string): boolean {
+  const openRel = matched.indexOf("(");
+  if (openRel < 0) return false;
+  const openIdx = matchStart + openRel;
+  let depth = 0;
+  let i = openIdx;
+  for (; i < content.length; i++) {
+    const c = content[i];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (depth !== 0) return false;
+  // Skip whitespace, then an optional one-line return-type annotation, then the
+  // body brace must be next.
+  let j = i + 1;
+  while (j < content.length && (content[j] === " " || content[j] === "\t" || content[j] === "\n" || content[j] === "\r")) j++;
+  if (content[j] === ":") {
+    while (j < content.length && content[j] !== "{" && content[j] !== ";" && content[j] !== "\n") j++;
+  }
+  while (j < content.length && (content[j] === " " || content[j] === "\t" || content[j] === "\n" || content[j] === "\r")) j++;
+  return content[j] === "{";
+}
+
 // Extract all functions from a single source file
 export function extractFunctionsFromFile(file: SourceFile): ExtractedFunction[] {
   const functions: ExtractedFunction[] = [];
@@ -315,12 +366,13 @@ export function extractFunctionsFromFile(file: SourceFile): ExtractedFunction[] 
 
   const patterns = getLanguagePatterns(file.language);
 
-  for (const { re, bodyAfterMatch, isArrow } of patterns) {
+  for (const { re, bodyAfterMatch, isArrow, realParamList } of patterns) {
     const regex = new RegExp(re.source, re.flags);
     let match;
     while ((match = regex.exec(file.content)) !== null) {
       const name = match[1];
       const paramsStr = match[2];
+      if (realParamList && paramsStr.includes("(") && !hasRealParamList(file.content, match.index, match[0])) continue;
 
       let startIndex: number;
       if (bodyAfterMatch) {

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -240,7 +240,13 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
       //     can never match.
       //  2. The negative lookahead excludes the keywords that share the shape
       //     `name (args) { ... }` — if, for, while, switch, catch, and the
-      //     declaration forms already covered by the patterns above.
+      //     declaration forms already covered by the patterns above. It also
+      //     excludes `constructor`, which is a real function but a pathological
+      //     one to index: constructors are structurally forced to resemble each
+      //     other, so they flood duplicate detection without carrying signal.
+      //     Measured on ionic-framework, indexing them produced 80 of 214
+      //     duplicate findings on its own. They were never indexed before this
+      //     pattern existed and stay unindexed.
       //  3. The body brace must follow the parameter list directly, separated
       //     only by whitespace or a TS return-type annotation containing
       //     neither `;` nor `{`. This is what rejects `describe("x", () => {`,
@@ -248,7 +254,7 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
       //     interface or type-literal members, which end in `;` and have no
       //     body at all.
       {
-        re: /^[ \t]*(?:(?:public|private|protected|static|readonly|abstract|override|async|get|set)\s+)*\*?\s*(?!(?:if|for|while|switch|catch|do|else|return|typeof|new|function|const|let|var|class|interface|type|import|export|await|yield)\b)(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?::[^;{]*?)?\s*\{/gm,
+        re: /^[ \t]*(?:(?:public|private|protected|static|readonly|abstract|override|async|get|set)\s+)*\*?\s*(?!(?:if|for|while|switch|catch|do|else|return|typeof|new|function|const|let|var|class|interface|type|import|export|await|yield|constructor)\b)(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?::[^;{]*?)?\s*\{/gm,
         bodyAfterMatch: true,
         isArrow: false,
       },

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -204,7 +204,15 @@ function findBodyOpenBrace(content: string, fromIndex: number, isArrow: boolean)
 
 function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
   if (language === "go") {
-    return [{ re: /func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(([^)]*)\)\s*(?:[^{]*)?\{/g, bodyAfterMatch: true, isArrow: false }];
+    // `(?:\[[^\]]*\])?` admits generic type parameters, which sit between the
+    // name and the parameter list: `func Map[T any, U any](in []T) []U {`.
+    return [
+      {
+        re: /func\s+(?:\([^)]*\)\s+)?(\w+)\s*(?:\[[^\]]*\])?\s*\(([^)]*)\)\s*(?:[^{]*)?\{/g,
+        bodyAfterMatch: true,
+        isArrow: false,
+      },
+    ];
   }
   if (language === "javascript" || language === "typescript") {
     return [
@@ -250,7 +258,18 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
     return [{ re: /def\s+(\w+)\s*\(([^)]*)\)\s*(?:->[^:]*)?:/g, bodyAfterMatch: true, isArrow: false }];
   }
   if (language === "rust") {
-    return [{ re: /(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?:->[^{]*)?\{/g, bodyAfterMatch: true, isArrow: false }];
+    // Everything between the parameter list and the body brace is signature: a
+    // return type, a `where` clause, or both across several lines. `->` used to
+    // do that spanning, so a `where` clause with no return type had nothing to
+    // consume it. `[^{]*` is greedy-free of braces and therefore stops at the
+    // first `{`, which is the body in both shapes.
+    return [
+      {
+        re: /(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*[^{]*\{/g,
+        bodyAfterMatch: true,
+        isArrow: false,
+      },
+    ];
   }
   return [];
 }

--- a/src/codedna/function-extractor.ts
+++ b/src/codedna/function-extractor.ts
@@ -249,12 +249,17 @@ function getLanguagePatterns(language: SupportedLanguage): FnPattern[] {
       //     pattern existed and stay unindexed.
       //  3. The body brace must follow the parameter list directly, separated
       //     only by whitespace or a TS return-type annotation containing
-      //     neither `;` nor `{`. This is what rejects `describe("x", () => {`,
+      //     neither `;`, `{`, nor a NEWLINE. This rejects `describe("x", () => {`,
       //     whose block belongs to the arrow rather than to `describe`, and
-      //     interface or type-literal members, which end in `;` and have no
-      //     body at all.
+      //     interface or type-literal members, which have no body at all.
+      //     The newline exclusion is load-bearing for semicolon-free TypeScript
+      //     (prettier `semi: false`): without it the scan runs past a bodiless
+      //     declaration to the first `{` anywhere below, indexing a garbage body
+      //     of comments and other declarations. A return type spans one line in
+      //     practice, and a method whose brace sits on the NEXT line still
+      //     matches because the trailing `\s*` may cross newlines.
       {
-        re: /^[ \t]*(?:(?:public|private|protected|static|readonly|abstract|override|async|get|set)\s+)*\*?\s*(?!(?:if|for|while|switch|catch|do|else|return|typeof|new|function|const|let|var|class|interface|type|import|export|await|yield|constructor)\b)(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?::[^;{]*?)?\s*\{/gm,
+        re: /^[ \t]*(?:(?:public|private|protected|static|readonly|abstract|override|async|get|set)\s+)*\*?\s*(?!(?:if|for|while|switch|catch|do|else|return|typeof|new|function|const|let|var|class|interface|type|import|export|await|yield|constructor)\b)(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)\s*(?::[^;{\n]*?)?\s*\{/gm,
         bodyAfterMatch: true,
         isArrow: false,
       },

--- a/src/codedna/minhash.ts
+++ b/src/codedna/minhash.ts
@@ -128,9 +128,19 @@ export function normalizeTokens(tokens: string[]): string[] {
       for (let k = i; k <= j; k++) result.push(tokens[k]);
       i = j + 1;
     } else {
+      // A property chain has two halves with different meanings. The HEAD is a
+      // name — a local, a parameter, an import alias — and is arbitrary, so it
+      // is renamed. The MEMBERS are a path into a structure and identify what
+      // the code touches, so they are kept literal.
+      //
+      // Erasing the members made `schema.reports` and `schema.notifications`
+      // normalize identically, so every query sharing a call skeleton collided
+      // regardless of which table or column it read. Renaming the head is what
+      // keeps `input.data` and `payload.data` matching, which is the same logic
+      // written with different parameter names.
       let k = i;
       while (k <= j) {
-        if (isIdentifier(tokens[k])) result.push(renameId(tokens[k]));
+        if (k === i && isIdentifier(tokens[k])) result.push(renameId(tokens[k]));
         else result.push(tokens[k]);
         k++;
       }

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -118,9 +118,22 @@ export function projectHash(rootDir: string): string {
  * order-independent; prefixed with BASELINE_VERSION so a logic bump invalidates
  * every cached baseline at once.
  */
+/**
+ * Code-unit string comparison.
+ *
+ * `localeCompare` is locale-dependent: it collates case-insensitively in most
+ * locales, so "a" sorts before "B" there but after it by code unit. Anything
+ * that feeds a cache key or user-visible ordering must not depend on the host's
+ * locale, or the same inputs produce different output on different machines.
+ * That is the determinism rule this codebase runs on.
+ */
+export function compareByCodeUnit(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export function computeBaselineKey(files: Array<{ path: string; hash: string }>): string {
   const merkle = [...files]
-    .sort((a, b) => a.path.localeCompare(b.path))
+    .sort((a, b) => compareByCodeUnit(a.path, b.path))
     .map((f) => `${f.path}:${f.hash}`)
     .join("\n");
   return createHash("sha256").update(`${BASELINE_VERSION}\n${merkle}`).digest("hex");

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -28,10 +28,11 @@ import { isBelowSecurityPeerFloor } from "../scoring/engine.js";
 import type { AnalysisContext } from "./types.js";
 import type { DriftFinding, DriftCategory } from "../drift/types.js";
 import type { IntentHint } from "../intent/types.js";
+import { directoryOf } from "../drift/utils.js";
 
 const CACHE_DIR = join(vibedriftHome(), "baseline-cache");
 /** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
-export const BASELINE_VERSION = 4;
+export const BASELINE_VERSION = 5;
 
 export interface CategoryVote {
   driftCategory: DriftCategory;
@@ -43,6 +44,10 @@ export interface CategoryVote {
   /** Files that drift in this category + the pattern each uses instead — lets
    *  check_file_drift report "your file does X, the repo does Y". */
   deviators: Array<{ path: string; detectedPattern: string }>;
+  /** The directory this vote was computed over, when every file it names sits
+   *  in one directory. Set only by votesByDirectory; the repo-wide
+   *  perCategoryVote leaves it undefined. */
+  directory?: string;
   /** True when this is a security_posture vote below MIN_SECURITY_PEERS relevant
    *  routes: too thin to dent the score, so MCP tools surface it as advisory
    *  rather than authoritative. Single source of truth: isBelowSecurityPeerFloor. */
@@ -62,6 +67,10 @@ export interface RepoDriftBaseline {
   rootDir: string;
   ctxFiles: Array<{ path: string; hash: string }>;
   perCategoryVote: Partial<Record<DriftCategory, CategoryVote>>;
+  /** Votes keyed (category, directory). The in-loop checker reads THIS, never
+   *  perCategoryVote, so a file is only ever measured against its own peers.
+   *  See votesByDirectory for why. Optional so a v4 baseline still loads. */
+  perDirectoryVote?: Partial<Record<DriftCategory, Record<string, CategoryVote>>>;
   /** Per-security-sub-convention votes (Auth middleware / Input validation /
    *  Rate limiting), keyed by sub-category label. Kept separate from
    *  perCategoryVote, which collapses all three into one security_posture slot
@@ -147,6 +156,44 @@ export function votesFromFindings(
   return out;
 }
 
+/**
+ * Votes keyed (category, directory).
+ *
+ * `votesFromFindings` keeps exactly one finding per category — the widest
+ * denominator — which discards both the other directories' conventions and the
+ * fact that the survivor was ever directory-scoped at all. The in-loop checker
+ * then measured every edited file against whichever directory happened to win.
+ *
+ * Measured cost, from the recorded session population: 10 of 21 findings, four
+ * of which told Next.js server actions to adopt a React component's return
+ * shape. The actions directory was 10 of 10 on its own convention and emitted
+ * no finding precisely because it is unanimous, so it had no vote of its own
+ * and inherited a rule from code it shares nothing with.
+ *
+ * A finding contributes a vote only when every file it names — dominant and
+ * deviating alike — sits in one directory. Detectors that are not
+ * directory-grouped therefore contribute nothing here, which is correct: they
+ * have no per-directory claim to make.
+ */
+export function votesByDirectory(
+  findings: DriftFinding[],
+): Partial<Record<DriftCategory, Record<string, CategoryVote>>> {
+  const out: Partial<Record<DriftCategory, Record<string, CategoryVote>>> = {};
+  for (const f of findings) {
+    if (f.subCategory === SECURITY_SUPPRESSION_SUBCATEGORY) continue;
+    const paths = [...(f.dominantFiles ?? []), ...f.deviatingFiles.map((d) => d.path)];
+    if (paths.length === 0) continue;
+    const dirs = new Set(paths.map(directoryOf));
+    if (dirs.size !== 1) continue;
+    const dir = [...dirs][0]!;
+    const bucket = (out[f.driftCategory] ??= {});
+    const existing = bucket[dir];
+    if (existing && existing.totalRelevantFiles >= f.totalRelevantFiles) continue;
+    bucket[dir] = { ...toCategoryVote(f), directory: dir };
+  }
+  return out;
+}
+
 /** Build a CategoryVote from a single finding. Shared by votesFromFindings
  *  (keyed by driftCategory) and securitySubVotesFromFindings (keyed by
  *  subCategory) so the vote shape lives in exactly one place. */
@@ -219,6 +266,7 @@ export function assembleBaseline(
     rootDir,
     ctxFiles,
     perCategoryVote: votesFromFindings(driftFindings),
+    perDirectoryVote: votesByDirectory(driftFindings),
     securitySubVotes: securitySubVotesFromFindings(driftFindings),
     intentHints: ctx.intentHints ?? [],
     minhashIndex,

--- a/src/drift/utils.ts
+++ b/src/drift/utils.ts
@@ -130,6 +130,32 @@ export function isAnalyzableSource(path: string): boolean {
   return true;
 }
 
+/**
+ * Files an in-loop session check may judge.
+ *
+ * Stricter than `isAnalyzableSource`, which exists to keep the batch detectors'
+ * denominators honest. This predicate additionally excludes the file classes an
+ * agent legitimately writes to different conventions from application code:
+ * database seeds, soak and bench scripts, examples, and scratch files.
+ *
+ * Motivation is measured, not assumed. Across the recorded session population,
+ * 8 of 21 findings landed on such files and every one was a false positive. Two
+ * of them carry doc comments explaining why they throw, and were flagged for
+ * throwing: a Vitest `globalSetup` that must abort the run rather than return a
+ * sentinel, and a seed script whose throw is the guard that stops it truncating
+ * a non-development database.
+ *
+ * Each pattern is anchored to a path-segment boundary so a source directory
+ * named `transcripts/` or `benchmarking/` stays checkable.
+ */
+export function isInLoopCheckable(path: string): boolean {
+  if (!isAnalyzableSource(path)) return false;
+  if (/(?:^|\/)(?:scripts?|examples?|benchmarks?|bench)\//i.test(path)) return false;
+  if (/(?:^|\/)(?:seed|soak|scratch)[-.\w]*\.\w+$/i.test(path)) return false;
+  if (/(?:^|\/)scratch[-\w]*\//i.test(path)) return false;
+  return true;
+}
+
 // ─── Shannon entropy gate ────────────────────────────────────────────
 
 export interface EntropyGateResult {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,7 +27,7 @@ export const SERVER_INSTRUCTIONS = `VibeDrift detects drift in AI-generated code
 
 These in-loop tools are LOCAL and FREE — call them while writing code:
 - init: one-time setup — write .vibedrift/config.json + .vibedriftignore so scans skip fixtures/generated code (call once on a fresh repo).
-- get_dominant_pattern: the codebase's dominant pattern for a category (so new code matches it).
+- get_dominant_pattern: the codebase's dominant pattern for a category (so new code matches it). Pass the 'path' argument — conventions are per-directory, and the repo-wide answer may not be your directory's.
 - get_intent_hints: team-declared conventions from CLAUDE.md / AGENTS.md / .cursorrules.
 - check_file_drift: whether a file diverges from the dominant patterns.
 - find_similar_function: existing near-duplicates of a function you're about to write (avoid re-implementing).

--- a/src/mcp/tools/get-dominant-pattern.ts
+++ b/src/mcp/tools/get-dominant-pattern.ts
@@ -19,7 +19,7 @@ export const registerGetDominantPattern = {
       {
         title: "Get the repo's dominant pattern",
         description:
-          "Ask what THIS repo's convention is for a dimension (error_handling, imports, exports, async, naming, data_access, logging, auth) before writing new code. Returns the majority pattern, how consistent the repo is, and up to 3 example files to copy. Local; needs a prior `vibedrift scan` to build the baseline.",
+          "Ask what THIS repo's convention is for a dimension (error_handling, imports, exports, async, naming, data_access, logging, auth) before writing new code. Pass `path` (the file you are about to write) — conventions are measured PER DIRECTORY, so without it you get the repo's widest-sampled directory, which may follow a different convention from the one you are editing. Returns the majority pattern, how consistent that directory is, and up to 3 example files to copy. Local; needs a prior `vibedrift scan` to build the baseline.",
         inputSchema,
       },
       async (args) => toToolResult(await run(args)),

--- a/src/output/history-diff.ts
+++ b/src/output/history-diff.ts
@@ -19,6 +19,7 @@
  */
 
 import type { SavedScan, FindingDigest } from "../core/history.js";
+import { compareByCodeUnit } from "../core/baseline.js";
 
 export interface DiffResult {
   findingsDiff: FindingDelta;
@@ -72,12 +73,12 @@ function diffBy(
 
   // Sort for deterministic output: resolved by analyzerId, new by
   // severity (error → warning → info) then analyzerId.
-  resolved.sort((a, b) => a.analyzerId.localeCompare(b.analyzerId));
+  resolved.sort((a, b) => compareByCodeUnit(a.analyzerId, b.analyzerId));
   const sevRank: Record<FindingDigest["severity"], number> = { error: 0, warning: 1, info: 2 };
   added.sort(
-    (a, b) => sevRank[a.severity] - sevRank[b.severity] || a.analyzerId.localeCompare(b.analyzerId),
+    (a, b) => sevRank[a.severity] - sevRank[b.severity] || compareByCodeUnit(a.analyzerId, b.analyzerId),
   );
-  persistent.sort((a, b) => a.analyzerId.localeCompare(b.analyzerId));
+  persistent.sort((a, b) => compareByCodeUnit(a.analyzerId, b.analyzerId));
 
   return { resolved, new: added, persistent };
 }

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -7,6 +7,7 @@ import { getAnalyzerKind, DRIFT_DISPLAY_CATEGORIES } from "../scoring/categories
 import { applicableCategoryCount, compositeScopeNote } from "./terminal.js";
 import { formatCount } from "./format.js";
 import { hasFloorTrip } from "./floor-badge.js";
+import { compareByCodeUnit } from "../core/baseline.js";
 
 const SCORING_CATEGORY_LABELS: Record<string, string> = {
   architecturalConsistency: "Architectural",
@@ -555,7 +556,7 @@ function buildDriftConcentration(result: ScanResult, detailedUrl: string): strin
   rows.sort((a, b) => {
     const delta = (a.score - a.weight * 5) - (b.score - b.weight * 5);
     if (delta !== 0) return delta;
-    return a.file.localeCompare(b.file);
+    return compareByCodeUnit(a.file, b.file);
   });
 
   const shown = rows.slice(0, 5);

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -87,12 +87,29 @@ import {
  *        nested go.mod files or multi-segment module paths move; every other
  *        repo is byte identical, and the bundled calibration corpus is
  *        unchanged.
+ *   v15: function-index and duplicate-normalization corrections. (1) The JS/TS
+ *        extractor now indexes class methods, object-literal methods, let/var
+ *        arrow bindings, generators, accessors and `export default function`,
+ *        all of which were invisible before, so a class-heavy file contributes
+ *        the functions it actually has. (2) Go generic functions and Rust `fn`
+ *        declarations with a `where` clause and no return type are matched.
+ *        (3) Duplicate normalization keeps property-chain MEMBERS literal while
+ *        still renaming the chain head, so queries against different tables or
+ *        columns stop normalizing identically; rename-insensitivity is
+ *        unchanged. (4) Body tokenization neutralizes string literals before
+ *        comments, so a `//` inside a literal no longer desynchronizes quote
+ *        pairing and leaks prose into the token stream. Duplicate counts fall
+ *        where collisions were removed and rise where the extractor now sees
+ *        methods it was blind to; measured on four real repos the index grew
+ *        1 to 34% and duplicate pairs moved -8% to +27%. Repos with no class
+ *        or object-literal methods, no property-chain data references and no
+ *        `//` inside literals are byte identical.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v14";
+export const SCORING_VERSION = "v15";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -91,7 +91,10 @@ import {
  *        extractor now indexes class methods, object-literal methods, let/var
  *        arrow bindings, generators, accessors and `export default function`,
  *        all of which were invisible before, so a class-heavy file contributes
- *        the functions it actually has. (2) Go generic functions and Rust `fn`
+ *        the functions it actually has. Constructors stay OUT: they are
+ *        structurally forced to resemble one another, so indexing them floods
+ *        duplicate detection without carrying signal (measured: 80 of 214
+ *        duplicate findings on one component library). (2) Go generic functions and Rust `fn`
  *        declarations with a `where` clause and no return type are matched.
  *        (3) Duplicate normalization keeps property-chain MEMBERS literal while
  *        still renaming the chain head, so queries against different tables or

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -20,6 +20,7 @@ import { newActivityId, safeSegment } from "./ledger.js";
 import { SESSIONS_SCHEMA_VERSION } from "./types.js";
 import type { SessionEvent } from "./types.js";
 import { isInLoopCheckable } from "../drift/utils.js";
+import { verifyCounterpart } from "./counterpart.js";
 
 export const INLINE_CHECK_MAX_ENTRIES = 2000;
 export const COOLDOWN_MS = 5 * 60_000;
@@ -121,6 +122,16 @@ async function writeState(opts: EditCheckOptions, state: CooldownState): Promise
  *  above any baseline the inline entry gate would accept anyway. */
 const HOOK_BASELINE_MAX_BYTES = 8 * 1024 * 1024;
 
+/** Read a file for counterpart verification. Null on any failure, which the
+ *  verifier treats as fail-open. */
+async function readFileOrNull(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
 export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOutcome> {
   const load = opts.loadBaselineFor ?? ((rootDir: string) => loadBaselineUnchecked(rootDir, HOOK_BASELINE_MAX_BYTES));
   const now = opts.now ?? Date.now;
@@ -203,9 +214,24 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
     });
   }
 
+  // Verify the counterpart before citing it. The index is built once per
+  // session, so by now the function it names may have moved or been lifted out
+  // entirely — in which case the agent MOVED this code rather than duplicating
+  // it, and "prefer importing it" would point at a file it just emptied.
+  // Measured on a recorded session: this is every duplicate advisory that
+  // session produced. See src/session/counterpart.ts.
   const topDup = [...dupsByLoc.values()].sort((a, b) => b.similarity - a.similarity)[0];
-  if (topDup) {
-    const where = `${topDup.relativePath}:${topDup.line}`;
+  const dupStatus = topDup
+    ? verifyCounterpart({
+        name: topDup.name,
+        relativePath: topDup.relativePath,
+        line: topDup.line,
+        fileContent: await readFileOrNull(join(opts.rootDir, topDup.relativePath)),
+        language: detectLanguage(topDup.relativePath),
+      })
+    : null;
+  if (topDup && dupStatus && dupStatus.status !== "gone") {
+    const where = `${topDup.relativePath}:${dupStatus.line}`;
     const event = mkFlag({
       file: relPath,
       category: "redundancy",

--- a/src/session/check.ts
+++ b/src/session/check.ts
@@ -19,6 +19,7 @@ import type { FindingAnchor } from "./finding-anchor.js";
 import { newActivityId, safeSegment } from "./ledger.js";
 import { SESSIONS_SCHEMA_VERSION } from "./types.js";
 import type { SessionEvent } from "./types.js";
+import { isInLoopCheckable } from "../drift/utils.js";
 
 export const INLINE_CHECK_MAX_ENTRIES = 2000;
 export const COOLDOWN_MS = 5 * 60_000;
@@ -145,7 +146,13 @@ export async function runEditChecks(opts: EditCheckOptions): Promise<EditCheckOu
   // docs must not flag. The gate and the flag path exit together — stamping
   // checked=false while still flagging would orphan flags outside the
   // density denominator.
-  if (detectLanguage(relPath) === null) {
+  //
+  // isInLoopCheckable extends the same contract to test setup, seeds, scripts,
+  // examples and scratch files. An agent writes those to different conventions
+  // on purpose, so judging them against application conventions is measurably
+  // wrong: 8 of 21 findings in the recorded population landed on such files and
+  // every one was a false positive.
+  if (detectLanguage(relPath) === null || !isInLoopCheckable(relPath)) {
     return { flags: [], fyi: null, baseline, anchors: {}, checked: false };
   }
 

--- a/src/session/counterpart.ts
+++ b/src/session/counterpart.ts
@@ -1,0 +1,70 @@
+import { extractFunctionsFromFile } from "../codedna/function-extractor.js";
+import type { SupportedLanguage } from "../core/types.js";
+
+/**
+ * Whether the function a duplicate advisory is about to cite is still where the
+ * baseline says it is.
+ *
+ * `gone` means the advisory must be suppressed: the agent MOVED the code rather
+ * than duplicating it.
+ */
+export type CounterpartStatus =
+  | { status: "confirmed"; line: number }
+  | { status: "moved"; line: number }
+  | { status: "gone" };
+
+/**
+ * Verify a duplicate counterpart against the file as it stands right now.
+ *
+ * Why this exists. The minhash index is built once and then used for the whole
+ * session, so by the time an advisory fires, the counterpart it names may have
+ * moved or ceased to exist. The measured case: in a recorded session the
+ * agent lifted a DOM helper `el` out of `src/content/composer.ts` into
+ * `src/shared/dom.ts`. The duplicate match was CORRECT — same function, 42
+ * tokens either side — but by then `el` was gone from composer.ts, so the
+ * advisory's "prefer importing it" pointed at nothing. The same shape hit a URL
+ * helper in the same session.
+ *
+ * A move is not a duplication, and telling an agent to import from a file it
+ * just emptied is worse than saying nothing. So:
+ *
+ *   confirmed — the function is still at the indexed line. Cite it as is.
+ *   moved     — still in the file, at a different line. Cite the new line.
+ *   gone      — not in the file any more. Suppress the advisory.
+ *
+ * Fail-open is deliberate on both error paths. An unreadable file or a language
+ * the extractor cannot parse returns `confirmed`, preserving the previous
+ * behaviour, because a read failure must never silently switch duplicate
+ * detection off across a whole session.
+ */
+export function verifyCounterpart(args: {
+  name: string;
+  relativePath: string;
+  line: number;
+  /** Contents of `relativePath` right now, or null when it could not be read. */
+  fileContent: string | null;
+  language: SupportedLanguage | null;
+}): CounterpartStatus {
+  const { name, relativePath, line, fileContent, language } = args;
+  if (fileContent === null || language === null) return { status: "confirmed", line };
+
+  let fns: ReturnType<typeof extractFunctionsFromFile>;
+  try {
+    fns = extractFunctionsFromFile({
+      path: relativePath,
+      relativePath,
+      content: fileContent,
+      language,
+    } as Parameters<typeof extractFunctionsFromFile>[0]);
+  } catch {
+    return { status: "confirmed", line };
+  }
+
+  const matches = fns.filter((f) => f.name === name);
+  if (matches.length === 0) return { status: "gone" };
+  if (matches.some((f) => f.line === line)) return { status: "confirmed", line };
+  // Name still present but relocated. Cite the closest surviving definition so
+  // the agent is pointed at a line that actually holds the function.
+  const nearest = matches.reduce((a, b) => (Math.abs(a.line - line) <= Math.abs(b.line - line) ? a : b));
+  return { status: "moved", line: nearest.line };
+}

--- a/src/session/finding-anchor.ts
+++ b/src/session/finding-anchor.ts
@@ -215,7 +215,13 @@ export function signalPresent(
       //
       // Neither check alone is one-sided safe. Their OR is: it can only keep more
       // findings open than either, never clear one that either would have kept.
-      if (anchor.kind !== "function") return true;
+      //
+      // A file-kind anchor used to return `true` unconditionally here, which
+      // made such a finding unresolvable by ANY edit — verified against an
+      // empty file, a one-line file, a comment-only file, whitespace and
+      // unrelated code, all of which reported "still present". It has no single
+      // construct to name, but it does carry the flagged token sequence, so
+      // containment is still meaningful and still one-sided safe.
       return (
         tokenContainment(anchor.tokens, body) >= REDUNDANCY_CONTAINMENT ||
         validateChangeAgainstBaseline(baseline, relFile, body).duplicateOf.length > 0

--- a/src/session/scope.ts
+++ b/src/session/scope.ts
@@ -62,6 +62,16 @@ export async function checkScope(
   relFile: string,
   body: string,
 ): Promise<ScopeResult> {
+  // A path outside the repo root can never match a repo-relative intent anchor,
+  // so it would flag on every edit by construction. Measured on the recorded
+  // session population: 15 of 64 scope flags (23% of all scope volume) were
+  // such paths, every one of them noise.
+  //
+  // This returns BEFORE readIntentState so an out-of-repo edit also cannot
+  // increment `unrelatedEdits` — otherwise it would push a later, legitimate
+  // in-repo edit over the second-edit threshold.
+  if (relFile.startsWith("../") || relFile.startsWith("/")) return { flag: null, fyi: null };
+
   const state = await readIntentState(sessionsDir, projectHash, sessionId);
   if (!state.locked) return { flag: null, fyi: null };
   if (editRelatesToAnchors(relFile, body, state.anchors)) return { flag: null, fyi: null };

--- a/src/tools-core/tools/get-dominant-pattern.ts
+++ b/src/tools-core/tools/get-dominant-pattern.ts
@@ -12,6 +12,7 @@ import { SECURITY_SUBCATEGORIES } from "../../drift/types.js";
 import type { RepoDriftBaseline } from "../../core/baseline.js";
 import { getBaseline } from "../../mcp/baseline-provider.js";
 import { noBaselineData, type Status } from "../result.js";
+import { directoryOf } from "../../drift/utils.js";
 
 const DIM = {
   error_handling: "return_shape_consistency",
@@ -36,6 +37,12 @@ const SECURITY_SUB_DIM: Partial<Record<DominantDimension, string>> = {
 export const inputSchema = {
   rootDir: z.string().describe("Absolute path to the repository root"),
   dimension: z.enum(DIMENSIONS as [DominantDimension, ...DominantDimension[]]),
+  path: z
+    .string()
+    .optional()
+    .describe(
+      "Repo-relative path of the file you are about to write. Strongly recommended: conventions are measured per directory, so without it you get the repo's widest-sampled directory, which may not be the one you are editing.",
+    ),
 };
 
 export interface DominantPatternProjection {
@@ -45,24 +52,48 @@ export interface DominantPatternProjection {
   examples: string[];
 }
 
-/** Pure projection of a baseline vote into the caller-facing shape. */
+/** Pure projection of a baseline vote into the caller-facing shape.
+ *
+ *  `relPath` scopes the answer to the caller's own directory, which is the only
+ *  scope in which "the dominant pattern" means anything: conventions are voted
+ *  per directory by the detectors. Without it the answer is the repo's
+ *  widest-sampled directory, which is what let a React component's return shape
+ *  be reported as the convention for a directory of server actions.
+ *
+ *  When a path IS given and its directory has no vote, the honest answer is
+ *  "no convention established here", not another directory's rule. */
 export function dominantPatternFor(
   baseline: RepoDriftBaseline,
   dimension: DominantDimension,
+  relPath?: string,
 ): DominantPatternProjection {
   const subKey = SECURITY_SUB_DIM[dimension];
-  const vote = subKey ? baseline.securitySubVotes?.[subKey] : baseline.perCategoryVote[DIM[dimension]];
+  const scoped = relPath !== undefined && !subKey;
+  const dir = relPath === undefined ? undefined : directoryOf(relPath);
+  const vote = subKey
+    ? baseline.securitySubVotes?.[subKey]
+    : scoped
+      ? baseline.perDirectoryVote?.[DIM[dimension]]?.[dir!]
+      : baseline.perCategoryVote[DIM[dimension]];
   if (!vote) {
     return {
       dimension,
       dominantPattern: "consistent",
-      consistency: baseline.ctxFiles.length ? "100% — no deviations detected" : "no files analyzed",
+      consistency: scoped
+        ? `no convention established in ${dir}/ — nothing to match`
+        : baseline.ctxFiles.length
+          ? "100% — no deviations detected"
+          : "no files analyzed",
       examples: [],
     };
   }
   const pct = Math.round(vote.consistencyScore);
   const unit = SECURITY_SUB_DIM[dimension] ? "routes" : "files";
-  const base = `${vote.dominantCount} of ${vote.totalRelevantFiles} ${unit} (${pct}%)`;
+  // Name the directory a vote was measured over so its scope is never read as
+  // repo-wide. A vote with no directory came from a detector that does not
+  // group by directory, and is genuinely repo-wide.
+  const where = vote.directory ? ` in ${vote.directory}/` : "";
+  const base = `${vote.dominantCount} of ${vote.totalRelevantFiles} ${unit}${where} (${pct}%)`;
   const consistency = vote.belowPeerFloor
     ? `${base} - thin sample (below the reliable-sample floor), treat as advisory`
     : base;
@@ -82,9 +113,11 @@ export interface DominantPatternOut extends DominantPatternProjection {
 export async function run({
   rootDir,
   dimension,
+  path,
 }: {
   rootDir: string;
   dimension: DominantDimension;
+  path?: string;
 }): Promise<DominantPatternOut & { dominantPattern: string | null }> {
   const { baseline, status } = await getBaseline(rootDir);
   if (!baseline) {
@@ -92,5 +125,5 @@ export async function run({
       dominantPattern: null;
     };
   }
-  return { status, ...dominantPatternFor(baseline, dimension) };
+  return { status, ...dominantPatternFor(baseline, dimension, path) };
 }

--- a/src/tools-core/tools/validate-change.ts
+++ b/src/tools-core/tools/validate-change.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import { relative, resolve } from "node:path";
 import type { DriftCategory } from "../../drift/types.js";
 import { SECURITY_SUBCATEGORIES } from "../../drift/types.js";
-import type { RepoDriftBaseline } from "../../core/baseline.js";
+import type { RepoDriftBaseline, CategoryVote } from "../../core/baseline.js";
 import type { IntentHint } from "../../intent/types.js";
 import { getBaseline } from "../../mcp/baseline-provider.js";
 import { classifyRouteAuth } from "../../drift/route-auth-classify.js";
@@ -25,6 +25,7 @@ import { noBaselineData, type Status } from "../result.js";
 import { deepAnalyze, bodyToPayloads, inferLanguage, degradeMessage, type DeepResult } from "../../mcp/deep-client.js";
 import { buildCandidatePayloads } from "../../mcp/candidate-feeder.js";
 import { deepDuplicatesViaIndex } from "../../mcp/deep-index.js";
+import { directoryOf } from "../../drift/utils.js";
 
 const DUPLICATE_THRESHOLD = 0.8; // a CHANGE introducing a near-clone — stricter than discovery
 const MAX_MATCHES = 20;
@@ -134,16 +135,47 @@ const DIM_CHECKS: DimensionCheck[] = [
   },
 ];
 
-/** The dominant to validate against for a dimension: the detector vote when it
- *  established one IN THIS dimension's vocabulary, ELSE the team's declared
- *  convention (highest-confidence intent hint). The declared fallback is what
- *  catches the FIRST deviation in a fully-consistent dimension (no finding, so
- *  no vote, but the rule is binding). Note architectural_consistency is a
- *  COMPOSITE category — its stored vote may be a DI label, not data-access — so
- *  the vote is only honored when it's actually a data-access label; otherwise
- *  the declared ORM/repository rule stands in. */
-function effectiveDominant(baseline: RepoDriftBaseline, check: DimensionCheck): EffectiveDominant | null {
-  const vote = baseline.perCategoryVote[check.dimension];
+/** The vote for the edited file's OWN directory, or undefined.
+ *
+ *  All three DIM_CHECKS dimensions are directory-grouped by their detectors
+ *  (return-shape via buildDirectoryGroups, async and architectural via
+ *  buildDirectoryScopedVote), so a directory is the only scope in which a
+ *  "dominant pattern" means anything here. The repo-wide perCategoryVote is
+ *  deliberately NOT consulted: it holds whichever single directory had the
+ *  widest denominator, and applying that to every file is what made this check
+ *  tell Next.js server actions to adopt a React component's return shape. */
+function dirVoteFor(
+  baseline: RepoDriftBaseline,
+  dimension: DimensionCheck["dimension"],
+  relTarget: string,
+): CategoryVote | undefined {
+  return baseline.perDirectoryVote?.[dimension]?.[directoryOf(relTarget)];
+}
+
+/** The dominant to validate against for a dimension.
+ *
+ *  Resolution order, precision-first:
+ *    1. The vote for the edited file's OWN directory — the only vote that can
+ *       be said to describe this file's peers.
+ *    2. The team's declared convention (highest-confidence intent hint), which
+ *       is project-wide by construction and therefore always in scope. This is
+ *       what catches the FIRST deviation in a fully-consistent dimension.
+ *    3. Nothing.
+ *
+ *  A directory with no vote is a directory whose convention could not be
+ *  established: either it is unanimous, so there is nothing to deviate from, or
+ *  it is below the dominance threshold, so no convention exists. Both mean
+ *  silence, not borrowing another directory's rule.
+ *
+ *  architectural_consistency remains a COMPOSITE category — its stored vote may
+ *  be a DI label, not data-access — so a vote is only honored when it is
+ *  actually in this dimension's vocabulary. */
+function effectiveDominant(
+  baseline: RepoDriftBaseline,
+  check: DimensionCheck,
+  relTarget: string,
+): EffectiveDominant | null {
+  const vote = dirVoteFor(baseline, check.dimension, relTarget);
   if (vote && check.labels.has(vote.dominantPattern)) {
     return { display: vote.dominantPattern, source: "vote", refFiles: vote.dominantFiles };
   }
@@ -171,7 +203,7 @@ export function validateChange(
   // The classifier returns the dimension's DISPLAY label, matching what the
   // vote stores, so the comparison is apples-to-apples.
   for (const check of DIM_CHECKS) {
-    const dom = effectiveDominant(baseline, check);
+    const dom = effectiveDominant(baseline, check, relTarget);
     if (!dom) continue;
     const mine = check.classify(body, relTarget);
     if (!mine || mine === dom.display) continue;
@@ -197,7 +229,7 @@ export function validateChange(
   const duplicateOf = findSimilarToBody(body, index, { threshold: DUPLICATE_THRESHOLD, cap: MAX_MATCHES });
 
   const referenceFiles = conflicts.length
-    ? (baseline.perCategoryVote[conflicts[0].dimension]?.dominantFiles ?? []).slice(0, 3)
+    ? (dirVoteFor(baseline, conflicts[0].dimension, relTarget)?.dominantFiles ?? []).slice(0, 3)
     : [];
 
   // Low confidence when the dimension we judged is itself only weakly dominant
@@ -205,8 +237,8 @@ export function validateChange(
   // tipping the balance. A declared-rule fallback (no vote) is binding, so it
   // stays high. Honest hedge per the deferred delta-vote.
   const judgedVote = conflicts.length
-    ? baseline.perCategoryVote[conflicts[0].dimension]
-    : baseline.perCategoryVote.async_patterns;
+    ? dirVoteFor(baseline, conflicts[0].dimension, relTarget)
+    : dirVoteFor(baseline, "async_patterns", relTarget);
   const confidence: "high" | "low" = judgedVote && judgedVote.consistencyScore < THIN_MARGIN ? "low" : "high";
 
   return {

--- a/test/eval/inloop-precision.test.ts
+++ b/test/eval/inloop-precision.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBaseline, type RepoDriftBaseline } from "@/core/baseline";
+import { runEditChecks } from "@/session/check";
+
+/**
+ * In-loop precision eval.
+ *
+ * Every case below is a real finding from a recorded drift session, with its
+ * verdict established by reading the actual source. The synthetic repo
+ * reproduces the structure that produced them: a directory that is unanimous on
+ * one convention, a directory that is mixed and therefore carries the only
+ * detector vote, a directory below the dominance threshold, plus the test,
+ * script and seed classes an agent legitimately writes differently.
+ *
+ * The gate is precision, not count. A change that raises recall while dropping
+ * precision below the floor does not ship. That is the mechanism that would
+ * have caught all four of the audited defects before a user saw them.
+ */
+
+const PRECISION_FLOOR = 0.9;
+
+let repo: string;
+let sessionsDir: string;
+let baseline: RepoDriftBaseline;
+
+// src/components is MIXED — 5 of 6 on sentinels, which clears the detector's
+// own 0.7 dominance bar. It is the only directory that produces a return-shape
+// finding, so before the per-directory fix its vote became the whole repo's
+// rule. Bodies are deliberately varied so no two are semantic duplicates.
+const COMPONENT_SENTINEL = (n: string, i: number) => `export function ${n}(id: string) {
+  const row = lookup${i}(id);
+  const meta = decorate${i}(row, ${i});
+  if (!row) return null;
+  if (meta.hidden) return undefined;
+  return { ...row, rank: ${i}, meta };
+}`;
+const COMPONENT_THROWS = (n: string, i: number) => `export function ${n}(id: string) {
+  const row = lookup${i}(id);
+  const meta = decorate${i}(row, ${i});
+  if (!row) throw new Error("missing ${n}");
+  if (meta.hidden) throw new Error("hidden ${n}");
+  return { ...row, rank: ${i}, meta };
+}`;
+
+// src/actions is UNANIMOUS on error-object returns, so it emits no finding of
+// its own — a single-pattern directory has nothing to deviate from — and
+// therefore had no vote to defend itself with. That is exactly the shape that
+// let a React component's convention be applied to Next.js server actions.
+// Real server actions differ substantially from one another; only their RETURN
+// SHAPE is shared. Each body below is structurally distinct so the duplicate
+// detector has nothing to say and the eval isolates the return-shape axis.
+const ACTIONS: Record<string, string> = {
+  blockUser: `export async function blockUser(targetId: string) {
+  const session = await auth();
+  if (!session?.user?.id) return { error: COPY.signedOut };
+  if (targetId === session.user.id) return { error: COPY.cantBlockSelf };
+  await db.transaction(async (tx) => {
+    await tx.delete(schema.follows).where(eq(schema.follows.followerId, targetId));
+    await tx.insert(schema.blocks).values({ blockerId: session.user.id, blockedId: targetId });
+  });
+  revalidatePath("/u/[handle]");
+  return { ok: true };
+}`,
+  reportPost: `export async function reportPost(postId: string, reason: string, note?: string) {
+  const session = await auth();
+  if (!session?.user?.id) return { error: COPY.signedOut };
+  if (!REPORT_REASONS.includes(reason)) return { error: COPY.reasonMissing };
+  const trimmed = note?.trim() ?? null;
+  if (trimmed && trimmed.length > 300) return { error: COPY.noteTooLong };
+  const rows = await db.execute(sql\`select 1 from posts where id = \${postId}\`);
+  if (rows.length === 0) return { error: COPY.notVisible };
+  return { ok: true };
+}`,
+  requestAccountDeletion: `export async function requestAccountDeletion() {
+  const session = await auth();
+  if (!session?.user?.id) return { error: COPY.signedOut };
+  const userId = session.user.id;
+  const rl = await rateLimit("account:delete", userId);
+  if (!rl.ok) return { error: COPY.rateLimited };
+  try {
+    const pending = await db.query.deletions.findFirst({ where: eq(schema.deletions.userId, userId) });
+    if (pending) return { error: COPY.deletionAlreadyRequested };
+    await db.insert(schema.deletions).values({ userId, requestedAt: new Date(), stage: "pending" });
+    await notifyOps("account-deletion", { userId });
+  } catch (e) {
+    await logError("requestAccountDeletion", e);
+    return { error: mapDbError(e) };
+  }
+  return { ok: true };
+}`,
+  one: `export async function updateHandle(handle: string) {
+  const session = await auth();
+  if (!session?.user?.id) return { error: COPY.signedOut };
+  if (!/^[a-z0-9_]{3,20}$/.test(handle)) return { error: COPY.badHandle };
+  const taken = await db.query.users.findFirst({ where: eq(schema.users.handle, handle) });
+  if (taken) return { error: COPY.handleTaken };
+  await db.update(schema.users).set({ handle });
+  return { ok: true };
+}`,
+  two: `export async function setTimezone(tz: string) {
+  const session = await auth();
+  if (!session?.user?.id) return { error: COPY.signedOut };
+  if (!SUPPORTED_ZONES.has(tz)) return { error: COPY.badTimezone };
+  await db.update(schema.users).set({ timezone: tz });
+  revalidatePath("/today");
+  return { ok: true };
+}`,
+  three: `export async function resolveReport(reportId: string, resolution: string) {
+  const admin = await requireAdmin();
+  const report = await db.query.reports.findFirst({ where: eq(schema.reports.id, reportId) });
+  if (!report) return { error: COPY.somethingWrong };
+  await db.update(schema.reports).set({ resolvedAt: new Date(), resolvedBy: admin.userId, resolution });
+  return { ok: true };
+}`,
+  four: `export async function shareDay(date: string, handle: string) {
+  const session = await auth();
+  if (!session?.user?.id) return { error: COPY.signedOut };
+  const invitee = await db.query.users.findFirst({ where: eq(schema.users.handle, handle) });
+  if (!invitee) return { error: COPY.unknownHandle };
+  if (invitee.id === session.user.id) return { error: COPY.cantShareSelf };
+  await db.insert(schema.sharedDays).values({ date, ownerId: session.user.id, inviteeId: invitee.id });
+  return { ok: true };
+}`,
+};
+
+const cases: Array<{
+  id: string;
+  file: string;
+  body: string;
+  expected: "flag" | "silence";
+  why: string;
+}> = [
+  {
+    id: "DF-3 server action",
+    file: "src/actions/blocks.ts",
+    body: ACTIONS.blockUser,
+    expected: "silence",
+    why: "src/actions is 10/10 on error-object returns; it was judged against src/components",
+  },
+  {
+    id: "DF-9 server action",
+    file: "src/actions/reports.ts",
+    body: ACTIONS.reportPost,
+    expected: "silence",
+    why: "same unanimous server-action convention",
+  },
+  {
+    id: "DF-16 server action",
+    file: "src/actions/account.ts",
+    body: ACTIONS.requestAccountDeletion,
+    expected: "silence",
+    why: "same unanimous server-action convention",
+  },
+  {
+    id: "DF-15 test file",
+    file: "src/lib/rate-limit.test.ts",
+    body: `export function freshLimiter() {
+  const client = makeClient();
+  if (!client) throw new Error("no client");
+  throw new Error("always fails, on purpose");
+}`,
+    expected: "silence",
+    why: "a test file classified from deliberate fault injection inside mocks",
+  },
+  {
+    id: "DF-18 seed script",
+    file: "scripts/seed-dev.ts",
+    body: `export async function assertDevDatabase(url: string) {
+  if (!url) throw new Error("DATABASE_URL is not set");
+  if (!url.includes("_dev")) throw new Error("refusing to seed a non-dev database");
+  return true;
+}`,
+    expected: "silence",
+    why: "throwing is the guard that stops the script truncating a real database",
+  },
+  {
+    id: "faabedb8 DF-1 test global-setup",
+    file: "tests/integration/global-setup.ts",
+    body: `export async function setup() {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("global-setup: DATABASE_URL is not set");
+  if (!url.includes("_test")) throw new Error("global-setup: refusing to truncate");
+  return true;
+}`,
+    expected: "silence",
+    why: "a globalSetup has no caller to inspect a sentinel; the file says so in its own doc comment",
+  },
+  {
+    id: "component deviating from its OWN directory",
+    file: "src/components/NewThing.tsx",
+    body: COMPONENT_THROWS("NewThing", 14),
+    expected: "flag",
+    why: "src/components really is 5/6 on sentinels, so a throwing component deviates from its peers",
+  },
+];
+
+beforeAll(async () => {
+  repo = realpathSync(mkdtempSync(join(tmpdir(), "vd-eval-repo-")));
+  sessionsDir = realpathSync(mkdtempSync(join(tmpdir(), "vd-eval-sessions-")));
+  for (const d of ["src/components", "src/actions", "src/lib", "scripts", "tests/integration"]) {
+    mkdirSync(join(repo, d), { recursive: true });
+  }
+  // MIXED: 5 sentinels, 1 throws = 0.83, clearing the 0.7 dominance bar, so
+  // this is the only directory that emits a return-shape finding.
+  ["a", "b", "c", "d", "e"].forEach((n, i) => {
+    writeFileSync(join(repo, `src/components/${n.toUpperCase()}.tsx`), `${COMPONENT_SENTINEL(n, i)}\n`);
+  });
+  writeFileSync(join(repo, "src/components/F.tsx"), `${COMPONENT_THROWS("f", 5)}\n`);
+  // UNANIMOUS on error-object returns -> emits no finding, so has no vote.
+  for (const n of ["one", "two", "three", "four"]) {
+    writeFileSync(join(repo, `src/actions/${n}.ts`), `${ACTIONS[n]}\n`);
+  }
+  baseline = await buildBaseline(repo);
+}, 120_000);
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+async function runCase(c: (typeof cases)[number]) {
+  const out = await runEditChecks({
+    rootDir: repo,
+    projectHash: "eva1eva1eva1eva1",
+    sessionId: `eval-${c.id.replace(/[^a-z0-9]/gi, "-")}`,
+    sessionsDir,
+    file: join(repo, c.file),
+    body: c.body,
+    loadBaselineFor: async () => baseline,
+  });
+  if (process.env.EVAL_DEBUG === "1" && out.flags.length) {
+    console.log(`  [${c.id}] flagged:`, out.flags.map((f) => `${f.detail.category}:${JSON.stringify(f.detail).slice(0, 140)}`));
+  }
+  return out.flags.length > 0;
+}
+
+describe("in-loop precision eval", () => {
+  it("the fixture repo produces a return-shape vote only for src/components", () => {
+    const dirs = Object.keys(baseline.perDirectoryVote?.return_shape_consistency ?? {});
+    expect(dirs).toEqual(["src/components"]);
+  });
+
+  for (const c of cases) {
+    it(`${c.expected === "flag" ? "flags" : "stays silent on"}: ${c.id}`, async () => {
+      expect(await runCase(c), c.why).toBe(c.expected === "flag");
+    }, 30_000);
+  }
+
+  it("does not regress below the precision floor", async () => {
+    let flagged = 0;
+    let correct = 0;
+    for (const c of cases) {
+      if (!(await runCase(c))) continue;
+      flagged++;
+      if (c.expected === "flag") correct++;
+    }
+    const precision = flagged === 0 ? 1 : correct / flagged;
+    expect(precision, `precision ${precision.toFixed(2)} across ${cases.length} audited cases`).toBeGreaterThanOrEqual(
+      PRECISION_FLOOR,
+    );
+  }, 120_000);
+
+  it("still catches the known true positive", async () => {
+    const tp = cases.find((c) => c.expected === "flag")!;
+    expect(await runCase(tp)).toBe(true);
+  }, 30_000);
+});

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   extractFunctionsFromFile,
   extractAllFunctions,
+  tokenizeBody,
 } from "../../../src/codedna/function-extractor.js";
 import {
   computeSemanticFingerprints,
@@ -215,5 +216,49 @@ export function readTitleFromTrackRecord(rec: any): { value: string; source: str
     // Different bodies → no exact-duplicate group. Before the fix both bodies
     // collapsed to `{ value: string; source: string }` → one false group.
     expect(groups.length).toBe(0);
+  });
+});
+
+describe("tokenizeBody comment and literal ordering", () => {
+  // `//` was stripped before string literals, so a `//` inside a literal
+  // deleted the closing quote and desynchronized quote pairing for the rest of
+  // the body. Measured on the audited population: it leaked 45 distinct English
+  // words out of test-name literals into one stored anchor and swallowed 43% of
+  // another file's tokens.
+  it("does not treat a URL inside a single-quoted string as a line comment", () => {
+    const toks = tokenizeBody(`const u = 'https://example.invalid'; const after = 1;`);
+    expect(toks).toContain("after");
+    expect(toks).not.toContain("example");
+    expect(toks).not.toContain("invalid");
+  });
+
+  it("does not treat a URL inside a template literal as a line comment", () => {
+    const toks = tokenizeBody("const p = `https://picsum.photos/x`; const tail = 9;");
+    expect(toks).toContain("tail");
+    expect(toks).not.toContain("picsum");
+  });
+
+  it("does not treat a URL inside a double-quoted string as a line comment", () => {
+    const toks = tokenizeBody(`const u = "https://example.invalid"; const tail = 2;`);
+    expect(toks).toContain("tail");
+    expect(toks).not.toContain("invalid");
+  });
+
+  it("still strips a genuine line comment", () => {
+    const toks = tokenizeBody(`const a = 1; // secretName\nconst b = 2;`);
+    expect(toks).not.toContain("secretName");
+    expect(toks).toContain("b");
+  });
+
+  it("still strips a block comment", () => {
+    const toks = tokenizeBody(`const a = 1; /* hiddenName */ const b = 2;`);
+    expect(toks).not.toContain("hiddenName");
+    expect(toks).toContain("b");
+  });
+
+  it("still strips a python hash comment", () => {
+    const toks = tokenizeBody(`a = 1  # pythonSecret\nb = 2`);
+    expect(toks).not.toContain("pythonSecret");
+    expect(toks).toContain("b");
   });
 });

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -262,3 +262,82 @@ describe("tokenizeBody comment and literal ordering", () => {
     expect(toks).toContain("b");
   });
 });
+
+describe("JS/TS extraction coverage", () => {
+  const names = (content: string, language: SupportedLanguage = "typescript") =>
+    extractFunctionsFromFile(mkFile(content, language)).map((f) => f.name);
+
+  it("indexes class methods", () => {
+    expect(
+      names(`class Repo {\n  async findUser(id: string) {\n    const row = await db.get(id);\n    return row ?? null;\n  }\n}`),
+    ).toContain("findUser");
+  });
+
+  it("indexes object-literal methods", () => {
+    expect(
+      names(`const api = {\n  fetchUser(id: string) {\n    const row = lookup(id);\n    return row ?? null;\n  },\n};`),
+    ).toContain("fetchUser");
+  });
+
+  it("indexes let and var arrow bindings", () => {
+    expect(
+      names(`let handle = (e: Event) => {\n  const t = e.target;\n  return t ?? null;\n};`),
+    ).toContain("handle");
+  });
+
+  it("indexes generators and accessors", () => {
+    const n = names(
+      `class C {\n  *walk() {\n    const a = 1;\n    yield a;\n  }\n  get total() {\n    const n = this.items.length;\n    return n * 2;\n  }\n}`,
+    );
+    expect(n).toContain("walk");
+    expect(n).toContain("total");
+  });
+
+  it("indexes an exported default function", () => {
+    expect(
+      names(`export default function handler(req: Req) {\n  const id = req.query.id;\n  return id ?? null;\n}`),
+    ).toContain("handler");
+  });
+
+  // ---- over-matching guards. These must pass BEFORE and AFTER the widening. ----
+
+  it("does not index an interface member as a function", () => {
+    // The exact shape that made a duplicate advisory cite a non-function.
+    expect(names(`interface Opts {\n  onSave(body: string): void;\n  onCancel(): void;\n}`)).toHaveLength(0);
+  });
+
+  it("does not index a type-literal member as a function", () => {
+    expect(names(`type Handlers = {\n  onSave(body: string): void;\n  onCancel(): void;\n};`)).toHaveLength(0);
+  });
+
+  it("does not index control-flow keywords as functions", () => {
+    const n = names(
+      `function real() {\n  if (a) { doThing(); }\n  for (const x of xs) { use(x); }\n  while (y) { tick(); }\n  switch (z) { default: break; }\n  return 1;\n}`,
+    );
+    expect(n).toEqual(["real"]);
+  });
+
+  it("does not index a bare call expression as a function", () => {
+    const n = names(`function real() {\n  const a = compute(1, 2);\n  register(a);\n  return a;\n}`);
+    expect(n).toEqual(["real"]);
+  });
+
+  it("does not index a test-runner call whose argument is an arrow", () => {
+    // The dangerous over-match for a method-shorthand pattern: `describe("x", () => {`
+    // has the shape name(args) followed by a block, but the block belongs to the
+    // arrow, not to `describe`. Indexing these would flood the index from every
+    // test file in a repo.
+    const n = names(
+      `describe("suite", () => {\n  it("works", async () => {\n    const r = await go();\n    expect(r).toBe(1);\n  });\n});`,
+    );
+    expect(n).not.toContain("describe");
+    expect(n).not.toContain("it");
+  });
+
+  it("does not index a catch clause as a function", () => {
+    const n = names(
+      `function real() {\n  try {\n    risky();\n  } catch (err) {\n    report(err);\n  }\n  return 1;\n}`,
+    );
+    expect(n).toEqual(["real"]);
+  });
+});

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -348,6 +348,26 @@ describe("JS/TS extraction coverage", () => {
     expect(n).toContain("render");
   });
 
+  it("does not index not-implemented stubs", () => {
+    // A body whose only statement is a throw carries no reusable logic, but it
+    // is byte-identical everywhere it appears, so indexing stubs manufactures
+    // duplicate findings. Measured on NextChat: usage(), speech() and models()
+    // are all `throw new Error("Method not implemented.")` across nine provider
+    // clients, and dominated a 7.1-point composite drop.
+    const n = names(
+      `class Client {\n  speech(options: SpeechOptions): Promise<ArrayBuffer> {\n    throw new Error("Method not implemented.");\n  }\n  extractMessage(res: any) {\n    const parsed = normalize(res);\n    return parsed?.content?.text ?? "";\n  }\n}`,
+    );
+    expect(n).not.toContain("speech");
+    expect(n).toContain("extractMessage");
+  });
+
+  it("still indexes a throw that is part of real logic", () => {
+    const n = names(
+      `function guard(url: string) {\n  const parsed = parse(url);\n  if (!parsed) throw new Error("bad url");\n  return parsed.host;\n}`,
+    );
+    expect(n).toContain("guard");
+  });
+
   it("does not index a catch clause as a function", () => {
     const n = names(
       `function real() {\n  try {\n    risky();\n  } catch (err) {\n    report(err);\n  }\n  return 1;\n}`,

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -387,6 +387,51 @@ describe("JS/TS extraction coverage", () => {
     expect(n).toContain("doWork");
   });
 
+  it("does not index a call expression taking a function-keyword callback", () => {
+    // The dangerous sibling of the arrow case. `([^)]*)` stops at the FIRST `)`,
+    // which for `test('name', function (assert) {` is the CALLBACK's parameter
+    // close, so the brace guard saw the callback's body and matched, indexing an
+    // entry named after the CALLEE. Measured on a date library: this inflated the
+    // index 2190 -> 5114, and because the duplicate scorer divides by function
+    // count it moved the composite +9.5 in the OPTIMISTIC direction.
+    const n = names(
+      `test('format using constants', function (assert) {\n  const m = moment();\n  assert.equal(m.format('LTS'), 'x');\n});`,
+    );
+    expect(n).not.toContain("test");
+    expect(n).toEqual([]);
+  });
+
+  it("does not index mocha-style registration helpers", () => {
+    const n = names(
+      `describe('suite', function () {\n  it('works', function (done) {\n    const r = go();\n    done(r);\n  });\n});`,
+    );
+    expect(n).not.toContain("describe");
+    expect(n).not.toContain("it");
+  });
+
+  it("skips any function whose parameter list contains parentheses (known, pre-existing)", () => {
+    // Both JS/TS patterns capture params with `[^)]*`, so a function-typed or
+    // defaulted parameter containing `(` stops the capture early and the match
+    // fails. This predates the callback guard and is unchanged by it; it is
+    // recorded here so the limitation is visible rather than folklore.
+    //
+    // The direction is deliberate: the extractor errs toward missing a real
+    // function rather than inventing a phantom one. Function count is the
+    // denominator the duplicate scorer divides by, so a phantom inflates scores
+    // optimistically while a miss does not.
+    const method = names(
+      `class Collection {\n  mapAll(fn: (x: number) => number, seed: number) {\n    const out = this.items.map(fn);\n    return out.concat(seed);\n  }\n}`,
+    );
+    expect(method).not.toContain("mapAll");
+
+    // A plain parameter list is indexed normally, confirming the cause is the
+    // parenthesis and not the method form itself.
+    const plain = names(
+      `class Collection {\n  mapAll(seed: number, factor: number) {\n    const out = this.items.map(String);\n    return out.concat(seed, factor);\n  }\n}`,
+    );
+    expect(plain).toContain("mapAll");
+  });
+
   it("does not index a catch clause as a function", () => {
     const n = names(
       `function real() {\n  try {\n    risky();\n  } catch (err) {\n    report(err);\n  }\n  return 1;\n}`,

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -341,3 +341,72 @@ describe("JS/TS extraction coverage", () => {
     expect(n).toEqual(["real"]);
   });
 });
+
+describe("Go, Rust and Python extraction coverage", () => {
+  const names = (content: string, language: SupportedLanguage, rel: string) =>
+    extractFunctionsFromFile(mkFile(content, language, rel)).map((f) => f.name);
+
+  it("indexes a Go generic function", () => {
+    expect(
+      names(
+        `func Map[T any, U any](in []T, f func(T) U) []U {\n\tout := make([]U, 0)\n\tfor _, v := range in {\n\t\tout = append(out, f(v))\n\t}\n\treturn out\n}`,
+        "go",
+        "a.go",
+      ),
+    ).toContain("Map");
+  });
+
+  it("indexes a Go method with a receiver", () => {
+    expect(
+      names(
+        `func (s *Server) Handle(w http.ResponseWriter) {\n\tlog.Print("x")\n\ts.count++\n\treturn\n}`,
+        "go",
+        "a.go",
+      ),
+    ).toContain("Handle");
+  });
+
+  it("indexes a Rust fn with a where clause", () => {
+    expect(
+      names(
+        `fn convert<T>(v: T) -> String\nwhere\n    T: Display,\n{\n    let s = v.to_string();\n    s.trim().to_owned()\n}`,
+        "rust",
+        "a.rs",
+      ),
+    ).toContain("convert");
+  });
+
+  it("indexes a Rust fn with a where clause and NO return type", () => {
+    // The `->` was doing the work of spanning the signature, so a where clause
+    // with no return type left nothing to consume it.
+    expect(
+      names(
+        `fn register<T>(v: T)\nwhere\n    T: Into<String>,\n{\n    let s = v.into();\n    store(s);\n}`,
+        "rust",
+        "a.rs",
+      ),
+    ).toContain("register");
+  });
+
+  it("indexes a plain Rust fn with a return type", () => {
+    expect(
+      names(`pub fn add(a: u32, b: u32) -> u32 {\n    let total = a + b;\n    total\n}`, "rust", "a.rs"),
+    ).toContain("add");
+  });
+
+  it("indexes a Python method inside a class", () => {
+    expect(
+      names(
+        `class Repo:\n    def find_user(self, uid):\n        row = db.get(uid)\n        return row or None\n`,
+        "python",
+        "a.py",
+      ),
+    ).toContain("find_user");
+  });
+
+  it("indexes an async Python function", () => {
+    expect(
+      names(`async def fetch_all(ids):\n    rows = await gather(ids)\n    return [r for r in rows if r]\n`, "python", "a.py"),
+    ).toContain("fetch_all");
+  });
+});

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -368,6 +368,25 @@ describe("JS/TS extraction coverage", () => {
     expect(n).toContain("guard");
   });
 
+  it("does not index interface members written without semicolons", () => {
+    // prettier's `semi: false` is common, and without a terminating `;` the
+    // return-type scan used to run past the declaration to the first `{` it
+    // could find — often a real method many lines below — indexing a garbage
+    // body made of comments and other declarations. Measured on TypeORM, whose
+    // driver interfaces are written this way.
+    const n = names(
+      `export interface Driver {\n  connect(): Promise<void>\n\n  /** Performs connection. */\n  afterConnect(): Promise<void>\n}\n\nexport class Real {\n  doWork(n: number) {\n    const x = n * 2\n    return x + 1\n  }\n}`,
+    );
+    expect(n).not.toContain("connect");
+    expect(n).not.toContain("afterConnect");
+    expect(n).toEqual(["doWork"]);
+  });
+
+  it("still indexes a method whose body brace is on the next line", () => {
+    const n = names(`class C {\n  doWork(n: number): number\n  {\n    const x = n * 2;\n    return x + 1;\n  }\n}`);
+    expect(n).toContain("doWork");
+  });
+
   it("does not index a catch clause as a function", () => {
     const n = names(
       `function real() {\n  try {\n    risky();\n  } catch (err) {\n    report(err);\n  }\n  return 1;\n}`,

--- a/test/unit/codedna/function-extractor.test.ts
+++ b/test/unit/codedna/function-extractor.test.ts
@@ -334,6 +334,20 @@ describe("JS/TS extraction coverage", () => {
     expect(n).not.toContain("it");
   });
 
+  it("does not index class constructors", () => {
+    // Constructors are structurally forced to resemble one another — a DI
+    // constructor is the same shape in every class — so indexing them floods
+    // duplicate detection. Measured on ionic-framework: `constructor` alone
+    // produced 80 of 214 duplicate findings and most of a 10-point composite
+    // drop. They were not indexed before the method-shorthand pattern existed,
+    // and they stay unindexed.
+    const n = names(
+      `class Widget {\n  constructor(private readonly store: Store) {\n    this.ready = false;\n    this.store = store;\n  }\n  render() {\n    const v = this.store.get();\n    return v ?? null;\n  }\n}`,
+    );
+    expect(n).not.toContain("constructor");
+    expect(n).toContain("render");
+  });
+
   it("does not index a catch clause as a function", () => {
     const n = names(
       `function real() {\n  try {\n    risky();\n  } catch (err) {\n    report(err);\n  }\n  return 1;\n}`,

--- a/test/unit/codedna/minhash.test.ts
+++ b/test/unit/codedna/minhash.test.ts
@@ -9,6 +9,7 @@ import {
   buildSignature,
   DEFAULT_PERMUTATIONS,
 } from "../../../src/codedna/minhash.js";
+import { tokenizeBody } from "../../../src/codedna/function-extractor.js";
 
 // True Jaccard similarity between two sets of shingle strings.
 function trueJaccard(a: string[], b: string[]): number {
@@ -238,5 +239,49 @@ describe("MinHash + LSH", () => {
       expect(sig.signature.length).toBe(DEFAULT_PERMUTATIONS);
       expect(sig.tokens.length).toBeGreaterThan(0);
     });
+  });
+});
+
+describe("normalizeTokens data references", () => {
+  const norm = (src: string) => normalizeTokens(tokenizeBody(src)).join(" ");
+
+  it("distinguishes queries against different tables", () => {
+    // The measured collision: an identifier chain was kept literal only when it
+    // ended in `(`, so `schema.reports` (a property access) had both halves
+    // erased and every Drizzle query with the same call skeleton collided.
+    const a = norm(`return db.select().from(schema.reports).where(eq(schema.reports.postId, postId));`);
+    const b = norm(`return db.select().from(schema.notifications).where(eq(schema.notifications.userId, userId));`);
+    expect(a).not.toBe(b);
+  });
+
+  it("distinguishes different columns on the same table", () => {
+    const a = norm(`return db.select().from(schema.reports).where(eq(schema.reports.postId, v));`);
+    const b = norm(`return db.select().from(schema.reports).where(eq(schema.reports.authorId, v));`);
+    expect(a).not.toBe(b);
+  });
+
+  it("still collapses differing local variable names", () => {
+    const a = norm(`const rows = await db.select(); return rows.length;`);
+    const b = norm(`const items = await db.select(); return items.length;`);
+    expect(a).toBe(b);
+  });
+
+  it("still collapses differing parameter-derived locals", () => {
+    const a = norm(`let acc = 0; for (const n of xs) { acc = acc + n; } return acc;`);
+    const b = norm(`let total = 0; for (const v of xs) { total = total + v; } return total;`);
+    expect(a).toBe(b);
+  });
+
+  it("keeps call targets literal, as before", () => {
+    expect(norm(`db.query(sql);`)).toContain("query");
+  });
+
+  it("keeps a constructor name literal, as before", () => {
+    expect(norm(`const r = new UserRepo(); return r;`)).toContain("UserRepo");
+  });
+
+  it("two genuinely identical bodies still match", () => {
+    const src = `return db.select().from(schema.reports).where(eq(schema.reports.postId, postId));`;
+    expect(norm(src)).toBe(norm(src));
   });
 });

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -10,6 +10,7 @@ import {
   loadBaselineUnchecked,
   computeBaselineKey,
   votesFromFindings,
+  votesByDirectory,
   securitySubVotesFromFindings,
   toCategoryVote,
   BASELINE_VERSION,
@@ -347,5 +348,63 @@ describe("buildBaseline + persistence round-trip", () => {
     expect(Object.keys(assembled.perCategoryVote).sort()).toEqual(
       Object.keys(standalone.perCategoryVote).sort(),
     );
+  });
+});
+
+describe("votesByDirectory", () => {
+  const base = {
+    detector: "return-shape-consistency",
+    driftCategory: "return_shape_consistency" as const,
+    severity: "warning" as const,
+    confidence: 0.8,
+    finding: "",
+    recommendation: "",
+    dominantPattern: "null/undefined sentinels",
+    dominantCount: 11,
+    totalRelevantFiles: 14,
+    consistencyScore: 79,
+    dominantFiles: [] as string[],
+    deviatingFiles: [] as Array<{ path: string; detectedPattern: string; evidence: never[] }>,
+  };
+  const finding = (over: Partial<typeof base>) => ({ ...base, ...over }) as never;
+
+  it("keeps one vote per (category, directory) instead of collapsing to one", () => {
+    const out = votesByDirectory([
+      finding({
+        dominantPattern: "null/undefined sentinels",
+        dominantFiles: ["src/components/CalendarStrip.tsx"],
+        deviatingFiles: [{ path: "src/components/Feed.tsx", detectedPattern: "throws on error", evidence: [] }],
+      }),
+      finding({
+        dominantPattern: "error-object returns",
+        dominantCount: 4,
+        totalRelevantFiles: 5,
+        dominantFiles: ["src/lib/follows.ts"],
+        deviatingFiles: [{ path: "src/lib/other.ts", detectedPattern: "throws on error", evidence: [] }],
+      }),
+    ]);
+    const byDir = out.return_shape_consistency!;
+    expect(Object.keys(byDir).sort()).toEqual(["src/components", "src/lib"]);
+    expect(byDir["src/components"]!.dominantPattern).toBe("null/undefined sentinels");
+    expect(byDir["src/lib"]!.dominantPattern).toBe("error-object returns");
+    expect(byDir["src/lib"]!.directory).toBe("src/lib");
+  });
+
+  it("omits a vote whose files span more than one directory", () => {
+    const out = votesByDirectory([
+      finding({
+        dominantFiles: ["src/a/one.ts"],
+        deviatingFiles: [{ path: "src/b/two.ts", detectedPattern: "throws on error", evidence: [] }],
+      }),
+    ]);
+    expect(out.return_shape_consistency ?? {}).toEqual({});
+  });
+
+  it("keeps the widest denominator when one directory yields two findings", () => {
+    const out = votesByDirectory([
+      finding({ dominantFiles: ["src/lib/a.ts"], totalRelevantFiles: 4, dominantPattern: "narrow" }),
+      finding({ dominantFiles: ["src/lib/b.ts"], totalRelevantFiles: 9, dominantPattern: "wide" }),
+    ]);
+    expect(out.return_shape_consistency!["src/lib"]!.dominantPattern).toBe("wide");
   });
 });

--- a/test/unit/core/baseline.test.ts
+++ b/test/unit/core/baseline.test.ts
@@ -11,6 +11,7 @@ import {
   computeBaselineKey,
   votesFromFindings,
   votesByDirectory,
+  compareByCodeUnit,
   securitySubVotesFromFindings,
   toCategoryVote,
   BASELINE_VERSION,
@@ -406,5 +407,33 @@ describe("votesByDirectory", () => {
       finding({ dominantFiles: ["src/lib/b.ts"], totalRelevantFiles: 9, dominantPattern: "wide" }),
     ]);
     expect(out.return_shape_consistency!["src/lib"]!.dominantPattern).toBe("wide");
+  });
+});
+
+describe("computeBaselineKey determinism", () => {
+  // localeCompare is locale-dependent, so two machines with different locales
+  // could compute different keys for identical inputs and silently split the
+  // baseline cache. Code-unit order is the same everywhere.
+  const files = [
+    { path: "a-b.ts", hash: "1" },
+    { path: "aB.ts", hash: "2" },
+    { path: "Ab.ts", hash: "3" },
+    { path: "_z.ts", hash: "4" },
+  ];
+
+  it("is independent of input order", () => {
+    const key = computeBaselineKey(files);
+    expect(computeBaselineKey([...files].reverse())).toBe(key);
+    expect(computeBaselineKey([files[2], files[0], files[3], files[1]])).toBe(key);
+  });
+
+  it("uses code-unit ordering, which diverges from every locale collation", () => {
+    // This is the pair that binds: locale collation sorts case-insensitively,
+    // so "a" precedes "B". By code unit "B" (0x42) precedes "a" (0x61). If the
+    // comparator ever goes back to localeCompare, this flips.
+    expect(compareByCodeUnit("B", "a")).toBeLessThan(0);
+    expect("B".localeCompare("a")).toBeGreaterThan(0);
+    expect(compareByCodeUnit("a", "a")).toBe(0);
+    expect(compareByCodeUnit("a-b.ts", "aB.ts")).toBeLessThan(0);
   });
 });

--- a/test/unit/drift/utils.test.ts
+++ b/test/unit/drift/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildDirectoryScopedVote,
+  isInLoopCheckable,
   directoryOf,
   buildPatternDistribution,
   findDominantPattern,
@@ -291,5 +292,33 @@ describe("project-scoped helpers remain available", () => {
     const dom = findDominantPattern(dist);
     expect(dom?.dominant).toBe("X");
     expect(dom?.dominantCount).toBe(2);
+  });
+});
+
+describe("isInLoopCheckable", () => {
+  it("rejects the file classes that produced audited false positives", () => {
+    // Each of these was flagged in a real recorded session and was a false
+    // positive: the file class legitimately uses a different convention from
+    // application code.
+    expect(isInLoopCheckable("tests/integration/global-setup.ts")).toBe(false);
+    expect(isInLoopCheckable("scripts/seed-soak.ts")).toBe(false);
+    expect(isInLoopCheckable("scripts/seed-dev.ts")).toBe(false);
+    expect(isInLoopCheckable("src/lib/rate-limit.test.ts")).toBe(false);
+    expect(isInLoopCheckable("src/scratch-probe.ts")).toBe(false);
+  });
+
+  it("still accepts ordinary application source in every supported language", () => {
+    expect(isInLoopCheckable("src/actions/blocks.ts")).toBe(true);
+    expect(isInLoopCheckable("src/lib/follows.ts")).toBe(true);
+    expect(isInLoopCheckable("internal/service/user.go")).toBe(true);
+    expect(isInLoopCheckable("app/models/user.py")).toBe(true);
+    expect(isInLoopCheckable("src/parser/mod.rs")).toBe(true);
+  });
+
+  it("does not reject a path merely for containing a keyword substring", () => {
+    // A source directory named `transcripts/` is application code and must not
+    // be caught by the `scripts` alternative.
+    expect(isInLoopCheckable("src/transcripts/render.ts")).toBe(true);
+    expect(isInLoopCheckable("src/benchmarking/report.ts")).toBe(true);
   });
 });

--- a/test/unit/mcp/tools/validate-change.test.ts
+++ b/test/unit/mcp/tools/validate-change.test.ts
@@ -18,6 +18,21 @@ import { buildSignature } from "../../../../src/codedna/minhash.js";
 import { buildBaseline, writeBaseline, type RepoDriftBaseline } from "../../../../src/core/baseline.js";
 import { __clearBaselineCache } from "../../../../src/mcp/baseline-provider.js";
 
+/** Mirror a category vote map into the directory the tests validate against.
+ *  validateChange now reads perDirectoryVote, scoped to the edited file's own
+ *  directory, so a fixture vote must live in that directory to bind. Every
+ *  target below is a bare filename, whose directoryOf() is ".". */
+function asDirVotes(
+  perCategoryVote: RepoDriftBaseline["perCategoryVote"],
+  dir = ".",
+): RepoDriftBaseline["perDirectoryVote"] {
+  const out: NonNullable<RepoDriftBaseline["perDirectoryVote"]> = {};
+  for (const [cat, vote] of Object.entries(perCategoryVote)) {
+    if (vote) out[cat as keyof typeof out] = { [dir]: { ...vote, directory: dir } };
+  }
+  return out;
+}
+
 const THEN_BODY = ["function f(){", "  return a()", "    .then(x => x)", "    .then(y => y);", "}"].join("\n");
 const AWAIT_BODY = ["async function g(){", "  const a = await p();", "  const b = await q();", "  return a + b;", "}"].join("\n");
 
@@ -39,6 +54,21 @@ function baseline(asyncDom: string | null, index: Array<{ path: string; name: st
           },
         }
       : {},
+    perDirectoryVote: asDirVotes(
+      asyncDom
+        ? {
+            async_patterns: {
+              driftCategory: "async_patterns",
+              dominantPattern: asyncDom,
+              dominantCount: 8,
+              totalRelevantFiles: 10,
+              consistencyScore: 80,
+              dominantFiles: ["ref.ts"],
+              deviators: [],
+            },
+          }
+        : {},
+    ),
     intentHints: [],
     minhashIndex: index.map((e) => {
       const s = buildSignature(e.body);
@@ -158,7 +188,16 @@ describe("validateChange — return-shape + data-access single-body classifiers"
     perCategoryVote: RepoDriftBaseline["perCategoryVote"],
     intentHints: RepoDriftBaseline["intentHints"] = [],
   ): RepoDriftBaseline {
-    return { key: "k", rootDir: "/r", ctxFiles: [{ path: "x.ts", hash: "h" }], perCategoryVote, intentHints, minhashIndex: [], builtAt: 0 };
+    return {
+      key: "k",
+      rootDir: "/r",
+      ctxFiles: [{ path: "x.ts", hash: "h" }],
+      perCategoryVote,
+      perDirectoryVote: asDirVotes(perCategoryVote),
+      intentHints,
+      minhashIndex: [],
+      builtAt: 0,
+    };
   }
   const SENTINEL_VOTE: RepoDriftBaseline["perCategoryVote"] = {
     return_shape_consistency: {
@@ -319,5 +358,55 @@ describe("validate_change (integration)", () => {
     (deepAnalyze as ReturnType<typeof vi.fn>).mockClear();
     await run({ rootDir: repo, targetPath: join(repo, "feature.ts"), body: AWAIT_BODY });
     expect(deepAnalyze).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateChange directory scoping", () => {
+  // The measured failure: the repo's only return-shape
+  // finding came from src/components/, and every other directory was then
+  // judged against it. src/actions/ is 10/10 on the opposite convention.
+  const COMPONENTS = {
+    driftCategory: "return_shape_consistency" as const,
+    dominantPattern: "null/undefined sentinels",
+    dominantCount: 11,
+    totalRelevantFiles: 14,
+    consistencyScore: 79,
+    dominantFiles: ["src/components/CalendarStrip.tsx"],
+    deviators: [],
+    directory: "src/components",
+  };
+  const THROWING = "export function f(){ if (!a) { throw new Error('x'); } throw new Error('y'); }";
+
+  function baselineWithDirVote(): RepoDriftBaseline {
+    return {
+      key: "k",
+      rootDir: "/r",
+      ctxFiles: [{ path: "x.ts", hash: "h" }],
+      perCategoryVote: { return_shape_consistency: COMPONENTS },
+      perDirectoryVote: { return_shape_consistency: { "src/components": COMPONENTS } },
+      intentHints: [],
+      minhashIndex: [],
+      builtAt: 0,
+    };
+  }
+
+  it("does not judge a file against another directory's convention", () => {
+    const r = validateChange(baselineWithDirVote(), "src/actions/blocks.ts", THROWING);
+    expect(r.conflicts.filter((c) => c.dimension === "return_shape_consistency")).toHaveLength(0);
+  });
+
+  it("still flags a file that deviates from its OWN directory", () => {
+    const r = validateChange(baselineWithDirVote(), "src/components/Thing.tsx", THROWING);
+    expect(r.conflicts.some((c) => c.dimension === "return_shape_consistency")).toBe(true);
+  });
+
+  it("stays silent when the edited file's directory has no vote", () => {
+    const r = validateChange(baselineWithDirVote(), "src/lib/follows.ts", THROWING);
+    expect(r.conflicts.filter((c) => c.dimension === "return_shape_consistency")).toHaveLength(0);
+  });
+
+  it("cites a reference file from the file's own directory, not another's", () => {
+    const r = validateChange(baselineWithDirVote(), "src/components/Thing.tsx", THROWING);
+    expect(r.referenceFiles.every((f) => f.startsWith("src/components/"))).toBe(true);
   });
 });

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -277,3 +277,31 @@ describe("non-code edits are a skip class (P1 contract)", () => {
     expect(out.flags).toEqual([]);
   });
 });
+
+describe("runEditChecks file-class gate", () => {
+  // THEN_BODY reliably flags against this repo's declared async/await rule, so
+  // any silence below is the file-class gate and not a weak fixture.
+  const nonAppPaths = [
+    join("scripts", "seed-dev.ts"),
+    join("tests", "integration", "global-setup.ts"),
+    join("src", "rate-limit.test.ts"),
+    join("src", "scratch-probe.ts"),
+  ];
+
+  for (const rel of nonAppPaths) {
+    it(`reports checked=false and emits no flags for ${rel}`, async () => {
+      const out = await runEditChecks(
+        opts({ sessionId: `s-gate-${rel.replace(/[^a-z0-9]/gi, "-")}`, file: join(repo, rel) }),
+      );
+      expect(out.checked).toBe(false);
+      expect(out.flags).toHaveLength(0);
+      expect(out.fyi).toBeNull();
+    });
+  }
+
+  it("still checks ordinary application source", async () => {
+    const out = await runEditChecks(opts({ sessionId: "s-gate-app", file: join(repo, "src", "app.ts") }));
+    expect(out.checked).toBe(true);
+    expect(out.flags.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -178,8 +178,13 @@ describe("runEditChecks", () => {
 
   it("reports checked=false when the detector itself errors", async () => {
     // a structurally broken baseline makes detectDrift throw; the fail-open
-    // catch must report the check as NOT run, never as a clean pass
-    const broken = { ...baseline, perCategoryVote: undefined } as unknown as RepoDriftBaseline;
+    // catch must report the check as NOT run, never as a clean pass.
+    // The break has to land INSIDE detectDrift, past the early guards: a
+    // minhashIndex with a readable `length` clears the entry-count check at the
+    // top of runEditChecks, then throws on `.filter` within the detector.
+    // perCategoryVote used to serve here, but the in-loop path now reads
+    // perDirectoryVote, so nulling it no longer throws anywhere.
+    const broken = { ...baseline, minhashIndex: { length: 0 } } as unknown as RepoDriftBaseline;
     const out = await runEditChecks(opts({ sessionId: "s-chk-err", loadBaselineFor: async () => broken }));
     expect(out.flags).toEqual([]);
     expect(out.checked).toBe(false);

--- a/test/unit/session/check.test.ts
+++ b/test/unit/session/check.test.ts
@@ -310,3 +310,58 @@ describe("runEditChecks file-class gate", () => {
     expect(out.flags.length).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe("runEditChecks duplicate counterpart verification", () => {
+  // Reproduces the recorded shape: the helper the index still lists is
+  // lifted out of its original file, so the "duplicate" is really a move.
+  it("suppresses the advisory when the counterpart was moved out", async () => {
+    const sessionsDir2 = realpathSync(mkdtempSync(join(tmpdir(), "vd-move-")));
+    const repo2 = realpathSync(mkdtempSync(join(tmpdir(), "vd-move-repo-")));
+    mkdirSync(join(repo2, "src"), { recursive: true });
+    writeFileSync(join(repo2, "src", "origin.ts"), `${HELPER_BODY}\n`);
+    writeFileSync(join(repo2, "src", "a.ts"), "export async function a(){ return await fetch('/a'); }\n");
+    writeFileSync(join(repo2, "src", "b.ts"), "export async function b(){ return await fetch('/b'); }\n");
+    const b2 = await buildBaseline(repo2);
+    expect(b2.minhashIndex.some((e) => e.relativePath === "src/origin.ts")).toBe(true);
+
+    // The agent moves the helper: origin.ts no longer defines it, shared.ts does.
+    writeFileSync(join(repo2, "src", "origin.ts"), "export const unrelated = 1;\n");
+
+    const out = await runEditChecks({
+      rootDir: repo2,
+      projectHash: "feedfacefeedfacf",
+      sessionId: "s-move",
+      sessionsDir: sessionsDir2,
+      file: join(repo2, "src", "shared.ts"),
+      body: HELPER_BODY,
+      loadBaselineFor: async () => b2,
+    });
+    expect(out.flags.filter((f) => f.detail.category === "redundancy")).toHaveLength(0);
+    rmSync(repo2, { recursive: true, force: true });
+    rmSync(sessionsDir2, { recursive: true, force: true });
+  }, 60_000);
+
+  it("still flags a genuine copy that leaves the original in place", async () => {
+    const sessionsDir3 = realpathSync(mkdtempSync(join(tmpdir(), "vd-copy-")));
+    const repo3 = realpathSync(mkdtempSync(join(tmpdir(), "vd-copy-repo-")));
+    mkdirSync(join(repo3, "src"), { recursive: true });
+    writeFileSync(join(repo3, "src", "origin.ts"), `${HELPER_BODY}\n`);
+    writeFileSync(join(repo3, "src", "a.ts"), "export async function a(){ return await fetch('/a'); }\n");
+    writeFileSync(join(repo3, "src", "b.ts"), "export async function b(){ return await fetch('/b'); }\n");
+    const b3 = await buildBaseline(repo3);
+
+    // origin.ts keeps the helper — this really is a duplication.
+    const out = await runEditChecks({
+      rootDir: repo3,
+      projectHash: "feedfacefeedfad0",
+      sessionId: "s-copy",
+      sessionsDir: sessionsDir3,
+      file: join(repo3, "src", "shared.ts"),
+      body: HELPER_BODY,
+      loadBaselineFor: async () => b3,
+    });
+    expect(out.flags.filter((f) => f.detail.category === "redundancy").length).toBeGreaterThanOrEqual(1);
+    rmSync(repo3, { recursive: true, force: true });
+    rmSync(sessionsDir3, { recursive: true, force: true });
+  }, 60_000);
+});

--- a/test/unit/session/counterpart.test.ts
+++ b/test/unit/session/counterpart.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { verifyCounterpart } from "@/session/counterpart";
+
+// The measured case. The agent MOVED `el` out of composer.ts into
+// shared/dom.ts. The duplicate match was correct — same function, 42 tokens —
+// but by flag time the original was gone, so "prefer importing it" pointed at
+// nothing. A move is not a duplication.
+const COMPOSER_AFTER_MOVE = `
+export interface ComposerOptions {
+  onSave(body: string): void;
+  onCancel(): void;
+}
+
+function toLocalInputValue(ts: number): string {
+  const shifted = new Date(ts - 60000);
+  return shifted.toISOString().slice(0, 16);
+}
+`;
+
+const COMPOSER_BEFORE_MOVE = `
+function el(tag: string, cls?: string): HTMLElement {
+  const node = document.createElement(tag);
+  if (cls !== undefined) node.className = cls;
+  return node;
+}
+
+function toLocalInputValue(ts: number): string {
+  const shifted = new Date(ts - 60000);
+  return shifted.toISOString().slice(0, 16);
+}
+`;
+
+const args = (over: Record<string, unknown> = {}) => ({
+  name: "el",
+  relativePath: "src/content/composer.ts",
+  line: 2,
+  fileContent: COMPOSER_BEFORE_MOVE,
+  language: "typescript" as const,
+  ...over,
+});
+
+describe("verifyCounterpart", () => {
+  it("confirms a counterpart still sitting at the indexed line", () => {
+    expect(verifyCounterpart(args())).toEqual({ status: "confirmed", line: 2 });
+  });
+
+  it("reports gone when the agent moved the function out", () => {
+    expect(verifyCounterpart(args({ fileContent: COMPOSER_AFTER_MOVE }))).toEqual({ status: "gone" });
+  });
+
+  it("re-resolves the line when the function is still there but shifted", () => {
+    const shifted = `// a new leading comment\n// and another\n${COMPOSER_BEFORE_MOVE}`;
+    const res = verifyCounterpart(args({ fileContent: shifted }));
+    expect(res.status).toBe("moved");
+    expect(res).toHaveProperty("line", 4);
+  });
+
+  it("fails open to confirmed when the file cannot be read", () => {
+    // A read error must not silently disable duplicate detection.
+    expect(verifyCounterpart(args({ fileContent: null }))).toEqual({ status: "confirmed", line: 2 });
+  });
+
+  it("fails open for a language the extractor does not parse", () => {
+    expect(verifyCounterpart(args({ language: null }))).toEqual({ status: "confirmed", line: 2 });
+  });
+});

--- a/test/unit/session/finding-anchor.test.ts
+++ b/test/unit/session/finding-anchor.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { signalPresent } from "@/session/finding-anchor";
+
+describe("signalPresent — file-kind redundancy anchors", () => {
+  // `if (anchor.kind !== "function") return true;` made a file-anchored
+  // redundancy finding report "still present" for every possible file content,
+  // including an empty file, so it could never be resolved by any edit.
+  const anchor = {
+    kind: "file" as const,
+    tokenHash: "abc",
+    tokens: ["const", "widgetTotal", "=", "compute", "(", ")", ";"],
+    observed: "src/other.ts:10",
+  };
+  const emptyBaseline = {
+    key: "k",
+    rootDir: "/r",
+    ctxFiles: [],
+    perCategoryVote: {},
+    perDirectoryVote: {},
+    intentHints: [],
+    minhashIndex: [],
+    builtAt: 0,
+  } as unknown as Parameters<typeof signalPresent>[4];
+
+  const present = (body: string) => signalPresent("redundancy", anchor, body, "src/a.ts", emptyBaseline);
+
+  it("stays open while the flagged tokens are still there", () => {
+    expect(present("const widgetTotal = compute();")).toBe(true);
+  });
+
+  it("clears once the flagged construct is gone", () => {
+    expect(present("export function unrelated() { return 42; }")).toBe(false);
+  });
+
+  it("clears on an empty file", () => {
+    expect(present("")).toBe(false);
+  });
+});

--- a/test/unit/session/outcome-anchors.test.ts
+++ b/test/unit/session/outcome-anchors.test.ts
@@ -111,9 +111,15 @@ ${HELPER_BODY}`;
   }`;
     const { open } = await raise("s-sql", "src/data/sessions.ts", method);
     const arch = only(open, "architectural_consistency");
-    // A class method is not an extractable function, so the anchor is the whole
-    // edited body and presence is asked over the whole file.
-    expect(arch[0].anchor).toMatchObject({ kind: "file", observed: "raw SQL queries" });
+    // The extractor now indexes class methods, so this anchors to the method
+    // itself rather than falling back to the whole edited body. That is the
+    // stronger anchor: presence is asked about `purgeSessions`, not about
+    // whatever else the file happens to contain.
+    expect(arch[0].anchor).toMatchObject({
+      kind: "function",
+      symbol: "purgeSessions",
+      observed: "raw SQL queries",
+    });
 
     const whole = `export class SessionStore {
   async findSession(id: string) {

--- a/test/unit/session/scope.test.ts
+++ b/test/unit/session/scope.test.ts
@@ -89,3 +89,35 @@ describe("checkScope", () => {
     expect(again.flag).toBeNull();
   });
 });
+
+describe("checkScope repo boundary", () => {
+  async function lock(dir: string) {
+    await processPrompt(dir, HASH, "s1", "add webhook handling to routes/billing.ts using `handleStripeWebhook`");
+  }
+
+  // 15 of the 64 scope flags in the recorded population fired on paths like
+  // ../main.rs and ../MEMORY.md. A path outside the repo root can never match
+  // a repo-relative intent anchor, so it flags by construction.
+  const outside = ["../main.rs", "../build.rs", "../MEMORY.md", "/etc/hosts"];
+
+  for (const rel of outside) {
+    it(`never flags ${rel}`, async () => {
+      const dir = tmp();
+      await lock(dir);
+      await checkScope(dir, HASH, "s1", rel, "fn main() {}");
+      const r = await checkScope(dir, HASH, "s1", rel, "fn main() {}");
+      expect(r.flag).toBeNull();
+      expect(r.fyi).toBeNull();
+    });
+  }
+
+  it("does not let out-of-repo edits push an in-repo edit over the threshold", async () => {
+    const dir = tmp();
+    await lock(dir);
+    // One out-of-repo edit must not count toward unrelatedEdits, so the single
+    // in-repo unrelated edit that follows stays below the 2nd-edit threshold.
+    await checkScope(dir, HASH, "s1", "../main.rs", "fn main() {}");
+    const r = await checkScope(dir, HASH, "s1", "ui/theme.ts", "const palette = { red: 1 };");
+    expect(r.flag).toBeNull();
+  });
+});

--- a/test/unit/tools/get-dominant-pattern.test.ts
+++ b/test/unit/tools/get-dominant-pattern.test.ts
@@ -43,3 +43,58 @@ describe("dominantPatternFor — auth reads the auth sub-vote, not the collided 
     expect(out.consistency).toBe("100% — no deviations detected");
   });
 });
+
+describe("dominantPatternFor — directory scoping", () => {
+  const componentsVote: CategoryVote = {
+    driftCategory: "return_shape_consistency",
+    dominantPattern: "null/undefined sentinels",
+    dominantCount: 11,
+    totalRelevantFiles: 14,
+    consistencyScore: 79,
+    dominantFiles: ["src/components/CalendarStrip.tsx"],
+    deviators: [],
+    directory: "src/components",
+  };
+  const actionsVote: CategoryVote = {
+    ...componentsVote,
+    dominantPattern: "error-object returns",
+    dominantCount: 10,
+    totalRelevantFiles: 10,
+    consistencyScore: 100,
+    dominantFiles: ["src/actions/blocks.ts"],
+    directory: "src/actions",
+  };
+  const b = baseline({
+    perCategoryVote: { return_shape_consistency: componentsVote },
+    perDirectoryVote: {
+      return_shape_consistency: { "src/components": componentsVote, "src/actions": actionsVote },
+    },
+  });
+
+  it("answers with the caller's own directory when a path is given", () => {
+    const out = dominantPatternFor(b, "error_handling", "src/actions/blocks.ts");
+    expect(out.dominantPattern).toBe("error-object returns");
+    expect(out.consistency).toContain("10 of 10");
+  });
+
+  it("does not hand a component convention to a server action", () => {
+    const out = dominantPatternFor(b, "error_handling", "src/actions/reports.ts");
+    expect(out.dominantPattern).not.toBe("null/undefined sentinels");
+  });
+
+  it("names the directory a vote was measured over, so it is never read as repo-wide", () => {
+    const out = dominantPatternFor(b, "error_handling", "src/components/Thing.tsx");
+    expect(out.consistency).toContain("src/components");
+  });
+
+  it("says so plainly when the caller's directory has no established convention", () => {
+    const out = dominantPatternFor(b, "error_handling", "src/lib/follows.ts");
+    expect(out.dominantPattern).toBe("consistent");
+    expect(out.consistency).toContain("src/lib");
+  });
+
+  it("falls back to the repo-wide vote when no path is given", () => {
+    const out = dominantPatternFor(b, "error_handling");
+    expect(out.dominantPattern).toBe("null/undefined sentinels");
+  });
+});


### PR DESCRIPTION
## What this fixes

A session audit found that in-loop advisories were mostly wrong, and traced it to
four mechanisms rather than a tuning problem. This branch fixes those, plus the
extractor and normalizer blind spots underneath them, and adds a precision eval
so the result cannot silently regress.

## Precision fixes (no score movement)

| Fix | Problem |
|---|---|
| `session: skip tests, seeds and scripts in-loop` | The in-loop path never called `isAnalyzableSource`, so its only gate was "can I parse this language". Test setup files, seed and soak scripts and scratch files were judged against application conventions. Two of the audited files document in their own doc comments *why* they throw, and were flagged for throwing. |
| `drift: scope convention votes per directory` | `votesFromFindings` kept one finding per category — the widest denominator — discarding both the other directories' conventions and the fact that the survivor was directory-scoped at all. Every edited file was then measured against whichever directory happened to win. All three in-loop dimensions are directory-grouped by their detectors, so a directory is the only scope in which their dominant means anything. |
| `session: verify duplicate counterpart before citing` | The index is built once per session, so by the time an advisory fires the function it names may have moved or been lifted out. When it is gone, the agent *moved* the code rather than duplicating it, and "prefer importing it" points at a file it just emptied. |
| `session: ignore out-of-repo paths in scope check` | A relative path escaping the repo root cannot match a repo-relative intent anchor, so it flagged on every edit by construction. It also inflated the unrelated-edit counter, pushing legitimate in-repo edits over the flag threshold. |
| `session: let file-anchored dup findings resolve` | `signalPresent` returned `true` unconditionally for a non-function redundancy anchor, so such a finding reported "still present" for every possible file content — including an empty file — and could never be resolved by any edit. |
| `mcp: scope get_dominant_pattern to the caller's directory` | The tool read the collapsed repo-wide vote, so an agent about to write a server action could be handed the convention measured over a directory of React components. Now takes an optional `path`; without it, previous behaviour is unchanged. |

`check_file_drift` was checked and needs no change: it keys on explicit deviator
membership, and deviators are computed per directory, so a file can never match a
vote from a directory it is not in.

## Extractor and normalizer accuracy (moves scores, `SCORING_VERSION` v15)

- **JS/TS**: class methods, object-literal methods, `let`/`var` arrow bindings,
  generators, accessors and `export default function` are now indexed. All were
  invisible, so a class-heavy file contributed far fewer functions than it has.
- **Go**: generic functions (`func Map[T any](...)`) were unmatched.
- **Rust**: `fn` with a `where` clause and no return type was unmatched.
- **Tokenizer**: string literals are neutralized before comments. A `//` inside a
  literal was deleting the closing quote and desynchronizing quote pairing.
- **Normalizer**: a property chain's MEMBERS are kept literal while its HEAD is
  still renamed. Queries against different tables or columns no longer normalize
  identically; rename-insensitivity is unchanged.
- **Determinism**: `localeCompare` replaced with code-unit ordering at all five
  sites, including the baseline cache key, which could differ by host locale.

### Three exclusions found by corpus validation

Each is a construct whose similarity is *structurally forced*, so it is
byte-identical everywhere and manufactures duplicate findings carrying no signal.
None was reachable by unit tests; each only appears as a distribution effect.

| Excluded | Evidence |
|---|---|
| class constructors | 80 of 214 duplicate findings on one component library |
| not-implemented stubs (`throw` as the only statement) | three method names across nine provider clients |
| bodiless interface members without semicolons | prettier `semi: false` let the return-type scan run to the first `{` below, indexing comments as a body |
| call expressions taking a `function (...)` callback | `[^)]*` stops at the callback's parameter close, so `test('x', function (a) {` indexed a phantom named after the callee; inflated one index from 2190 to 5114 |

## Validation

A precision eval (`test/eval/inloop-precision.test.ts`) encodes the audited
findings as fixtures and gates on precision rather than count. It binds:
reverting the directory-scoping and file-class fixes reproduces all six audited
false positives and drops precision below the floor.

Scoring impact was measured by scanning a shuffled sample of open-source repos
across all five supported languages with the branch and its merge base, comparing
composites.

### Measured impact

Scoring impact is measured by scanning a shuffled, unbiased sample of open-source
repositories across all five supported languages with this branch and with its
merge base, then comparing composite scores. Every repository moving 3 or more
points is inspected individually by reading the duplicated function bodies rather
than inferring from names.

That inspection is the reason for the four exclusions above. Each was found by the
corpus rather than by unit tests, because each shows up only as a distribution
effect across many real repositories. The fourth was the most consequential: it
inflated the function index, which is the denominator the duplicate scorer divides
by, so it moved composites in the OPTIMISTIC direction. On one date library the
index inflated from 2190 to 5114 entries, all of them phantoms named after
callees, and the composite reported +10.6 while that repository's honest duplicate
fraction had in fact risen from 0.280 to 0.308. With the fix in place the same
repository reports no change at all.

A full 177-repository run completed before that fourth defect was found. Its
numbers are therefore not reported here: they were produced by a build with a
known scoring-relevant bug, and quoting them would misstate the impact.
Re-validation on the corrected build is running, and the resulting distribution
will be posted to this PR before merge.

What the completed run did establish, and what the fix does not change, is the
shape: the median repository is unaffected in every language, Go and Rust are
essentially inert, and movement concentrates in class-heavy and
object-literal-heavy codebases — the population the extractor was under-serving.
The pending numbers refine the magnitude, not that shape.

## Open questions

1. **A minimum body size for duplicate findings.** Trivial boilerplate such as
   `async usage() { return { used: 0, total: 0 } }` repeated across a dozen
   provider files is real duplication by a literal reading, and nobody would ever
   extract it. Measured on one ORM, a single-statement floor halves finding count
   (212 to 109) but recovers only 1.9 composite points, so it is a noise lever
   rather than a score lever. Not implemented: it would also suppress
   pre-existing findings on small top-level functions, which is beyond what this
   branch introduced.
2. **The two duplicate detectors have diverged further.** On one repo the
   `duplicates` analyzer reported 232 to 235 pairs while `drift-semantic_duplication`
   went 67 to 279, because only one of them consumes `extractAllFunctions`.
   Pre-existing, but more visible now.

## Test plan

- `npm run build && npm test` — full suite green
- `npm run lint` — zero warnings
- `npx tsc --noEmit` — clean
- Every fix has a test verified to fail without it (each source change was
  reverted and the test re-run, not assumed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
