### PR TITLE
ci: bound the verdaccio fetch in the release rehearsal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,16 @@ jobs:
           cache: npm
       - run: npm ci
       # The rehearsal runs Verdaccio through npx, which installs it under the
-      # npm cache in _npx (73 MB). Keeping that across runs makes the common
-      # case no download at all: measured locally, a warm _npx answers in 1 s
-      # against 26 s cold. setup-node's own npm cache is keyed on the lockfile
-      # and saved only on a miss, so it cannot be relied on to hold _npx.
-      # Keep the version in the key in step with REHEARSAL_VERDACCIO_SPEC in
-      # scripts/release-rehearsal.sh.
+      # npm cache in _npx. A warm _npx answers in 1 s against 14 s or more
+      # cold. GitHub scopes caches by ref, so a pull request's first run is
+      # always a miss and downloads cold; this pays off once main has run CI
+      # with the step and pull requests can restore from the default branch.
+      # The bounded fetch in scripts/release-rehearsal.sh, not this cache, is
+      # what makes a cold run reliable. setup-node's own npm cache is keyed on
+      # the lockfile and saved only on a miss, so it cannot be relied on to
+      # hold _npx. Keep the version in the key in step with
+      # REHEARSAL_VERDACCIO_SPEC in scripts/release-rehearsal.sh; a corrupt
+      # _npx would persist under a static key until the key is bumped.
       - uses: actions/cache@v4
         with:
           path: ~/.npm/_npx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,17 @@ jobs:
           node-version: "22.x"
           cache: npm
       - run: npm ci
+      # The rehearsal runs Verdaccio through npx, which installs it under the
+      # npm cache in _npx (73 MB). Keeping that across runs makes the common
+      # case no download at all: measured locally, a warm _npx answers in 1 s
+      # against 26 s cold. setup-node's own npm cache is keyed on the lockfile
+      # and saved only on a miss, so it cannot be relied on to hold _npx.
+      # Keep the version in the key in step with REHEARSAL_VERDACCIO_SPEC in
+      # scripts/release-rehearsal.sh.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm/_npx
+          key: npx-verdaccio-5.33.0-${{ runner.os }}
       - run: bash scripts/release-rehearsal.sh
 
   # Dogfooding: VibeDrift scans itself. The fail threshold is DISABLED for now —

--- a/scripts/release-rehearsal.sh
+++ b/scripts/release-rehearsal.sh
@@ -55,11 +55,16 @@ packages:
     proxy: npmjs
 log: { type: stdout, level: warn }
 EOF
+# `npx --yes verdaccio@5` downloads verdaccio cold on every CI run (setup-node's
+# cache only covers the lockfile), which alone can take longer than 30 s on a
+# slow registry day: 6 of 8 runs on 2026-09-03 died here at 29 s with npm still
+# printing download warnings. Give it two minutes; a healthy start takes ~10 s.
 npx --yes verdaccio@5 --config "$WORK/verdaccio.yaml" --listen "$PORT" >"$WORK/verdaccio.log" 2>&1 &
 VERDACCIO_PID=$!
-for i in $(seq 1 30); do
+START_BUDGET_S="${REHEARSAL_START_BUDGET_S:-120}"
+for i in $(seq 1 "$START_BUDGET_S"); do
   curl -sf "$REG/-/ping" >/dev/null 2>&1 && break
-  [ "$i" = 30 ] && { echo "verdaccio did not start"; tail -5 "$WORK/verdaccio.log"; exit 1; }
+  [ "$i" = "$START_BUDGET_S" ] && { echo "verdaccio did not start within ${START_BUDGET_S}s"; tail -5 "$WORK/verdaccio.log"; exit 1; }
   sleep 1
 done
 say "registry up (pid $VERDACCIO_PID)"

--- a/scripts/release-rehearsal.sh
+++ b/scripts/release-rehearsal.sh
@@ -55,19 +55,24 @@ packages:
     proxy: npmjs
 log: { type: stdout, level: warn }
 EOF
