### PR TITLE
fix(drift): phantom-scaffolding reads the AST import graph, not regex

### DIFF
--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -32,7 +32,7 @@ import { directoryOf } from "../drift/utils.js";
 
 const CACHE_DIR = join(vibedriftHome(), "baseline-cache");
 /** Bump when vote logic / detector set / signature format changes (invalidates all caches). */
-export const BASELINE_VERSION = 5;
+export const BASELINE_VERSION = 6;
 
 export interface CategoryVote {
   driftCategory: DriftCategory;

--- a/src/drift/phantom-scaffolding.ts
+++ b/src/drift/phantom-scaffolding.ts
@@ -98,11 +98,15 @@ export const phantomScaffolding: DriftDetector = {
     const jsFiles: SourceFile[] = ctx.files
       .filter((f) => f.language === "javascript" || f.language === "typescript")
       .map((f) => ({
+        // Spread, not a field list. buildImportGraph parses with the AST when a
+        // tree is present and falls back to regex over raw content when it is
+        // not, so a field list that forgets `tree` silently puts the WHOLE repo
+        // on the regex path, where export/import patterns match inside string
+        // literals and comments. Spreading keeps that (and anything later added
+        // to DriftFile) attached; only `path` has no DriftFile equivalent.
+        ...f,
         path: f.relativePath,
-        relativePath: f.relativePath,
         language: f.language as "javascript" | "typescript",
-        content: f.content,
-        lineCount: f.lineCount,
       }));
     if (jsFiles.length < 2) return [];
 

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -107,12 +107,22 @@ import {
  *        1 to 34% and duplicate pairs moved -8% to +27%. Repos with no class
  *        or object-literal methods, no property-chain data references and no
  *        `//` inside literals are byte identical.
+ *   v16: phantom-scaffolding reads the AST import graph. The detector rebuilt
+ *        `SourceFile` objects for `buildImportGraph` without the parsed tree,
+ *        so the graph fell back to regex parsing of raw content for every file
+ *        and matched `export` inside string literals and comments. Sample code
+ *        embedded in a template literal counted as a real export; the detector
+ *        flagged its own test fixtures. Measured on eight repos, reported
+ *        phantom exports fall 111 to 16. Composites move only slightly (this
+ *        repo 86.2 to 86.3) because the false findings concentrated in `test/`,
+ *        where WEIGHT_TEST damps them. Repos whose phantom exports were all
+ *        real are byte identical.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v15";
+export const SCORING_VERSION = "v16";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;

--- a/test/unit/drift/tree-plumbing.test.ts
+++ b/test/unit/drift/tree-plumbing.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect } from "vitest";
 import { buildDriftContext } from "../../../src/drift/index.js";
 import type { AnalysisContext } from "../../../src/core/types.js";
 import { parseFile } from "../../../src/utils/ast.js";
+import { phantomScaffolding } from "../../../src/drift/phantom-scaffolding.js";
+import type { DriftContext, DriftFile } from "../../../src/drift/types.js";
+
+const mkCtx = (files: DriftFile[]): DriftContext => ({
+  files,
+  totalLines: files.reduce((s, f) => s + f.lineCount, 0),
+  dominantLanguage: "typescript",
+});
 
 describe("buildDriftContext tree plumbing", () => {
   it("carries the parsed tree onto DriftFile", async () => {
@@ -59,5 +67,63 @@ describe("buildDriftContext goModulePath threading", () => {
   it("is undefined when go.mod has an empty module path", () => {
     const drift = buildDriftContext(ctxWith({ module: "", require: [] }));
     expect(drift.goModulePath).toBeUndefined();
+  });
+});
+
+// Regression: the plumbing above stops one layer short. `buildDriftContext`
+// carries the tree onto DriftFile, but a detector that rebuilds SourceFile
+// objects to hand to `buildImportGraph` can drop it again, and the graph then
+// silently falls back to regex parsing of raw file content. Regex export
+// extraction matches inside string literals, so sample code embedded in a
+// template literal registers as a real export (issue: phantom-scaffolding
+// flagged its own test fixtures this way).
+describe("phantom-scaffolding uses the AST import graph", () => {
+  const mk = async (relativePath: string, content: string): Promise<DriftFile> => {
+    const source = {
+      path: `/r/${relativePath}`,
+      relativePath,
+      language: "typescript" as const,
+      content,
+      lineCount: content.split("\n").length,
+    };
+    const tree = await parseFile(source);
+    expect(tree).not.toBeNull();
+    return { ...source, tree: tree ?? undefined };
+  };
+
+  const phantomNames = (findings: { deviatingFiles: { evidence?: { code: string }[] }[] }[]): string[] =>
+    findings
+      .flatMap((f) => f.deviatingFiles)
+      .flatMap((d) => d.evidence ?? [])
+      .map((e) => /^export (\w+)\(\)/.exec(e.code)?.[1] ?? "")
+      .filter(Boolean);
+
+  it("ignores a CRUD export that only appears inside a template literal", async () => {
+    // `createUser` is a real unrouted export. `getOrder` exists only as text
+    // inside a string, so it is not an export of anything.
+    const files = [
+      await mk("src/handlers/real.ts", `export function createUser() {\n  return 1;\n}\n`),
+      await mk(
+        "src/docs/snippet.ts",
+        "const sample = `export function getOrder() {\\n  return 2;\\n}`;\nexport const note = sample.length;\n",
+      ),
+    ];
+    const names = phantomNames(phantomScaffolding.detect(mkCtx(files)));
+    // Control: without this the test would pass on a detector that found nothing.
+    expect(names).toContain("createUser");
+    expect(names).not.toContain("getOrder");
+  });
+
+  it("ignores a CRUD export that only appears inside a line comment", async () => {
+    const files = [
+      await mk("src/handlers/real.ts", `export function createUser() {\n  return 1;\n}\n`),
+      await mk(
+        "src/docs/note.ts",
+        "// export function deleteToken() {}\nexport const note = 1;\n",
+      ),
+    ];
+    const names = phantomNames(phantomScaffolding.detect(mkCtx(files)));
+    expect(names).toContain("createUser");
+    expect(names).not.toContain("deleteToken");
   });
 });


### PR DESCRIPTION
## Summary

`phantom-scaffolding` rebuilds `SourceFile` objects to hand to `buildImportGraph` and the rebuild dropped `tree`. It now spreads the `DriftFile` instead of listing fields, so the next field added to `DriftFile` cannot go missing the same way. `buildImportGraph` branches on exactly that field, so the condition was false for every file and the entire graph got built by `parseExports` / `parseImports`, which run regexes over raw `file.content` with no string or comment stripping.

Result: sample code inside a template literal counts as a real export. On this repo the detector was flagging its own test fixtures.

The tree was already there. `buildDriftContext` sets it on `DriftFile` (`src/drift/index.ts:46`) and `tree-plumbing.test.ts` asserts that it arrives. Nothing checked that a consumer used it.

The fix is one line plus a comment saying which branch it feeds.

This is a regression with a date. The map predates `DriftFile` having a `tree` field. #35 added the field, #36 replaced the import graph's regex parsing with AST, and neither updated this caller, so the AST import graph has never been reachable from this detector.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed (no flag or command changed)
- [x] This change improves how accurately or confidently VibeDrift measures drift
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Closes #106 

---

## The measurement

Eight repos, scanned on `7eb89b4` and again with the fix, `--local-only --format json`, counting 
`drift-phantom_scaffolding` findings and the exports they claim:

| repo | findings before → after | phantom exports before → after |
| --- | --- | --- |
| VibeDrift | 9 → 0 | **81 → 0** |
| underscore | 1 → 1 | 10 → 10 |
| eslint | 2 → 0 | **8 → 0** |
| zod | 4 → 3 | 5 → 3 |
| date-fns | 2 → 1 | 4 → 3 |
| moment | 2 → 0 | **2 → 0** |
| dayjs | 1 → 0 | **1 → 0** |
| htmx | 0 → 0 | 0 → 0 |

**111 reported phantom exports drop to 16, so 86% of the population did not exist.**

Composites barely move (this repo 86.2 → 86.3, dayjs 80.6 → 80.9) because the false findings concentrate in `test/` where `WEIGHT_TEST = 0.35` damps them. That is most of why this went unnoticed: the findings were wrong, they were just cheap.

Confirming the mechanism rather than the symptom, on this repo after `parseFiles`:

```
after parseFiles: 411 files, tree=411, noTree=0

test/unit/drift/phantom-scaffolding.test.ts   AST crud exports=0   regex crud exports=25
test/unit/analyzers/duplicates.test.ts        AST crud exports=0   regex crud exports=8
test/integration/intent-hints.test.ts         AST crud exports=0   regex crud exports=5

import graph CRUD exports: 77 total, 0 under test/
```

The AST parser already returned the right answer. It was never being called from here.

Three of the removed findings, for flavour:

```
test/unit/analyzers/duplicates.test.ts:31    content: `export async function fetchUsers(page: number) {
test/integration/session-hook.test.ts:276    'export function loadReport(id: string) {',
test/unit/drift/phantom-scaffolding.test.ts:24  `export function createUser() {}\nexport function getUser() {}...`
```

The third is the detector flagging the fixture its own test feeds it.

## The regression proof

Both new tests were written first and watched fail on `7eb89b4` (`expected [ 'getOrder', 'createUser' ] to not include 'getOrder'`), then pass with the one-line change. Each carries a `createUser` control assertion that a detector finding nothing would fail, so they cannot go green vacuously.

Worth knowing: the existing `phantom-scaffolding.test.ts` builds `DriftFile`s without trees, so all 7 of its tests exercise the regex path exclusively and stay green either way. That is why this survived. The new tests live in `tree-plumbing.test.ts`, which already asserted the tree reaches `DriftFile` and stopped one layer short of any consumer.

## The blast radius

`buildImportGraph` has exactly two callers in `src/`:

```
$ command grep -rn "buildImportGraph" src/
src/analyzers/dead-code.ts:25    import { buildImportGraph, ... }
src/analyzers/dead-code.ts:87    const graph = buildImportGraph(files);
src/core/import-graph.ts:190     export function buildImportGraph(...)
src/drift/phantom-scaffolding.ts:31   import { buildImportGraph } ...
src/drift/phantom-scaffolding.ts:114  const graph = buildImportGraph(jsFiles);
```

`dead-code.ts:87` passes `AnalysisContext` `SourceFile` objects straight through with their trees intact, so it is already on the AST path and this changes nothing for it. Verified rather than assumed: scanned all eight repos with and without the change and hashed the sorted `dead-code` finding messages.

```
                with fix      base
VibeDrift    2  8bff3df1af    2  8bff3df1af
zod          2  8a40beca2c    2  8a40beca2c
eslint       2  c47370d6ed    2  c47370d6ed
date-fns     2  3155483b11    2  3155483b11
moment       1  0ac3790e88    1  0ac3790e88
dayjs        2  b2e7f95f12    2  b2e7f95f12
underscore   2  582176ea7d    2  582176ea7d
htmx         1  81799a5753    1  81799a5753
```

Identical on every one.

Nothing else reads `jsFiles`, and the object is local to `detect`.

## Version bumps

**`SCORING_VERSION` v15 → v16** with a history entry. Scores move, and the precedent for a
detection-precision change bumping this is v12.

**`BASELINE_VERSION` 5 → 6.** `votesFromFindings` (`src/core/baseline.ts:161-170`) stores one `CategoryVote` per drift category including `phantom_scaffolding`, so cached baselines carry votes derived from the bad extraction. Per `src/mcp/baseline-provider.ts:126-133`, content-only drift stays "stale" and never rebuilds; a version mismatch is the only thing that forces the one-time rebuild. Without the bump those votes would be served indefinitely.

## Calibration

`npm run calibrate:monotonic`, before and after, same machine:

```
            0%     10%    25%    50%    75%    90%
before     86.7   87.4   86.6   80.9   73.3   71.5     0->10  +0.7
after      86.7   87.4   86.6   80.9   73.3   71.5     0->10  +0.7
```

Byte identical. The harness corpus has no phantom exports hiding in string literals, so the fix does not touch it. The `0% → 10%` monotonicity failure is **pre-existing on `main`** and unchanged by this PR.

`npm run calibrate` is unaffected: it has no `phantom_scaffolding` row, and the one gate it enforces is `security-floor` precision.

## What this deliberately does not do

**No `isAnalyzableSource` gate.** Handbook ch05:42 documents phantom scaffolding's exemption from that filter as intentional ("phantom scaffolding works from the import graph"), and the scope question is separate from the parsing bug. This PR only makes the detector read what is actually there.

**No fix for the surviving 16.** I did look at them, and they are not true positives either. They split into three classes, none of which this PR touches:

| repo | survivors | what they actually are |
| --- | --- | --- |
| underscore | 10 | all in `underscore-node.mjs`, a build-output entry file at the repo root. Nothing imports it because it *is* the package entry. |
| zod | 3 | `packages/docs/app/*/route.ts` exporting `GET`. That is Next.js App Router file-based routing (`next.config.mjs` sits alongside), so these are the most-routed functions in the repo. `extractRouteRegistrations` covers Express, Echo, Gorilla, Flask and FastAPI, not Next.js. |
| date-fns | 3 | `pkgs/core/scripts/_lib/list*.ts`. `listFns` **is** imported, at `pkgs/core/scripts/build/indices.ts:12`, so the graph missed a real edge. The specifier is `"../_lib/listFns.ts"` with an explicit `.ts`, and the resolver documents `.js` to `.ts` mapping; worth its own look. |

So the honest read is that this PR removes 86% of a population that was wrong, and the remainder is wrong for three unrelated reasons. Each looks like a separate, tractable issue (Next.js route extraction, explicit-extension resolution, entry-file weighting) and I am happy to file them. None of them is a reason to hold this change, which strictly reduces false positives and touches none of those paths.

**Handbook unchanged.** Checked ch04 and ch05: ch05:202 says "build the JS/TS import graph (`src/core/import-graph.ts`)", which stays true. Nothing claims a parsing strategy, so no chapter goes stale and no `npm run handbook` rebuild is needed.

## One coordination note

I took `SCORING_VERSION` v16 and #103 also claims v16. Whichever lands second needs v17 and a rewritten history entry. This one is four files and #103 is currently parked on a calibration question, so landing this first is probably easiest.

Also relevant to #104: its phantom-scaffolding magnitude numbers were measured on this population, so that half is worth re-measuring after this lands. The `naming` and `imports` half is unaffected.
