### PR TITLE
fix(scoring): count-based detectors score item volume

### DIFF
--- a/src/analyzers/imports.ts
+++ b/src/analyzers/imports.ts
@@ -66,7 +66,7 @@ export const importsAnalyzer: Analyzer = {
   requiresAST: false,
   applicableLanguages: ["javascript", "typescript"],
   // Bumped when detection changes — invalidates the S1 findings cache.
-  version: 2,
+  version: 3,
 
   async analyze(ctx: AnalysisContext): Promise<Finding[]> {
     const findings: Finding[] = [];
@@ -117,6 +117,11 @@ export const importsAnalyzer: Analyzer = {
         analyzerId: "imports",
         severity: "warning",
         confidence: 0.85,
+        // The minority side is the deviating population. Without this the
+        // engine's count branch divides by the number of FINDINGS, and this
+        // detector emits exactly one, so 3 stray CJS files and 800 score the
+        // same (issue #104).
+        itemCount: minorityFiles.length,
         message: `Mixed ESM/CommonJS across project: ${esmFiles.length} ESM files, ${cjsFiles.length} CJS files`,
         locations: minorityFiles.slice(0, 10).map((f) => ({ file: f })),
         tags: ["imports", "project-inconsistency"],

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -407,6 +407,14 @@ export interface Finding {
    */
   dupGroupSize?: number;
   /**
+   * For findings that roll several deviating items into ONE finding: how many
+   * items this finding accounts for. The count-based branch of the scoring
+   * engine sums it across a detector's findings, so a single finding reading
+   * "112 files use CommonJS" registers as 112 rather than as 1. Absent on
+   * one-item-per-finding detectors, where it defaults to 1. See issue #104.
+   */
+  itemCount?: number;
+  /**
    * Structured context that downstream renderers (HTML, terminal, fix-
    * prompt template) use to build the Copy-as-AI-context block and
    * reference the peer baseline this finding deviates from. Populated

--- a/src/scoring/engine.ts
+++ b/src/scoring/engine.ts
@@ -107,12 +107,22 @@ import {
  *        1 to 34% and duplicate pairs moved -8% to +27%. Repos with no class
  *        or object-literal methods, no property-chain data references and no
  *        `//` inside literals are byte identical.
+ *   v17: count-based detectors score item volume, not finding count. A detector
+ *        that rolls N deviating items into ONE finding had that N discarded,
+ *        because both count branches divided by `findings.length`. `imports`
+ *        emits exactly one project-level finding, so a repo with 3 stray
+ *        CommonJS files and one with 800 scored identically. Findings now carry
+ *        `itemCount` and the branches sum it; a finding without one counts as
+ *        1, which is the previous number. Measured on ten repos, three move:
+ *        eslint -0.4 (112 minority files), moment -0.2 (23), underscore -0.1
+ *        (4). The other seven are byte identical, including three that mix ESM
+ *        and CJS but whose minority side is 1 to 3 files. Reported in #104.
  *
  * A change here is absorbed silently for users: stored scores are re-aligned
  * where possible and a one-time release-notes notice is shown (see
  * src/core/scoring-notice.ts). Users never see this string.
  */
-export const SCORING_VERSION = "v15";
+export const SCORING_VERSION = "v17";
 
 /** The bundled corpus distribution, typed. Placeholder until the corpus build lands. */
 export const scorePercentiles = scorePercentilesArtifact as ScorePercentiles;
@@ -496,11 +506,16 @@ function groupDeviation(
   // with FUNCTION COUNT, not lines. Normalize as a size-fair per-function rate when
   // the function count is known so structural similarity that grows with scale
   // doesn't sink large clean repos; fall back to per-KLOC density when it isn't.
+  // Volume, not finding count. A detector that rolls N deviating items into one
+  // finding carries `itemCount`; one that emits a finding per item omits it and
+  // contributes 1 each, which is the same number as before (issue #104).
+  let items = 0;
+  for (const f of findings) items += f.itemCount ?? 1;
   if (functionCount > 0) {
-    const rate = findings.length / functionCount;
+    const rate = items / functionCount;
     return 1 - Math.exp(-rate / COUNT_RATE_SCALE);
   }
-  const density = findings.length / klocCount;
+  const density = items / klocCount;
   return 1 - Math.exp(-density / COUNT_DENSITY_SCALE);
 }
 

--- a/test/unit/analyzers/imports.test.ts
+++ b/test/unit/analyzers/imports.test.ts
@@ -27,6 +27,36 @@ describe("imports analyzer", () => {
     expect(findings.some((f) => f.message.includes("Mixed ESM/CommonJS"))).toBe(true);
   });
 
+  // Issue #104: this analyzer emits exactly ONE project-level finding however
+  // many files deviate, and the engine's count branch divides by the number of
+  // findings. Without itemCount, 1 stray CommonJS file and 40 score the same.
+  it("carries the minority file count as itemCount on the project finding", async () => {
+    const esm = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        path: `/test/e${i}.js`, relativePath: `e${i}.js`, language: "javascript" as const,
+        content: 'import foo from "foo";\n', lineCount: 1,
+      }));
+    const cjs = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        path: `/test/c${i}.js`, relativePath: `c${i}.js`, language: "javascript" as const,
+        content: 'const bar = require("bar");\n', lineCount: 1,
+      }));
+    const run = async (nEsm: number, nCjs: number) => {
+      const ctx: AnalysisContext = { ...BASE, files: [...esm(nEsm), ...cjs(nCjs)], totalLines: nEsm + nCjs };
+      const findings = await importsAnalyzer.analyze(ctx);
+      return findings.find((f) => f.message.includes("across project"));
+    };
+
+    // Minority is the CJS side.
+    const few = await run(20, 1);
+    expect(few?.itemCount).toBe(1);
+
+    // Same single finding, forty times the deviating population.
+    const many = await run(20, 40);
+    expect(many?.itemCount).toBe(20); // minority flips to the ESM side at 20 vs 40
+    expect(many?.locations.length).toBe(10); // locations still truncate; itemCount does not
+  });
+
   it("returns empty for consistent imports", async () => {
     const ctx: AnalysisContext = {
       ...BASE,
@@ -73,7 +103,10 @@ describe("imports analyzer", () => {
     expect(findings.some((f) => f.message.includes("Mixed"))).toBe(true);
   });
 
-  it("bumps version to 2 (invalidates findings cache)", () => {
-    expect(importsAnalyzer.version).toBe(2);
+  // Pinned on purpose: this analyzer's findings are cached by version, so a
+  // behaviour change that forgets to bump it is served stale and will not
+  // reproduce on a warm machine. v3 adds itemCount (issue #104).
+  it("pins version to 3 (invalidates findings cache)", () => {
+    expect(importsAnalyzer.version).toBe(3);
   });
 });

--- a/test/unit/scoring/discrimination.test.ts
+++ b/test/unit/scoring/discrimination.test.ts
@@ -321,3 +321,64 @@ describe("scoring decompression (v4)", () => {
     expect(small.compositeScore).toBeGreaterThan(20);
   });
 });
+
+/**
+ * Issue #104: a detector that rolls N deviating items into ONE finding had its
+ * volume discarded, because the count branch divides by `findings.length`.
+ * `imports` emits exactly one project-level finding, so 3 stray CommonJS files
+ * and 800 scored identically. `itemCount` carries the real population through.
+ */
+describe("count-based item volume (issue #104)", () => {
+  const ctxWithFunctions = (): AnalysisContext => {
+    const files = Array.from({ length: 20 }, (_, i) => ({
+      path: `src/m${i}.ts`,
+      relativePath: `src/m${i}.ts`,
+      language: "typescript" as const,
+      content: `export function unit${i}(a: number, b: number): number {\n  const t = a * ${i + 1};\n  return t + b;\n}\n`,
+      lineCount: 4,
+    }));
+    return makeCtx(5000, files);
+  };
+
+  const mkImports = (itemCount?: number): Finding => ({
+    analyzerId: "imports",
+    severity: "warning",
+    confidence: 0.85,
+    message: "Mixed ESM/CommonJS across project",
+    locations: [{ file: "src/m0.ts", line: 1 }],
+    tags: ["imports", "project-inconsistency"],
+    ...(itemCount === undefined ? {} : { itemCount }),
+  });
+
+  it("a rolled-up finding covering many items scores worse than one covering few", () => {
+    const ctx = ctxWithFunctions();
+    const few = computeScores([mkImports(1)], 5000, ctx).compositeScore;
+    const many = computeScores([mkImports(60)], 5000, ctx).compositeScore;
+    // Control: the low-volume case must not already be at the floor, or the
+    // comparison would hold for a detector that scored nothing at all.
+    expect(few).toBeGreaterThan(many);
+    expect(few).toBeGreaterThan(90);
+  });
+
+  it("volume scales monotonically, not as a step", () => {
+    const ctx = ctxWithFunctions();
+    const scores = [1, 10, 30, 60].map((n) => computeScores([mkImports(n)], 5000, ctx).compositeScore);
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeLessThan(scores[i - 1]);
+    }
+  });
+
+  it("a finding with no itemCount counts as one item (no change for per-item detectors)", () => {
+    const ctx = ctxWithFunctions();
+    const absent = computeScores([mkImports(undefined)], 5000, ctx).compositeScore;
+    const explicitOne = computeScores([mkImports(1)], 5000, ctx).compositeScore;
+    expect(absent).toBe(explicitOne);
+  });
+
+  it("two findings of one item each equal one finding of two items", () => {
+    const ctx = ctxWithFunctions();
+    const split = computeScores([mkImports(1), mkImports(1)], 5000, ctx).compositeScore;
+    const rolled = computeScores([mkImports(2)], 5000, ctx).compositeScore;
+    expect(split).toBe(rolled);
+  });
+});


