### PR TITLE
fix(output): neutralize CSV formula injection, align the renderers, drop CodeDnaResult from JSON

### DIFF
--- a/src/output/csv.ts
+++ b/src/output/csv.ts
@@ -10,11 +10,24 @@
 import type { ScanResult } from "../core/types.js";
 import type { CodeDnaResult } from "../codedna/types.js";
 
+// Formula-injection guard (CWE-1236): a cell whose first character is one of
+// = + - @ or a leading tab/CR can be interpreted by Excel/Sheets as a formula
+// when the CSV is opened, letting repo-controlled text (paths, TODO text,
+// finding messages) execute. Prefixing a single quote neutralizes it while
+// keeping the value readable. This applies to every leading '-' cell,
+// including ordinary negative numbers rendered as strings — intentionally
+// erring safe over preserving numeric formula-free ergonomics.
+const FORMULA_LEADING_CHARS = /^[=+\-@\t\r]/;
+
 function csvEscape(val: string): string {
-  if (val.includes(",") || val.includes('"') || val.includes("\n")) {
-    return '"' + val.replace(/"/g, '""') + '"';
+  let out = val;
+  if (FORMULA_LEADING_CHARS.test(out)) {
+    out = "'" + out;
   }
-  return val;
+  if (out.includes(",") || out.includes('"') || out.includes("\n")) {
+    return '"' + out.replace(/"/g, '""') + '"';
+  }
+  return out;
 }
 
 function row(...cells: (string | number)[]): string {

--- a/src/output/docx.ts
+++ b/src/output/docx.ts
@@ -4,6 +4,12 @@ import type { CodeDnaResult } from "../codedna/types.js";
 import { getVersion } from "../core/version.js";
 import { formatCount } from "./format.js";
 import { getAnalyzerKind } from "../scoring/categories.js";
+import { createAnalyzerRegistry } from "../analyzers/index.js";
+
+// Analyzer count for the "N findings from M static analyzers" line — derived
+// from the registry (read-only) instead of a hardcoded literal, so this
+// stays correct as analyzers are added or removed.
+const STATIC_ANALYZER_COUNT = createAnalyzerRegistry().length;
 
 // ──── Minimal ZIP generator (OOXML requires ZIP container) ────
 
@@ -135,7 +141,16 @@ function styles(): string {
 const W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
 function xml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  // Strip characters XML 1.0 forbids outright (control chars other than tab
+  // \x09, LF \x0A, CR \x0D). A source snippet containing e.g. NUL, VT, or FF
+  // would otherwise be emitted verbatim into word/document.xml and corrupt
+  // the .docx (Word fails to open it / repairs it, dropping content).
+  return s
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function para(text: string, style?: string, props?: string): string {
@@ -434,7 +449,13 @@ function buildDocxFindingsTable(result: ScanResult): string {
     getAnalyzerKind(f.analyzerId) === "hygiene" ||
     (!f.tags?.includes("drift") && !f.tags?.includes("codedna")),
   );
-  parts.push(para(`${statics.length} findings from ${13} static analyzers.`));
+  parts.push(para(`${statics.length} findings from ${STATIC_ANALYZER_COUNT} static analyzers.`));
+  // Hygiene composite — same scalar the terminal ("Hygiene Score: NN/MM") and
+  // HTML report surface. Independent of the Vibe Drift Score; shown here so
+  // DOCX readers get the same context instead of only the raw finding list.
+  if (result.maxHygieneScore > 0) {
+    parts.push(para(`Hygiene Score: ${result.hygieneScore.toFixed(1)}/${result.maxHygieneScore} (not part of the Vibe Drift Score).`));
+  }
   parts.push(para(""));
 
   for (const f of statics.slice(0, 50)) {

--- a/src/output/format.ts
+++ b/src/output/format.ts
@@ -1,5 +1,9 @@
 export function scoreBar(score: number, max: number, width = 20): string {
-  const filled = Math.round((score / max) * width);
+  const raw = Math.round((score / max) * width);
+  // Clamp: score > max (or max <= 0) would otherwise produce a filled count
+  // outside [0, width], and String#repeat throws a RangeError on a negative
+  // count.
+  const filled = Math.min(width, Math.max(0, raw));
   return "\u2588".repeat(filled) + "\u2591".repeat(width - filled);
 }
 

--- a/src/output/html.ts
+++ b/src/output/html.ts
@@ -853,8 +853,12 @@ function buildHygiene(result: ScanResult): string {
 
   const more = sorted.length > 10 ? `<div class="hyg-row"><span class="sev"></span><span class="txt" style="color:var(--text-tertiary)">+ ${sorted.length - 10} more hygiene checks</span><span class="file"></span></div>` : "";
 
+  const hygieneScoreLine = result.maxHygieneScore > 0
+    ? `<span class="meta">Hygiene Score: ${result.hygieneScore.toFixed(1)}/${result.maxHygieneScore} &middot; not part of your Vibe Drift Score</span>`
+    : `<span class="meta">not part of your Vibe Drift Score</span>`;
+
   return `<section class="va-sect">
-    <div class="va-sect-h"><h3>Hygiene</h3><span class="meta">not part of your Vibe Drift Score</span></div>
+    <div class="va-sect-h"><h3>Hygiene</h3>${hygieneScoreLine}</div>
     <div class="hyg">
       <p class="hyg-note">General code-quality checks (complexity, duplication, dead code). Useful context, but they don't measure drift, so they're excluded from the score.</p>
       ${rows}
@@ -1421,12 +1425,13 @@ ${buildHygiene(result)}
 ${buildDeepScanSection(result)}
 ${buildFooter(result, "detailed")}`;
 
+  const beaconUrl = `${opts.beaconApiUrl ?? "https://vibedrift-api.fly.dev"}/v1/beacon/report-open`;
   const beacon = opts.scanId ? `
 // Report-open beacon — fires once when the report loads in a browser.
 (function(){
   try{
-    var url="${opts.beaconApiUrl ?? "https://vibedrift-api.fly.dev"}/v1/beacon/report-open";
-    fetch(url,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({scan_id:"${opts.scanId}",opened_at:new Date().toISOString()})}).catch(function(){});
+    var url=${JSON.stringify(beaconUrl)};
+    fetch(url,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({scan_id:${JSON.stringify(opts.scanId)},opened_at:new Date().toISOString()})}).catch(function(){});
   }catch(e){}
 })();` : "";
 
@@ -1517,7 +1522,7 @@ ${beacon}
   if(csv)csv.addEventListener('click',function(){
     var d=window.__VIBEDRIFT_DATA;
     if(!d){toast('Report data not available');return;}
-    var q=function(v){var s=String(v);return /[",\\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s;};
+    var q=function(v){var s=String(v);if(/^[=+\\-@\\t\\r]/.test(s)){s="'"+s;}return /[",\\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s;};
     var row=function(){return Array.prototype.slice.call(arguments).map(q).join(',');};
     var L=[];
     L.push('VIBEDRIFT REPORT');

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -304,18 +304,33 @@ function renderFixPlan(result: ScanResult, driftFirst = false, maxItems = 5): st
       return (b.consistencyImpact ?? 0) - (a.consistencyImpact ?? 0);
     });
     // Deduplicate by analyzer — show at most 1 finding per analyzer type
-    // to maximize variety in the preview.
+    // to maximize variety in the preview. The diversity cap scales with
+    // maxItems (rather than a fixed constant) so it never leaves headroom
+    // unused: a fixed cap below maxItems under-fills the plan whenever the
+    // top findings cluster in one analyzer and there aren't enough other
+    // analyzers left in prioritySorted to reach maxItems.
+    const diverseCap = Math.max(1, maxItems - 2);
     const seen = new Set<string>();
     const diverse: Finding[] = [];
     for (const f of prioritySorted) {
       const key = f.analyzerId;
       if (seen.has(key) && diverse.length < maxItems) {
         // Allow a second from the same analyzer only if we're short of the cap
-        if (diverse.length >= 3) continue;
+        if (diverse.length >= diverseCap) continue;
       }
       seen.add(key);
       diverse.push(f);
       if (diverse.length >= maxItems) break;
+    }
+    // Backfill: if the diversity cap left the plan short of maxItems (e.g.
+    // every top finding shares one analyzer), fill the remaining slots from
+    // prioritySorted allowing duplicates, rather than under-filling.
+    if (diverse.length < maxItems) {
+      for (const f of prioritySorted) {
+        if (diverse.length >= maxItems) break;
+        if (diverse.includes(f)) continue;
+        diverse.push(f);
+      }
     }
     top = diverse;
   } else {
@@ -357,7 +372,10 @@ function renderFixPlan(result: ScanResult, driftFirst = false, maxItems = 5): st
 
   lines.push("");
   if (gain > 0.5) {
-    const approx = Math.round(after.compositeScore / 5) * 5;
+    // 1 decimal to match the composite/category precision everywhere else
+    // (HTML, JSON, CSV, DOCX) — a rounded-to-nearest-5 approximation here
+    // reads as a different number than the same projection in the report.
+    const approx = after.compositeScore.toFixed(1);
     lines.push(`  Fix these ${top.length} → projected ~${chalk.green(approx + "/" + after.maxCompositeScore)} ${currentGrade !== afterGrade ? chalk.green(`(${currentGrade} → ${afterGrade})`) : `(${currentGrade})`}`);
   }
   lines.push("");
@@ -563,7 +581,7 @@ function renderHygienePane(result: ScanResult): string[] {
   lines.push(chalk.bold.yellow("\u2500\u2500 Hygiene findings (not part of Vibe Drift Score) \u2500\u2500\u2500\u2500\u2500\u2500"));
   lines.push(chalk.dim("  Generic hygiene checks — complexity, dead code, TODOs, generic"));
   lines.push(chalk.dim("  security and dependency issues. These feed the Hygiene Score"));
-  lines.push(chalk.dim(`  (${result.hygieneScore.toFixed(0)}/${result.maxHygieneScore}), not the drift composite.`));
+  lines.push(chalk.dim(`  (${result.hygieneScore.toFixed(1)}/${result.maxHygieneScore}), not the drift composite.`));
   lines.push("");
 
   for (const cat of ALL_CATEGORIES) {
@@ -651,7 +669,7 @@ function renderCategoryBars(result: ScanResult): string[] {
         const arrow = s.delta > 0 ? "\u25B2" : "\u25BC";
         deltaStr = " " + dColor(`${arrow}${Math.abs(s.delta).toFixed(1)}`);
       }
-      lines.push(`  ${label} ${color(`${s.score.toFixed(0).padStart(2)}/${s.maxScore}`)}  ${bar}${deltaStr}`);
+      lines.push(`  ${label} ${color(`${s.score.toFixed(1).padStart(4)}/${s.maxScore}`)}  ${bar}${deltaStr}`);
     }
 
     if (cat === "securityPosture") {
@@ -674,7 +692,7 @@ function renderCategoryBars(result: ScanResult): string[] {
     DRIFT_DISPLAY_CATEGORIES.length,
   );
   const scopeSuffix = scopeNote ? `  ${chalk.dim(scopeNote)}` : "";
-  lines.push(`  ${padRight("Vibe Drift Score:", 28)} ${totalColor(`${result.compositeScore.toFixed(0)}/${result.maxCompositeScore}`)}${scopeSuffix}`);
+  lines.push(`  ${padRight("Vibe Drift Score:", 28)} ${totalColor(`${result.compositeScore.toFixed(1)}/${result.maxCompositeScore}`)}${scopeSuffix}`);
   // Floor-gate badge (render-only): an absolute security floor trip (committed
   // secret, disabled TLS, unsanitized input reaching eval/exec) is surfaced as
   // a warning line but NEVER changes compositeScore or the letter grade — see
@@ -693,7 +711,7 @@ function renderCategoryBars(result: ScanResult): string[] {
   // scalar so it's clearly NOT part of the drift score.
   if (result.maxHygieneScore > 0) {
     const hygieneColor = scoreColorFn(result.hygieneScore, result.maxHygieneScore);
-    lines.push(`  ${chalk.dim(padRight("Hygiene Score:", 28))} ${hygieneColor(`${result.hygieneScore.toFixed(0)}/${result.maxHygieneScore}`)}`);
+    lines.push(`  ${chalk.dim(padRight("Hygiene Score:", 28))} ${hygieneColor(`${result.hygieneScore.toFixed(1)}/${result.maxHygieneScore}`)}`);
   }
   // One-line gloss so a first-time reader understands what each
   // scalar represents. Dim so it's easy to skip once internalized.
@@ -1015,6 +1033,14 @@ export function renderJsonOutput(result: ScanResult): string {
       hygieneScore: result.hygieneScore,
       maxHygieneScore: result.maxHygieneScore,
       findings: result.findings,
+      // Cross-file drift findings and the Code DNA result (duplicates, taint
+      // flows, pattern distributions) — present in every other output format
+      // (HTML/CSV/DOCX). --format json is the machine surface for CI/tooling
+      // consumers, so it must not be the one format missing them.
+      driftFindings: result.driftFindings,
+      codeDnaResult: result.codeDnaResult,
+      teaseMessages: result.teaseMessages,
+      reimplementationCandidates: result.reimplementationCandidates,
       deepInsights: result.deepInsights,
       // The deep-scan coherence audit (AI-powered) — included so --json / CI /
       // analytics consumers can read the same hero report the terminal and HTML

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -1036,9 +1036,12 @@ export function renderJsonOutput(result: ScanResult): string {
       // Cross-file drift findings and the Code DNA result (duplicates, taint
       // flows, pattern distributions) — present in every other output format
       // (HTML/CSV/DOCX). --format json is the machine surface for CI/tooling
-      // consumers, so it must not be the one format missing them.
+      // consumers, so it must not be the one format missing them. The raw
+      // CodeDnaResult is deliberately NOT included: it embeds every extracted
+      // function's full source body, which roughly doubles the output and puts
+      // complete source into a surface that never carried it. Its findings are
+      // already in `findings` above.
       driftFindings: result.driftFindings,
-      codeDnaResult: result.codeDnaResult,
       teaseMessages: result.teaseMessages,
       reimplementationCandidates: result.reimplementationCandidates,
       deepInsights: result.deepInsights,

--- a/test/unit/output/csv-formula-injection.test.ts
+++ b/test/unit/output/csv-formula-injection.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { renderCsvReport } from "../../../src/output/csv.js";
+import type { Finding, ScanResult } from "../../../src/core/types.js";
+
+/**
+ * P0 (CWE-1236): a CSV cell whose text starts with =, +, -, @, tab, or CR can
+ * be interpreted by Excel/Sheets as a formula when the sheet is opened. Since
+ * cell text here is repo-controlled (file paths, TODO text, finding
+ * messages), an attacker who controls source under scan could get code to
+ * execute in a reviewer's spreadsheet app. csvEscape must prefix a single
+ * quote on any such leading character before its existing quote-wrap logic.
+ */
+
+function minimalScanResult(overrides?: Partial<ScanResult>): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map(),
+      totalLines: 1000,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 90,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    findings: [],
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+function findingWithMessage(message: string): Finding {
+  return {
+    analyzerId: "todo-density",
+    severity: "info",
+    confidence: 0.8,
+    message,
+    locations: [{ file: "src/a.ts", line: 1 }],
+    tags: [],
+  };
+}
+
+describe("csv formula-injection guard (csvEscape)", () => {
+  it("neutralizes a formula-leading finding message with a leading single quote", () => {
+    const payload = "=cmd|' /C calc'!A0";
+    const result = minimalScanResult({ findings: [findingWithMessage(payload)] });
+    const csv = renderCsvReport(result);
+    // The raw formula must never appear un-neutralized (it would be a bare
+    // "=cmd|..." cell, interpreted as a formula on open).
+    expect(csv).not.toMatch(/(?<!')=cmd\|/);
+    expect(csv).toContain("'=cmd|");
+  });
+
+  it.each(["=1+1", "+1+1", "-1+1", "@SUM(A1)", "\t=evil", "\revil"])(
+    "prefixes a leading %j with a single quote",
+    (payload) => {
+      const result = minimalScanResult({ findings: [findingWithMessage(payload)] });
+      const csv = renderCsvReport(result);
+      expect(csv).toContain("'" + payload);
+    },
+  );
+
+  it("does not touch text that doesn't start with a formula-leading char", () => {
+    const result = minimalScanResult({ findings: [findingWithMessage("normal message")] });
+    const csv = renderCsvReport(result);
+    expect(csv).toContain("normal message");
+    expect(csv).not.toContain("'normal message");
+  });
+
+  it("prefixes ALL leading '-' cells, including ordinary negative numbers rendered as text — an intentional safe-over-ergonomic choice, since csvEscape only ever sees stringified cell values and can't distinguish a negative number from a formula", () => {
+    const result = minimalScanResult({ findings: [findingWithMessage("-42 findings avoided")] });
+    const csv = renderCsvReport(result);
+    expect(csv).toContain("'-42 findings avoided");
+  });
+
+  it("still quote-wraps when the neutralized value also contains a comma", () => {
+    const result = minimalScanResult({ findings: [findingWithMessage("=A1,B1")] });
+    const csv = renderCsvReport(result);
+    expect(csv).toContain(`"'=A1,B1"`);
+  });
+});

--- a/test/unit/output/docx-control-chars.test.ts
+++ b/test/unit/output/docx-control-chars.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { inflateRawSync } from "node:zlib";
+import { renderDocxReport } from "../../../src/output/docx.js";
+import type { DriftFindingReport, ScanResult } from "../../../src/core/types.js";
+
+/**
+ * P2: docx.ts's xml() helper escaped XML markup characters (&, <, >) but not
+ * the raw control characters XML 1.0 forbids outright. A source snippet
+ * containing e.g. \x0B (vertical tab) or \x00 (NUL) — plausible in scanned
+ * source, especially binary-ish or minified files — would be emitted
+ * verbatim into word/document.xml, producing a document Word refuses to
+ * open (or silently repairs, dropping content). xml() must strip
+ * /[\x00-\x08\x0B\x0C\x0E-\x1F]/g before entity-escaping.
+ */
+
+function minimalScanResult(overrides?: Partial<ScanResult>): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map([["typescript", { files: 3, lines: 1000 }]]),
+      totalLines: 1000,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 90,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    findings: [],
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+/** Inflate a DOCX (OOXML zip) and return word/document.xml as text. */
+function docxDocumentXml(zip: Buffer): string {
+  let off = 0;
+  while (off + 4 <= zip.length && zip.readUInt32LE(off) === 0x04034b50) {
+    const compSize = zip.readUInt32LE(off + 18);
+    const nameLen = zip.readUInt16LE(off + 26);
+    const extraLen = zip.readUInt16LE(off + 28);
+    const name = zip.slice(off + 30, off + 30 + nameLen).toString("utf-8");
+    const dataStart = off + 30 + nameLen + extraLen;
+    const data = zip.slice(dataStart, dataStart + compSize);
+    if (name === "word/document.xml") return inflateRawSync(data).toString("utf-8");
+    off = dataStart + compSize;
+  }
+  throw new Error("word/document.xml not found in DOCX");
+}
+
+function driftFindingWithControlChar(): DriftFindingReport {
+  return {
+    detector: "naming-convention",
+    driftCategory: "architectural_consistency",
+    severity: "warning",
+    confidence: 0.9,
+    finding: "snippet with a control char",
+    dominantPattern: "camelCase",
+    dominantCount: 7,
+    totalRelevantFiles: 10,
+    consistencyScore: 70,
+    deviatingFiles: [
+      {
+        path: "src/legacy.ts",
+        detectedPattern: "snake_case",
+        // \x0B (vertical tab) — XML-1.0-illegal control char.
+        evidence: [{ line: 3, code: "let user_id\x0B = 1;" }],
+      },
+    ],
+    recommendation: "Rename to camelCase.",
+  };
+}
+
+describe("docx xml() strips XML-1.0-illegal control characters", () => {
+  it("produces a document.xml with no raw control char, and the DOCX still unzips/inflates cleanly", () => {
+    const result = minimalScanResult({ driftFindings: [driftFindingWithControlChar()] });
+    const zip = renderDocxReport(result);
+    const xmlText = docxDocumentXml(zip);
+
+    // No XML-1.0-illegal control char anywhere in the produced document part.
+    // eslint-disable-next-line no-control-regex
+    expect(xmlText).not.toMatch(/[\x00-\x08\x0B\x0C\x0E-\x1F]/);
+    // The surrounding text still made it through, just without the illegal char.
+    expect(xmlText).toContain("let user_id");
+    expect(xmlText).toContain("= 1;");
+  });
+
+  it("still entity-escapes ordinary markup characters alongside the control-char strip", () => {
+    const result = minimalScanResult({
+      driftFindings: [
+        {
+          ...driftFindingWithControlChar(),
+          deviatingFiles: [
+            {
+              path: "src/legacy.ts",
+              detectedPattern: "snake_case",
+              evidence: [{ line: 3, code: "if (a \x0B< b && b > c) {}" }],
+            },
+          ],
+        },
+      ],
+    });
+    const xmlText = docxDocumentXml(renderDocxReport(result));
+    expect(xmlText).toContain("&lt;");
+    expect(xmlText).toContain("&gt;");
+    // eslint-disable-next-line no-control-regex
+    expect(xmlText).not.toMatch(/[\x00-\x08\x0B\x0C\x0E-\x1F]/);
+  });
+});

--- a/test/unit/output/docx-static-analyzer-count.test.ts
+++ b/test/unit/output/docx-static-analyzer-count.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { inflateRawSync } from "node:zlib";
+import { renderDocxReport } from "../../../src/output/docx.js";
+import { createAnalyzerRegistry } from "../../../src/analyzers/index.js";
+import type { ScanResult } from "../../../src/core/types.js";
+
+/**
+ * P3: docx.ts hardcoded `${13} static analyzers` in the STATIC ANALYSIS
+ * FINDINGS section header, which silently goes stale whenever an analyzer is
+ * added or removed from the registry. The fix derives the count from
+ * createAnalyzerRegistry().length instead.
+ */
+
+function minimalScanResult(overrides?: Partial<ScanResult>): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map([["typescript", { files: 3, lines: 1000 }]]),
+      totalLines: 1000,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 55.5,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    findings: [
+      {
+        analyzerId: "complexity",
+        severity: "warning",
+        confidence: 0.7,
+        message: "Function too complex",
+        locations: [{ file: "src/big.ts", line: 10 }],
+        tags: [],
+      },
+    ],
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+function docxDocumentXml(zip: Buffer): string {
+  let off = 0;
+  while (off + 4 <= zip.length && zip.readUInt32LE(off) === 0x04034b50) {
+    const compSize = zip.readUInt32LE(off + 18);
+    const nameLen = zip.readUInt16LE(off + 26);
+    const extraLen = zip.readUInt16LE(off + 28);
+    const name = zip.slice(off + 30, off + 30 + nameLen).toString("utf-8");
+    const dataStart = off + 30 + nameLen + extraLen;
+    const data = zip.slice(dataStart, dataStart + compSize);
+    if (name === "word/document.xml") return inflateRawSync(data).toString("utf-8");
+    off = dataStart + compSize;
+  }
+  throw new Error("word/document.xml not found in DOCX");
+}
+
+describe("docx STATIC ANALYSIS FINDINGS header derives the analyzer count from the registry", () => {
+  it("matches createAnalyzerRegistry().length, not a hardcoded literal", () => {
+    const expectedCount = createAnalyzerRegistry().length;
+    const text = docxDocumentXml(renderDocxReport(minimalScanResult())).replace(/<[^>]+>/g, " ");
+    expect(text).toContain(`static analyzers`);
+    expect(text).toMatch(new RegExp(`findings from ${expectedCount} static analyzers`));
+  });
+
+  it("also surfaces the Hygiene Score scalar in that section", () => {
+    const text = docxDocumentXml(renderDocxReport(minimalScanResult())).replace(/<[^>]+>/g, " ");
+    expect(text).toContain("Hygiene Score: 55.5/100");
+  });
+});

--- a/test/unit/output/fix-plan-diversity.test.ts
+++ b/test/unit/output/fix-plan-diversity.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { renderTerminalOutput, renderConciseSummary } from "../../../src/output/terminal.js";
+import type { Finding, ScanResult } from "../../../src/core/types.js";
+
+/**
+ * P2: the drift-first Fix Plan's diversity guard (renderFixPlan) hardcoded
+ * "3" as the max duplicates-per-analyzer allowance while maxItems defaults
+ * to 5. When the top-priority findings all share one analyzer, the guard
+ * stopped filling at 3 items even though 2 more slots (and 2 more qualifying
+ * findings) were available — the plan under-filled instead of using the
+ * full cap. The fix derives the cap from maxItems and backfills any
+ * remaining slots with duplicates rather than leaving them empty.
+ */
+
+function minimalScanResult(overrides?: Partial<ScanResult>): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map(),
+      totalLines: 1000,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 90,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    findings: [],
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+/** Five findings, all from the same analyzer (no diversity possible). */
+function fiveSameAnalyzerFindings(): Finding[] {
+  return Array.from({ length: 5 }, (_, i) => ({
+    analyzerId: "naming",
+    severity: "warning",
+    confidence: 0.9,
+    message: `naming-drift-item-${i + 1}`,
+    locations: [{ file: `src/file-${i + 1}.ts`, line: 1 }],
+    tags: [],
+    consistencyImpact: 5 - i, // 5,4,3,2,1 — all above the 0.05 display floor
+  }));
+}
+
+describe("Fix Plan diversity guard scales with maxItems", () => {
+  it("fills all 5 slots (maxItems=5) even when every top finding shares one analyzer", () => {
+    const result = minimalScanResult({ findings: fiveSameAnalyzerFindings() });
+    // brief output with no `concise` flag uses maxFixes=5 and driftFirst=true
+    // (renderBriefOutput -> renderFixPlan(result, true, 5)).
+    const out = renderTerminalOutput(result, { brief: true });
+    for (let i = 1; i <= 5; i++) {
+      expect(out).toContain(`naming-drift-item-${i}`);
+    }
+  });
+
+  it("still shows only 3 items for the concise (authenticated) summary cap", () => {
+    const result = minimalScanResult({ findings: fiveSameAnalyzerFindings() });
+    // renderConciseSummary caps maxFixes at 3 regardless of the diversity fix.
+    const out = renderConciseSummary(result);
+    let count = 0;
+    for (let i = 1; i <= 5; i++) {
+      if (out.includes(`naming-drift-item-${i}`)) count++;
+    }
+    expect(count).toBe(3);
+  });
+});

--- a/test/unit/output/format.test.ts
+++ b/test/unit/output/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatCount } from "../../../src/output/format.js";
+import { formatCount, scoreBar } from "../../../src/output/format.js";
 
 /**
  * formatCount must be byte-stable across machine locales. `Number#toLocaleString()`
@@ -31,5 +31,32 @@ describe("formatCount", () => {
       if (prev === undefined) delete process.env.LANG;
       else process.env.LANG = prev;
     }
+  });
+});
+
+/**
+ * P3: scoreBar computed `filled = Math.round((score / max) * width)` with no
+ * clamp. A score above max (a real possibility — e.g. a projected/"after
+ * fixes" score, or a caller passing an already-summed delta) pushes `filled`
+ * past `width`, and `width - filled` goes negative — String#repeat throws a
+ * RangeError on a negative count. Clamp `filled` to [0, width].
+ */
+describe("scoreBar", () => {
+  it("renders a fully-filled bar at score === max", () => {
+    expect(scoreBar(20, 20, 10)).toBe("█".repeat(10));
+  });
+
+  it("does not throw when score > max, and clamps to a fully-filled bar", () => {
+    expect(() => scoreBar(25, 20, 10)).not.toThrow();
+    expect(scoreBar(25, 20, 10)).toBe("█".repeat(10));
+  });
+
+  it("does not throw and clamps to empty when score is negative", () => {
+    expect(() => scoreBar(-5, 20, 10)).not.toThrow();
+    expect(scoreBar(-5, 20, 10)).toBe("░".repeat(10));
+  });
+
+  it("renders a partially-filled bar within range", () => {
+    expect(scoreBar(10, 20, 10)).toBe("█".repeat(5) + "░".repeat(5));
   });
 });

--- a/test/unit/output/html-output-hardening.test.ts
+++ b/test/unit/output/html-output-hardening.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { renderHtmlReport } from "../../../src/output/html.js";
+import type { ScanResult } from "../../../src/core/types.js";
+
+function minimalScanResult(overrides?: Partial<ScanResult>): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map(),
+      totalLines: 1000,
+      files: [{}],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 42.7,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    findings: [],
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+/**
+ * P3: opts.scanId (and the beaconApiUrl string build) were spliced raw into
+ * an inline `<script>` JS string via template-literal interpolation, unlike
+ * every other dynamic value in this file which goes through esc()/JSON
+ * encoding. A scanId containing a quote or backslash would break out of the
+ * JS string literal it's embedded in. The fix wraps both in JSON.stringify.
+ */
+describe("html report — scanId is JSON-encoded into the beacon script, not spliced raw", () => {
+  it("a scanId containing a double quote does not break out of the JS string literal", () => {
+    const malicious = `abc"});fetch("https://evil.example/x`;
+    const html = renderHtmlReport(minimalScanResult(), "summary", {}, { scanId: malicious, isPaid: false });
+    // The JSON-encoded form must appear (quotes escaped) — this is what
+    // JSON.stringify(malicious) produces.
+    expect(html).toContain(JSON.stringify(malicious));
+    // The raw, unescaped payload must never appear verbatim inside the script.
+    expect(html).not.toContain(`scan_id:"${malicious}"`);
+  });
+
+  it("beaconApiUrl is also JSON-encoded, not string-concatenated raw", () => {
+    const html = renderHtmlReport(minimalScanResult(), "summary", {}, { scanId: "scan_123", beaconApiUrl: "https://api.example.com", isPaid: false });
+    expect(html).toContain(JSON.stringify("https://api.example.com/v1/beacon/report-open"));
+  });
+
+  it("omits the beacon entirely (and thus stays safe) when no scanId is provided", () => {
+    const html = renderHtmlReport(minimalScanResult(), "summary", {}, { isPaid: false });
+    expect(html).not.toContain("report-open");
+  });
+});
+
+/**
+ * P0 (client-side twin of csv.ts's csvEscape): the "Export CSV" button's
+ * embedded q() helper builds a CSV client-side from window.__VIBEDRIFT_DATA.
+ * It escaped quotes/commas/newlines but not formula-leading characters, so
+ * the same CWE-1236 formula-injection risk applied to the in-browser export.
+ */
+describe("html report — client-side CSV export q() helper neutralizes formula-leading cells", () => {
+  it("ships a q() that single-quote-prefixes a leading = + - @ tab or CR before wrapping", () => {
+    const html = renderHtmlReport(minimalScanResult(), "detailed", {}, { isPaid: false });
+    const match = html.match(/var q=function\(v\)\{[\s\S]*?\};/);
+    expect(match).not.toBeNull();
+    const qSource = match![0];
+
+    // Extract and execute the function body in isolation to assert behavior,
+    // rather than just eyeballing the regex — this is a real regression test
+    // against the shipped script text.
+    const q = new Function(`${qSource}\nreturn q;`)() as (v: unknown) => string;
+
+    expect(q("=cmd|' /C calc'!A0")).toBe("'=cmd|' /C calc'!A0");
+    expect(q("+1+1")).toBe("'+1+1");
+    expect(q("-1+1")).toBe("'-1+1");
+    expect(q("@SUM(A1)")).toBe("'@SUM(A1)");
+    expect(q("normal value")).toBe("normal value");
+    // Still quote-wraps on comma, same as before.
+    expect(q("a,b")).toBe('"a,b"');
+  });
+});
+
+/**
+ * P2: the Hygiene Score scalar ("Hygiene Score: NN/MM") that terminal output
+ * shows was absent from the HTML report entirely — buildHygiene() rendered
+ * only the "not part of your Vibe Drift Score" note with no number.
+ */
+describe("html report — Hygiene section surfaces the hygieneScore/maxHygieneScore scalar", () => {
+  it("shows the hygiene score next to the hygiene findings", () => {
+    const hygieneFinding = {
+      analyzerId: "complexity",
+      severity: "warning" as const,
+      confidence: 0.7,
+      message: "Function exceeds complexity threshold",
+      locations: [{ file: "src/big.ts", line: 10 }],
+      tags: [],
+    };
+    const html = renderHtmlReport(
+      minimalScanResult({ findings: [hygieneFinding] }),
+      "detailed",
+      {},
+      { isPaid: false },
+    );
+    expect(html).toContain("Hygiene Score: 42.7/100");
+  });
+});

--- a/test/unit/output/json-output-drift.test.ts
+++ b/test/unit/output/json-output-drift.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { renderJsonOutput } from "../../../src/output/terminal.js";
+import type { DriftFindingReport, ScanResult } from "../../../src/core/types.js";
+
+/**
+ * P1: --format json is the machine surface for CI/tooling consumers, and
+ * every OTHER renderer (HTML, CSV, DOCX) already includes drift findings and
+ * the Code DNA result. renderJsonOutput dropped both, silently making the
+ * one machine-readable format the least complete one.
+ */
+
+function minimalScanResult(overrides?: Partial<ScanResult>): ScanResult {
+  const emptyCat = { score: 18, maxScore: 20, locked: false, findingCount: 0, applicable: true };
+  return {
+    context: {
+      rootDir: "/tmp/proj",
+      dominantLanguage: "typescript",
+      languageBreakdown: new Map(),
+      totalLines: 1000,
+      files: [],
+      intentHints: [],
+    },
+    compositeScore: 84,
+    maxCompositeScore: 100,
+    percentile: null,
+    peerLanguage: "typescript",
+    scores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    hygieneScore: 90,
+    maxHygieneScore: 100,
+    hygieneScores: {
+      architecturalConsistency: { ...emptyCat },
+      redundancy: { ...emptyCat },
+      dependencyHealth: { ...emptyCat },
+      securityPosture: { ...emptyCat },
+      intentClarity: { ...emptyCat },
+    },
+    findings: [],
+    driftFindings: [],
+    driftScores: {},
+    perFileScores: new Map(),
+    teaseMessages: [],
+    deepInsights: [],
+    scanTimeMs: 5,
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+function driftFinding(): DriftFindingReport {
+  return {
+    detector: "naming-convention",
+    driftCategory: "architectural_consistency",
+    severity: "warning",
+    confidence: 0.9,
+    finding: "3 of 10 files use snake_case while the rest use camelCase",
+    dominantPattern: "camelCase",
+    dominantCount: 7,
+    totalRelevantFiles: 10,
+    consistencyScore: 70,
+    deviatingFiles: [{ path: "src/legacy.ts", detectedPattern: "snake_case", evidence: [{ line: 3, code: "let user_id = 1;" }] }],
+    recommendation: "Rename to camelCase to match the dominant convention.",
+  };
+}
+
+describe("renderJsonOutput includes driftFindings and codeDnaResult", () => {
+  it("includes non-empty driftFindings", () => {
+    const result = minimalScanResult({ driftFindings: [driftFinding()] });
+    const parsed = JSON.parse(renderJsonOutput(result));
+    expect(parsed.driftFindings).toHaveLength(1);
+    expect(parsed.driftFindings[0].finding).toContain("snake_case");
+  });
+
+  it("includes codeDnaResult when present", () => {
+    const dna = { functions: [], findings: [], duplicateGroups: [{ groupId: "g1", functions: [] }] };
+    const result = minimalScanResult({ codeDnaResult: dna as unknown as ScanResult["codeDnaResult"] });
+    const parsed = JSON.parse(renderJsonOutput(result));
+    expect(parsed.codeDnaResult).toBeDefined();
+    expect(parsed.codeDnaResult.duplicateGroups).toHaveLength(1);
+  });
+
+  it("includes teaseMessages and reimplementationCandidates when present", () => {
+    const result = minimalScanResult({
+      teaseMessages: ["3 more findings available with deep scan"],
+      reimplementationCandidates: 2,
+    });
+    const parsed = JSON.parse(renderJsonOutput(result));
+    expect(parsed.teaseMessages).toEqual(["3 more findings available with deep scan"]);
+    expect(parsed.reimplementationCandidates).toBe(2);
+  });
+
+  it("still includes driftFindings as an empty array when there are none (not silently omitted)", () => {
+    const parsed = JSON.parse(renderJsonOutput(minimalScanResult()));
+    expect(parsed.driftFindings).toEqual([]);
+  });
+});

--- a/test/unit/output/json-output-drift.test.ts
+++ b/test/unit/output/json-output-drift.test.ts
@@ -67,7 +67,7 @@ function driftFinding(): DriftFindingReport {
   };
 }
 
-describe("renderJsonOutput includes driftFindings and codeDnaResult", () => {
+describe("renderJsonOutput includes driftFindings but not the raw CodeDnaResult", () => {
   it("includes non-empty driftFindings", () => {
     const result = minimalScanResult({ driftFindings: [driftFinding()] });
     const parsed = JSON.parse(renderJsonOutput(result));
@@ -75,12 +75,16 @@ describe("renderJsonOutput includes driftFindings and codeDnaResult", () => {
     expect(parsed.driftFindings[0].finding).toContain("snake_case");
   });
 
-  it("includes codeDnaResult when present", () => {
-    const dna = { functions: [], findings: [], duplicateGroups: [{ groupId: "g1", functions: [] }] };
+  it("omits codeDnaResult (it embeds every extracted function's full source body)", () => {
+    const dna = {
+      functions: [{ name: "secret", rawBody: "return process.env.SECRET;" }],
+      findings: [],
+      duplicateGroups: [{ groupId: "g1", functions: [] }],
+    };
     const result = minimalScanResult({ codeDnaResult: dna as unknown as ScanResult["codeDnaResult"] });
-    const parsed = JSON.parse(renderJsonOutput(result));
-    expect(parsed.codeDnaResult).toBeDefined();
-    expect(parsed.codeDnaResult.duplicateGroups).toHaveLength(1);
+    const out = renderJsonOutput(result);
+    expect(JSON.parse(out).codeDnaResult).toBeUndefined();
+    expect(out).not.toContain("process.env.SECRET");
   });
 
   it("includes teaseMessages and reimplementationCandidates when present", () => {


### PR DESCRIPTION
**Stack 1 of 9.** Low risk, panel-verified.

- CSV export neutralises formula injection (`=`, `+`, `-`, `@` prefixes) and the renderers are aligned on the same finding shape.
- Review-round fix: `--format json` no longer dumps the raw `CodeDnaResult`, which embedded every extracted function's full source body. Drift findings and reimplementation candidates stay. Test asserts a function body never reaches the JSON.

Review items: the `--format json` P2. Validation on the full branch: typecheck and lint clean; 3049 tests pass, the 46 failures are the known Windows-only set (macOS/Linux green per review). Per-PR: typecheck clean and the area's test directories green (see the stack comment).

---
Stacked split of #113 (whole-repo audit), in the order requested in review. Each PR is its area commit from that branch plus its review-round fix commit; the top of the stack is byte-identical to `fix/whole-repo-audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KphwfjdmG6vFhxVye4dy7