### PR TITLE
fix: score duplicate volume, not directory count (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `@vibedrift/cli` are documented here. The format
 follows Keep-a-Changelog loosely; breaking-shape changes are called out
 explicitly under **Breaking** so CI users can recalibrate.
 
+## [Unreleased]
+
+### Fixed
+
+- **Duplicate volume now affects the Redundancy score.** `drift-semantic_duplication`
+  was emitted as count-based but never carried `dupGroupSize`, so the scoring
+  engine's duplicate-fraction branch was unreachable for it and it fell through
+  to the generic count branch, whose divisor is the number of *findings*. Because
+  its findings are rolled up per directory, one near-duplicate pair and twenty in
+  the same directory produced an identical score. The detector now reports the
+  redundant copies each directory holds, so twenty duplicates register as twenty.
+  Reported in #102.
+
+  Two properties the fix has to preserve, both pinned by tests: it counts
+  redundant *copies* rather than pairs, because a cluster of m mutually-duplicate
+  functions is m(m-1)/2 pairs but only m-1 redundant copies; and a cluster
+  spanning two directories is counted once rather than in both, by attributing
+  each copy to the directory that actually holds it.
+
+### Scoring
+
+**Composite scores move in this release and baselines rebuild.** `SCORING_VERSION`
+advances to v16. Repos with several near-duplicate functions in one directory
+score lower, which is the defect being corrected. Repos whose duplicate
+directories hold a single pair each are unchanged, as are repos with no
+near-duplicates.
+
 ## 0.20.0 — 2026-08-19
 
 **The in-loop checks stop telling you your own conventions are wrong, and the function index finally sees the methods it was blind to.**

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -323,6 +323,10 @@ export function driftFindingToFinding(d: DriftFinding): Finding {
     // they have no real dominance ratio, so we omit driftSignal and let the engine
     // size-normalize them through its count-based density branch instead of reading
     // a fabricated consistencyScore as a deviation rate.
+    // A count-based DUPLICATE detector still carries volume: `dupGroupSize`
+    // routes it to the engine's duplicate-fraction branch instead of the
+    // generic count branch, whose divisor is finding count (issue #102).
+    ...(d.dupGroupSize !== undefined ? { dupGroupSize: d.dupGroupSize } : {}),
     ...(d.countBased
       ? {}
       : {

--- a/src/drift/semantic-duplication.ts
+++ b/src/drift/semantic-duplication.ts
@@ -160,6 +160,42 @@ export const semanticDuplication: DriftDetector = {
     }
     const sizeOf = (f: ExtractedFunction): number => clusterSize.get(find(fnKey(f))) ?? 1;
 
+    // Redundant copies per directory (issue #102).
+    //
+    // The scoring engine's duplicate-fraction branch reads `dupGroupSize - 1` as
+    // the number of REDUNDANT copies and sums it across a detector's findings.
+    // Two properties have to hold for that sum to mean anything:
+    //
+    //   1. It must count copies, not pairs. A cluster of m mutually-duplicate
+    //      functions is m(m-1)/2 pairs but only m-1 redundant copies — one
+    //      member is the original. Counting pairs would overstate quadratically.
+    //   2. It must not double-count. A pair spanning two directories emits a
+    //      finding in BOTH (see byDir below), so attributing a cluster's copies
+    //      to every directory it touches would inflate the sum.
+    //
+    // Both hold if we pick one canonical member per cluster and attribute every
+    // OTHER member to the directory that actually holds it. Summed over
+    // directories that is exactly (m-1) per cluster, once. The canonical member
+    // is the lowest fnKey so the choice is deterministic — same input, same
+    // attribution, which the repo requires of anything reaching a score.
+    const clusterMembers = new Map<string, string[]>();
+    for (const node of parent.keys()) {
+      const root = find(node);
+      const list = clusterMembers.get(root);
+      if (list) list.push(node);
+      else clusterMembers.set(root, [node]);
+    }
+    const redundantByDir = new Map<string, number>();
+    for (const members of clusterMembers.values()) {
+      if (members.length < 2) continue;
+      // fnKey is `${file}:${name}`; sort by code unit, never localeCompare.
+      const sorted = [...members].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      for (const member of sorted.slice(1)) {
+        const dir = directoryOf(member.slice(0, member.lastIndexOf(":")));
+        redundantByDir.set(dir, (redundantByDir.get(dir) ?? 0) + 1);
+      }
+    }
+
     // Group pairs by directory — the directory that owns the higher-numbered
     // duplicate is where we attribute the drift.
     const byDir = new Map<string, DuplicatePair[]>();
@@ -234,6 +270,10 @@ export const semanticDuplication: DriftDetector = {
         severity,
         confidence: 0.85,
         countBased: true,
+        // 1 + redundant copies held by THIS directory. Findings whose directory
+        // holds only cluster originals carry 1 and contribute no damage, which
+        // is correct: the redundancy belongs to whoever holds the copies.
+        dupGroupSize: (redundantByDir.get(dir) ?? 0) + 1,
         finding: `${dir}/: ${dirPairs.length} pair(s) of semantically duplicate functions detected (MinHash + LCS verified)`,
         dominantPattern: "unique function bodies",
         dominantCount: 0,

--- a/src/drift/types.ts
+++ b/src/drift/types.ts
@@ -152,6 +152,15 @@ export interface DriftFinding {
    * carried for the report bars, but it does not drive the composite.
    */
   countBased?: boolean;
+  /**
+   * For duplicate detectors: 1 + the number of REDUNDANT copies this finding
+   * accounts for (so `dupGroupSize - 1` is the redundancy it contributes).
+   * Carried into `Finding` so the scoring engine's duplicate-fraction branch
+   * can see duplicate VOLUME; without it a count-based duplicate detector
+   * falls through to the generic count branch, where the divisor is the
+   * number of findings and volume is discarded. See issue #102.
+   */
+  dupGroupSize?: number;
   deviatingFiles: DeviatingFile[];
   /**
    * Up to 3 files that exemplify the dominant pattern — used by fix-prompt

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -107,12 +107,23 @@ import {
  *        1 to 34% and duplicate pairs moved -8% to +27%. Repos with no class
  *        or object-literal methods, no property-chain data references and no
  *        `//` inside literals are byte identical.
+ *   v16: duplicate VOLUME reaches the score. `drift-semantic_duplication` was
+ *        emitted as count-based but carried no `dupGroupSize`, so the engine's
+ *        duplicate-fraction branch was unreachable for it and it fell through to
+ *        the generic count branch, whose divisor is the number of FINDINGS.
+ *        Findings are rolled up per directory, so one near-duplicate pair and
+ *        twenty in the same directory scored identically. The detector now
+ *        carries redundant copies per directory, attributing each cluster's
+ *        copies to the directory that holds them so a cluster spanning two
+ *        directories is not counted twice. Repos with several near-duplicates in
+ *        one directory score lower; repos whose duplicate directories hold a
+ *        single pair each are unchanged. Reported in #102.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v15";
+export const SCORING_VERSION = "v16";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;

--- a/test/unit/drift/semantic-duplication.test.ts
+++ b/test/unit/drift/semantic-duplication.test.ts
@@ -106,3 +106,67 @@ describe("semantic-duplication detector", () => {
     }
   });
 });
+
+describe("semantic-duplication dupGroupSize (issue #102)", () => {
+  // Bodies that MinHash treats as duplicates: identical structure, differing
+  // only in a string literal (tokenize collapses literals to STR).
+  const clone = (name: string, marker: string) => `export function ${name}(input: string, acc: number): string {
+  const s0 = stageAlpha(acc, input);
+  const s1 = stageBravo(acc, s0);
+  const s2 = stageCharlie(acc, s1);
+  const label = "${marker}";
+  return finish(s2, label);
+}`;
+
+  it("carries redundant-copy count so duplicate VOLUME reaches the scoring engine", () => {
+    // Three mutually-duplicate functions in one directory = 1 original + 2 copies.
+    const ctx = mkCtx([
+      file("src/svc/a.ts", clone("alpha", "m-a")),
+      file("src/svc/b.ts", clone("bravo", "m-b")),
+      file("src/svc/c.ts", clone("charlie", "m-c")),
+    ]);
+    const findings = semanticDuplication.detect(ctx);
+    expect(findings.length).toBeGreaterThan(0);
+
+    // The engine's duplicate-fraction branch is gated on dupGroupSize > 1
+    // (src/scoring/engine.ts). Without it the detector falls through to the
+    // count branch, where findings.length is the DIRECTORY count and duplicate
+    // volume is discarded.
+    const total = findings.reduce((n, f) => n + ((f.dupGroupSize ?? 0) > 1 ? f.dupGroupSize! - 1 : 0), 0);
+    expect(total).toBe(2);
+
+    // and it must survive the conversion into a scoring Finding
+    const converted = findings.map((f) => driftFindingToFinding(f));
+    expect(converted.some((f) => (f.dupGroupSize ?? 0) > 1)).toBe(true);
+  });
+
+  it("scales with duplicate volume rather than with directory count", () => {
+    const two = semanticDuplication.detect(
+      mkCtx([file("src/svc/a.ts", clone("alpha", "m-a")), file("src/svc/b.ts", clone("bravo", "m-b"))]),
+    );
+    const four = semanticDuplication.detect(
+      mkCtx([
+        file("src/svc/a.ts", clone("alpha", "m-a")),
+        file("src/svc/b.ts", clone("bravo", "m-b")),
+        file("src/svc/c.ts", clone("charlie", "m-c")),
+        file("src/svc/d.ts", clone("delta", "m-d")),
+      ]),
+    );
+    const copies = (fs: ReturnType<typeof semanticDuplication.detect>) =>
+      fs.reduce((n, f) => n + Math.max(0, (f.dupGroupSize ?? 1) - 1), 0);
+    expect(copies(two)).toBe(1);
+    expect(copies(four)).toBe(3);
+  });
+
+  it("does not double-count a cluster that spans two directories", () => {
+    // One pair, two directories. The detector emits a finding for EACH
+    // directory, so a naive sum would report two redundant copies for one
+    // duplicated function. Exactly one copy is redundant.
+    const findings = semanticDuplication.detect(
+      mkCtx([file("src/one/a.ts", clone("alpha", "m-a")), file("src/two/b.ts", clone("bravo", "m-b"))]),
+    );
+    expect(findings.length).toBe(2);
+    const total = findings.reduce((n, f) => n + Math.max(0, (f.dupGroupSize ?? 1) - 1), 0);
+    expect(total).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #102.

## The defect

`drift-semantic_duplication` is emitted as `countBased: true` but never carried
`dupGroupSize`, so the scoring engine's duplicate-fraction branch was unreachable
for it. It fell through to the generic count branch, where the divisor is
`findings.length` — and because its findings are rolled up **per directory**, that
is the *directory* count. The pair count was rendered into the message string and
discarded before scoring.

Net effect, reproduced: one near-duplicate pair and twenty in the same directory
scored identically. Redundancy pinned at **19.7/20** across a 20x change in volume.

The root cause is one step deeper than the report states: `DriftFinding` had no
`dupGroupSize` field at all, so the detector could not have set it.

## What changed

Three edits plus the version bump:

1. `src/drift/types.ts` — `DriftFinding` gains `dupGroupSize?: number`.
2. `src/drift/index.ts` — `driftFindingToFinding` carries it through.
3. `src/drift/semantic-duplication.ts` — populated from the union-find the
   detector already builds, so this is arithmetic on existing data.

## The two decisions this required

Neither is a tuning knob, and the issue's implied model gets the first one wrong.

**Copies, not pairs.** `dupGroupSize - 1` means redundant *copies* — that is how
`semantic-fingerprint.ts` sets it and how `engine.ts` consumes it. A cluster of
`m` mutually-duplicate functions is `m(m-1)/2` pairs but only `m-1` redundant
copies; one member is the original. Counting pairs would overstate quadratically,
by up to 2.3x on the worst repo measured.

**Each cluster counted once.** A pair spanning two directories emits a finding in
*both*, so attributing a cluster's copies to every directory it touches would
inflate the total (measured 36% inflation: 321 directory-attributed slots for 236
unique pairs). Each cluster now keeps one canonical member — lowest key, so the
choice is deterministic — and every other member is attributed to the directory
that holds it. Summed across directories that is exactly `m-1` per cluster, once.

A directory holding only cluster originals carries `dupGroupSize: 1` and
contributes no damage. That is correct: the redundancy belongs to whoever holds
the copies.

## Scoring impact

**Scores move. `SCORING_VERSION` v15 → v16, so baselines rebuild and the
first scan after upgrading suppresses its delta.**

Measured against v0.20.0:

| repo | composite | redundancy |
|---|---|---|
| A (Next.js, 37k lines) | 90.2 → 83.1 | 17.7 → 13.8 |
| B (Next.js, 23k lines) | 89.9 → 86.1 | 19.2 → 16.9 |
| C (TypeScript, 81k lines) | 86.2 → 84.1 | 19.7 → 18.3 |
| D (Rust + Python, 55k lines) | 75.3 → 73.3 | 17.2 → 16.3 |
| E (TypeScript extension) | 97.3 → 97.2 | 19.8 → 19.7 |
| F (Python API) | 75.0 → 74.6 | 19.9 → 19.7 |

Repos whose duplicate directories hold a single pair each are unchanged, as are
repos with no near-duplicates. A wider corpus run across all five supported
languages is in progress and its distribution will be posted here before merge.

**Worth stating plainly:** this is a larger movement than the issue's framing
suggests, and it is in the direction of *lower* scores. The detector was
under-penalising real duplication. It is also the second scoring migration in a
short window, so it may be worth batching with other scoring work rather than
shipping alone.

## Testing

Three tests, each verified to fail against `main`:

- redundant-copy count reaches the engine and survives conversion to a `Finding`
- the count scales with duplicate volume, not with directory count
- a cluster spanning two directories is not double-counted

`npm test` 2728 passing, `npm run lint` clean, `npx tsc --noEmit` clean.

## Not in this PR

Two findings from triaging #102 that deserve their own issues:

- **`phantom-scaffolding` has the identical defect** — `countBased: true`, no
  `dupGroupSize`, 30 findings covering 126 phantom exports with the largest
  carrying 30. Left out to keep this reviewable; its severity grading on
  `deadShare` partially mitigates it.
- **An absolute-path leak disables `codedna-fingerprint`.** It calls
  `allNonShippable()` on `SourceFile.path`, which is the *absolute* path, so a
  repo checked out under `/examples/`, `/tests/`, `/spec/` or `/mocks/` silently
  loses exact-duplicate detection. This is what the issue's "reproduction gotcha"
  was really hitting; the functions it names are correctly segment-anchored.

## Still unmeasured

Whether the 236 near-duplicate pairs found across the measured repos are true
positives. This PR changes how much they count, not whether they should count at
all. If detector precision is poor, this makes wrong findings louder.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
