### PR TITLE
docs: lead Drift Sessions with vibedrift enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,36 @@ No MCP client? The five query tools above, everything except `init`, `enable`, a
 
 **VibeDrift pushes.** A scan finds drift after the code exists, and MCP only helps when the agent thinks to ask. Drift Sessions flags a drifting edit while your agent is still typing, asked or not.
 
-`vibedrift watch-session` rides inside a Claude Code session through the agent's own hooks, which Claude Code runs at session start, on each prompt, after each edit, after each Bash command, and when the session stops. With the plugin installed the hooks are already there and `vibedrift enable` (or `/vibedrift:setup`) is all it takes, writing no repo-local copy; `watch-session` installs them repo-locally for anyone without the plugin, and follows the live tape either way. When an edit diverges from the patterns your repo already follows, VibeDrift writes a one line advisory straight into the agent's context, so the agent can correct itself on the spot instead of waiting for a review it will never see.
+### Turn it on
+
+Run this once inside the project you want it for. Typing the command is the consent.
+
+```bash
+cd ~/your/project
+vibedrift enable
+```
+
+That is the whole setup. It records the activation and makes sure the hooks are in place, then gets out of your way: your next Claude Code session in that repo is watched, with nothing else to run and no terminal to keep open.
+
+To turn several repositories on at once, point `--dir` at the directory that holds them. It shows you the resolved path and asks you to confirm by typing, and it refuses your home directory and filesystem roots.
+
+```bash
+vibedrift enable --dir ~/work        # activates every repo underneath
+vibedrift watch-session --status     # is this repo set up?
+vibedrift decline                    # turn it off; reversible with enable
+```
+
+Drift Sessions ride inside a Claude Code session through the agent's own hooks, which Claude Code runs at session start, on each prompt, after each edit, after each Bash command, and when the session stops. When an edit diverges from the patterns your repo already follows, VibeDrift writes a one line advisory straight into the agent's context, so the agent can correct itself on the spot instead of waiting for a review it will never see.
+
+### Watch it happen (optional)
+
+`vibedrift enable` is all you need. If you also want to see the session as it runs, `watch-session` opens a live event tape and follows along until you stop it. It is a viewer, not a second setup step, though it will install the hooks itself if the repo does not have them yet.
 
 ```bash
 vibedrift watch-session
 ```
+
+The two commands differ in one way worth knowing. `enable` will let the Claude Code plugin provide the hooks when the installed plugin ships them, so nothing is written into your repo. `watch-session` always writes the hooks into `.claude/settings.local.json` for that repo, and that copy then owns the capture.
 
 <div align="center">
 <img src="docs/media/drift-sessions-live-tape.gif" alt="The Drift Sessions live event tape: prompts, edits, and drift flags streaming in real time" width="840" />


### PR DESCRIPTION
## Summary

A user could not find how to turn Drift Sessions on, and the README is why. The whole section is written around `vibedrift watch-session`, which does install the hooks but then takes over the terminal following the live tape, so it reads like a monitoring tool rather than the way you switch the feature on. The one-line setup command, `vibedrift enable`, appeared exactly once in the entire README, as a row in the command reference table near the bottom, and never in the setup narrative or in any fenced example.

The section now leads with `vibedrift enable`, keeps `watch-session` as the optional live view, and states the difference between them.

- **Turn it on**: `cd` into the project and run `vibedrift enable`. Typing the command is the consent, and it is the whole setup.
- **Several repositories at once**: `vibedrift enable --dir ~/work`, with the guards named (it shows the resolved path, asks you to confirm by typing, and refuses `$HOME` and filesystem roots).
- **Check and undo**: `vibedrift watch-session --status` and `vibedrift decline`.
- **Watch it happen (optional)**: `watch-session` is a viewer, not a second setup step, though it installs the hooks if the repo has none.
- **The one difference worth knowing**: `enable` lets the Claude Code plugin provide the hooks when the installed plugin ships them, so nothing is written into the repo; `watch-session` always writes them into that repo, and that copy then owns capture.

## Type

- [x] Documentation

## Measurement

Every command and guarantee in the new text was checked against the shipped code, not against the old prose:

- `vibedrift enable --help` lists exactly one option, `--dir <path>`, described as "shown resolved, always asks for typed confirmation; $HOME and roots are refused". `src/cli/commands/enable.ts` says the same in its header and `src/session/activation.ts` stores dir grants canonicalized with the same refusal.
- `enable` puts the hooks in place: it calls `installHooks`, which upgrades an existing install in place and adds only what is absent.
- `watch-session --status`, `--uninstall`, `--sync on` and `--no-watch` all exist as documented in that command's help.
- `decline` is reversible by running `enable`, as stated in `enable.ts`'s header.
- The plugin-versus-repo-local split is the behaviour of `vibedriftPluginActive` after #134.

Verified by running it: on a repository with an older four-group install, `vibedrift enable` upgraded it in place to five groups including the new `Bash` matcher, and on a fresh repository it wrote all five.

## Blast radius

`README.md` only, one section. No code, no commands changed. The equivalent section of the guide on the website is updated in the landing-page repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNxUo7XgdMP1F4g71Yccpk