### PR DESCRIPTION
## Summary

Both count branches in `groupDeviation` divided by `findings.length`. A detector that rolls N deviating items into **one** finding had that N discarded: it went into the message string and was dropped before scoring.

`imports` is the clearest case. It emits exactly one project-level finding however many files deviate, so a repo with 3 stray CommonJS files and one with 800 produced the same deviation.

Findings now carry `itemCount` and both branches sum it. A finding without one contributes 1, which is exactly what the branch counted before, so per-item detectors are untouched.

**Scoped to `imports` on purpose.** #104 names three detectors. The other two are not ready to have their volume amplified, and the measurements are below.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Chore / infra

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` all pass
- [x] New behavior has tests (bug fixes include a regression test)
- [x] `README.md` updated if a flag, command, or feature changed (nothing user-facing changed)
- [x] This change improves how accurately or confidently VibeDrift measures drift
- [x] No secrets, credentials, pricing, or internal strategy added
- [x] Copy uses "Vibe Drift Score" (never "debt score" or "quality score")

## Related issues

Partially addresses #104 (the `imports` third of it).

---

## The measurement

Ten repos, `--local-only --no-cache`, `7eb89b4` against this branch:

| repo | minority files | base | with fix | Δ |
| --- | --- | --- | --- | --- |
| eslint | 112 | 85.2 | 84.8 | **-0.4** |
| moment | 23 | 68.2 | 68.0 | **-0.2** |
| underscore | 4 | 54.5 | 54.4 | **-0.1** |
| VibeDrift | 3 | 86.2 | 86.2 | 0.0 |
| date-fns | 3 | 67.2 | 67.2 | 0.0 |
| dayjs | 1 | 80.6 | 80.6 | 0.0 |
| zod / htmx / starship / edex-ui | 0 | | | 0.0 |

**Three of ten move, largest 0.4.** That is the same magnitude class #104 reports (7 of 10 unchanged, max 1.2), measured independently on a different repo set.

Worth stating plainly: this is a correctness fix with a small effect, not a scoring change anyone will feel. eslint at 112 minority files is the loudest case in the set and it moves 0.4.

## Why `naming` and `phantom-scaffolding` are excluded

Both were measured, and both are currently counting the wrong things. Amplifying them would make existing false positives louder rather than making the score more accurate.

**`phantom-scaffolding`.** Its reported population on eight repos was 86% code inside string literals, read by a regex fallback the detector fell into by dropping the parsed tree (#106, fixed in #107). After that fix six of eight repos have **zero** phantom findings. The 16 survivors are not true positives either: 10 are exports from `underscore-node.mjs`, a
build-output entry file; 3 are `export GET` in `packages/docs/app/*/route.ts`, which is Next.js file-based routing, so they are the most-routed functions in the repo; 3 are `date-fns` script helpers that **are** imported, at `pkgs/core/scripts/build/indices.ts:12`, through a specifier the resolver misses. There is essentially nothing left to scale.

**`naming`.** `detectConvention` (`src/analyzers/naming.ts:22-28`) tests camelCase before snake_case, and the camelCase pattern is `/^[a-z][a-zA-Z0-9]*$/`, which matches any lowercase name with no underscore:

```
config     -> camelCase
main       -> camelCase
parse      -> camelCase
bug_report -> snake_case
```

A one-word snake_case name is indistinguishable from camelCase and resolves to camelCase every time. That is why starship, a Rust repo, reports *"238 files use camelCase while majority uses snake_case"*. Those are Rust files containing the word `config`. Wiring `itemCount` here costs starship 1.3 composite points for a misclassification, which was the single largest move in the whole #104 measurement.

The opposite direction is sound, because it requires a real underscore: `date-fns` reporting *"24 files use snake_case while majority uses camelCase"* is a genuine signal. So `naming` is reliable one way and broken the other, and it should be fixed before its volume is amplified. Happy to file that separately.

## The regression proof

The four scoring tests were written first and watched fail on `7eb89b4`; three of them fail with the source reverted while the test file is kept, and the fourth is a deliberate no-regression assertion (a finding with no `itemCount` must score exactly as it did before, so it passes both ways by design). The two analyzer tests also fail against base.

The volume test carries a control asserting the low-volume case is still above 90, so it cannot pass against a detector that scores nothing at all.

## The blast radius

`itemCount` is a new optional field, so nothing that does not set it changes behavior. The two count branches are the only readers:

```
$ command grep -rn "itemCount" src/
src/analyzers/imports.ts:124:        itemCount: minorityFiles.length,
src/core/types.ts:416:  itemCount?: number;
src/scoring/engine.ts:115: *        `itemCount` and the branches sum it; a finding without one counts as
src/scoring/engine.ts:510:  // finding carries `itemCount`; one that emits a finding per item omits it and
src/scoring/engine.ts:513:  for (const f of findings) items += f.itemCount ?? 1;
```

One declaration, one producer, one reader. The other two hits are the history entry and a comment.

Every other count-based detector keeps its previous number, because absent `itemCount` sums to `findings.length`. Verified by the fourth test and by seven of ten repos being byte identical.

## Version bumps

**`imports` `Analyzer.version` 2 → 3.** The analyzer layer is cached by version. Without this bump a warm cache serves pre-change findings and the fix is invisible. I lost an afternoon to exactly this while measuring: `itemCount` was set in the source, arrived at the engine as `undefined`, and every delta came out 0.0. It looks precisely like "the change does nothing."

**`SCORING_VERSION` v15 → v17**, skipping v16, which #107 claims. If #107 is closed unmerged this should become v16. The history block already has gaps at v8, v9 and v14, so a gap is consistent with the existing ledger.

`BASELINE_VERSION` deliberately **not** bumped: `imports` is an analyzer, and the persisted baseline stores drift-detector `CategoryVote` projections, which this does not touch.

## Calibration

`npm run calibrate:monotonic`, before and after:

```
            0%     10%    25%    50%    75%    90%
before     86.7   87.4   86.6   80.9   73.3   71.5     0->10  +0.7
after      86.7   87.4   86.6   80.9   73.3   71.5     0->10  +0.7
```

Byte identical. The harness baseline has no ESM/CJS mixing, so this does not reach it. The `0% → 10%` monotonicity failure is pre-existing on `main` and unchanged here.