-# Fetch verdaccio into the npx cache FIRST, in the foreground, with short fetch
-# timeouts and a retry loop, so the start-up wait below never includes the
-# download. npm's default fetch timeout is five minutes, so a stalled registry
-# connection sits there silently: nine rehearsal runs on 2026-09-03 died with
-# "verdaccio did not start" and nothing but npm's deprecation warnings in the
-# log, even with a 120 s wait. Measured locally: a warm npx cache answers in
-# 1 s, a cold fetch takes about 25 s, a hung connection under npm defaults is
-# still hanging at 90 s, and with the bounds below a dead registry fails an
-# attempt in about 75 s. CI keeps ~/.npm/_npx across runs (see ci.yml), so the
-# common case is the 1 s one.
+# Fetch verdaccio into the npx cache FIRST, in the foreground and bounded, so
+# the start-up wait below never includes the download. Eight rehearsal runs on
+# 2026-09-03 died with "verdaccio did not start" and nothing in verdaccio's own
+# log, first at a 30 s wait and then at 120 s; verdaccio never ran, npx was
+# still downloading it. npm's fetch-timeout bounds an IDLE socket only, and its
+# default is five minutes, so a registry that accepts a connection and then
+# stalls hangs almost indefinitely (measured: still hanging at 90 s under npm
+# defaults, 11 s with the bound below). npm does not bound TCP connect at all,
+# so an unreachable registry costs the OS connect timeout instead, about 75 s
+# on macOS and longer on Linux; `timeout` caps that when it is installed.
+#
+# Measured cold fetch times ranged from 14 s to over 120 s, and that tail is
+# the bug; a warm npx cache answers in 1 s. Three attempts, because partial
+# progress stays in the npm cache and a retry resumes from it.
 VERDACCIO_SPEC="${REHEARSAL_VERDACCIO_SPEC:-verdaccio@5.33.0}"
+FETCH_CAP=""; command -v timeout >/dev/null 2>&1 && FETCH_CAP="timeout ${REHEARSAL_FETCH_CAP_S:-90}"
 fetch_verdaccio() {
-  npm_config_fetch_timeout=10000 npm_config_fetch_retries=0 \
+  $FETCH_CAP env npm_config_fetch_timeout=10000 npm_config_fetch_retries=0 \
     npx --yes "$VERDACCIO_SPEC" --version >"$WORK/verdaccio-fetch.log" 2>&1
 }
 for attempt in 1 2 3; do

--- a/scripts/release-rehearsal.sh
+++ b/scripts/release-rehearsal.sh
@@ -55,16 +55,35 @@ packages:
     proxy: npmjs
 log: { type: stdout, level: warn }
 EOF
-# `npx --yes verdaccio@5` downloads verdaccio cold on every CI run (setup-node's
-# cache only covers the lockfile), which alone can take longer than 30 s on a
-# slow registry day: 6 of 8 runs on 2026-09-03 died here at 29 s with npm still
-# printing download warnings. Give it two minutes; a healthy start takes ~10 s.
-npx --yes verdaccio@5 --config "$WORK/verdaccio.yaml" --listen "$PORT" >"$WORK/verdaccio.log" 2>&1 &
+# Fetch verdaccio into the npx cache FIRST, in the foreground, with short fetch
+# timeouts and a retry loop, so the start-up wait below never includes the
+# download. npm's default fetch timeout is five minutes, so a stalled registry
+# connection sits there silently: nine rehearsal runs on 2026-09-03 died with
+# "verdaccio did not start" and nothing but npm's deprecation warnings in the
+# log, even with a 120 s wait. Measured locally: a warm npx cache answers in
+# 1 s, a cold fetch takes about 25 s, a hung connection under npm defaults is
+# still hanging at 90 s, and with the bounds below a dead registry fails an
+# attempt in about 75 s. CI keeps ~/.npm/_npx across runs (see ci.yml), so the
+# common case is the 1 s one.
+VERDACCIO_SPEC="${REHEARSAL_VERDACCIO_SPEC:-verdaccio@5.33.0}"
+fetch_verdaccio() {
+  npm_config_fetch_timeout=10000 npm_config_fetch_retries=0 \
+    npx --yes "$VERDACCIO_SPEC" --version >"$WORK/verdaccio-fetch.log" 2>&1
+}
+for attempt in 1 2 3; do
+  fetch_verdaccio && break
+  [ "$attempt" = 3 ] && { echo "could not fetch $VERDACCIO_SPEC in 3 attempts"; tail -20 "$WORK/verdaccio-fetch.log"; exit 1; }
+  echo "fetching $VERDACCIO_SPEC failed or stalled (attempt $attempt), retrying"
+  sleep 5
+done
+echo "  ✓ $VERDACCIO_SPEC fetched"
+
+npx --yes "$VERDACCIO_SPEC" --config "$WORK/verdaccio.yaml" --listen "$PORT" >"$WORK/verdaccio.log" 2>&1 &
 VERDACCIO_PID=$!
-START_BUDGET_S="${REHEARSAL_START_BUDGET_S:-120}"
+START_BUDGET_S="${REHEARSAL_START_BUDGET_S:-60}"
 for i in $(seq 1 "$START_BUDGET_S"); do
   curl -sf "$REG/-/ping" >/dev/null 2>&1 && break
-  [ "$i" = "$START_BUDGET_S" ] && { echo "verdaccio did not start within ${START_BUDGET_S}s"; tail -5 "$WORK/verdaccio.log"; exit 1; }
+  [ "$i" = "$START_BUDGET_S" ] && { echo "verdaccio did not start within ${START_BUDGET_S}s"; tail -20 "$WORK/verdaccio.log"; exit 1; }
   sleep 1
 done
 say "registry up (pid $VERDACCIO_PID)"

--- a/scripts/release-rehearsal.sh
+++ b/scripts/release-rehearsal.sh
@@ -57,7 +57,7 @@ log: { type: stdout, level: warn }
 EOF
 # Fetch verdaccio into the npx cache FIRST, in the foreground and bounded, so
 # the start-up wait below never includes the download. Eight rehearsal runs on
-# 2026-09-03 died with "verdaccio did not start" and nothing in verdaccio's own
+# 2026-09-04 UTC died with "verdaccio did not start" and nothing in verdaccio's own
 # log, first at a 30 s wait and then at 120 s; verdaccio never ran, npx was
 # still downloading it. npm's fetch-timeout bounds an IDLE socket only, and its
 # default is five minutes, so a registry that accepts a connection and then


### PR DESCRIPTION
## Summary

Eight rehearsal runs on 2026-09-04 UTC died with `verdaccio did not start`, first at a 30 s wait for `/-/ping` and then at 120 s. Verdaccio was never the problem: it had not started because `npx --yes verdaccio@5` was still downloading it inside that wait. npm's `fetch-timeout` bounds an idle socket only and defaults to five minutes, so a registry that accepts a connection and then stalls hangs nearly indefinitely, and npm does not bound TCP connect at all.

Two changes:

- `scripts/release-rehearsal.sh` fetches Verdaccio in the foreground first, pinned (`verdaccio@5.33.0`), with `npm_config_fetch_timeout=10000`, `npm_config_fetch_retries=0` and a `timeout 90` cap per attempt when `timeout` is installed, up to three attempts. Only then does it start Verdaccio and wait 60 s for the ping. Seams: `REHEARSAL_VERDACCIO_SPEC`, `REHEARSAL_FETCH_CAP_S`, `REHEARSAL_START_BUDGET_S`.
- `ci.yml` caches `~/.npm/_npx` keyed on the pinned spec.

## Type

- [x] CI / tooling

## Measurement

Independently re-executed, and adversarially refuted by a second pass that ran the change rather than reading it:

- **The runs.** Eight rehearsal runs carry `verdaccio did not start`, counted over the ten candidate run ids: 33830107886, 33830110386, 33830131815, 33830454423, 33830456973, 33837662953, 33837664388, 33837671998. Not counted: 33808962819 (a test timeout, different failure) and 33830455912 (passed on re-run).
- **Verdaccio does not fail silently.** With this exact config a busy port logs `fatal--- cannot create server: listen EADDRINUSE`, an unreadable config logs `cannot open config file`, and a healthy start logs its `http address` line. `fatal` outranks the configured `warn` level, so a crash would have shown in the `tail`. No failing run has a single Verdaccio line.
- **The failure signature reproduces.** On a cold fetch all seven npm deprecation warnings land between 5.7 s and 6.5 s, and that same fetch was still running at 120 s. Warnings plus nothing else is npm mid-download, which is exactly what the failing runs show.
- **It is a continuum, not a binary.** One passing run under the old script took 61 s from banner to registry up; the three 120 s failures were on the same runner image, in the same batch, as two passes eight seconds apart.
- **Timings.** Warm npx cache 1 s. Cold fetch 14 s to over 120 s locally, 15 s to 25 s on CI; that tail is the bug. A registry that accepts then stalls fails in 11 s under the bounds and is still hanging at 90 s under npm defaults. An unreachable address costs the OS connect timeout, about 75 s on macOS and longer on Linux, which is what the `timeout` cap is for.
- **A slow but progressing download is not aborted.** npm maps `fetch-timeout` to an idle-socket timeout in `@npmcli/agent` (`timeouts: { idle: opts.timeout ?? 0, connection: 0 }`), not a deadline. Confirmed empirically: a 25 s CI fetch and a 14 s local fetch both succeeded under a 10 s setting with no retry line.
- **Fail paths.** A nonexistent version gives two retry lines, `could not fetch verdaccio@5.999.0 in 3 attempts` and `npm error notarget`, exit 1 in 13 s. A 2 s cap on a cold cache gives the same three bounded attempts in 16 s, which is how the cap was shown to bind. Either way CI now names the real cause instead of pointing at Verdaccio.
- **Full script locally:** exit 0, through the publish gate (231 test files / 3,169 tests on the rebased tree), the local publish, install, version, doctor and offline scan. Wall time is dominated by that gate and grows with the suite, so it is not a stable number to quote.
- **On CI:** 30 of 30 checks green across #128 to #133, where the same jobs failed 8 times before. On the first green pass the separated fetch took 15 s to 16 s and Verdaccio answered the ping 1 s to 2 s later, which is the diagnosis in one line. Later runs restore the per-ref npx cache, so the fetch is about 1.2 s and the bounded path is not exercised.

## Honest limits

- **#128 already carries these three commits byte-identically**, because the stack needed a green rehearsal without waiting for this to merge. Whichever of the two merges second contributes nothing from them, and an empty diff on the second is expected, not a mistake. Land whichever suits the review order.

- The cache step is **not** why the runs pass. GitHub scopes caches by ref, so each pull request's first rehearsal is a miss and downloads cold; six per-ref copies exist and none on `refs/heads/main`. It starts paying off once this lands on `main` and pull requests can restore from the default branch. The bounded fetch is what does the work.
- `fetch-retries=0` removes npm's own per-request retry, so a single transient reset now fails an npx attempt. The outer three-attempt loop plus the npm cache recovers it.
- A corrupt `_npx` would persist under a static cache key until the key is bumped.
- Latent, not fixed here: `--listen "$PORT"` binds `[::1]` only on macOS, so a client resolving `localhost` to IPv4 would be refused. It has never failed on the GitHub image. Pinning both sides to `127.0.0.1` would remove the class.

## Blast radius

`scripts/release-rehearsal.sh` and the `release-rehearsal` job in `ci.yml`. No package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNxUo7XgdMP1F4g71Yccpk

